### PR TITLE
Fixed CompAmmoGiver allowing pawns to carry over maximum amount

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoGiver.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoGiver.cs
@@ -39,7 +39,7 @@ namespace CombatExtended
                                 if (ammo.AmmoDef.AmmoSetDefs.Contains(user.Props.ammoSet))
                                 {
                                     int outAmmoCount = 0;
-                                    if (dad.TryGetComp<CompInventory>()?.CanFitInInventory(ammo, out outAmmoCount) ?? false && outAmmoCount >= ammo.stackCount)
+                                    if ((dad.TryGetComp<CompInventory>()?.CanFitInInventory(ammo, out outAmmoCount) ?? false) && outAmmoCount >= ammo.stackCount)
                                     {
                                         options.Add(new FloatMenuOption("CE_Give".Translate() + " " + ammo.Label + " (" + "All".Translate() + ")", delegate
                                         {


### PR DESCRIPTION
## Changes

- Changed condition for `CompAmmoGiver` so the final condition is no longer ignored (`outAmmoCount >= ammo.stackCount`).

## Reasoning

- The current implementation was basically `potentiallyNullValue ?? (false && condition)`, the changed version is `(potentiallyNullValue ?? false) && condition`.
- Without this fix, a pawn could give another pawn as much ammunition as they themselves could carry, as long as the other pawn had space for at least 1 more.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (tested for a few minutes on dev quick start)
