### PR TITLE
Bombardment damage/pen adjustment

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_Bombardment.cs
+++ b/Source/CombatExtended/Harmony/Harmony_Bombardment.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Emit;
+using System.Text;
+using System.Threading.Tasks;
+using HarmonyLib;
+using RimWorld;
+using Verse;
+
+namespace CombatExtended.HarmonyCE
+{
+    [HarmonyPatch(typeof(Bombardment), nameof(Bombardment.TryDoExplosion))]
+    public static class Bombardment_TryDoExplosion_Patch
+    {
+        static IEnumerable<CodeInstruction> Transpiler (IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            foreach (var instruction in instructions)
+            {  // Replaces the default damage and armor pen values of -1
+                if (instruction.opcode == OpCodes.Ldc_I4_M1)
+                {
+                    yield return new CodeInstruction(OpCodes.Ldc_I4, 546); // new damage
+                }
+                else if (instruction.opcode == OpCodes.Ldc_R4 &&  (float)instruction.operand == -1f)
+                {
+                    yield return new CodeInstruction(OpCodes.Ldc_R4, 180f); // new pen
+                }
+                else
+                {
+                    yield return instruction;
+                }
+            }
+        }
+    }
+}

--- a/Source/CombatExtended/Harmony/Harmony_Bombardment.cs
+++ b/Source/CombatExtended/Harmony/Harmony_Bombardment.cs
@@ -13,7 +13,7 @@ namespace CombatExtended.HarmonyCE
     [HarmonyPatch(typeof(Bombardment), nameof(Bombardment.TryDoExplosion))]
     public static class Bombardment_TryDoExplosion_Patch
     {
-        static IEnumerable<CodeInstruction> Transpiler (IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
         {
             foreach (var instruction in instructions)
             {  // Replaces the default damage and armor pen values of -1
@@ -21,7 +21,7 @@ namespace CombatExtended.HarmonyCE
                 {
                     yield return new CodeInstruction(OpCodes.Ldc_I4, 546); // new damage
                 }
-                else if (instruction.opcode == OpCodes.Ldc_R4 &&  (float)instruction.operand == -1f)
+                else if (instruction.opcode == OpCodes.Ldc_R4 && (float)instruction.operand == -1f)
                 {
                     yield return new CodeInstruction(OpCodes.Ldc_R4, 180f); // new pen
                 }


### PR DESCRIPTION
## Additions

- Transpiled the bombardment class to use its own damage and pen values, allowing it to be adjusted separately.

## References

- Required for #2590 

## Reasoning

- High default damage for Bomb damage can lead to unintended behavior, bombardment is the largest outlier contributing to the increased default damage.


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
