### PR TITLE
Empire Champion pawnKind buff

### DIFF
--- a/Royalty/Patches/PawnKindDefs_Royalty/PawnKinds_Royalty.xml
+++ b/Royalty/Patches/PawnKindDefs_Royalty/PawnKinds_Royalty.xml
@@ -144,16 +144,48 @@
   	<value>
       <li Class="CombatExtended.LoadoutPropertiesExtension">
 		<shieldMoney>
-		  <min>300</min>
-		  <max>800</max>
+		  <min>400</min>
+		  <max>1000</max>
 		</shieldMoney>
 		<shieldTags>
 		  <li>OutlanderShield</li>
 		</shieldTags>
-		<shieldChance>0.5</shieldChance>			
+		<shieldChance>0.75</shieldChance>
       </li>
   	</value>
   </Operation>
+
+  <Operation Class="PatchOperationAdd">
+  	<xpath>Defs/PawnKindDef[defName="Empire_Fighter_Champion"]</xpath>
+  	<value>
+      <apparelMoney>2500~3750</apparelMoney>
+  	</value>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
+  	<xpath>Defs/PawnKindDef[defName="Empire_Fighter_Champion"]/apparelRequired</xpath>
+  	<value>
+      <li>CE_Apparel_PlateHelmet</li>
+  	</value>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/PawnKindDef[defName="Empire_Fighter_Champion"]</xpath>
+      <value>
+        <specificApparelRequirements>
+          <li>
+            <bodyPartGroup>Torso</bodyPartGroup>
+            <apparelLayer>Shell</apparelLayer>
+            <stuff>Plasteel</stuff>
+          </li>
+          <li>
+            <bodyPartGroup>FullHead</bodyPartGroup>
+            <apparelLayer>Overhead</apparelLayer>
+            <stuff>Plasteel</stuff>
+          </li>
+        </specificApparelRequirements>
+      </value>
+   </Operation>
 
   <Operation Class="PatchOperationAdd">
     <xpath>Defs/PawnKindDef[defName="Empire_Fighter_Cataphract"]/weaponTags</xpath>


### PR DESCRIPTION
## Changes

- Changed the apparel generation of the empire champions to make them spawn with plasteel plate armor instead of steel, increased their apparel budget as well to allow for that.
- Added the plate helmet to their required apparel.
- Increased their shield budget and spawn chance.

## Reasoning

- Empire champions are anemic in CE when it comes to survivability compared to the other pawnKinds of the empire, better armor does help with that without messing with too much stuff.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Spawned several pawns to see the apparel generation, working reasonably well considering the randomness of the apparel generation system)
