### PR TITLE
Constructoid melee tool tweak

### DIFF
--- a/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Light.xml
+++ b/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Light.xml
@@ -130,11 +130,11 @@
 					<capacities>
 						<li>Blunt</li>
 					</capacities>
-					<power>7</power>
+					<power>10</power>
 					<cooldownTime>3.0</cooldownTime>
 					<linkedBodyPartsGroup>Torso</linkedBodyPartsGroup>
 					<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
-					<armorPenetrationBlunt>2.0</armorPenetrationBlunt>
+					<armorPenetrationBlunt>8.0</armorPenetrationBlunt>
 				</li>
 			</tools>
 		</value>


### PR DESCRIPTION
## Changes

- Adjusted the melee attack of the constructoid mech as it's supposed to be slightly weaker and slower than a pikeman headbutt.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
