### PR TITLE
Ammo recipe skill checks

### DIFF
--- a/Defs/Ammo/Advanced/12x64mmCharged.xml
+++ b/Defs/Ammo/Advanced/12x64mmCharged.xml
@@ -119,6 +119,9 @@
     <products>
       <Ammo_12x64mmCharged>200</Ammo_12x64mmCharged>
     </products>
+    <skillRequirements>
+      <Crafting>8</Crafting>
+    </skillRequirements>
     <workAmount>36080</workAmount>  <!-- 10% more work -->
   </RecipeDef>
 

--- a/Defs/Ammo/Advanced/15x65mmDiffusingCharged.xml
+++ b/Defs/Ammo/Advanced/15x65mmDiffusingCharged.xml
@@ -14,7 +14,7 @@
     <defName>AmmoSet_15x65mmDiffusingCharged</defName>
     <label>15x65mm Diffusing Charged</label>
     <ammoTypes>
-      <Ammo_15x65mmDiffusingCharged_Buck>Bullet_15x65mmDiffusingCharged_Buck</Ammo_15x65mmDiffusingCharged_Buck>
+      <Ammo_15x65mmDiffusingCharged>Bullet_15x65mmDiffusingCharged</Ammo_15x65mmDiffusingCharged>
     </ammoTypes>
     <similarTo>AmmoSet_MechCharged</similarTo>
   </CombatExtended.AmmoSetDef>
@@ -36,7 +36,7 @@
   </ThingDef>
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="15x65mmDiffusingChargedBase">
-    <defName>Ammo_15x65mmDiffusingCharged_Buck</defName>
+    <defName>Ammo_15x65mmDiffusingCharged</defName>
     <label>15x65mm Diffusing Charged cartridge</label>
     <graphicData>
       <texPath>Things/Ammo/Charged/ShotgunMech</texPath>
@@ -46,7 +46,7 @@
       <MarketValue>6.35</MarketValue> <!-- value intentionally decreased to help reduce wealth bloat/free silver -->
     </statBases>
     <ammoClass>BuckShot</ammoClass>
-    <cookOffProjectile>Bullet_15x65mmDiffusingCharged_Buck</cookOffProjectile>
+    <cookOffProjectile>Bullet_15x65mmDiffusingCharged</cookOffProjectile>
   </ThingDef>
 	
 	<!-- ================== Projectiles ================== -->
@@ -60,7 +60,7 @@
 	</ThingDef>
 
 	<ThingDef ParentName="Base15x65mmDiffusingChargedBullet">
-		<defName>Bullet_15x65mmDiffusingCharged_Buck</defName>
+		<defName>Bullet_15x65mmDiffusingCharged</defName>
 		<label>diffusing charged shot</label>
 		<graphicData>
 			<texPath>Things/Projectile/Charged/ChargeShot</texPath>
@@ -82,5 +82,52 @@
 	</ThingDef>
   
 	<!-- ==================== Recipes ========================== -->
-	
+
+  <RecipeDef ParentName="ChargeAmmoRecipeBase" MayRequire="Ludeon.RimWorld.Biotech">
+    <defName>MakeAmmo_15x65mmDiffusingCharged</defName>
+    <label>make 15x65mm Diffusing Charged cartridge x200</label>
+    <description>Craft 200 15x65mm Diffusing Charged cartridges.</description>
+    <jobString>Making 15x65mm Diffusing Charged cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Plasteel</li>
+          </thingDefs>
+        </filter>
+        <count>60</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>14</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>22</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Plasteel</li>
+        <li>Steel</li>
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_12x64mmCharged>200</Ammo_12x64mmCharged>
+    </products>
+    <skillRequirements>
+      <Crafting>8</Crafting>
+    </skillRequirements>
+    <workAmount>42460</workAmount>  <!-- 10% more work -->
+  </RecipeDef>
+
 </Defs>

