### PR TITLE
#252 and #2550 revised

### DIFF
--- a/Patches/Core/DamageDefs/Damages_LocalInjury.xml
+++ b/Patches/Core/DamageDefs/Damages_LocalInjury.xml
@@ -66,14 +66,14 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/DamageDef[defName="Bomb"]/defaultDamage</xpath>
 		<value>
-			<defaultDamage>635</defaultDamage>
+			<defaultDamage>156</defaultDamage>
 		</value>
 	</Operation>
   
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/DamageDef[defName="Bomb"]/defaultArmorPenetration</xpath>
 		<value>
-			<defaultArmorPenetration>210</defaultArmorPenetration>
+			<defaultArmorPenetration>52</defaultArmorPenetration>
 		</value>
 	</Operation>
 

--- a/Patches/Vanilla Apparel Expanded - Accessories/Apparel_Utility.xml
+++ b/Patches/Vanilla Apparel Expanded - Accessories/Apparel_Utility.xml
@@ -104,16 +104,6 @@
 			</li>
 
 			<!-- == Explosive Belt == -->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs</xpath>
-				<value>
-					<DamageDef ParentName="Bomb">
-						<defName>BombSmall</defName>
-						<defaultDamage>200</defaultDamage>
-						<defaultArmorPenetration>66</defaultArmorPenetration>
-					</DamageDef>
-				</value>
-			</li>
 
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="VAEA_Apparel_ExplosiveBelt"]/statBases</xpath>
@@ -134,12 +124,6 @@
 				</value>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAEA_Apparel_ExplosiveBelt"]/comps/li[@Class="VAE_Accessories.CompProperties_ExplodeOnDeath"]/damageDef</xpath>
-				<value>
-					<damageDef>BombSmall</damageDef>
-				</value>
-			</li>
 
 			<!-- == Ranged Shield Pack == -->
 

--- a/Patches/Vanilla Apparel Expanded - Accessories/Apparel_Utility.xml
+++ b/Patches/Vanilla Apparel Expanded - Accessories/Apparel_Utility.xml
@@ -105,6 +105,17 @@
 
 			<!-- == Explosive Belt == -->
 			<li Class="PatchOperationAdd">
+				<xpath>Defs</xpath>
+				<value>
+					<DamageDef ParentName="Bomb">
+						<defName>BombSmall</defName>
+						<defaultDamage>200</defaultDamage>
+						<defaultArmorPenetration>66</defaultArmorPenetration>
+					</DamageDef>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="VAEA_Apparel_ExplosiveBelt"]/statBases</xpath>
 				<value>
 					<Bulk>5</Bulk>
@@ -123,10 +134,10 @@
 				</value>
 			</li>
 
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VAEA_Apparel_ExplosiveBelt"]/comps/li[@Class="VAE_Accessories.CompProperties_ExplodeOnDeath"]</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VAEA_Apparel_ExplosiveBelt"]/comps/li[@Class="VAE_Accessories.CompProperties_ExplodeOnDeath"]/damageDef</xpath>
 				<value>
-					<damageAmountBase>200</damageAmountBase>
+					<damageDef>BombSmall</damageDef>
 				</value>
 			</li>
 


### PR DESCRIPTION
## Changes

- Removed the problematic patch added in #2550.
- Adjusted the Bomb damage patch introduced in #252 that changed its default damage and AP as it was causing problems in cases like the explosive belt from VAE Accessories. There are cases that are not solvable in XML with how the default bomb damage is absurdly high. The new values are replicated 81mm HE shells.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony
