### PR TITLE
Gas mask hediff label housekeeping

### DIFF
--- a/Defs/HediffDefs/Hediffs_CE.xml
+++ b/Defs/HediffDefs/Hediffs_CE.xml
@@ -7,8 +7,8 @@
     <defName>WearingGasMask</defName>
     <hediffClass>HediffWithComps</hediffClass>
     <defaultLabelColor>(0.88, 0.88, 0.88)</defaultLabelColor>
-    <label>wearing gas mask</label>
-	<description>Wearing a gas mask</description>
+    <label>gas mask</label>
+    <description>Wearing a gas mask</description>
     <makesSickThought>false</makesSickThought>
     <scenarioCanAdd>false</scenarioCanAdd>
     <stages>
@@ -39,7 +39,7 @@
     <hediffClass>HediffWithComps</hediffClass>
     <defaultLabelColor>(0.58, 0.35, 0.35)</defaultLabelColor>
     <label>smoke inhalation</label>
-	<description>Inhaled Smoke</description>
+    <description>Inhaled Smoke</description>
     <lethalSeverity>1</lethalSeverity>
     <makesSickThought>true</makesSickThought>
     <scenarioCanAdd>true</scenarioCanAdd>
@@ -146,7 +146,7 @@
     <hediffClass>HediffWithComps</hediffClass>
     <defaultLabelColor>(0.7, 1.0, 0.7)</defaultLabelColor>
     <label>venom buildup</label>
-	<description>Venom building up</description>
+    <description>Venom building up</description>
     <lethalSeverity>1</lethalSeverity>
     <makesSickThought>true</makesSickThought>
     <scenarioCanAdd>true</scenarioCanAdd>
@@ -259,7 +259,7 @@
   <HediffDef>
     <defName>MuscleSpasms</defName>
     <label>muscle spasms</label>
-	<description>Muscle Spasms</description>
+    <description>Muscle Spasms</description>
     <hediffClass>HediffWithComps</hediffClass>
     <comps>
       <li Class="CombatExtended.HediffCompProperties_FleshOnly" />
@@ -337,7 +337,7 @@
   <HediffDef>
     <defName>PrometheumSoaked</defName>
     <label>Prometheum-soaked</label>
-	<description>Soaked in Prometheum</description>
+    <description>Soaked in Prometheum</description>
     <hediffClass>HediffWithComps</hediffClass>
     <comps>
       <li Class="HediffCompProperties_SeverityPerDay">
@@ -383,7 +383,7 @@
   <HediffDef>
 	<defName>Tranquilizer</defName>
 	<label>tranquilizer</label>
-    <description>the effects of a tranquilizer dart</description>	
+	<description>the effects of a tranquilizer dart</description>	
 	<hediffClass>HediffWithComps</hediffClass>
 	<defaultLabelColor>(0.8, 0.8, 0.35)</defaultLabelColor>
     <initialSeverity>0.001</initialSeverity>


### PR DESCRIPTION
## Changes

- Changed the label of the hediff so that there are no double mentions of "wearing" in the label when the mask is worn.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