--- a/Defs/Ammo/Advanced/5x16mmCharged.xml
+++ b/Defs/Ammo/Advanced/5x16mmCharged.xml
@@ -122,6 +122,9 @@
     <products>
       <Ammo_5x16mmCharged>500</Ammo_5x16mmCharged>
     </products>
+    <skillRequirements>
+      <Crafting>8</Crafting>
+    </skillRequirements>
     <workAmount>7040</workAmount>  <!-- 10% more work -->
   </RecipeDef>
 

--- a/Defs/Ammo/Advanced/5x35mmCharged.xml
+++ b/Defs/Ammo/Advanced/5x35mmCharged.xml
@@ -118,6 +118,9 @@
     <products>
       <Ammo_5x35mmCharged>500</Ammo_5x35mmCharged>
     </products>
+    <skillRequirements>
+      <Crafting>8</Crafting>
+    </skillRequirements>
     <workAmount>9900</workAmount>  <!-- 10% more work -->
   </RecipeDef>
 

--- a/Defs/Ammo/Advanced/66mmThermalBolt.xml
+++ b/Defs/Ammo/Advanced/66mmThermalBolt.xml
@@ -144,6 +144,9 @@
     <products>
       <Ammo_66mmThermalBolt_Incendiary>5</Ammo_66mmThermalBolt_Incendiary>
     </products>
+    <skillRequirements>
+      <Crafting>8</Crafting>
+    </skillRequirements>
     <workAmount>4620</workAmount>  <!-- 10% more work -->
   </RecipeDef>
 

--- a/Defs/Ammo/Advanced/6x22mmCharged.xml
+++ b/Defs/Ammo/Advanced/6x22mmCharged.xml
@@ -117,6 +117,9 @@
     <products>
       <Ammo_6x22mmCharged>500</Ammo_6x22mmCharged>
     </products>
+    <skillRequirements>
+      <Crafting>8</Crafting>
+    </skillRequirements>
     <workAmount>9460</workAmount>  <!-- 10% more work -->
   </RecipeDef>
 

--- a/Defs/Ammo/Advanced/70mmMechanoidGrenade.xml
+++ b/Defs/Ammo/Advanced/70mmMechanoidGrenade.xml
@@ -120,4 +120,91 @@
 		</projectile>
 	</ThingDef>
 
+  <!-- ==================== Recipes ========================== -->
+
+  <RecipeDef ParentName="ChargeAmmoRecipeBase" MayRequire="Ludeon.RimWorld.Biotech">
+    <defName>MakeAmmo_70mmMechanoidGrenade_HE</defName>
+    <label>make 70mm Mechanoid HE Grenade x5</label>
+    <description>Craft 5 70mm Mechanoid HE Grenades.</description>
+    <jobString>Making 70mm Mechanoid HE Grenades.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>FSX</li>
+          </thingDefs>
+        </filter>
+        <count>8</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>18</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>2</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>FSX</li>
+        <li>Steel</li>
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_70mmMechanoidGrenade_HE>5</Ammo_70mmMechanoidGrenade_HE>
+    </products>
+    <skillRequirements>
+      <Crafting>8</Crafting>
+    </skillRequirements>
+    <workAmount>6820</workAmount>  <!-- 10% more work -->
+  </RecipeDef>
+
+  <RecipeDef ParentName="ChargeAmmoRecipeBase" MayRequire="Ludeon.RimWorld.Biotech">
+    <defName>MakeAmmo_70mmMechanoidGrenade_EMP</defName>
+    <label>make 70mm Mechanoid EMP Grenade x5</label>
+    <description>Craft 5 70mm Mechanoid EMP Grenades.</description>
+    <jobString>Making 70mm Mechanoid EMP Grenades.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>18</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>11</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_70mmMechanoidGrenade_EMP>5</Ammo_70mmMechanoidGrenade_EMP>
+    </products>
+    <skillRequirements>
+      <Crafting>8</Crafting>
+    </skillRequirements>
+    <workAmount>9240</workAmount>  <!-- 10% more work -->
+  </RecipeDef>
+
 </Defs>

