### PR TITLE
Medieval Overhaul Patch Update

### DIFF
--- a/Patches/Medieval Overhaul/MO_Apparel_Armor.xml
+++ b/Patches/Medieval Overhaul/MO_Apparel_Armor.xml
@@ -31,16 +31,15 @@
                   <Mass>3</Mass>
                </value>
             </li>
-
+			
             <!-- Added extra coverage -->
             <li Class="PatchOperationAdd">
                <xpath>Defs/ThingDef[defName="DankPyon_Apparel_Padded_Surcoat" or defName="Dankpyon_Apparel_Gambeson"]/apparel/bodyPartGroups</xpath>
                <value>
-                  <li>Legs</li>
                   <li>Arms</li>
                </value>
             </li>
-
+					
             <li Class="PatchOperationReplace">
                <xpath>Defs/ThingDef[defName="DankPyon_Apparel_Padded_Surcoat" or defName="Dankpyon_Apparel_Gambeson"]/statBases/StuffEffectMultiplierArmor</xpath>
                <value>
@@ -136,7 +135,7 @@
             </li>
 
             <li Class="PatchOperationRemove">
-               <xpath>Defs/ThingDef[defName="DankPyon_Apparel_Hauberk" or @Name="DankPyon_HeraldicHauberkBase" or defName="DankPyon_Apparel_AdornedMailShirt"]/equippedStatOffsets/MoveSpeed</xpath>
+               <xpath>Defs/ThingDef[defName="DankPyon_Apparel_Hauberk" or defName="DankPyon_Apparel_Heavy_Hauberk" or @Name="DankPyon_HeraldicHauberkBase" or defName="DankPyon_Apparel_AdornedMailShirt"]/equippedStatOffsets/MoveSpeed</xpath>
             </li>
 
             <li Class="PatchOperationAdd">
@@ -309,6 +308,13 @@
                   <ArmorRating_Blunt>12.8</ArmorRating_Blunt>
                </value>
             </li>
+			
+			<li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="DankPyon_Apparel_FullPlateNamed"]/statBases/ArmorRating_Heat</xpath>
+               <value>
+                  <ArmorRating_Heat>0.05</ArmorRating_Heat>
+               </value>
+            </li>
 
             <li Class="PatchOperationReplace">
                <xpath>Defs/ThingDef[defName="DankPyon_Apparel_FullPlateNamed"]/statBases/Mass</xpath>
@@ -379,6 +385,55 @@
                         </li>
                      </stats>
                   </li>
+               </value>
+            </li>
+
+			<!-- ==== Pants ==== -->	
+			<!-- Padded Chausses -->
+			<li Class="PatchOperationAdd">
+               <xpath>Defs/ThingDef[defName="DankPyon_Apparel_ChaussesPadded"]/statBases</xpath>
+               <value>
+                  <Bulk>15</Bulk>
+                  <WornBulk>3</WornBulk>
+               </value>
+            </li>
+
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="DankPyon_Apparel_ChaussesPadded"]/statBases/StuffEffectMultiplierArmor</xpath>
+               <value>
+                  <StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>
+               </value>
+            </li>
+			
+			<!-- Splinted Chausses -->
+			<li Class="PatchOperationAdd">
+               <xpath>Defs/ThingDef[defName="DankPyon_Apparel_ChaussesSplinted"]/statBases</xpath>
+               <value>
+                  <Bulk>15</Bulk>
+                  <WornBulk>3</WornBulk>
+               </value>
+            </li>
+
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="DankPyon_Apparel_ChaussesSplinted"]/statBases/StuffEffectMultiplierArmor</xpath>
+               <value>
+                  <StuffEffectMultiplierArmor>1.85</StuffEffectMultiplierArmor>
+               </value>
+            </li>
+			
+			<!-- Plated Chausses -->
+			<li Class="PatchOperationAdd">
+               <xpath>Defs/ThingDef[defName="DankPyon_Apparel_ChaussesPlate"]/statBases</xpath>
+               <value>
+                  <Bulk>15</Bulk>
+                  <WornBulk>4</WornBulk>
+               </value>
+            </li>
+
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="DankPyon_Apparel_ChaussesPlate"]/statBases/StuffEffectMultiplierArmor</xpath>
+               <value>
+                  <StuffEffectMultiplierArmor>2.7</StuffEffectMultiplierArmor>
                </value>
             </li>
 

