### PR TITLE
Add Heat armorCategory to Frostbite damageDef

### DIFF
--- a/Patches/Alpha Mechs/ThingDefs_Misc/AlphaMechs_RangedMechanoid.xml
+++ b/Patches/Alpha Mechs/ThingDefs_Misc/AlphaMechs_RangedMechanoid.xml
@@ -191,8 +191,8 @@
 								<flyOverhead>false</flyOverhead>
 								<speed>40</speed>
 								<damageDef>Frostbite</damageDef>
-								<damageAmountBase>2</damageAmountBase>
-								<explosionRadius>1.9</explosionRadius>
+								<damageAmountBase>3</damageAmountBase>
+								<explosionRadius>2.9</explosionRadius>
 								<soundExplode>AM_Cryogun</soundExplode>
 							</projectile>
 						</ThingDef>

--- a/Patches/Core/DamageDefs/Damages_LocalInjury.xml
+++ b/Patches/Core/DamageDefs/Damages_LocalInjury.xml
@@ -122,6 +122,15 @@
 		</value>
 	</Operation>
 
+	<!-- ========== Add heat armor to Frostbite damage ========== -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/DamageDef[defName="Frostbite"]</xpath>
+		<value>
+			<armorCategory>Heat</armorCategory>
+		</value>
+	</Operation>
+
 	<!-- ========== Venom Bite & Scratch ========== -->
 
 	<Operation Class="PatchOperationAdd">


### PR DESCRIPTION
## Additions

- What it says on the tin, just to make direct frostbite attacks be counter-able with CE's percentage damage reduction code.

## Changes

- A small tweak the the Alpha Mech's cryo weapon to adjust for the new change.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Working as intended)
