### PR TITLE
Fix Typo in Mushroomwine patch for Biomes Cavern

### DIFF
--- a/Patches/Biomes Caverns/Weapons/CE_MushroomWine.xml
+++ b/Patches/Biomes Caverns/Weapons/CE_MushroomWine.xml
@@ -3,7 +3,7 @@
 <Patch>
 	<Operation Class="PatchOperationFindMod">
 	<mods>
-		<li>Vanilla Factions Expanded - Vikings</li>
+		<li>Biomes! Caverns</li>
 	</mods>
 		<match Class="PatchOperationSequence">
 		<operations>


### PR DESCRIPTION
Wrong mod name patched.