--- a/Defs/Ammo/Advanced/80x256mmFuelCell.xml
+++ b/Defs/Ammo/Advanced/80x256mmFuelCell.xml
@@ -141,6 +141,9 @@
     <products>
       <Ammo_80x256mmFuel_Incendiary>5</Ammo_80x256mmFuel_Incendiary>
     </products>
+    <skillRequirements>
+      <Crafting>8</Crafting>
+    </skillRequirements>
     <workAmount>3730</workAmount>  <!-- 10% more work -->
   </RecipeDef>
 

--- a/Defs/Ammo/Advanced/8x40mmCharged.xml
+++ b/Defs/Ammo/Advanced/8x40mmCharged.xml
@@ -123,6 +123,9 @@
     <products>
       <Ammo_8x40mmCharged>500</Ammo_8x40mmCharged>
     </products>
+    <skillRequirements>
+      <Crafting>8</Crafting>
+    </skillRequirements>
     <workAmount>21120</workAmount>  <!-- 10% more work -->
   </RecipeDef>
 

--- a/Defs/Ammo/AmmoBases.xml
+++ b/Defs/Ammo/AmmoBases.xml
@@ -124,14 +124,23 @@
 
 	<RecipeDef Name="AdvancedAmmoRecipeBase" ParentName="AmmoRecipeBase" Abstract="true">
 		<researchPrerequisite>CE_AdvancedAmmo</researchPrerequisite>
+		<skillRequirements>
+			<Crafting>6</Crafting>
+		</skillRequirements>
 	</RecipeDef>
 
 	<RecipeDef Name="LauncherAmmoRecipeBase" ParentName="AmmoRecipeBase" Abstract="true">
 		<researchPrerequisite>CE_Launchers</researchPrerequisite>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
 	</RecipeDef>
 
 	<RecipeDef Name="ChargeAmmoRecipeBase" ParentName="AmmoRecipeBase" Abstract="true">
 		<researchPrerequisite>ChargedShot</researchPrerequisite>
+		<skillRequirements>
+			<Crafting>7</Crafting>
+		</skillRequirements>
 	</RecipeDef>
 
 	<RecipeDef Name="AmmoRecipeNeolithicBase" Abstract="true">

--- a/Defs/Ammo/Flamethrower.xml
+++ b/Defs/Ammo/Flamethrower.xml
@@ -186,6 +186,9 @@
     <products>
       <Ammo_Flamethrower_Prometheum>100</Ammo_Flamethrower_Prometheum>
     </products>
+    <skillRequirements>
+      <Crafting>4</Crafting>
+    </skillRequirements>
   </RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/GENERIC/Mech.xml
+++ b/Defs/Ammo/GENERIC/Mech.xml
@@ -44,9 +44,9 @@
   <ThingDef Class="CombatExtended.AmmoDef" Name="MechChargedAmmo" ParentName="SpacerAmmoBase" Abstract="True">
     <description>Charged shot ammo used by mechanoid weaponry.</description>
     <statBases>
-      <Mass>0.013</Mass>
-      <Bulk>0.01</Bulk>
-      <MarketValue>0.45</MarketValue>
+      <Mass>0.058</Mass>
+      <Bulk>0.04</Bulk>
+      <MarketValue>3.39</MarketValue>
     </statBases>
     <tradeTags>
       <li>CE_AutoEnableTrade_Sellable</li>
@@ -59,7 +59,7 @@
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="MechChargedAmmo">
     <defName>Ammo_MechCharged</defName>
-    <label>mech charged cartridge</label>
+    <label>Mech Charged cartridge</label>
     <graphicData>
       <texPath>Things/Ammo/Charged/MediumMech</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -73,7 +73,8 @@
     <description>Large shell used by mechanoid cannons and heavy weapons.</description>
     <statBases>
       <Mass>0.85</Mass>
