### PR TITLE
Prevent mechanoids from dropping their weapons

### DIFF
--- a/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
@@ -242,7 +242,7 @@ namespace CombatExtended
             Rect rect = new Rect(0f, y, width, _thingRowHeight);
             Widgets.InfoCardButton(rect.width - 24f, y, thing.GetInnerIfMinified());
             rect.width -= 24f;
-            if (CanControl || (SelPawnForGear.Faction == Faction.OfPlayer && SelPawnForGear.RaceProps.packAnimal) || (showDropButtonIfPrisoner && SelPawnForGear.IsPrisonerOfColony))
+            if ((CanControl || (SelPawnForGear.Faction == Faction.OfPlayer && SelPawnForGear.RaceProps.packAnimal) || (showDropButtonIfPrisoner && SelPawnForGear.IsPrisonerOfColony)) && !SelPawnForGear.IsItemMechanoidWeapon(thing))
             {
                 var dropForbidden = SelPawnForGear.IsItemQuestLocked(thing);
                 Color color = dropForbidden ? Color.grey : Color.white;
@@ -445,7 +445,8 @@ namespace CombatExtended
                         floatOptionList.Add(new FloatMenuOption("CE_CannotDropThing".Translate() + ": " + "DropThingLocked".Translate(), null));
                         floatOptionList.Add(new FloatMenuOption("CE_CannotDropThingHaul".Translate() + ": " + "DropThingLocked".Translate(), null));
                     }
-                    else
+                    // Don't display drop option for mechanoids
+                    else if (!SelPawnForGear.IsItemMechanoidWeapon(eq))
                     {
                         floatOptionList.Add(new FloatMenuOption("DropThing".Translate(), new Action(delegate
                         {

--- a/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
@@ -242,7 +242,7 @@ namespace CombatExtended
             Rect rect = new Rect(0f, y, width, _thingRowHeight);
             Widgets.InfoCardButton(rect.width - 24f, y, thing.GetInnerIfMinified());
             rect.width -= 24f;
-            if ((CanControl || (SelPawnForGear.Faction == Faction.OfPlayer && SelPawnForGear.RaceProps.packAnimal) || (showDropButtonIfPrisoner && SelPawnForGear.IsPrisonerOfColony)) && !SelPawnForGear.RaceProps.IsMechanoid)
+            if ((CanControl || (SelPawnForGear.Faction == Faction.OfPlayer && SelPawnForGear.RaceProps.packAnimal) || (showDropButtonIfPrisoner && SelPawnForGear.IsPrisonerOfColony)) && !SelPawnForGear.IsItemMechanoidWeapon(thing))
             {
                 var dropForbidden = SelPawnForGear.IsItemQuestLocked(thing);
                 Color color = dropForbidden ? Color.grey : Color.white;
@@ -446,7 +446,7 @@ namespace CombatExtended
                         floatOptionList.Add(new FloatMenuOption("CE_CannotDropThingHaul".Translate() + ": " + "DropThingLocked".Translate(), null));
                     }
                     // Don't display drop option for mechanoids
-                    else if (!SelPawnForGear.RaceProps.IsMechanoid)
+                    else if (!SelPawnForGear.IsItemMechanoidWeapon(eq))
                     {
                         floatOptionList.Add(new FloatMenuOption("DropThing".Translate(), new Action(delegate
                         {

--- a/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
@@ -242,7 +242,7 @@ namespace CombatExtended
             Rect rect = new Rect(0f, y, width, _thingRowHeight);
             Widgets.InfoCardButton(rect.width - 24f, y, thing.GetInnerIfMinified());
             rect.width -= 24f;
-            if ((CanControl || (SelPawnForGear.Faction == Faction.OfPlayer && SelPawnForGear.RaceProps.packAnimal) || (showDropButtonIfPrisoner && SelPawnForGear.IsPrisonerOfColony)) && !SelPawnForGear.IsItemMechanoidWeapon(thing))
+            if ((CanControl || (SelPawnForGear.Faction == Faction.OfPlayer && SelPawnForGear.RaceProps.packAnimal) || (showDropButtonIfPrisoner && SelPawnForGear.IsPrisonerOfColony)) && !SelPawnForGear.RaceProps.IsMechanoid)
             {
                 var dropForbidden = SelPawnForGear.IsItemQuestLocked(thing);
                 Color color = dropForbidden ? Color.grey : Color.white;
@@ -446,7 +446,7 @@ namespace CombatExtended
                         floatOptionList.Add(new FloatMenuOption("CE_CannotDropThingHaul".Translate() + ": " + "DropThingLocked".Translate(), null));
                     }
                     // Don't display drop option for mechanoids
-                    else if (!SelPawnForGear.IsItemMechanoidWeapon(eq))
+                    else if (!SelPawnForGear.RaceProps.IsMechanoid)
                     {
                         floatOptionList.Add(new FloatMenuOption("DropThing".Translate(), new Action(delegate
                         {

--- a/Source/CombatExtended/CombatExtended/Loadouts/Utility_Loadouts.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/Utility_Loadouts.cs
@@ -397,6 +397,16 @@ namespace CombatExtended
                    || (thing.def.IsWeapon && pawn.IsQuestLodger() && !EquipmentUtility.QuestLodgerCanUnequip(thing, pawn));
         }
 
+        public static bool IsItemMechanoidWeapon(this Pawn pawn, Thing thing)
+        {
+            if (pawn == null || thing == null)
+            {
+                return false;
+            }
+
+            return pawn.RaceProps.IsMechanoid && thing.def.IsWeapon;
+        }
+
         #endregion Methods
     }
 }

--- a/Source/CombatExtended/CombatExtended/Loadouts/Utility_Loadouts.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/Utility_Loadouts.cs
@@ -397,16 +397,6 @@ namespace CombatExtended
                    || (thing.def.IsWeapon && pawn.IsQuestLodger() && !EquipmentUtility.QuestLodgerCanUnequip(thing, pawn));
         }
 
-        public static bool IsItemMechanoidWeapon(this Pawn pawn, Thing thing)
-        {
-            if (pawn == null || thing == null)
-            {
-                return false;
-            }
-
-            return pawn.RaceProps.IsMechanoid && thing.def.IsWeapon;
-        }
-
         #endregion Methods
     }
 }


### PR DESCRIPTION
## Changes

- Mechanoids can no longer drop their weapons from inventory

## Reasoning

- Since mechanoids are generally not supposed to be able to drop weapons, I haven't included the option (even as a disabled/greyed out one)
- Adding a disabled option would most likely require adding new text, as the vanilla generic text doesn't match too well ("This person refuses to drop this" doesn't really work well with mechanoids).

## Alternatives

- `IsItemMechanoidWeapon` could be expanded to checking if the weapon's `weaponTags` in any way with mech's tags. I thought this shouldn't be needed and current code would be enough, but let me know if it it's needed for any reason
- This code could potentially be expanded to all inventory, possibly excluding ammo. I've decided against it, but it shouldn't be hard to change.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (around 15 minutes of testing)
