### PR TITLE
Fix turret night vision

### DIFF
--- a/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
@@ -115,6 +115,7 @@
       <Bulk>25</Bulk>
       <AimingAccuracy>0.75</AimingAccuracy>
       <ShootingAccuracyTurret>1.25</ShootingAccuracyTurret>
+      <NightVisionEfficiency>0.5</NightVisionEfficiency>
     </statBases>
     <techLevel>Spacer</techLevel>
     <comps>

--- a/Defs/ThingDefs_Misc/Weapons_Turrets.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Turrets.xml
@@ -49,7 +49,6 @@
       <ShotSpread>0.06</ShotSpread>
       <SwayFactor>0.86</SwayFactor>
       <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-      <NightVisionEfficiency_Weapon>0.5</NightVisionEfficiency_Weapon>
       <Mass>10</Mass>
     </statBases>
     <verbs>
@@ -225,7 +224,6 @@
       <ShotSpread>0.01</ShotSpread>
       <SwayFactor>1.89</SwayFactor>
       <RangedWeapon_Cooldown>0.5</RangedWeapon_Cooldown>
-      <NightVisionEfficiency_Weapon>0.5</NightVisionEfficiency_Weapon>
       <Mass>50</Mass>
     </statBases>
     <verbs>

--- a/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
@@ -117,6 +117,7 @@
 		<xpath>Defs/ThingDef[defName="Turret_Sniper"]/statBases</xpath>
 		<value>
 			<AimingAccuracy>0.75</AimingAccuracy>
+			<NightVisionEfficiency>0.5</NightVisionEfficiency>
 		</value>
 	</Operation>
 

--- a/Patches/Reinforced Mechanoid 2/ThingDefs_Misc/RM_Buildings_Security_Turrets.xml
+++ b/Patches/Reinforced Mechanoid 2/ThingDefs_Misc/RM_Buildings_Security_Turrets.xml
@@ -29,6 +29,7 @@
 				<xpath>Defs/ThingDef[defName="RM_Turret_AutoShardLance"]/statBases</xpath>
 				<value>
 					<AimingAccuracy>0.75</AimingAccuracy>
+					<NightVisionEfficiency>0.4</NightVisionEfficiency>
 				</value>
 			</li>
 			
@@ -73,7 +74,6 @@
 				  <ShotSpread>0.01</ShotSpread>
 				  <SwayFactor>0.44</SwayFactor>
 				  <Bulk>13.00</Bulk>
-				  <NightVisionEfficiency_Weapon>0.4</NightVisionEfficiency_Weapon>
 				</statBases>
 				<Properties>
 				  <recoilAmount>0.75</recoilAmount>
@@ -119,6 +119,7 @@
 				<xpath>Defs/ThingDef[defName="RM_Turret_AutoShardSwarmer"]/statBases</xpath>
 				<value>
 					<AimingAccuracy>0.5</AimingAccuracy>
+					<NightVisionEfficiency>0.4</NightVisionEfficiency>
 				</value>
 			</li>
 			
@@ -178,7 +179,6 @@
 				  <ShotSpread>0.01</ShotSpread>
 				  <SwayFactor>1.33</SwayFactor>
 				  <Bulk>13.00</Bulk>
-				  <NightVisionEfficiency_Weapon>0.4</NightVisionEfficiency_Weapon>
 				</statBases>
 				<Properties>
 				  <recoilAmount>1.08</recoilAmount>

--- a/Patches/Rimsenal Collection/Security/Patch_Security.xml
+++ b/Patches/Rimsenal Collection/Security/Patch_Security.xml
@@ -532,7 +532,19 @@
 					<AimingAccuracy>1.0</AimingAccuracy>
 				</value>
 			</li>
