### PR TITLE
Sync CompAmmoGiver in Multiplayer

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoGiver.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoGiver.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using CombatExtended.Compatibility;
 using Verse;
 using Verse.AI;
 using RimWorld;
@@ -43,13 +44,7 @@ namespace CombatExtended
                                     {
                                         options.Add(new FloatMenuOption("CE_Give".Translate() + " " + ammo.Label + " (" + "All".Translate() + ")", delegate
                                         {
-                                            ammoAmountToGive = ammo.stackCount;
-
-                                            var jobdef = CE_JobDefOf.GiveAmmo;
-
-                                            var job = new Job { def = jobdef, targetA = dad, targetB = ammo };
-
-                                            selPawn.jobs.StartJob(job, JobCondition.InterruptForced);
+                                            GiveAmmo(selPawn, ammo, ammo.stackCount);
                                         }));
                                     }
 
@@ -82,6 +77,20 @@ namespace CombatExtended
                 }
             }
 
+        }
+
+        // Needs to be a sync method for 2 reasons - MP only auto synchronizes jobs through TryTakeOrderedJob/TryTakeOrderedJobPrioritizedWork,
+        // and ammoAmountToGive field is set before ordering the job - which means only 1 player would have the value set.
+        [Multiplayer.SyncMethod]
+        public void GiveAmmo(Pawn selPawn, Thing ammo, int amount)
+        {
+            ammoAmountToGive = amount;
+
+            var jobdef = CE_JobDefOf.GiveAmmo;
+
+            var job = new Job { def = jobdef, targetA = dad, targetB = ammo };
+
+            selPawn.jobs.StartJob(job, JobCondition.InterruptForced);
         }
     }
 }

--- a/Source/CombatExtended/CombatExtended/GUI/Windows/Window_GiveAmmoAmountSlider.cs
+++ b/Source/CombatExtended/CombatExtended/GUI/Windows/Window_GiveAmmoAmountSlider.cs
@@ -54,13 +54,7 @@ namespace CombatExtended
         {
             if (finalized)
             {
-                sourceComp.ammoAmountToGive = this.ammoToGiveAmount;
-
-                var jobdef = CE_JobDefOf.GiveAmmo;
-
-                var job = new Job { def = jobdef, targetA = dad, targetB = sourceAmmo };
-
-                selPawn.jobs.StartJob(job, JobCondition.InterruptForced);
+                sourceComp.GiveAmmo(selPawn, sourceAmmo, this.ammoToGiveAmount);
             }
 
             base.Close(doCloseSound);


### PR DESCRIPTION
## Changes

- Added `GiveAmmo` method inside of `CompAmmoGiver`
- The method is marked with `SyncMethodAttribute` to be synchronized with Multiplayer present
- The method is called from the `FloatMenuOption` initialized in `CompAmmoGiver:CompFloatMenuOptions`, as well as `Window_GiveAmmoAmountSlider:Close`
- Both places previously had very similar code to start the job for a pawn to give ammo to another one, so this will remove a bit of code repetition and allow it to be called from other places more easily

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [X] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (tested for a few minutes in dev quick start)
