### PR TITLE
Sync mech loadouts in Multiplayer

### DIFF
--- a/Source/CombatExtended/Contrib/MechTakeAmmoCE/Core/CompMechAmmo.cs
+++ b/Source/CombatExtended/Contrib/MechTakeAmmoCE/Core/CompMechAmmo.cs
@@ -9,6 +9,7 @@ using RimWorld;
 using UnityEngine;
 
 using CombatExtended;
+using CombatExtended.Compatibility;
 using Verse.AI;
 
 namespace CombatExtended
@@ -172,6 +173,7 @@ namespace CombatExtended
             Current.Game.GetComponent<GameComponent_MechLoadoutDialogManger>()?.RegisterCompMechAmmo(this);
         }
 
+        [Multiplayer.SyncMethod]
         public void TakeAmmoNow()
         {
             this.TryMakeAmmoJob(true);

--- a/Source/CombatExtended/Contrib/MechTakeAmmoCE/UI/Dialog_SetMagCountBatched.cs
+++ b/Source/CombatExtended/Contrib/MechTakeAmmoCE/UI/Dialog_SetMagCountBatched.cs
@@ -8,6 +8,7 @@ using Verse;
 using RimWorld;
 using UnityEngine;
 using CombatExtended;
+using CombatExtended.Compatibility;
 
 
 namespace CombatExtended
@@ -78,18 +79,24 @@ namespace CombatExtended
             curY += Margin;
             if (Widgets.ButtonText(new Rect(inRect.x, curY, inRect.width, BotAreaHeight), "OK".Translate(), true, true, true, null))
             {
-                //set the loadouts for all the comps
-                foreach (var compMechAmmo in _mechAmmoList)
-                {
-                    //copy the loadouts from the _tmpLoadouts
-                    foreach (var ammoDef in _tmpLoadouts.Keys)
-                    {
-                        compMechAmmo.Loadouts.SetOrAdd(ammoDef, _tmpLoadouts[ammoDef]);
-                    }
-                    compMechAmmo.TakeAmmoNow();
-                }
+                SetMagCount(_mechAmmoList, _tmpLoadouts);
                 Close(true);
 
+            }
+        }
+
+        [Multiplayer.SyncMethod]
+        private static void SetMagCount(List<CompMechAmmo> mechAmmoList, Dictionary<AmmoDef, int> tmpLoadouts)
+        {
+            //set the loadouts for all the comps
+            foreach (var compMechAmmo in mechAmmoList)
+            {
+                //copy the loadouts from the _tmpLoadouts
+                foreach ((AmmoDef ammoDef, int amount) in tmpLoadouts)
+                {
+                    compMechAmmo.Loadouts.SetOrAdd(ammoDef, amount);
+                }
+                compMechAmmo.TakeAmmoNow();
             }
         }
 


### PR DESCRIPTION
## Changes

- `CompMechAmmo:TakeAmmoNow` now has `SyncMethodAttribute`
- `Dialog_SetMagCountBatched` had the code for setting the loadout extracted into a separate method, which is now synced
- `Dialog_SetMagCount` now works more like the batched version for simplicity of syncing, so the changes are only applied when accepted in the dialog (instead of being instantly accepted). Since it was unused, I've tested it by opening this dialog instead of the batched one.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (tested for a couple of minutes with both dialogs to see if they worked)