--- a/Patches/Medieval Overhaul/MO_Apparel_Helmets.xml
+++ b/Patches/Medieval Overhaul/MO_Apparel_Helmets.xml
@@ -123,11 +123,11 @@
             <!--Chain Helmet Flat Top, Closed Flat Top, Kettle, Nasal-->
 
             <li Class="PatchOperationRemove">
-               <xpath>Defs/ThingDef[defName="DankPyon_Headgear_PaddedNasalHelmet" or defName="DankPyon_Headgear_PaddedKettleHelmet" or defName="DankPyon_Headgear_PaddedFlatTopHelmet" or defName="DankPyon_Headgear_ChainNasalHelmet" or defName="DankPyon_Headgear_ChainNasalRedHelmet" or defName="DankPyon_Headgear_ChainKettleHelmet" or defName="DankPyon_Headgear_Chain_FlatTopHelmet" or defName="DankPyon_Headgear_ChainClosedFlatTopHelmet" or defName="DankPyon_Headgear_ClosedChain_FlatTopHelmet" or @Name="DankPyon_ZweihanderHelmBase"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
+               <xpath>Defs/ThingDef[defName="DankPyon_Headgear_PaddedNasalHelmet" or defName="DankPyon_Headgear_PaddedKettleHelmet" or defName="DankPyon_Headgear_PaddedFlatTopHelmet" or defName="DankPyon_Headgear_ChainNasalHelmet" or defName="DankPyon_Headgear_ChainNasalRedHelmet" or defName="DankPyon_Headgear_ChainKettleHelmet" or defName="DankPyon_Headgear_Chain_FlatTopHelmet" or defName="DankPyon_Headgear_ChainClosedFlatTopHelmet" or defName="DankPyon_Headgear_ClosedChain_FlatTopHelmet" or @Name="DankPyon_ZweihanderHelmBase" or defName="DankPyon_Headgear_HeavyBarbrute" or defName="DankPyon_Headgear_OpenBascinet"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
             </li>
 
             <li Class="PatchOperationAdd">
-               <xpath>Defs/ThingDef[defName="DankPyon_Headgear_PaddedNasalHelmet" or defName="DankPyon_Headgear_PaddedKettleHelmet" or defName="DankPyon_Headgear_PaddedFlatTopHelmet" or defName="DankPyon_Headgear_ChainNasalHelmet" or defName="DankPyon_Headgear_ChainKettleHelmet" or defName="DankPyon_Headgear_ClosedChain_FlatTopHelmet" or defName="DankPyon_Headgear_ChainNasalRedHelmet" or defName="DankPyon_Headgear_ChainClosedFlatTopHelmet" or defName="DankPyon_Headgear_Chain_FlatTopHelmet" or @Name="DankPyon_ZweihanderHelmBase" or defName="DankPyon_Adorned_HeavyMailCoif"]/statBases</xpath>
+               <xpath>Defs/ThingDef[defName="DankPyon_Headgear_PaddedNasalHelmet" or defName="DankPyon_Headgear_PaddedKettleHelmet" or defName="DankPyon_Headgear_PaddedFlatTopHelmet" or defName="DankPyon_Headgear_ChainNasalHelmet" or defName="DankPyon_Headgear_ChainKettleHelmet" or defName="DankPyon_Headgear_ClosedChain_FlatTopHelmet" or defName="DankPyon_Headgear_ChainNasalRedHelmet" or defName="DankPyon_Headgear_ChainClosedFlatTopHelmet" or defName="DankPyon_Headgear_Chain_FlatTopHelmet" or @Name="DankPyon_ZweihanderHelmBase" or defName="DankPyon_Adorned_HeavyMailCoif" or defName="DankPyon_Headgear_HeavyBarbrute" or defName="DankPyon_Headgear_OpenBascinet"]/statBases</xpath>
                <value>
                   <Bulk>4</Bulk>
                   <WornBulk>1</WornBulk>
@@ -142,7 +142,7 @@
             </li>
 
             <li Class="PatchOperationReplace">
-               <xpath>Defs/ThingDef[defName="DankPyon_Headgear_ChainNasalHelmet" or defName="DankPyon_Headgear_ChainNasalRedHelmet" or defName="DankPyon_Headgear_ChainKettleHelmet" or defName="DankPyon_Headgear_Chain_FlatTopHelmet" or defName="DankPyon_Headgear_ClosedChain_FlatTopHelmet" or defName="DankPyon_Adorned_HeavyMailCoif"]/statBases/StuffEffectMultiplierArmor</xpath>
+               <xpath>Defs/ThingDef[defName="DankPyon_Headgear_ChainNasalHelmet" or defName="DankPyon_Headgear_ChainNasalRedHelmet" or defName="DankPyon_Headgear_ChainKettleHelmet" or defName="DankPyon_Headgear_Chain_FlatTopHelmet" or defName="DankPyon_Headgear_ClosedChain_FlatTopHelmet" or defName="DankPyon_Adorned_HeavyMailCoif" or defName="DankPyon_Headgear_HeavyBarbrute" or defName="DankPyon_Headgear_OpenBascinet"]/statBases/StuffEffectMultiplierArmor</xpath>
                <value>
                   <StuffEffectMultiplierArmor>2.7</StuffEffectMultiplierArmor>
                </value>

--- a/Patches/Medieval Overhaul/MO_Apparel_Misc.xml
+++ b/Patches/Medieval Overhaul/MO_Apparel_Misc.xml
@@ -180,7 +180,21 @@
                 <li Class="PatchOperationRemove">
                     <xpath>Defs/ThingDef[defName="DankPyon_Apparel_DirewolfPelt" or defName="DankPyon_Apparel_HyenaPelt"]/equippedStatOffsets/MoveSpeed</xpath>
                 </li>
+				
+				<li Class="PatchOperationAdd">
+                    <xpath>Defs/ThingDef[defName="DankPyon_Apparel_DirewolfPelt" or defName="DankPyon_Apparel_HyenaPelt"]/statBases</xpath>
+                    <value>
+                        <ArmorRating_Sharp>0.45</ArmorRating_Sharp>
+                    </value>
+                </li>
 
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs/ThingDef[defName="DankPyon_Apparel_DirewolfPelt" or defName="DankPyon_Apparel_HyenaPelt"]/statBases</xpath>
+                    <value>
+                        <ArmorRating_Blunt>0.20</ArmorRating_Blunt>
+                    </value>
+                </li>
+				
             </operations>
         </match>
     </Operation>

--- a/Patches/Medieval Overhaul/MO_Materials.xml
+++ b/Patches/Medieval Overhaul/MO_Materials.xml
@@ -32,6 +32,7 @@
                   <Bulk>20</Bulk>
                </value>
             </li>
+			
             <!--Basegame rebalance-->
             <!--Thrumbo Fur-->
             <li Class="PatchOperationReplace">
@@ -58,6 +59,35 @@
                <xpath>Defs/ThingDef[defName="Cloth"]/statBases/StuffPower_Armor_Blunt</xpath>
                <value>
                   <StuffPower_Armor_Blunt>0.02</StuffPower_Armor_Blunt>
+               </value>
+            </li>
+
+            <!--Linen-->
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="DankPyon_Linen"]/statBases/StuffPower_Armor_Sharp</xpath>
+               <value>
+                  <StuffPower_Armor_Sharp>0.2</StuffPower_Armor_Sharp>
+               </value>
+            </li>
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="DankPyon_Linen"]/statBases/StuffPower_Armor_Heat</xpath>
+               <value>
+                  <StuffPower_Armor_Heat>0.02</StuffPower_Armor_Heat>
+               </value>
+            </li>
+
+
+            <!--Silk-->
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="DankPyon_Silk"]/statBases/StuffPower_Armor_Sharp</xpath>
+               <value>
+                  <StuffPower_Armor_Sharp>0.3</StuffPower_Armor_Sharp>
+               </value>
+            </li>
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="DankPyon_Silk"]/statBases/StuffPower_Armor_Heat</xpath>
+               <value>
+                  <StuffPower_Armor_Heat>0.02</StuffPower_Armor_Heat>
                </value>
             </li>
 
