### PR TITLE
Fix CompLongRangeArtilleryCE for mortars (VFE - Security compat)

### DIFF
--- a/Source/ArtilleryCompat/ArtilleryCompat/Utility.cs
+++ b/Source/ArtilleryCompat/ArtilleryCompat/Utility.cs
@@ -11,7 +11,7 @@ namespace CombatExtended.Compatibility.Artillery
     {
         public static List<ActiveArtilleryStrike> HarmfulStrikes(List<ActiveArtilleryStrike> artilleryStrikes)
         {
-            return artilleryStrikes.Where(s => (s.shellDef.projectile?.damageDef?.harmsHealth ?? false) || ((s.shellDef is AmmoDef) && ((AmmoDef)s.shellDef).detonateProjectile.projectile.damageDef.harmsHealth)).ToList();
+            return artilleryStrikes.Where(s => s.shellDef.GetProjectileProperties()?.damageDef.harmsHealth == true).ToList();
         }
 
         public static ProjectileProperties GetProjectileProperties(this ThingDef thingDef)


### PR DESCRIPTION
## Changes

- Changed `CombatExtended.Compatibility.Artillery:HarmfulStrikes` to call `GetProjectileProperties` instead of doing a big condition

## Reasoning

- The current condition was a bit messy, the new implementation should be much more readable
- The current implementation did not properly handle all projectiles - it assumed the projectile will be either `ThingDef.projectile` or `AmmoDef.detonateProjectile`. The correct projectile for the mortar are obtained through `AmmoDef.Users`.
- Every other place that I can see is using `GetProjectileProperties` instead of trying to access the projectile from the shell def.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded - not really applicable, as the compat code (to my knowledge) is only active if VFE - Security is loaded, and has no effect if it's off
- [ ] Playtested a colony (tested by striking random tribals with artillery for over 15 minutes)
