### PR TITLE
Sync CompUnderBarrel in Multiplayer

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmosetSwitcher.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmosetSwitcher.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using CombatExtended.Compatibility;
 using RimWorld;
 using Verse;
 using UnityEngine;
@@ -114,6 +115,7 @@ namespace CombatExtended
 
         public bool usingUnderBarrel;
 
+        [Multiplayer.SyncMethod]
         public void SwitchToUB()
         {
             if (!Props.oneAmmoHolder)
@@ -141,6 +143,7 @@ namespace CombatExtended
             usingUnderBarrel = true;
         }
 
+        [Multiplayer.SyncMethod]
         public void SwithToB()
         {
             if (!Props.oneAmmoHolder)


### PR DESCRIPTION
## Changes

- In `CompUnderBarrel`, the methods `SwitchToUB` and `SwithToB` received `SyncMethodAttribute`

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (a few minutes of testing in dev quick start)