@@ -204,6 +234,50 @@
                <xpath>Defs/ThingDef[defName="DankPyon_Leather_Rawhide"]/statBases/StuffPower_Armor_Blunt</xpath>
                <value>
                   <StuffPower_Armor_Blunt>0.055</StuffPower_Armor_Blunt>
+               </value>
+            </li>
+
+			<!-- Unique Leathers
+			<li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="DankPyon_Leather_Direwolf"]/statBases/StuffPower_Armor_Sharp</xpath>
+               <value>
+                  <StuffPower_Armor_Sharp>0.14</StuffPower_Armor_Sharp>
+               </value>
+            </li>
+
+            <li Class="PatchOperationAdd">
+               <xpath>Defs/ThingDef[defName="DankPyon_Leather_Direwolf"]/statBases</xpath>
+               <value>
+                  <StuffPower_Armor_Blunt>0.1</StuffPower_Armor_Blunt>
+               </value>
+            </li>
+			
+			<li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="DankPyon_Leather_Hyena"]/statBases/StuffPower_Armor_Sharp</xpath>
+               <value>
+                  <StuffPower_Armor_Sharp>0.12</StuffPower_Armor_Sharp>
+               </value>
+            </li>
+
+            <li Class="PatchOperationAdd">
+               <xpath>Defs/ThingDef[defName="DankPyon_Leather_Hyena"]/statBases</xpath>
+               <value>
+                  <StuffPower_Armor_Blunt>0.08</StuffPower_Armor_Blunt>
+               </value> 
+            </li> -->
+			
+			<!-- Rare Creatures -->
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="DankPyon_Leather_Rox" or defName="DankPyon_Leather_Daer" or defName="DankPyon_Leather_Lindwurm"]/statBases/StuffPower_Armor_Sharp</xpath>
+               <value>
+                  <StuffPower_Armor_Sharp>0.3</StuffPower_Armor_Sharp>
+               </value>
+            </li>
+
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="DankPyon_Leather_Rox" or defName="DankPyon_Leather_Daer" or defName="DankPyon_Leather_Lindwurm"]/statBases/StuffPower_Armor_Blunt</xpath>
+               <value>
+                  <StuffPower_Armor_Blunt>0.15</StuffPower_Armor_Blunt>
                </value>
             </li>
 