-      <Bulk>3.87</Bulk>  
+      <Bulk>3.87</Bulk>
+      <MarketValue>10.38</MarketValue>
     </statBases>
     <tradeTags>
       <li>CE_AutoEnableTrade_Sellable</li>
@@ -105,5 +106,101 @@
       </li>
     </comps>    
   </ThingDef>
+
+  <!-- ==================== Recipes ========================== -->
+
+  <RecipeDef ParentName="ChargeAmmoRecipeBase" MayRequire="Ludeon.RimWorld.Biotech">
+    <defName>MakeAmmo_MechCharged</defName>
+    <label>make Mech Charged cartridge x200</label>
+    <description>Craft 200 Mech Charged cartridges.</description>
+    <jobString>Making Mech Charged cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Plasteel</li>
+          </thingDefs>
+        </filter>
+        <count>32</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>8</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>32</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Plasteel</li>
+        <li>Steel</li>
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_12x64mmCharged>200</Ammo_12x64mmCharged>
+    </products>
+    <skillRequirements>
+      <Crafting>8</Crafting>
+    </skillRequirements>
+    <workAmount>36080</workAmount>  <!-- 10% more work -->
+  </RecipeDef>
+
+  <RecipeDef ParentName="ChargeAmmoRecipeBase" MayRequire="Ludeon.RimWorld.Biotech">
+    <defName>MakeAmmo_MechShell</defName>
+    <label>make Mech Shell x5</label>
+    <description>Craft 5 Mech Shells.</description>
+    <jobString>Making Mech Shells.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Prometheum</li>
+          </thingDefs>
+        </filter>
+        <count>3</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>10</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>2</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Prometheum</li>
+        <li>Steel</li>
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_80x256mmFuel_Incendiary>5</Ammo_80x256mmFuel_Incendiary>
+    </products>
+    <skillRequirements>
+      <Crafting>8</Crafting>
+    </skillRequirements>
+    <workAmount>3730</workAmount>  <!-- 10% more work -->
+  </RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/GENERIC/ShotgunShell.xml
+++ b/Defs/Ammo/GENERIC/ShotgunShell.xml
@@ -222,6 +222,9 @@
 		<products>
 			<Ammo_Shotgun_ElectroSlug>200</Ammo_Shotgun_ElectroSlug>
 		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
 		<workAmount>4600</workAmount>
 	</RecipeDef>
 

--- a/Defs/Ammo/Rocket/RPG7.xml
+++ b/Defs/Ammo/Rocket/RPG7.xml
@@ -223,7 +223,7 @@
     </products>
   </RecipeDef>
 
-  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
+  <RecipeDef ParentName="LauncherAmmoRecipeBase">
     <defName>MakeAmmo_RPG7Grenade_Thermobaric</defName>
     <label>make RPG-7 thermobaric grenades x5</label>
     <description>Craft 5 RPG-7 thermobaric grenades.</description>

--- a/Defs/Ammo/Rocket/SPG9.xml
+++ b/Defs/Ammo/Rocket/SPG9.xml
@@ -256,7 +256,7 @@
     </products>
   </RecipeDef>
 
-  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
+  <RecipeDef ParentName="LauncherAmmoRecipeBase">
     <defName>MakeAmmo_SPG9Rocket_Thermobaric</defName>
     <label>make SPG-9 thermobaric rockets x5</label>
     <description>Craft 5 SPG-9 thermobaric rockets.</description>

--- a/Defs/Ammo/Shell/100x695mmR.xml
+++ b/Defs/Ammo/Shell/100x695mmR.xml
@@ -184,6 +184,9 @@
 		<products>
 			<Ammo_100x695mmRCannonShell_HEAT>2</Ammo_100x695mmRCannonShell_HEAT>
 		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
@@ -228,6 +231,9 @@
 		<products>
 			<Ammo_100x695mmRCannonShell_HE>2</Ammo_100x695mmRCannonShell_HE>
 		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
 	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Shell/105mmHowitzer.xml
