### PR TITLE
Mech loadout - holding shift/ctrl affects the amount of change

### DIFF
--- a/Source/CombatExtended/Contrib/MechTakeAmmoCE/UI/Dialog_SetMagCount.cs
+++ b/Source/CombatExtended/Contrib/MechTakeAmmoCE/UI/Dialog_SetMagCount.cs
@@ -73,14 +73,14 @@ namespace CombatExtended
             Widgets.Label(new Rect(rect.x + BotAreaWidth + Margin, curY + BotAreaHeight / 4, rect.width - BotAreaWidth * 4, BotAreaHeight), label);
             if (Widgets.ButtonText(new Rect(rect.x + rect.width - BotAreaWidth * 4, curY, BotAreaWidth, BotAreaHeight), "-", true, true, true, null))
             {
-                count--;
+                count -= GenUI.CurrentAdjustmentMultiplier();
             }
             Text.Anchor = TextAnchor.UpperCenter;
             Widgets.Label(new Rect(rect.x + rect.width - BotAreaWidth * 3, curY + BotAreaHeight / 4, BotAreaWidth * 2, BotAreaHeight), count.ToString());
             Text.Anchor = TextAnchor.UpperLeft;
             if (Widgets.ButtonText(new Rect(rect.x + rect.width - BotAreaWidth, curY, BotAreaWidth, BotAreaHeight), "+", true, true, true, null))
             {
-                count++;
+                count += GenUI.CurrentAdjustmentMultiplier();
             }
 
             count = count < 0 ? 0 : count;

--- a/Source/CombatExtended/Contrib/MechTakeAmmoCE/UI/Dialog_SetMagCountBatched.cs
+++ b/Source/CombatExtended/Contrib/MechTakeAmmoCE/UI/Dialog_SetMagCountBatched.cs
@@ -101,7 +101,7 @@ namespace CombatExtended
             Widgets.Label(new Rect(rect.x + BotAreaWidth + Margin, curY, rect.width - BotAreaWidth * 4, BotAreaHeight), label);
             if (Widgets.ButtonText(new Rect(rect.x + rect.width - BotAreaWidth * 4, curY, BotAreaWidth, BotAreaHeight), "-", true, true, true, null))
             {
-                count--;
+                count -= GenUI.CurrentAdjustmentMultiplier();
             }
             Text.Font = GameFont.Tiny;
             Text.Anchor = TextAnchor.MiddleCenter;
@@ -109,7 +109,7 @@ namespace CombatExtended
             Text.Anchor = TextAnchor.UpperLeft;
             if (Widgets.ButtonText(new Rect(rect.x + rect.width - BotAreaWidth, curY, BotAreaWidth, BotAreaHeight), "+", true, true, true, null))
             {
-                count++;
+                count += GenUI.CurrentAdjustmentMultiplier();
             }
 
             count = count < 0 ? 0 : count;


### PR DESCRIPTION
## Changes

- Modifying mech loadout now uses `GenUI.CurrentAdjustmentMultiplier()` for modifying the current amount
- This will make it so holding ctrl and/or shift will modify the amount for 10/100/1000 instead of only 1

## Reasoning

- This is a quality-of-life feature
- Modifying by 1000 may be a niche feature, but 10 and 100 are quite likely to be usable in more situations

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (around half an hour of testing with other changes, a couple of minutes on its own)