@@ -722,21 +796,6 @@
                   <MeleePenetrationFactor>0.3</MeleePenetrationFactor>
                </value>
             </li>
-
-            <li Class="PatchOperationReplace">
-               <xpath>Defs/ThingDef[defName="DankPyon_Leather_Daer" or defName="DankPyon_Leather_Lindwurm"]/statBases/StuffPower_Armor_Sharp</xpath>
-               <value>
-                  <StuffPower_Armor_Sharp>1</StuffPower_Armor_Sharp>
-               </value>
-            </li>
-
-            <li Class="PatchOperationReplace">
-               <xpath>Defs/ThingDef[defName="DankPyon_Leather_Daer" or defName="DankPyon_Leather_Lindwurm"]/statBases/StuffPower_Armor_Blunt</xpath>
-               <value>
-                  <StuffPower_Armor_Blunt>0.4</StuffPower_Armor_Blunt>
-               </value>
-            </li>
-
 
             <!--This thing was also a bit annoying-->
             <li Class="PatchOperationReplace">

--- a/Patches/Medieval Overhaul/MO_Pawns_Medieval.xml
+++ b/Patches/Medieval Overhaul/MO_Pawns_Medieval.xml
@@ -98,12 +98,12 @@
 						<li Class="CombatExtended.LoadoutPropertiesExtension">
 							<primaryMagazineCount>
 								<min>12</min>
-								<max>15</max>
+								<max>20</max>
 							</primaryMagazineCount>
 							<forcedSidearm>
 								<sidearmMoney>
-									<min>150</min>
-									<max>250</max>
+									<min>100</min>
+									<max>200</max>
 								</sidearmMoney>
 								<weaponTags>
 									<li>NeolithicMeleeBasic</li>