+++ b/Defs/Ammo/Shell/105mmHowitzer.xml
@@ -424,6 +424,9 @@
 		<products>
 			<Ammo_105mmHowitzerShell_HE>2</Ammo_105mmHowitzerShell_HE>
 		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
 	</RecipeDef>
 	
 	<RecipeDef ParentName="AmmoRecipeBase">
@@ -468,6 +471,9 @@
 		<products>
 			<Ammo_105mmHowitzerShell_HEAT>2</Ammo_105mmHowitzerShell_HEAT>
 		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
@@ -512,6 +518,9 @@
 		<products>
 			<Ammo_105mmHowitzerShell_Incendiary>2</Ammo_105mmHowitzerShell_Incendiary>
 		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
@@ -548,6 +557,9 @@
 		<products>
 			<Ammo_105mmHowitzerShell_EMP>2</Ammo_105mmHowitzerShell_EMP>
 		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
@@ -592,6 +604,9 @@
 		<products>
 			<Ammo_105mmHowitzerShell_Smoke>2</Ammo_105mmHowitzerShell_Smoke>
 		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
 	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Shell/105x607mmR.xml
+++ b/Defs/Ammo/Shell/105x607mmR.xml
@@ -183,6 +183,9 @@
 		<products>
 			<Ammo_105x607mmRCannonShell_HEAT>2</Ammo_105x607mmRCannonShell_HEAT>
 		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
@@ -227,6 +230,9 @@
 		<products>
 			<Ammo_105x607mmRCannonShell_HE>2</Ammo_105x607mmRCannonShell_HE>
 		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
 	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Shell/120mmCannon.xml
+++ b/Defs/Ammo/Shell/120mmCannon.xml
@@ -183,6 +183,9 @@
 		<products>
 			<Ammo_120mmCannonShell_HEAT>2</Ammo_120mmCannonShell_HEAT>
 		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
@@ -227,6 +230,9 @@
 		<products>
 			<Ammo_120mmCannonShell_HE>2</Ammo_120mmCannonShell_HE>
 		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
 	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Shell/155mmHowitzer.xml
+++ b/Defs/Ammo/Shell/155mmHowitzer.xml
@@ -367,6 +367,9 @@
 		<products>
 			<Ammo_155mmHowitzerShell_HE>1</Ammo_155mmHowitzerShell_HE>
 		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
@@ -411,6 +414,9 @@
 		<products>
 			<Ammo_155mmHowitzerShell_Incendiary>1</Ammo_155mmHowitzerShell_Incendiary>
 		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
@@ -447,6 +453,9 @@
 		<products>
 			<Ammo_155mmHowitzerShell_EMP>1</Ammo_155mmHowitzerShell_EMP>
 		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
@@ -491,6 +500,9 @@
 		<products>
 			<Ammo_155mmHowitzerShell_Smoke>1</Ammo_155mmHowitzerShell_Smoke>
 		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
 	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Shell/15cmNebelwerfer.xml
+++ b/Defs/Ammo/Shell/15cmNebelwerfer.xml
@@ -125,6 +125,9 @@
 		<products>
 			<Ammo_15cmNebelwerfer_HE>6</Ammo_15cmNebelwerfer_HE>
 		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
 	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Shell/28cmSpgr.xml
+++ b/Defs/Ammo/Shell/28cmSpgr.xml
@@ -142,6 +142,9 @@
 		<products>
 			<Ammo_28cmSpgrShell_HE>5</Ammo_28cmSpgrShell_HE>
 		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
 	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Shell/37x223mmR.xml
+++ b/Defs/Ammo/Shell/37x223mmR.xml
@@ -133,6 +133,9 @@
 		<products>
 			<Ammo_37x223mmR_HE>25</Ammo_37x223mmR_HE>
 		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
 		<workAmount>12600</workAmount>
 	</RecipeDef>
 