-			
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[
+					defName="Turret_ShardSentry" or 
+					defName="Turret_SuvTurret" or
+					defName="Turret_WaveEmitter" or
+					defName="RocketTurret"
+				]/statBases</xpath>
+				<value>
+				  <NightVisionEfficiency>0.5</NightVisionEfficiency>
+				</value>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[
 				defName="Gun_SuvTurret" or 

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Security_Turrets.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Security_Turrets.xml
@@ -28,6 +28,7 @@
 				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoChargeBlaster"]/statBases</xpath>
 				<value>
 					<AimingAccuracy>0.5</AimingAccuracy>
+					<NightVisionEfficiency>0.4</NightVisionEfficiency>
 				</value>
 			</li>
 			
@@ -87,7 +88,6 @@
 				  <ShotSpread>0.01</ShotSpread>
 				  <SwayFactor>1.33</SwayFactor>
 				  <Bulk>13.00</Bulk>
-				  <NightVisionEfficiency_Weapon>0.4</NightVisionEfficiency_Weapon>
 				</statBases>
 				<Properties>
 				  <recoilAmount>1.08</recoilAmount>
@@ -134,6 +134,7 @@
 				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoChargeLance"]/statBases</xpath>
 				<value>
 					<AimingAccuracy>0.75</AimingAccuracy>
+					<NightVisionEfficiency>0.4</NightVisionEfficiency>
 				</value>
 			</li>
 			
@@ -178,7 +179,6 @@
 				  <ShotSpread>0.01</ShotSpread>
 				  <SwayFactor>0.44</SwayFactor>
 				  <Bulk>13.00</Bulk>
-				  <NightVisionEfficiency_Weapon>0.4</NightVisionEfficiency_Weapon>
 				</statBases>
 				<Properties>
 				  <recoilAmount>0.75</recoilAmount>
@@ -223,6 +223,7 @@
 				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoInfernoCannon"]/statBases</xpath>
 				<value>
 					<AimingAccuracy>0.5</AimingAccuracy>
+					<NightVisionEfficiency>0.4</NightVisionEfficiency>
 				</value>
 			</li>
 			
@@ -282,7 +283,6 @@
 				  <ShotSpread>0.01</ShotSpread>
 				  <SwayFactor>0.82</SwayFactor>
 				  <Bulk>20.00</Bulk>
-				  <NightVisionEfficiency_Weapon>0.4</NightVisionEfficiency_Weapon>
 				</statBases>
 				<Properties>
 				  <recoilAmount>1.01</recoilAmount>

--- a/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Sentry.xml
+++ b/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Sentry.xml
@@ -92,6 +92,17 @@
 	  	</value>
 		</li>
 
+		<li Class="PatchOperationAdd">
+	  	<xpath>Defs/ThingDef[
+			defName = "VFES_Turret_ChargeRailgunTurret" or
+			defName = "VFES_Turret_ChargeTurret" or
+			defName = "VFES_Turret_EMPTurret"
+		]/statBases</xpath>
+	  	<value>
+			<NightVisionEfficiency>0.5</NightVisionEfficiency>
+	  	</value>
+		</li>
+
 		<li Class="PatchOperationReplace">
 	  	<xpath>Defs/ThingDef[
 			defName = "VFES_Turret_EMPTurret" or

--- a/Royalty/Defs/ThingDefs_Buildings/Weapons_Turrets.xml
+++ b/Royalty/Defs/ThingDefs_Buildings/Weapons_Turrets.xml
@@ -16,7 +16,6 @@
         <ShotSpread>0.08</ShotSpread>
         <SwayFactor>0.72</SwayFactor>
         <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-        <NightVisionEfficiency_Weapon>0.6</NightVisionEfficiency_Weapon>
       </statBases>
       <verbs>
         <li Class="CombatExtended.VerbPropertiesCE">
@@ -63,7 +62,6 @@
       <SightsEfficiency>1</SightsEfficiency>
       <ShotSpread>0.01</ShotSpread>
       <SwayFactor>1.33</SwayFactor>
-      <NightVisionEfficiency_Weapon>0.6</NightVisionEfficiency_Weapon>
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
@@ -110,7 +108,6 @@
       <SightsEfficiency>1</SightsEfficiency>
       <ShotSpread>0.01</ShotSpread>
       <SwayFactor>0.82</SwayFactor>
-      <NightVisionEfficiency_Weapon>0.6</NightVisionEfficiency_Weapon>
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">

--- a/Royalty/Patches/ThingDefs_Buildings/Buildings_Mechanoid.xml
+++ b/Royalty/Patches/ThingDefs_Buildings/Buildings_Mechanoid.xml
@@ -70,6 +70,7 @@
 		<xpath>Defs/ThingDef[defName="Turret_AutoMiniTurret"]/statBases</xpath>
 		<value>
 			<AimingAccuracy>0.75</AimingAccuracy>
+			<NightVisionEfficiency>0.6</NightVisionEfficiency>
 		</value>
 	</Operation>
 
@@ -125,6 +126,7 @@
 		<xpath>Defs/ThingDef[defName="Turret_AutoChargeBlaster"]/statBases</xpath>
 		<value>
 			<AimingAccuracy>0.5</AimingAccuracy>
+			<NightVisionEfficiency>0.6</NightVisionEfficiency>
 		</value>
 	</Operation>
 
@@ -180,6 +182,7 @@
 		<xpath>Defs/ThingDef[defName="Turret_AutoInferno"]/statBases</xpath>
 		<value>
 			<AimingAccuracy>0.5</AimingAccuracy>
+			<NightVisionEfficiency>0.6</NightVisionEfficiency>
 		</value>
 	</Operation>
 
@@ -244,6 +247,7 @@
 		<xpath>Defs/ThingDef[defName="Turret_AutoMortar"]/statBases</xpath>
 		<value>
 			<AimingAccuracy>0.25</AimingAccuracy>
+			<NightVisionEfficiency>0.6</NightVisionEfficiency>
 		</value>
 	</Operation>
 


### PR DESCRIPTION
## Changes

- Gave the proper night vision node to turrets that already had them.

## Reasoning

- `NightVisionEfficiency_Weapon` actually does not give night vision to turrets if it's used on the turret gun itself. The turret building needs the `NightVisionEfficiency` node that pawns get to actually have night vision.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Works for the Royalty mech turrets)
