### PR TITLE
MAC-10 cost adjustment

### DIFF
--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -523,8 +523,8 @@
       <WorkToMake>24500</WorkToMake>
     </statBases>
     <costList>
-      <Steel>30</Steel>
-      <ComponentIndustrial>5</ComponentIndustrial>
+      <Steel>35</Steel>
+      <ComponentIndustrial>3</ComponentIndustrial>
     </costList>
     <Properties>
       <recoilAmount>1.71</recoilAmount>

--- a/Patches/Vanilla Weapons Expanded/Industrial_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded/Industrial_Ranged.xml
@@ -277,11 +277,11 @@
 						<ShotSpread>0.12</ShotSpread>
 						<SwayFactor>3.30</SwayFactor>
 						<Bulk>4.70</Bulk>
-						<WorkToMake>13000</WorkToMake>
+						<WorkToMake>24000</WorkToMake>
 					</statBases>
 					<costList>
 						<Steel>30</Steel>
-						<ComponentIndustrial>5</ComponentIndustrial>
+						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
 						<recoilAmount>1.39</recoilAmount>


### PR DESCRIPTION
## Changes

- Adjusted the crafting cost of the MAC-10 according to the gun spreadsheet, simple blowback guns require 2 less components to craft now.

## References

- https://docs.google.com/spreadsheets/d/1lbT0zzagCRPDJG4GctkeeoTsFCt3lYfM4SRnWt8ql-k/edit#gid=1573763037

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
