### PR TITLE
Mechanitor power armor adjustments and housekeeping

### DIFF
--- a/Biotech/Patches/ThingDefs_Misc/Apparel_BiotechHeadgear.xml
+++ b/Biotech/Patches/ThingDefs_Misc/Apparel_BiotechHeadgear.xml
@@ -75,8 +75,13 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_ArmorHelmetMechlordHelmet"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
 		<value>
-			<AimingAccuracy>-0.25</AimingAccuracy>
+			<ToxicEnvironmentResistance>0.50</ToxicEnvironmentResistance>
+			<SmokeSensitivity>-1</SmokeSensitivity>
 		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorHelmetMechlordHelmet"]/equippedStatOffsets/MeleeHitChance</xpath>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">

--- a/Biotech/Patches/ThingDefs_Misc/Apparel_BiotechVarious.xml
+++ b/Biotech/Patches/ThingDefs_Misc/Apparel_BiotechVarious.xml
@@ -37,10 +37,13 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_MechlordSuit"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
 		<value>
-			<ShootingAccuracyPawn>-1</ShootingAccuracyPawn>
 			<CarryWeight>65</CarryWeight>
 			<CarryBulk>10</CarryBulk>
 		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Apparel_MechlordSuit"]/equippedStatOffsets/MeleeHitChance</xpath>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Misc/Apparel.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Misc/Apparel.xml
@@ -67,6 +67,14 @@
 						</value>
 					</li>
 
+					<li Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="AM_MechCommanderHelm"]/equippedStatOffsets</xpath>
+						<value>
+							<ToxicEnvironmentResistance>0.5</ToxicEnvironmentResistance>
+							<SmokeSensitivity>-1</SmokeSensitivity>
+						</value>
+					</li>
+
 					<!-- Mech Breaker Helmet -->
 
 					<li Class="PatchOperationAdd">
@@ -120,6 +128,14 @@
 						</value>
 					</li>
 
+					<li Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="AM_MechBreakerHelm"]/equippedStatOffsets</xpath>
+						<value>
+							<ToxicEnvironmentResistance>0.5</ToxicEnvironmentResistance>
+							<SmokeSensitivity>-1</SmokeSensitivity>
+						</value>
+					</li>
+
 					<!-- Mech Master Armor -->
 
 					<li Class="PatchOperationAdd">
@@ -163,6 +179,7 @@
 						<value>
 							<Bulk>100</Bulk>
 							<WornBulk>20</WornBulk>
+							<Mass>80</Mass>
 						</value>
 					</li>
 
@@ -196,6 +213,16 @@
 
 					<li Class="PatchOperationRemove">
 						<xpath>Defs/ThingDef[defName="AM_MechBreakerArmor"]/equippedStatOffsets/MoveSpeed</xpath>
+					</li>
+
+					<li Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="AM_MechBreakerArmor"]/equippedStatOffsets</xpath>
+						<value>
+							<CarryWeight>100</CarryWeight>
+							<CarryBulk>20</CarryBulk>
+							<ToxicEnvironmentResistance>0.5</ToxicEnvironmentResistance>
+							<MeleeDodgeChance>-0.15</MeleeDodgeChance>
+						</value>
 					</li>
 
 					<li Class="PatchOperationReplace">

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_PristineStrider.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_PristineStrider.xml
@@ -26,8 +26,8 @@
 					<li Class="PatchOperationAdd">
 						<xpath>Defs/ThingDef[defName="AM_PristineStrider"]/statBases</xpath>
 						<value>
-							<CarryWeight>200</CarryWeight>
-							<CarryBulk>50</CarryBulk>
+							<CarryWeight>300</CarryWeight>
+							<CarryBulk>100</CarryBulk>
 							<ArmorRating_Blunt>10</ArmorRating_Blunt>
 							<ArmorRating_Sharp>6</ArmorRating_Sharp>
 							<MeleeDodgeChance>0.03</MeleeDodgeChance>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Machines.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Machines.xml
@@ -295,8 +295,8 @@
     <li Class="PatchOperationAdd">
       <xpath>Defs/ThingDef[defName="VFE_Mechanoids_Autostrider"]/statBases</xpath>
       <value>
-        <CarryWeight>200</CarryWeight>
-        <CarryBulk>50</CarryBulk>
+        <CarryWeight>100</CarryWeight>
+        <CarryBulk>25</CarryBulk>
         <MeleeDodgeChance>0.03</MeleeDodgeChance>
         <MeleeCritChance>0.26</MeleeCritChance>
         <MeleeParryChance>0.52</MeleeParryChance>


### PR DESCRIPTION
## Changes

- Added some missing nodes to the mechanitor power armors.
- Removed the direct combat penalties from the mechanitor armors.
- Minor tweaks to the strider mech inventory capacities.

## Reasoning

- The mechanitor armors already take a lot of setup to get and are simply modified normal power armor. Leaving them with no accuracy bonuses (neutral status) is a better approach than a flat nerf since the helmets already do not provide any night vision which is penalizing enough. The neutral accuracy is also comparable to how normal power armors don't give an accuracy bonus in vanilla but do in CE.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