@@ -159,6 +162,9 @@
 		<products>
 			<Ammo_37x223mmR_AP>25</Ammo_37x223mmR_AP>
 		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
 		<workAmount>10800</workAmount>
 	</RecipeDef>
 

--- a/Defs/Ammo/Shell/40x365mmBofors.xml
+++ b/Defs/Ammo/Shell/40x365mmBofors.xml
@@ -139,6 +139,9 @@
 		<products>
 			<Ammo_40x365mmBofors_HE>25</Ammo_40x365mmBofors_HE>
 		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
 		<workAmount>24000</workAmount>
 	</RecipeDef>
 
@@ -165,6 +168,9 @@
 		<products>
 			<Ammo_40x365mmBofors_AP>25</Ammo_40x365mmBofors_AP>
 		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
 		<workAmount>10800</workAmount>
 	</RecipeDef>
 

--- a/Defs/Ammo/Shell/50mmType89Mortar.xml
+++ b/Defs/Ammo/Shell/50mmType89Mortar.xml
@@ -241,6 +241,9 @@
     <products>
       <Ammo_50mmType89MortarShell_HE>5</Ammo_50mmType89MortarShell_HE>
     </products>
+    <skillRequirements>
+      <Crafting>4</Crafting>
+    </skillRequirements>
   </RecipeDef>
 
   <RecipeDef ParentName="AmmoRecipeBase">
@@ -284,6 +287,9 @@
     <products>
       <Ammo_50mmType89MortarShell_Incendiary>5</Ammo_50mmType89MortarShell_Incendiary>
     </products>
+    <skillRequirements>
+      <Crafting>4</Crafting>
+    </skillRequirements>
     <workAmount>3000</workAmount>
   </RecipeDef>
 
@@ -320,6 +326,9 @@
     <products>
       <Ammo_50mmType89MortarShell_EMP>5</Ammo_50mmType89MortarShell_EMP>
     </products>
+    <skillRequirements>
+      <Crafting>4</Crafting>
+    </skillRequirements>
     <workAmount>3400</workAmount>
   </RecipeDef>
 
@@ -364,6 +373,9 @@
     <products>
       <Ammo_50mmType89MortarShell_Smoke>5</Ammo_50mmType89MortarShell_Smoke>
     </products>
+    <skillRequirements>
+      <Crafting>4</Crafting>
+    </skillRequirements>
     <workAmount>2600</workAmount>
   </RecipeDef>
 

--- a/Defs/Ammo/Shell/57x483mmBofors.xml
+++ b/Defs/Ammo/Shell/57x483mmBofors.xml
@@ -131,6 +131,9 @@
 		<products>
 			<Ammo_57x483mmBofors_HE>25</Ammo_57x483mmBofors_HE>
 		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
 		<workAmount>47400</workAmount>
 	</RecipeDef>
 

--- a/Defs/Ammo/Shell/60mmMortar.xml
+++ b/Defs/Ammo/Shell/60mmMortar.xml
@@ -286,6 +286,9 @@
     <products>
       <Shell_60mmMortar_HE>5</Shell_60mmMortar_HE>
     </products>
+    <skillRequirements>
+      <Crafting>4</Crafting>
+    </skillRequirements>
     <workAmount>4800</workAmount>
   </RecipeDef>
 
@@ -330,6 +333,9 @@
     <products>
       <Shell_60mmMortar_Incendiary>5</Shell_60mmMortar_Incendiary>
     </products>
+    <skillRequirements>
+      <Crafting>4</Crafting>
+    </skillRequirements>
     <workAmount>4000</workAmount>
   </RecipeDef>
 
@@ -366,6 +372,9 @@
     <products>
       <Shell_60mmMortar_EMP>5</Shell_60mmMortar_EMP>
     </products>
+    <skillRequirements>
+      <Crafting>4</Crafting>
+    </skillRequirements>
     <workAmount>5600</workAmount>
   </RecipeDef>
 
