### PR TITLE
Mech loadouts - handle issues caused by despawned and dead mechs

### DIFF
--- a/Source/CombatExtended/Contrib/MechTakeAmmoCE/UI/Dialog_SetMagCount.cs
+++ b/Source/CombatExtended/Contrib/MechTakeAmmoCE/UI/Dialog_SetMagCount.cs
@@ -46,6 +46,12 @@ namespace CombatExtended
         }
         public override void DoWindowContents(Rect inRect)
         {
+            if (!mechAmmo.parent.Spawned || mechAmmo.ParentPawn.Dead)
+            {
+                Close();
+                return;
+            }
+
             float curY = 0;
             string Maglabel = "MTA_MagazinePrefix".Translate(mechAmmo.AmmoUser.Props.magazineSize);
             DrawLabel(inRect, ref curY, Maglabel);

--- a/Source/CombatExtended/Contrib/MechTakeAmmoCE/UI/Dialog_SetMagCount.cs
+++ b/Source/CombatExtended/Contrib/MechTakeAmmoCE/UI/Dialog_SetMagCount.cs
@@ -31,6 +31,11 @@ namespace CombatExtended
 
         public override void PreOpen()
         {
+            if (mechAmmo == null)
+            {
+                return;
+            }
+            
             Vector2 initialSize = this.InitialSize;
             initialSize.y = (mechAmmo.AmmoUser.Props.ammoSet.ammoTypes.Count + 4) * (BotAreaHeight + Margin);
             this.windowRect = new Rect(((float)UI.screenWidth - initialSize.x) / 2f, ((float)UI.screenHeight - initialSize.y) / 2f, initialSize.x, initialSize.y);
@@ -46,7 +51,7 @@ namespace CombatExtended
         }
         public override void DoWindowContents(Rect inRect)
         {
-            if (!mechAmmo.parent.Spawned || mechAmmo.ParentPawn.Dead)
+            if (mechAmmo == null || !mechAmmo.parent.Spawned || mechAmmo.ParentPawn.Dead)
             {
                 Close();
                 return;

--- a/Source/CombatExtended/Contrib/MechTakeAmmoCE/UI/Dialog_SetMagCount.cs
+++ b/Source/CombatExtended/Contrib/MechTakeAmmoCE/UI/Dialog_SetMagCount.cs
@@ -35,7 +35,7 @@ namespace CombatExtended
             {
                 return;
             }
-            
+
             Vector2 initialSize = this.InitialSize;
             initialSize.y = (mechAmmo.AmmoUser.Props.ammoSet.ammoTypes.Count + 4) * (BotAreaHeight + Margin);
             this.windowRect = new Rect(((float)UI.screenWidth - initialSize.x) / 2f, ((float)UI.screenHeight - initialSize.y) / 2f, initialSize.x, initialSize.y);

--- a/Source/CombatExtended/Contrib/MechTakeAmmoCE/UI/Dialog_SetMagCountBatched.cs
+++ b/Source/CombatExtended/Contrib/MechTakeAmmoCE/UI/Dialog_SetMagCountBatched.cs
@@ -15,8 +15,9 @@ namespace CombatExtended
     public class Dialog_SetMagCountBatched : Window
     {
         private readonly List<CompMechAmmo> _mechAmmoList;
-        private readonly CompMechAmmo _mechAmmoShown;
         private readonly Dictionary<AmmoDef, int> _tmpLoadouts;
+        private readonly List<AmmoLink> _mechAmmoTypes;
+        private readonly int _mechMagazineSize;
 
         private const float BotAreaWidth = 30f;
         private const float BotAreaHeight = 30f;
@@ -30,22 +31,29 @@ namespace CombatExtended
             if (mechAmmoList == null || mechAmmoList.Count == 0)
             {
                 Log.Error("null or empty CompMechAmmo list for Dialog_SetMagCount");
+                _mechAmmoList = new List<CompMechAmmo>(); // Prevent potential issues later on, just in case
                 return;
             }
             _mechAmmoList = mechAmmoList;
-            _mechAmmoShown = mechAmmoList[0];
+            _mechAmmoTypes = mechAmmoList[0].AmmoUser.Props.ammoSet.ammoTypes;
+            _mechMagazineSize = _mechAmmoList[0].AmmoUser.Props.magazineSize;
             // copy the loadouts from the _mechAmmoShown
-            _tmpLoadouts = new Dictionary<AmmoDef, int>(_mechAmmoShown.Loadouts);
+            _tmpLoadouts = new Dictionary<AmmoDef, int>(mechAmmoList[0].Loadouts);
 
         }
 
         public override void PreOpen()
         {
+            if (_mechAmmoList.Count == 0)
+            {
+                return;
+            }
+            
             Vector2 initialSize = this.InitialSize;
-            Maglabel = "MTA_MagazinePrefix".Translate(_mechAmmoShown.AmmoUser.Props.magazineSize);
+            Maglabel = "MTA_MagazinePrefix".Translate(_mechMagazineSize);
             Text.Font = GameFont.Small;
             headerHeight = Text.CalcHeight(Maglabel, initialSize.x);
-            initialSize.y = (_mechAmmoShown.AmmoUser.Props.ammoSet.ammoTypes.Count + 3) * (BotAreaHeight) + headerHeight;
+            initialSize.y = (_mechAmmoTypes.Count + 3) * (BotAreaHeight) + headerHeight;
             this.windowRect = new Rect(((float)UI.screenWidth - initialSize.x) / 2f, ((float)UI.screenHeight - initialSize.y) / 2f, initialSize.x, initialSize.y);
             this.windowRect = this.windowRect.Rounded();
         }
@@ -59,13 +67,20 @@ namespace CombatExtended
         }
         public override void DoWindowContents(Rect inRect)
         {
+            _mechAmmoList.RemoveAll(m => !m.parent.Spawned || m.ParentPawn.Dead);
+            if (_mechAmmoList.Count == 0)
+            {
+                Close();
+                return;
+            }
+
             Text.Font = GameFont.Small;
             float curY = 0;
 
             Text.Anchor = TextAnchor.UpperCenter;
             Widgets.Label(inRect, Maglabel);
             curY += headerHeight + Margin;
-            foreach (var ammoType in _mechAmmoShown.AmmoUser.Props.ammoSet.ammoTypes)
+            foreach (var ammoType in _mechAmmoTypes)
             {
                 int value = 0;
                 _tmpLoadouts.TryGetValue(ammoType.ammo, out value);
@@ -105,7 +120,7 @@ namespace CombatExtended
             }
             Text.Font = GameFont.Tiny;
             Text.Anchor = TextAnchor.MiddleCenter;
-            Widgets.Label(new Rect(rect.x + rect.width - BotAreaWidth * 3, curY, BotAreaWidth * 2, BotAreaHeight), count.ToString() + " (" + (count * _mechAmmoShown.AmmoUser.Props.magazineSize).ToString() + ")");
+            Widgets.Label(new Rect(rect.x + rect.width - BotAreaWidth * 3, curY, BotAreaWidth * 2, BotAreaHeight), count.ToString() + " (" + (count * _mechMagazineSize).ToString() + ")");
             Text.Anchor = TextAnchor.UpperLeft;
             if (Widgets.ButtonText(new Rect(rect.x + rect.width - BotAreaWidth, curY, BotAreaWidth, BotAreaHeight), "+", true, true, true, null))
             {

--- a/Source/CombatExtended/Contrib/MechTakeAmmoCE/UI/Dialog_SetMagCountBatched.cs
+++ b/Source/CombatExtended/Contrib/MechTakeAmmoCE/UI/Dialog_SetMagCountBatched.cs
@@ -48,7 +48,7 @@ namespace CombatExtended
             {
                 return;
             }
-            
+
             Vector2 initialSize = this.InitialSize;
             Maglabel = "MTA_MagazinePrefix".Translate(_mechMagazineSize);
             Text.Font = GameFont.Small;


### PR DESCRIPTION
## Changes

- `Dialog_SetMagCount` will automatically close if the mechanoid is dead or despawned.
- `Dialog_SetMagCountBatched` will remove dead or despawned mechs from its list of mechs, and if there's none left it will close.
- Both dialogs will now handle more gracefully (no errors) situations of being opened with null data.
- `Dialog_SetMagCountBatched` no longer keeps a cached reference to a primary mech, as it would cause issues. Instead, ammo types and magazine size are cached (as it was the main reason the mech was cached in the first place).

## Reasoning

- Mechs despawning or dying could cause issues.
- Those dialogs don't force pause the game, allowing for those situations to happen.
- Even if the dialogs were set to force pause, it wouldn't be force paused with Multiplayer mod (without additional code and forcing the dialog to open for every player) and would cause issues.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (around half an hour testing with other changes, a couple of minutes on its own)
