### PR TITLE
Restored the patch that removes ToxicSensitivity for Starcrafter's Armoury

### DIFF
--- a/Patches/Star Crafter's Armory/CMC300.xml
+++ b/Patches/Star Crafter's Armory/CMC300.xml
@@ -85,9 +85,9 @@
 				</li>
 
 				<li Class="PatchOperationConditional">
-					<xpath>Defs/ThingDef[defName="CMC300a"]/equippedStatOffsets/ToxicResistance</xpath>
+					<xpath>Defs/ThingDef[defName="CMC300a"]/equippedStatOffsets/ToxicSensitivity</xpath>
 					<match Class="PatchOperationRemove">
-						<xpath>Defs/ThingDef[defName="CMC300a"]/equippedStatOffsets/ToxicResistance</xpath>
+						<xpath>Defs/ThingDef[defName="CMC300a"]/equippedStatOffsets/ToxicSensitivity</xpath>
 					</match>
 				</li>
 
@@ -165,9 +165,9 @@
 				</li>
 
 				<li Class="PatchOperationConditional">
-					<xpath>Defs/ThingDef[defName="CMC300H" or defName="CMC300Ha" or defName="CMC300Hb"]/equippedStatOffsets/ToxicResistance</xpath>
+					<xpath>Defs/ThingDef[defName="CMC300H" or defName="CMC300Ha" or defName="CMC300Hb"]/equippedStatOffsets/ToxicSensitivity</xpath>
 					<match Class="PatchOperationRemove">
-						<xpath>Defs/ThingDef[defName="CMC300H" or defName="CMC300Ha" or defName="CMC300Hb"]/equippedStatOffsets/ToxicResistance</xpath>
+						<xpath>Defs/ThingDef[defName="CMC300H" or defName="CMC300Ha" or defName="CMC300Hb"]/equippedStatOffsets/ToxicSensitivity</xpath>
 					</match>
 				</li>
 

--- a/Patches/Star Crafter's Armory/CMC405.xml
+++ b/Patches/Star Crafter's Armory/CMC405.xml
@@ -88,9 +88,9 @@
 				</li>
 
 				<li Class="PatchOperationConditional">
-					<xpath>Defs/ThingDef[defName="CMC405a"]/equippedStatOffsets/ToxicResistance</xpath>
+					<xpath>Defs/ThingDef[defName="CMC405a"]/equippedStatOffsets/ToxicSensitivity</xpath>
 					<match Class="PatchOperationRemove">
-						<xpath>Defs/ThingDef[defName="CMC405a"]/equippedStatOffsets/ToxicResistance</xpath>
+						<xpath>Defs/ThingDef[defName="CMC405a"]/equippedStatOffsets/ToxicSensitivity</xpath>
 					</match>
 				</li>
 
@@ -173,9 +173,9 @@
 				</li>
 
 				<li Class="PatchOperationConditional">
-					<xpath>Defs/ThingDef[defName="CMC405H"]/equippedStatOffsets/ToxicResistance</xpath>
+					<xpath>Defs/ThingDef[defName="CMC405H"]/equippedStatOffsets/ToxicSensitivity</xpath>
 					<match Class="PatchOperationRemove">
-						<xpath>Defs/ThingDef[defName="CMC405H"]/equippedStatOffsets/ToxicResistance</xpath>
+						<xpath>Defs/ThingDef[defName="CMC405H"]/equippedStatOffsets/ToxicSensitivity</xpath>
 					</match>
 				</li>
 

--- a/Patches/Star Crafter's Armory/PPS.xml
+++ b/Patches/Star Crafter's Armory/PPS.xml
@@ -45,9 +45,9 @@
 				</li>
 
 				<li Class="PatchOperationConditional">
-					<xpath>Defs/ThingDef[defName="PPSa"]/equippedStatOffsets/ToxicResistance</xpath>
+					<xpath>Defs/ThingDef[defName="PPSa"]/equippedStatOffsets/ToxicSensitivity</xpath>
 					<match Class="PatchOperationRemove">
-						<xpath>Defs/ThingDef[defName="PPSa"]/equippedStatOffsets/ToxicResistance</xpath>
+						<xpath>Defs/ThingDef[defName="PPSa"]/equippedStatOffsets/ToxicSensitivity</xpath>
 					</match>
 				</li>
 
@@ -174,7 +174,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="PPSH"]/equippedStatOffsets/ToxicResistance</xpath>
+					<xpath>Defs/ThingDef[defName="PPSH"]/equippedStatOffsets/ToxicSensitivity</xpath>
 					<value>
 						<ToxicEnvironmentResistance>-0.5</ToxicEnvironmentResistance>
 					</value>
@@ -182,9 +182,9 @@
 
 
 				<li Class="PatchOperationConditional">
-					<xpath>Defs/ThingDef[defName="PPSH"]/equippedStatOffsets/ToxicResistance</xpath>
+					<xpath>Defs/ThingDef[defName="PPSH"]/equippedStatOffsets/ToxicSensitivity</xpath>
 					<match Class="PatchOperationRemove">
-						<xpath>Defs/ThingDef[defName="PPSH"]/equippedStatOffsets/ToxicResistance</xpath>
+						<xpath>Defs/ThingDef[defName="PPSH"]/equippedStatOffsets/ToxicSensitivity</xpath>
 					</match>
 				</li>
 


### PR DESCRIPTION
Restored the patch that removes ToxicSensitivity, since the original mod uses the wrong node name.


## Changes
Restored the patch that was wrongly changed to "ToxicResistance" - in this case, it's correct, since we are _removing_ the bad node from target items.

## References

## Reasoning
Patch is fully correct otherwise, but this change caused the item to have unviewable description.

## Alternatives
Change the node to correct one in the target mod: author is unresponsive.

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [X] (For compatibility patches) ...with and without patched mod loaded
- [X] Playtested a colony (specify how long)