@@ -413,6 +422,9 @@
     <products>
       <Shell_60mmMortar_Firefoam>5</Shell_60mmMortar_Firefoam>
     </products>
+    <skillRequirements>
+      <Crafting>4</Crafting>
+    </skillRequirements>
     <workAmount>4600</workAmount>
   </RecipeDef>
 
@@ -457,6 +469,9 @@
     <products>
       <Shell_60mmMortar_Smoke>5</Shell_60mmMortar_Smoke>
     </products>
+    <skillRequirements>
+      <Crafting>4</Crafting>
+    </skillRequirements>
     <workAmount>3600</workAmount>
   </RecipeDef>
 

--- a/Defs/Ammo/Shell/762x385mmRCannon.xml
+++ b/Defs/Ammo/Shell/762x385mmRCannon.xml
@@ -224,6 +224,9 @@
 		<products>
 			<Ammo_762x385mmRCannonShell_HEAT>5</Ammo_762x385mmRCannonShell_HEAT>
 		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
@@ -304,6 +307,9 @@
 		<products>
 			<Ammo_762x385mmRCannonShell_EMP>5</Ammo_762x385mmRCannonShell_EMP>
 		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
 	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Shell/81mmMortar.xml
+++ b/Defs/Ammo/Shell/81mmMortar.xml
@@ -457,6 +457,9 @@
     <products>
       <Shell_HighExplosive>5</Shell_HighExplosive>
     </products>
+    <skillRequirements>
+      <Crafting>4</Crafting>
+    </skillRequirements>
     <workAmount>10600</workAmount>
   </RecipeDef>
 
@@ -501,6 +504,9 @@
     <products>
       <Shell_Incendiary>5</Shell_Incendiary>
     </products>
+    <skillRequirements>
+      <Crafting>4</Crafting>
+    </skillRequirements>
     <workAmount>9000</workAmount>
   </RecipeDef>
 
@@ -537,6 +543,9 @@
     <products>
       <Shell_EMP>5</Shell_EMP>
     </products>
+    <skillRequirements>
+      <Crafting>4</Crafting>
+    </skillRequirements>
     <workAmount>13800</workAmount>
   </RecipeDef>
 
@@ -584,6 +593,9 @@
     <products>
       <Shell_Firefoam>5</Shell_Firefoam>
     </products>
+    <skillRequirements>
+      <Crafting>4</Crafting>
+    </skillRequirements>
     <workAmount>8800</workAmount>
   </RecipeDef>
 
@@ -628,6 +640,9 @@
     <products>
       <Shell_Smoke>5</Shell_Smoke>
     </products>
+    <skillRequirements>
+      <Crafting>4</Crafting>
+    </skillRequirements>
     <workAmount>6600</workAmount>
   </RecipeDef>
 
@@ -673,6 +688,9 @@
     <products>
       <Shell_Toxic>5</Shell_Toxic>
     </products>
+    <skillRequirements>
+      <Crafting>4</Crafting>
+    </skillRequirements>
     <workAmount>6600</workAmount>
   </RecipeDef>
 

--- a/Defs/Ammo/Shell/90mmCannon.xml
+++ b/Defs/Ammo/Shell/90mmCannon.xml
@@ -310,6 +310,9 @@
     <products>
       <Ammo_90mmCannonShell_HEAT>5</Ammo_90mmCannonShell_HEAT>
     </products>
+    <skillRequirements>
+      <Crafting>4</Crafting>
+    </skillRequirements>
   </RecipeDef>
 
   <RecipeDef ParentName="AmmoRecipeBase">
@@ -354,6 +357,9 @@
     <products>
       <Ammo_90mmCannonShell_HE>5</Ammo_90mmCannonShell_HE>
     </products>
+    <skillRequirements>
+      <Crafting>4</Crafting>
+    </skillRequirements>
   </RecipeDef>
   
   <RecipeDef ParentName="AmmoRecipeBase">
@@ -399,6 +405,9 @@
     <products>
       <Ammo_90mmCannonShell_HE_TFuzed>5</Ammo_90mmCannonShell_HE_TFuzed>
     </products>