@@ -124,8 +124,8 @@
 							</primaryMagazineCount>
 							<forcedSidearm>
 								<sidearmMoney>
-									<min>150</min>
-									<max>250</max>
+									<min>50</min>
+									<max>150</max>
 								</sidearmMoney>
 								<weaponTags>
 									<li>NeolithicMeleeBasic</li>
@@ -135,18 +135,56 @@
 						</li>
 					</value>
 				</li>
-
+				
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/PawnKindDef[defName="DankPyon_BrigandMarksman"]</xpath>
+					<value>
+						<li Class="CombatExtended.LoadoutPropertiesExtension">
+							<primaryMagazineCount>
+								<min>12</min>
+								<max>20</max>
+							</primaryMagazineCount>
+							<forcedSidearm>
+								<sidearmMoney>
+									<min>50</min>
+									<max>150</max>
+								</sidearmMoney>
+								<weaponTags>
+									<li>NeolithicMeleeBasic</li>
+									<li>MedievalMeleeDecent</li>
+								</weaponTags>
+							</forcedSidearm>
+						</li>
+					</value>
+				</li>
+				
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/PawnKindDef[
 						defName="DankPyon_Medieval_Arbalester" or
-						defName="DankPyon_Medieval_Bowman"]</xpath>
+						defName="DankPyon_Medieval_Bowman" or
+						defName="DankPyon_BrigandMarksman"]</xpath>
 					<value>
 						<apparelRequired>
 							<li>CE_Apparel_TribalBackpack</li>
+							<li>DankPyon_Apparel_Quiver</li>
 						</apparelRequired>
 					</value>
-				</li>
-                
+				</li>		
+				
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/PawnKindDef[defName="DankPyon_Medieval_Arbalester" or defName="DankPyon_BrigandMarksman"]/weaponTags</xpath>
+						<value>
+							<li>CE_XBow</li>
+						</value>
+                </li>
+				
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/PawnKindDef[defName="DankPyon_Medieval_Bowman" or defName="DankPyon_BrigandMarksman"]/weaponTags</xpath>
+						<value>
+							<li>CE_Bow</li>
+						</value>
+                </li>
+				
             </operations>
 		</match>  
 	</Operation>

--- a/Patches/Medieval Overhaul/MO_Weapons_Ranged.xml
+++ b/Patches/Medieval Overhaul/MO_Weapons_Ranged.xml
@@ -112,8 +112,8 @@
                   <aiAimMode>AimedShot</aiAimMode>
                </FireModes>
                <weaponTags>
-                  <li>CE_Bow</li>
-                  <li>CE_OneHandedWeapon</li>
+                  <li>CE_XBow</li>
+		  <li>CE_OneHandedWeapon</li>
                </weaponTags>
             </li>
 
@@ -149,9 +149,8 @@
                   <aiAimMode>AimedShot</aiAimMode>
                </FireModes>
                <weaponTags>
-                  <li>CE_Bow</li>
-                  <li>CE_OneHandedWeapon</li>
-               </weaponTags>
+                  <li>CE_XBow</li>
+                </weaponTags>
             </li>
 
             <!-- ========== Hunting bow ========== -->


### PR DESCRIPTION
Multiple items have been added since last patched.

## Additions

- Added new armor to existing patches
- Patched various new leg armors
- Patched hyena and wolf pelt cloaks

## Changes

- Patched Silk and Linen. Were never patched from original mod. Heat armor was way off on these two
- Removed leg slot from Gambeson and Surcoat. These were previously added due to MO not having leg armors at that time.
- Reduced Daer and Lindwurm sharp and blunt. Previously at steel level of armor
- Reduced Named Plate Mail armor levels of heat.
- Added quiver and bow to pawnkinds that were to spawn with Bow/Crossbows. Should always spawn with ammo and simple melee weapon
- Changed weapon tags on MO ranged weapons to keep original mods weapon selection for ranged combatants. 
- Fixed Brigand Marksman from spawning periodically without the assigned ranged weapon
- Tweaked pawnkinds side arm money

## Reasoning

- Various armors would spawn with way to much armor  due to material values not being patched
- Bulk previously too high preventing ammo from generating on pawns


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
