### PR TITLE
Improve the check for mech loadout grouping to consider ammo instead of weapon

### DIFF
--- a/Source/CombatExtended/Contrib/MechTakeAmmoCE/Core/GameComponent_MechLoadoutDialogManger.cs
+++ b/Source/CombatExtended/Contrib/MechTakeAmmoCE/Core/GameComponent_MechLoadoutDialogManger.cs
@@ -25,10 +25,10 @@ namespace CombatExtended
             if (_compMechAmmoQueue.Count > 0)
             {
                 List<CompMechAmmo> compMechAmmoList = new List<CompMechAmmo>(_compMechAmmoQueue);
-                ThingDef euipmentDef = compMechAmmoList[0].ParentPawn?.equipment?.Primary?.def;
+                HashSet<AmmoLink> ammoTypes = new HashSet<AmmoLink>(compMechAmmoList[0].AmmoUser.Props.ammoSet.ammoTypes);
                 foreach (var compMechAmmo in compMechAmmoList)
                 {
-                    if (compMechAmmo.ParentPawn?.equipment?.Primary?.def != euipmentDef)
+                    if (!ammoTypes.SetEquals(compMechAmmo.AmmoUser.Props.ammoSet.ammoTypes))
                     {
                         Messages.Message("MTA_CannotSetLoadoutForMultipleEquipment".Translate(), MessageTypeDefOf.RejectInput);
                         _compMechAmmoQueue.Clear();


### PR DESCRIPTION
## Changes

- The code opening mech loadout will now consider what ammo types a mech uses, instead of only checking for their main weapon
- Mechs with different weapons but same identical ammo types can now be selected and have the dialog open at the same time
- This will also fix some edge cases where the same mechs can not be selected at the same time, despite having identical weapon and ammo types

## Reasoning

- This is a quality-of-life change
- I was unable to select one of my centipede gunners with others, as (for some reason) the minigun it had was different from the others (old save file, it had normal quality compared to modern centipedes having none)

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] Playtested a colony (5-10 minutes of testing done)