+    <skillRequirements>
+      <Crafting>4</Crafting>
+    </skillRequirements>
   </RecipeDef>
 
   <RecipeDef ParentName="AmmoRecipeBase">
@@ -435,6 +444,9 @@
     <products>
       <Ammo_90mmCannonShell_EMP>5</Ammo_90mmCannonShell_EMP>
     </products>
+    <skillRequirements>
+      <Crafting>4</Crafting>
+    </skillRequirements>
   </RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Shotgun/10Gauge.xml
+++ b/Defs/Ammo/Shotgun/10Gauge.xml
@@ -300,6 +300,9 @@
     <products>
       <Ammo_10Gauge_ElectroSlug>200</Ammo_10Gauge_ElectroSlug>
     </products>
+    <skillRequirements>
+      <Crafting>4</Crafting>
+    </skillRequirements>
     <workAmount>7800</workAmount>
   </RecipeDef>
 

--- a/Defs/Ammo/Shotgun/12Gauge.xml
+++ b/Defs/Ammo/Shotgun/12Gauge.xml
@@ -300,6 +300,9 @@
     <products>
       <Ammo_12Gauge_ElectroSlug>200</Ammo_12Gauge_ElectroSlug>
     </products>
+    <skillRequirements>
+      <Crafting>4</Crafting>
+    </skillRequirements>
     <workAmount>4600</workAmount>
   </RecipeDef>
 

--- a/Defs/Ammo/Shotgun/16Gauge.xml
+++ b/Defs/Ammo/Shotgun/16Gauge.xml
@@ -300,6 +300,9 @@
     <products>
       <Ammo_16Gauge_ElectroSlug>200</Ammo_16Gauge_ElectroSlug>
     </products>
+    <skillRequirements>
+      <Crafting>4</Crafting>
+    </skillRequirements>
     <workAmount>3800</workAmount>
   </RecipeDef>
 

--- a/Defs/Ammo/Shotgun/20Gauge.xml
+++ b/Defs/Ammo/Shotgun/20Gauge.xml
@@ -299,6 +299,9 @@
     <products>
       <Ammo_20Gauge_ElectroSlug>200</Ammo_20Gauge_ElectroSlug>
     </products>
+    <skillRequirements>
+      <Crafting>4</Crafting>
+    </skillRequirements>
     <workAmount>2800</workAmount>
   </RecipeDef>
 	

--- a/Defs/Ammo/Shotgun/23x75mmR.xml
+++ b/Defs/Ammo/Shotgun/23x75mmR.xml
@@ -299,6 +299,9 @@
     <products>
       <Ammo_23x75mmR_ElectroSlug>200</Ammo_23x75mmR_ElectroSlug>
     </products>
+    <skillRequirements>
+      <Crafting>4</Crafting>
+    </skillRequirements>
     <workAmount>12000</workAmount>
   </RecipeDef>
 	

--- a/Defs/Ammo/Shotgun/410Bore.xml
+++ b/Defs/Ammo/Shotgun/410Bore.xml
@@ -378,6 +378,9 @@
     <products>
       <Ammo_410Bore_ElectroSlug>500</Ammo_410Bore_ElectroSlug>
     </products>
+    <skillRequirements>
+      <Crafting>4</Crafting>
+    </skillRequirements>
     <workAmount>4000</workAmount>
   </RecipeDef>
 


### PR DESCRIPTION
## Changes

- Added proper skill checks for ammo recipes. Shells, rockets and launcher grenades require 4 crafting skill, advanced ammo requires 6, charged ammo requires 7 and mech ammo requires 8 crafting skill.
- Added missing recipes to certain ammo types.

## Reasoning

- Certain ammo types lacked the skill check in comparison to the vanilla game and some others required it due to being advanced in general.
- The required skill levels are consistent with vanilla skill checks for various ammo and weapon skill requirements.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
