### PR TITLE
FSX shear yield and market value rebalanced

### DIFF
--- a/Defs/Ammo/Advanced/30x64mmFuelCell.xml
+++ b/Defs/Ammo/Advanced/30x64mmFuelCell.xml
@@ -59,7 +59,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>5.96</MarketValue>
+      <MarketValue>4.91</MarketValue>
     </statBases>
     <ammoClass>ThermobaricFuel</ammoClass>
   </ThingDef>

--- a/Defs/Ammo/Grenade/20x42mmGrenade.xml
+++ b/Defs/Ammo/Grenade/20x42mmGrenade.xml
@@ -100,7 +100,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>1.82</MarketValue>
+      <MarketValue>1.54</MarketValue>
     </statBases>
     <ammoClass>ExplosiveAP</ammoClass>
 	<detonateProjectile>Bullet_20x42mm_APHE</detonateProjectile>
@@ -114,7 +114,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>1.95</MarketValue>
+      <MarketValue>1.8</MarketValue>
     </statBases>
     <ammoClass>GrenadeHE</ammoClass>
 	<detonateProjectile>Bullet_20x42mmGrenade_HE</detonateProjectile>

--- a/Defs/Ammo/Grenade/25x40mmGrenade.xml
+++ b/Defs/Ammo/Grenade/25x40mmGrenade.xml
@@ -49,7 +49,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>1.81</MarketValue>
+      <MarketValue>1.68</MarketValue>
     </statBases>
     <ammoClass>GrenadeHE</ammoClass>
 	<detonateProjectile>Bullet_25x40mmGrenade_HE</detonateProjectile>
@@ -63,7 +63,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>2.88</MarketValue>
+      <MarketValue>2.66</MarketValue>
     </statBases>
     <ammoClass>GrenadeHETF</ammoClass>
 	<detonateProjectile>Bullet_25x40mmGrenade_HE</detonateProjectile>
@@ -264,7 +264,7 @@
     <products>
       <Ammo_25x40mmGrenade_HE_TFuzed>100</Ammo_25x40mmGrenade_HE_TFuzed>
     </products>
-	<workAmount>8000</workAmount>
+	<workAmount>8200</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="LauncherAmmoRecipeBase">

--- a/Defs/Ammo/Grenade/25x59mmGrenade.xml
+++ b/Defs/Ammo/Grenade/25x59mmGrenade.xml
@@ -50,7 +50,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>2.32</MarketValue>
+      <MarketValue>2.2</MarketValue>
     </statBases>
     <ammoClass>GrenadeHEDP</ammoClass>
 	<detonateProjectile>Bullet_25x59mmGrenade_HEDP</detonateProjectile>
@@ -64,7 +64,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>2.32</MarketValue>
+      <MarketValue>2.2</MarketValue>
     </statBases>
     <ammoClass>GrenadeHE</ammoClass>
 	<detonateProjectile>Bullet_25x59mmGrenade_HE</detonateProjectile>
@@ -78,7 +78,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>3.01</MarketValue>
+      <MarketValue>3.17</MarketValue>
     </statBases>
     <ammoClass>GrenadeHETF</ammoClass>
     <detonateProjectile>Bullet_25x59mmGrenade_HE</detonateProjectile>
@@ -337,7 +337,7 @@
             <li>ComponentIndustrial</li>
           </thingDefs>
         </filter>
-        <count>6</count>
+        <count>5</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -350,7 +350,7 @@
     <products>
       <Ammo_25x59mmGrenade_HE_TFuzed>100</Ammo_25x59mmGrenade_HE_TFuzed>
     </products>
-    <workAmount>11000</workAmount>
+    <workAmount>10800</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="LauncherAmmoRecipeBase">

--- a/Defs/Ammo/Grenade/30x29mmGrenade.xml
+++ b/Defs/Ammo/Grenade/30x29mmGrenade.xml
@@ -49,7 +49,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>2.85</MarketValue>
+      <MarketValue>2.67</MarketValue>
     </statBases>
     <ammoClass>GrenadeHE</ammoClass>
 	<detonateProjectile>Bullet_30x29mmGrenade_HE</detonateProjectile>
@@ -63,7 +63,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>3.71</MarketValue>
+      <MarketValue>3.65</MarketValue>
     </statBases>
     <ammoClass>GrenadeHETF</ammoClass>
 	<detonateProjectile>Bullet_30x29mmGrenade_HE</detonateProjectile>
@@ -264,7 +264,7 @@
     <products>
       <Ammo_30x29mmGrenade_HE_TFuzed>100</Ammo_30x29mmGrenade_HE_TFuzed>
     </products>
-    <workAmount>13400</workAmount>
+    <workAmount>13200</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="LauncherAmmoRecipeBase">

--- a/Defs/Ammo/Grenade/35x32mmSRGrenade.xml
+++ b/Defs/Ammo/Grenade/35x32mmSRGrenade.xml
@@ -49,7 +49,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>2.27</MarketValue>
+      <MarketValue>2.12</MarketValue>
     </statBases>
     <ammoClass>GrenadeHE</ammoClass>
     <detonateProjectile>Bullet_35x32mmSRGrenade_HE</detonateProjectile>
@@ -63,7 +63,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>2.68</MarketValue>
+      <MarketValue>2.12</MarketValue>
     </statBases>
     <ammoClass>GrenadeHEDP</ammoClass>
     <detonateProjectile>Bullet_35x32mmSRGrenade_HE</detonateProjectile>
@@ -137,13 +137,13 @@
 		<label>35x32mmSR grenade (HEDP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageDef>Bullet</damageDef>
-		  <damageAmountBase>18</damageAmountBase>
-		  <armorPenetrationSharp>80</armorPenetrationSharp>
-		  <armorPenetrationBlunt>5.94</armorPenetrationBlunt>
+		  <damageAmountBase>17</damageAmountBase>
+		  <armorPenetrationSharp>55</armorPenetrationSharp>
+		  <armorPenetrationBlunt>5.552</armorPenetrationBlunt>
 		</projectile>
 		<comps>
 		  <li Class="CombatExtended.CompProperties_ExplosiveCE">
-			<damageAmountBase>12</damageAmountBase>
+			<damageAmountBase>19</damageAmountBase>
 			<explosiveDamageType>Bomb</explosiveDamageType>
 			<explosiveRadius>0.5</explosiveRadius>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/Defs/Ammo/Grenade/40x46mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x46mmGrenade.xml
@@ -50,7 +50,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>2.37</MarketValue>
+      <MarketValue>2.19</MarketValue>
     </statBases>
     <ammoClass>GrenadeHE</ammoClass>
     <detonateProjectile>Bullet_40x46mmGrenade_HE</detonateProjectile>
@@ -64,7 +64,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>3.08</MarketValue>
+      <MarketValue>3.17</MarketValue>
     </statBases>
     <ammoClass>GrenadeHETF</ammoClass>
     <detonateProjectile>Bullet_40x46mmGrenade_HE</detonateProjectile>
@@ -78,7 +78,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>2.37</MarketValue>
+      <MarketValue>2.19</MarketValue>
     </statBases>
     <ammoClass>GrenadeHEDP</ammoClass>
     <detonateProjectile>Bullet_40x46mmGrenade_HE</detonateProjectile>
@@ -317,7 +317,7 @@
             <li>ComponentIndustrial</li>
           </thingDefs>
         </filter>
-        <count>6</count>
+        <count>5</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -330,7 +330,7 @@
     <products>
       <Ammo_40x46mmGrenade_HE_TFuzed>100</Ammo_40x46mmGrenade_HE_TFuzed>
     </products>
-    <workAmount>11000</workAmount>
+    <workAmount>10800</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="LauncherAmmoRecipeBase">

--- a/Defs/Ammo/Grenade/40x47mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x47mmGrenade.xml
@@ -48,7 +48,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>2.51</MarketValue>
+      <MarketValue>2.31</MarketValue>
     </statBases>
     <ammoClass>GrenadeHE</ammoClass>
 	<detonateProjectile>Bullet_40x47mmGrenade_HE</detonateProjectile>

--- a/Defs/Ammo/Grenade/40x53mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmGrenade.xml
@@ -50,7 +50,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>2.89</MarketValue>
+      <MarketValue>2.71</MarketValue>
     </statBases>
     <ammoClass>GrenadeHE</ammoClass>
     <detonateProjectile>Bullet_40x53mmGrenade_HE</detonateProjectile>
@@ -64,7 +64,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>3.75</MarketValue>
+      <MarketValue>3.59</MarketValue>
     </statBases>
     <ammoClass>GrenadeHETF</ammoClass>
     <detonateProjectile>Bullet_40x53mmGrenade_HE</detonateProjectile>
@@ -78,7 +78,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>2.89</MarketValue>
+      <MarketValue>2.71</MarketValue>
     </statBases>
     <ammoClass>GrenadeHEDP</ammoClass>
     <detonateProjectile>Bullet_40x53mmGrenade_HE</detonateProjectile>
@@ -304,7 +304,7 @@
     <products>
       <Ammo_40x53mmGrenade_HE_TFuzed>100</Ammo_40x53mmGrenade_HE_TFuzed>
     </products>
-    <workAmount>13600</workAmount>
+    <workAmount>13400</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="LauncherAmmoRecipeBase">

--- a/Defs/Ammo/Grenade/40x53mmVOG25Grenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmVOG25Grenade.xml
@@ -49,7 +49,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>2.68</MarketValue>
+      <MarketValue>2.43</MarketValue>
     </statBases>
     <ammoClass>GrenadeHE</ammoClass>
 	<detonateProjectile>Bullet_40x53mmVOG25Grenade_HE</detonateProjectile>
@@ -63,7 +63,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>3.28</MarketValue>
+      <MarketValue>3.4</MarketValue>
     </statBases>
     <ammoClass>GrenadeHETF</ammoClass>
     <detonateProjectile>Bullet_40x53mmVOG25Grenade_HE_TFuzed</detonateProjectile>
@@ -251,7 +251,7 @@
             <li>ComponentIndustrial</li>
           </thingDefs>
         </filter>
-        <count>6</count>
+        <count>5</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -264,7 +264,7 @@
     <products>
       <Ammo_40x53mmVOG25Grenade_HE_TFuzed>100</Ammo_40x53mmVOG25Grenade_HE_TFuzed>
     </products>
-    <workAmount>10400</workAmount>
+    <workAmount>12000</workAmount>
   </RecipeDef>  
 
   <RecipeDef ParentName="LauncherAmmoRecipeBase">

--- a/Defs/Ammo/Grenade/50mmGS50Grenade.xml
+++ b/Defs/Ammo/Grenade/50mmGS50Grenade.xml
@@ -48,7 +48,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>4.16</MarketValue>
+			<MarketValue>3.91</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHE</ammoClass>
 		<detonateProjectile>Bullet_50mmGS50Grenade_HE</detonateProjectile>

--- a/Defs/Ammo/Grenade/83mmPIATGrenade.xml
+++ b/Defs/Ammo/Grenade/83mmPIATGrenade.xml
@@ -48,7 +48,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>44.3</MarketValue>
+      <MarketValue>39.8</MarketValue>
     </statBases>
     <ammoClass>RocketHEAT</ammoClass>
 	<detonateProjectile>Bullet_83mmPIATGrenade_HEAT</detonateProjectile>
@@ -62,7 +62,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>44.3</MarketValue>
+      <MarketValue>39.8</MarketValue>
     </statBases>
     <ammoClass>GrenadeHE</ammoClass>
 	<detonateProjectile>Bullet_83mmPIATGrenade_HE</detonateProjectile>

--- a/Defs/Ammo/HighCaliber/12.7x108mmSoviet.xml
+++ b/Defs/Ammo/HighCaliber/12.7x108mmSoviet.xml
@@ -91,7 +91,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>1.06</MarketValue>
+      <MarketValue>0.93</MarketValue>
     </statBases>
     <ammoClass>ExplosiveAP</ammoClass>
     <cookOffProjectile>Bullet_127x108mm_HE</cookOffProjectile>

--- a/Defs/Ammo/HighCaliber/13.2x92mmSRTuF.xml
+++ b/Defs/Ammo/HighCaliber/13.2x92mmSRTuF.xml
@@ -90,7 +90,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>1.15</MarketValue>
+			<MarketValue>1.01</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_132x92mmSRTuF_HE</cookOffProjectile>

--- a/Defs/Ammo/HighCaliber/14.5x114mmSoviet.xml
+++ b/Defs/Ammo/HighCaliber/14.5x114mmSoviet.xml
@@ -91,7 +91,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>1.43</MarketValue>
+      <MarketValue>1.27</MarketValue>
     </statBases>
     <ammoClass>ExplosiveAP</ammoClass>
     <cookOffProjectile>Bullet_145x114mm_HE</cookOffProjectile>

--- a/Defs/Ammo/HighCaliber/2-Bore.xml
+++ b/Defs/Ammo/HighCaliber/2-Bore.xml
@@ -91,7 +91,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>4.13</MarketValue>
+      <MarketValue>3.95</MarketValue>
     </statBases>
     <ammoClass>ExplosiveAP</ammoClass>
     <cookOffProjectile>Bullet_2Bore_HE</cookOffProjectile>

--- a/Defs/Ammo/HighCaliber/20x102mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/20x102mmNATO.xml
@@ -76,7 +76,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>2.02</MarketValue>
+			<MarketValue>1.78</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_20x102mmNATO_HE</cookOffProjectile>

--- a/Defs/Ammo/HighCaliber/20x110mmHispano.xml
+++ b/Defs/Ammo/HighCaliber/20x110mmHispano.xml
@@ -76,7 +76,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>2.22</MarketValue>
+      <MarketValue>1.94</MarketValue>
     </statBases>
     <ammoClass>ExplosiveAP</ammoClass>
     <cookOffProjectile>Bullet_20x110mmHispano_HE</cookOffProjectile>

--- a/Defs/Ammo/HighCaliber/20x128mmOerlikon.xml
+++ b/Defs/Ammo/HighCaliber/20x128mmOerlikon.xml
@@ -76,7 +76,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>2.60</MarketValue>
+			<MarketValue>2.31</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_20x128mmOerlikon_HE</cookOffProjectile>

--- a/Defs/Ammo/HighCaliber/20x138mmB.xml
+++ b/Defs/Ammo/HighCaliber/20x138mmB.xml
@@ -76,7 +76,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>2.38</MarketValue>
+			<MarketValue>2.1</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_20x138mmB_HE</cookOffProjectile>

--- a/Defs/Ammo/HighCaliber/20x139mm.xml
+++ b/Defs/Ammo/HighCaliber/20x139mm.xml
@@ -76,7 +76,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>2.4</MarketValue>
+			<MarketValue>2.12</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_20x139mm_HE</cookOffProjectile>

--- a/Defs/Ammo/HighCaliber/20x82mmMauser.xml
+++ b/Defs/Ammo/HighCaliber/20x82mmMauser.xml
@@ -76,7 +76,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>1.84</MarketValue>
+      <MarketValue>1.56</MarketValue>
     </statBases>
     <ammoClass>ExplosiveAP</ammoClass>
     <cookOffProjectile>Bullet_20x82mmMauser_HE</cookOffProjectile>

--- a/Defs/Ammo/HighCaliber/20x99mmShVAK.xml
+++ b/Defs/Ammo/HighCaliber/20x99mmShVAK.xml
@@ -76,7 +76,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>1.86</MarketValue>
+      <MarketValue>1.62</MarketValue>
     </statBases>
     <ammoClass>ExplosiveAP</ammoClass>
     <cookOffProjectile>Bullet_20x99mmRShVAK_HE</cookOffProjectile>

--- a/Defs/Ammo/HighCaliber/23x152mmB.xml
+++ b/Defs/Ammo/HighCaliber/23x152mmB.xml
@@ -76,7 +76,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>3.6</MarketValue>
+			<MarketValue>3.16</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_23x152mmB_APHE</cookOffProjectile>

--- a/Defs/Ammo/HighCaliber/25x137mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/25x137mmNATO.xml
@@ -76,7 +76,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>3.82</MarketValue>
+			<MarketValue>3.38</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_25x137mmNATO_HE</cookOffProjectile>

--- a/Defs/Ammo/HighCaliber/300WinchesterMagnum.xml
+++ b/Defs/Ammo/HighCaliber/300WinchesterMagnum.xml
@@ -90,7 +90,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.37</MarketValue>
+			<MarketValue>0.32</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_300WinchesterMagnum_HE</cookOffProjectile>

--- a/Defs/Ammo/HighCaliber/30x113mmB.xml
+++ b/Defs/Ammo/HighCaliber/30x113mmB.xml
@@ -76,7 +76,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>4.61</MarketValue>
+			<MarketValue>3.97</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_30x113mmB_HE</cookOffProjectile>

--- a/Defs/Ammo/HighCaliber/30x165mm.xml
+++ b/Defs/Ammo/HighCaliber/30x165mm.xml
@@ -62,7 +62,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>4.64</MarketValue>
+			<MarketValue>4.6</MarketValue>
 		</statBases>
 		<ammoClass>IncendiaryAP</ammoClass>
 		<cookOffProjectile>Bullet_30x165mm_Incendiary</cookOffProjectile>
@@ -76,7 +76,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>7.21</MarketValue>
+			<MarketValue>6.24</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_30x165mm_HE</cookOffProjectile>

--- a/Defs/Ammo/HighCaliber/30x173mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/30x173mmNATO.xml
@@ -76,7 +76,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>6.95</MarketValue>
+			<MarketValue>6.08</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_30x173mmNATO_HE</cookOffProjectile>

--- a/Defs/Ammo/HighCaliber/338LapuaMagnum.xml
+++ b/Defs/Ammo/HighCaliber/338LapuaMagnum.xml
@@ -90,7 +90,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.41</MarketValue>
+      <MarketValue>0.36</MarketValue>
     </statBases>
     <ammoClass>ExplosiveAP</ammoClass>
     <cookOffProjectile>Bullet_338Lapua_HE</cookOffProjectile>

--- a/Defs/Ammo/HighCaliber/338NormaMagnum.xml
+++ b/Defs/Ammo/HighCaliber/338NormaMagnum.xml
@@ -90,7 +90,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.46</MarketValue>
+      <MarketValue>0.4</MarketValue>
     </statBases>
     <ammoClass>ExplosiveAP</ammoClass>
     <cookOffProjectile>Bullet_338Norma_HE</cookOffProjectile>

--- a/Defs/Ammo/HighCaliber/408CheyenneTactical.xml
+++ b/Defs/Ammo/HighCaliber/408CheyenneTactical.xml
@@ -90,7 +90,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.58</MarketValue>
+			<MarketValue>0.52</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_408CheyenneTactical_HE</cookOffProjectile>

--- a/Defs/Ammo/HighCaliber/40x311mmR.xml
+++ b/Defs/Ammo/HighCaliber/40x311mmR.xml
@@ -62,7 +62,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>11.38</MarketValue>
+			<MarketValue>11.49</MarketValue>
 		</statBases>
 		<ammoClass>IncendiaryAP</ammoClass>
 		<cookOffProjectile>Bullet_40x311mmR_Incendiary</cookOffProjectile>
@@ -76,7 +76,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>17.32</MarketValue>
+			<MarketValue>15.0</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_40x311mmR_HE</cookOffProjectile>
@@ -91,7 +91,7 @@
 		</graphicData>
 		<statBases>
 			<Mass>1.763</Mass>
-			<MarketValue>9.8</MarketValue>
+			<MarketValue>9.58</MarketValue>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
 		<cookOffProjectile>Bullet_40x311mmR_Sabot</cookOffProjectile>

--- a/Defs/Ammo/HighCaliber/470NitroExpress.xml
+++ b/Defs/Ammo/HighCaliber/470NitroExpress.xml
@@ -90,7 +90,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.62</MarketValue>
+      <MarketValue>0.54</MarketValue>
     </statBases>
     <ammoClass>ExplosiveAP</ammoClass>
     <cookOffProjectile>Bullet_470NitroExpress_HE</cookOffProjectile>

--- a/Defs/Ammo/HighCaliber/50BMG.xml
+++ b/Defs/Ammo/HighCaliber/50BMG.xml
@@ -91,7 +91,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>1.02</MarketValue>
+      <MarketValue>0.89</MarketValue>
     </statBases>
     <ammoClass>ExplosiveAP</ammoClass>
     <cookOffProjectile>Bullet_50BMG_HE</cookOffProjectile>

--- a/Defs/Ammo/HighCaliber/55Boys.xml
+++ b/Defs/Ammo/HighCaliber/55Boys.xml
@@ -90,7 +90,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>1.23</MarketValue>
+			<MarketValue>1.07</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_55Boys_HE</cookOffProjectile>

--- a/Defs/Ammo/HighCaliber/600NitroExpress.xml
+++ b/Defs/Ammo/HighCaliber/600NitroExpress.xml
@@ -90,7 +90,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>1.01</MarketValue>
+			<MarketValue>0.87</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_600NitroExpress_HE</cookOffProjectile>

--- a/Defs/Ammo/HighCaliber/7.92x94mm Patronen.xml
+++ b/Defs/Ammo/HighCaliber/7.92x94mm Patronen.xml
@@ -91,7 +91,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.71</MarketValue>
+      <MarketValue>0.66</MarketValue>
     </statBases>
     <ammoClass>ExplosiveAP</ammoClass>
     <cookOffProjectile>Bullet_792x94mmPatronen_HE</cookOffProjectile>

--- a/Defs/Ammo/HighCaliber/950JDJ.xml
+++ b/Defs/Ammo/HighCaliber/950JDJ.xml
@@ -90,7 +90,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>3.52</MarketValue>
+			<MarketValue>2.98</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_50JDJ_HE</cookOffProjectile>

--- a/Defs/Ammo/Medieval/CannonBall.xml
+++ b/Defs/Ammo/Medieval/CannonBall.xml
@@ -77,7 +77,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>57.78</MarketValue>
+			<MarketValue>53.28</MarketValue>
 		</statBases>
 		<ammoClass>BurstingShell</ammoClass>
 		<cookOffProjectile>Bullet_CannonBall_Bursting</cookOffProjectile>

--- a/Defs/Ammo/Rifle/127x55mm.xml
+++ b/Defs/Ammo/Rifle/127x55mm.xml
@@ -106,7 +106,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.91</MarketValue>
+			<MarketValue>0.77</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_127x55mm_HE</cookOffProjectile>

--- a/Defs/Ammo/Rifle/243Winchester.xml
+++ b/Defs/Ammo/Rifle/243Winchester.xml
@@ -105,7 +105,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.17</MarketValue>
+			<MarketValue>0.15</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_243Winchester_HE</cookOffProjectile>

--- a/Defs/Ammo/Rifle/277Fury.xml
+++ b/Defs/Ammo/Rifle/277Fury.xml
@@ -105,7 +105,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.21</MarketValue>
+			<MarketValue>0.19</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_277Fury_HE</cookOffProjectile>

--- a/Defs/Ammo/Rifle/280British.xml
+++ b/Defs/Ammo/Rifle/280British.xml
@@ -105,7 +105,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.2</MarketValue>
+			<MarketValue>0.18</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_280British_HE</cookOffProjectile>

--- a/Defs/Ammo/Rifle/30-30Winchester.xml
+++ b/Defs/Ammo/Rifle/30-30Winchester.xml
@@ -105,7 +105,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.26</MarketValue>
+			<MarketValue>0.23</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_3030Winchester_HE</cookOffProjectile>

--- a/Defs/Ammo/Rifle/3006Springfield.xml
+++ b/Defs/Ammo/Rifle/3006Springfield.xml
@@ -105,7 +105,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.22</MarketValue>
+			<MarketValue>0.19</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_3006Springfield_HE</cookOffProjectile>

--- a/Defs/Ammo/Rifle/300AACBlackout.xml
+++ b/Defs/Ammo/Rifle/300AACBlackout.xml
@@ -105,7 +105,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.16</MarketValue>
+			<MarketValue>0.14</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_300AACBlackout_HE</cookOffProjectile>

--- a/Defs/Ammo/Rifle/303British.xml
+++ b/Defs/Ammo/Rifle/303British.xml
@@ -105,7 +105,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.26</MarketValue>
+			<MarketValue>0.23</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_303British_HE</cookOffProjectile>
@@ -114,11 +114,11 @@
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="303BritishBase">
 		<defName>Ammo_303British_Sabot</defName>
 		<label>.303 British cartridge (Sabot)</label>
-			<graphicData>
+		<graphicData>
 			<texPath>Things/Ammo/Rifle/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
-			<statBases>
+		<statBases>
 			<MarketValue>0.14</MarketValue>
 			<Mass>0.022</Mass>
 		</statBases>

--- a/Defs/Ammo/Rifle/30Carbine.xml
+++ b/Defs/Ammo/Rifle/30Carbine.xml
@@ -105,7 +105,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.16</MarketValue>
+      <MarketValue>0.14</MarketValue>
     </statBases>
     <ammoClass>ExplosiveAP</ammoClass>
     <cookOffProjectile>Bullet_30Carbine_HE</cookOffProjectile>

--- a/Defs/Ammo/Rifle/38-55Winchester.xml
+++ b/Defs/Ammo/Rifle/38-55Winchester.xml
@@ -105,7 +105,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.31</MarketValue>
+			<MarketValue>0.27</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_3855Winchester_HE</cookOffProjectile>

--- a/Defs/Ammo/Rifle/44-40Winchester.xml
+++ b/Defs/Ammo/Rifle/44-40Winchester.xml
@@ -106,7 +106,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.25</MarketValue>
+      <MarketValue>0.22</MarketValue>
     </statBases>
     <ammoClass>ExplosiveAP</ammoClass>
     <cookOffProjectile>Bullet_44-40Winchester_HE</cookOffProjectile>

--- a/Defs/Ammo/Rifle/4570Gov.xml
+++ b/Defs/Ammo/Rifle/4570Gov.xml
@@ -105,7 +105,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.36</MarketValue>
+			<MarketValue>0.31</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_4570Gov_HE</cookOffProjectile>

--- a/Defs/Ammo/Rifle/458SOCOM.xml
+++ b/Defs/Ammo/Rifle/458SOCOM.xml
@@ -105,7 +105,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.35</MarketValue>
+			<MarketValue>0.3</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_458SOCOM_HE</cookOffProjectile>

--- a/Defs/Ammo/Rifle/473x33mmCaseless.xml
+++ b/Defs/Ammo/Rifle/473x33mmCaseless.xml
@@ -105,7 +105,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.09</MarketValue>
+			<MarketValue>0.08</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_473x33mmCaseless_HE</cookOffProjectile>

--- a/Defs/Ammo/Rifle/485x49mm.xml
+++ b/Defs/Ammo/Rifle/485x49mm.xml
@@ -105,7 +105,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.14</MarketValue>
+			<MarketValue>0.12</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_485x49mm_HE</cookOffProjectile>

--- a/Defs/Ammo/Rifle/50Beowulf.xml
+++ b/Defs/Ammo/Rifle/50Beowulf.xml
@@ -105,7 +105,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.38</MarketValue>
+			<MarketValue>0.32</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_50Beowulf_HE</cookOffProjectile>

--- a/Defs/Ammo/Rifle/545x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/545x39mmSoviet.xml
@@ -119,7 +119,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.14</MarketValue>
+			<MarketValue>0.12</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_545x39mmSoviet_HE</cookOffProjectile>

--- a/Defs/Ammo/Rifle/556x45mmNATO.xml
+++ b/Defs/Ammo/Rifle/556x45mmNATO.xml
@@ -119,7 +119,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.14</MarketValue>
+			<MarketValue>0.12</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_556x45mmNATO_HE</cookOffProjectile>

--- a/Defs/Ammo/Rifle/56-56Spencer.xml
+++ b/Defs/Ammo/Rifle/56-56Spencer.xml
@@ -105,7 +105,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.37</MarketValue>
+      <MarketValue>0.33</MarketValue>
     </statBases>
     <ammoClass>ExplosiveAP</ammoClass>
     <cookOffProjectile>Bullet_5656Spencer_HE</cookOffProjectile>

--- a/Defs/Ammo/Rifle/58x42mmDBP10.xml
+++ b/Defs/Ammo/Rifle/58x42mmDBP10.xml
@@ -105,7 +105,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.16</MarketValue>
+      <MarketValue>0.14</MarketValue>
     </statBases>
     <ammoClass>ExplosiveAP</ammoClass>
     <cookOffProjectile>Bullet_58x42mmDBP10_HE</cookOffProjectile>

--- a/Defs/Ammo/Rifle/6.5Creedmoor.xml
+++ b/Defs/Ammo/Rifle/6.5Creedmoor.xml
@@ -105,7 +105,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.2</MarketValue>
+			<MarketValue>0.18</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_65x48mmCreedmoor_HE</cookOffProjectile>

--- a/Defs/Ammo/Rifle/6.5x52mm Carcano.xml
+++ b/Defs/Ammo/Rifle/6.5x52mm Carcano.xml
@@ -29,7 +29,7 @@
 	<ThingDef Class="CombatExtended.AmmoDef" Name="65x52mmCarcanoBase" ParentName="SmallAmmoBase" Abstract="True">
 		<description>A rimless, bottle-necked rifle cartridge found mostly in outdated bolt-action firearms.</description>
 		<statBases>
-		<Mass>0.022</Mass>
+		<Mass>0.025</Mass>
 		<Bulk>0.03</Bulk>
 		</statBases>
 		<tradeTags>
@@ -49,7 +49,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.1</MarketValue>
+			<MarketValue>0.11</MarketValue>
 		</statBases>
 		<ammoClass>FullMetalJacket</ammoClass>
 		<cookOffProjectile>Bullet_65x52mmCarcano_FMJ</cookOffProjectile>
@@ -63,7 +63,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.1</MarketValue>
+			<MarketValue>0.11</MarketValue>
 		</statBases>
 		<ammoClass>ArmorPiercing</ammoClass>
 		<cookOffProjectile>Bullet_65x52mmCarcano_AP</cookOffProjectile>
@@ -77,7 +77,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.1</MarketValue>
+			<MarketValue>0.111</MarketValue>
 		</statBases>
 		<ammoClass>HollowPoint</ammoClass>
 		<cookOffProjectile>Bullet_65x52mmCarcano_HP</cookOffProjectile>
@@ -91,7 +91,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.14</MarketValue>
+      <MarketValue>0.15</MarketValue>
     </statBases>
     <ammoClass>IncendiaryAP</ammoClass>
     <cookOffProjectile>Bullet_65x52mmCarcano_Incendiary</cookOffProjectile>
@@ -105,7 +105,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.2</MarketValue>
+      <MarketValue>0.22</MarketValue>
     </statBases>
     <ammoClass>ExplosiveAP</ammoClass>
     <cookOffProjectile>Bullet_65x52mmCarcano_HE</cookOffProjectile>
@@ -120,7 +120,7 @@
     </graphicData>
     <statBases>
       <MarketValue>0.11</MarketValue>
-	  <Mass>0.019</Mass>
+	  <Mass>0.02</Mass>
     </statBases>
     <ammoClass>Sabot</ammoClass>
     <cookOffProjectile>Bullet_65x52mmCarcano_Sabot</cookOffProjectile>

--- a/Defs/Ammo/Rifle/65x50mmSRArisaka.xml
+++ b/Defs/Ammo/Rifle/65x50mmSRArisaka.xml
@@ -105,7 +105,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.2</MarketValue>
+			<MarketValue>0.18</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_65x50mmSRArisaka_HE</cookOffProjectile>

--- a/Defs/Ammo/Rifle/7.92x57mmMauser.xml
+++ b/Defs/Ammo/Rifle/7.92x57mmMauser.xml
@@ -105,7 +105,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.27</MarketValue>
+      <MarketValue>0.23</MarketValue>
     </statBases>
     <ammoClass>ExplosiveAP</ammoClass>
     <cookOffProjectile>Bullet_792x57mmMauser_HE</cookOffProjectile>

--- a/Defs/Ammo/Rifle/75x54mmFrench.xml
+++ b/Defs/Ammo/Rifle/75x54mmFrench.xml
@@ -105,7 +105,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.21</MarketValue>
+      <MarketValue>0.19</MarketValue>
     </statBases>
     <ammoClass>ExplosiveAP</ammoClass>
     <cookOffProjectile>Bullet_75x54mmFrench_HE</cookOffProjectile>

--- a/Defs/Ammo/Rifle/762x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/762x39mmSoviet.xml
@@ -105,7 +105,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.18</MarketValue>
+			<MarketValue>0.15</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_762x39mmSoviet_HE</cookOffProjectile>

--- a/Defs/Ammo/Rifle/762x51mmNATO.xml
+++ b/Defs/Ammo/Rifle/762x51mmNATO.xml
@@ -105,7 +105,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.21</MarketValue>
+			<MarketValue>0.19</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_762x51mmNATO_HE</cookOffProjectile>

--- a/Defs/Ammo/Rifle/762x54mmR.xml
+++ b/Defs/Ammo/Rifle/762x54mmR.xml
@@ -105,7 +105,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.22</MarketValue>
+			<MarketValue>0.19</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_762x54mmR_HE</cookOffProjectile>

--- a/Defs/Ammo/Rifle/77x58mmArisaka.xml
+++ b/Defs/Ammo/Rifle/77x58mmArisaka.xml
@@ -105,7 +105,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.27</MarketValue>
+			<MarketValue>0.23</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_77x58mmArisaka_HE</cookOffProjectile>

--- a/Defs/Ammo/Rifle/792x33mmKurz.xml
+++ b/Defs/Ammo/Rifle/792x33mmKurz.xml
@@ -105,7 +105,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.19</MarketValue>
+			<MarketValue>0.16</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_792x33mmKurz_HE</cookOffProjectile>

--- a/Defs/Ammo/Rifle/8.6mmBlackout.xml
+++ b/Defs/Ammo/Rifle/8.6mmBlackout.xml
@@ -105,7 +105,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.28</MarketValue>
+			<MarketValue>0.24</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_86x43mmBlackout_HE</cookOffProjectile>

--- a/Defs/Ammo/Rifle/8x50mmRLebel.xml
+++ b/Defs/Ammo/Rifle/8x50mmRLebel.xml
@@ -105,7 +105,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.27</MarketValue>
+      <MarketValue>0.23</MarketValue>
     </statBases>
     <ammoClass>ExplosiveAP</ammoClass>
     <cookOffProjectile>Bullet_8x50mmRLebel_HE</cookOffProjectile>

--- a/Defs/Ammo/Rifle/8x50mmRMannlicher.xml
+++ b/Defs/Ammo/Rifle/8x50mmRMannlicher.xml
@@ -105,7 +105,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.30</MarketValue>
+			<MarketValue>0.26</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_8x50mmRMannlicher_HE</cookOffProjectile>

--- a/Defs/Ammo/Rifle/9x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/9x39mmSoviet.xml
@@ -105,7 +105,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.29</MarketValue>
+      <MarketValue>0.25</MarketValue>
     </statBases>
     <ammoClass>ExplosiveAP</ammoClass>
     <cookOffProjectile>Bullet_9x39mmSoviet_HE</cookOffProjectile>

--- a/Defs/Ammo/Rocket/130mmType63.xml
+++ b/Defs/Ammo/Rocket/130mmType63.xml
@@ -45,7 +45,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>204.44</MarketValue>
+			<MarketValue>192.94</MarketValue>
 			<Mass>33</Mass>
 			<Bulk>43.81</Bulk>
 		</statBases>

--- a/Defs/Ammo/Rocket/132mmM13.xml
+++ b/Defs/Ammo/Rocket/132mmM13.xml
@@ -46,7 +46,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>250</MarketValue>
+			<MarketValue>237.5</MarketValue>
 			<Mass>43</Mass>
 			<Bulk>59.53</Bulk>
 		</statBases>

--- a/Defs/Ammo/Rocket/20mmFliegerfaust.xml
+++ b/Defs/Ammo/Rocket/20mmFliegerfaust.xml
@@ -45,7 +45,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>14.83</MarketValue>
+      <MarketValue>14.58</MarketValue>
 	    <Mass>0.12</Mass>
 	    <Bulk>0.16</Bulk>
     </statBases>

--- a/Defs/Ammo/Rocket/50mmRocket.xml
+++ b/Defs/Ammo/Rocket/50mmRocket.xml
@@ -46,7 +46,7 @@
       <drawSize>0.70</drawSize>
     </graphicData>
     <statBases>
-      <MarketValue>14.83</MarketValue>
+      <MarketValue>44.76</MarketValue>
       <Mass>4.5</Mass>
       <Bulk>7.07</Bulk>
     </statBases>

--- a/Defs/Ammo/Rocket/70mmAPKWS.xml
+++ b/Defs/Ammo/Rocket/70mmAPKWS.xml
@@ -45,7 +45,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>106.17</MarketValue>
+			<MarketValue>101.17</MarketValue>
 			<Mass>15</Mass>
 			<Bulk>21.59</Bulk>
 		</statBases>

--- a/Defs/Ammo/Rocket/83mmSMAW.xml
+++ b/Defs/Ammo/Rocket/83mmSMAW.xml
@@ -47,7 +47,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>67.92</MarketValue>
+			<MarketValue>63.92</MarketValue>
 			<Mass>6.3</Mass>
 			<Bulk>17.91</Bulk>
 		</statBases>
@@ -63,7 +63,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>70.47</MarketValue>
+			<MarketValue>65.47</MarketValue>
 			<Mass>5.9</Mass>
 			<Bulk>15.87</Bulk>
 		</statBases>
@@ -79,7 +79,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>119.28</MarketValue>
+			<MarketValue>102.28</MarketValue>
 			<Mass>5.76</Mass>
 			<Bulk>17.27</Bulk>
 		</statBases>

--- a/Defs/Ammo/Rocket/84x246mmR.xml
+++ b/Defs/Ammo/Rocket/84x246mmR.xml
@@ -46,7 +46,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>53.16</MarketValue>
+      <MarketValue>49.66</MarketValue>
       <Mass>3.2</Mass>
       <Bulk>9.66</Bulk>
     </statBases>
@@ -62,7 +62,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>53.81</MarketValue>
+      <MarketValue>54.36</MarketValue>
       <Mass>3.1</Mass>
       <Bulk>7.26</Bulk>
     </statBases>

--- a/Defs/Ammo/Rocket/88mmRPzB.xml
+++ b/Defs/Ammo/Rocket/88mmRPzB.xml
@@ -45,7 +45,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>51.58</MarketValue>
+      <MarketValue>48.08</MarketValue>
       <Mass>2.7</Mass>
       <Bulk>11.59</Bulk>
     </statBases>

--- a/Defs/Ammo/Rocket/90mmRecoilless.xml
+++ b/Defs/Ammo/Rocket/90mmRecoilless.xml
@@ -46,7 +46,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>55.86</MarketValue>
+      <MarketValue>52.86</MarketValue>
       <Mass>4.196</Mass>
       <Bulk>13.63</Bulk>
     </statBases>

--- a/Defs/Ammo/Rocket/M6.xml
+++ b/Defs/Ammo/Rocket/M6.xml
@@ -48,7 +48,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>51.75</MarketValue>
+      <MarketValue>47.24</MarketValue>
 	    <Mass>1.59</Mass>
 	    <Bulk>4.66</Bulk>
     </statBases>

--- a/Defs/Ammo/Rocket/M6A1.xml
+++ b/Defs/Ammo/Rocket/M6A1.xml
@@ -37,7 +37,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>51.74</MarketValue>
+      <MarketValue>47.24</MarketValue>
 	    <Mass>1.59</Mass>
 	    <Bulk>4.66</Bulk>
     </statBases>

--- a/Defs/Ammo/Rocket/RPG32.xml
+++ b/Defs/Ammo/Rocket/RPG32.xml
@@ -46,7 +46,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>72.37</MarketValue>
+			<MarketValue>67.87</MarketValue>
 			<Mass>7</Mass>
 			<Bulk>23.95</Bulk>
 		</statBases>
@@ -62,7 +62,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>134.37</MarketValue>
+			<MarketValue>114.87</MarketValue>
 			<Mass>7</Mass>
 			<Bulk>23.95</Bulk>
 		</statBases>

--- a/Defs/Ammo/Rocket/RPG7.xml
+++ b/Defs/Ammo/Rocket/RPG7.xml
@@ -47,7 +47,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>57.78</MarketValue>
+      <MarketValue>52.78</MarketValue>
       <Mass>2.8</Mass>
       <Bulk>7.14</Bulk>
     </statBases>
@@ -63,7 +63,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>123.58</MarketValue>
+      <MarketValue>104.58</MarketValue>
       <Mass>4.7</Mass>
       <Bulk>8.61</Bulk>
     </statBases>
@@ -79,7 +79,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>38.86</MarketValue>
+      <MarketValue>37.86</MarketValue>
       <Mass>2.2</Mass>
       <Bulk>3.4</Bulk>
     </statBases>

--- a/Defs/Ammo/Rocket/SPG9.xml
+++ b/Defs/Ammo/Rocket/SPG9.xml
@@ -48,7 +48,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>55.69</MarketValue>
+      <MarketValue>53.69</MarketValue>
       <Mass>5.35</Mass>
       <Bulk>11.56</Bulk>
     </statBases>
@@ -64,7 +64,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>129.13</MarketValue>
+      <MarketValue>110.13</MarketValue>
       <Mass>6.2</Mass>
       <Bulk>11.56</Bulk>
     </statBases>
@@ -80,7 +80,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>64.58</MarketValue>
+      <MarketValue>61.58</MarketValue>
       <Mass>5.5</Mass>
       <Bulk>13.34</Bulk>
     </statBases>

--- a/Defs/Ammo/Rocket/TomahawkLAM.xml
+++ b/Defs/Ammo/Rocket/TomahawkLAM.xml
@@ -41,7 +41,7 @@
 			<drawSize>4,4</drawSize>
 		</graphicData>
 		<statBases>
-			<MarketValue>14026</MarketValue>
+			<MarketValue>12046</MarketValue>
 			<Mass>1440</Mass>
 			<Bulk>3830.29</Bulk>
 		</statBases>

--- a/Defs/Ammo/Shell/100x695mmR.xml
+++ b/Defs/Ammo/Shell/100x695mmR.xml
@@ -48,7 +48,7 @@
 		</graphicData>
 		<statBases>
 			<Mass>30.16</Mass>
-			<MarketValue>170</MarketValue>
+			<MarketValue>173.07</MarketValue>
 		</statBases>
 		<ammoClass>RocketHEAT</ammoClass>
 		<detonateProjectile>Bullet_100x695mmRCannonShell_HEAT</detonateProjectile>
@@ -63,7 +63,7 @@
 		</graphicData>
 		<statBases>
 			<Mass>30.27</Mass>
-			<MarketValue>183.19</MarketValue>
+			<MarketValue>180.9</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHE</ammoClass>
 		<detonateProjectile>Bullet_100x695mmRCannonShell_HE</detonateProjectile>

--- a/Defs/Ammo/Shell/105mmHowitzer.xml
+++ b/Defs/Ammo/Shell/105mmHowitzer.xml
@@ -68,7 +68,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>128.17</MarketValue>
+			<MarketValue>119.42</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHE</ammoClass>
 		<detonateProjectile>Bullet_105mmHowitzerShell_HE</detonateProjectile>
@@ -83,7 +83,7 @@
 		</graphicData>
 		<statBases>
 		  <Mass>21</Mass>
-		  <MarketValue>128.54</MarketValue>
+		  <MarketValue>123.54</MarketValue>
 		</statBases>
 		<ammoClass>RocketHEAT</ammoClass>
 		<detonateProjectile>Bullet_105mmHowitzerShell_HEAT_directfire</detonateProjectile>

--- a/Defs/Ammo/Shell/105x607mmR.xml
+++ b/Defs/Ammo/Shell/105x607mmR.xml
@@ -48,7 +48,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>109.12</MarketValue>
+			<MarketValue>101.62</MarketValue>
 		</statBases>
 		<ammoClass>RocketHEAT</ammoClass>
 		<detonateProjectile>Bullet_105x607mmRCannonShell_HEAT</detonateProjectile>
@@ -62,7 +62,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>150.45</MarketValue>
+			<MarketValue>132.95</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHE</ammoClass>
 		<detonateProjectile>Bullet_105x607mmRCannonShell_HE</detonateProjectile>

--- a/Defs/Ammo/Shell/120mmCannon.xml
+++ b/Defs/Ammo/Shell/120mmCannon.xml
@@ -48,7 +48,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>157.92</MarketValue>
+			<MarketValue>149.17</MarketValue>
 		</statBases>
 		<ammoClass>RocketHEAT</ammoClass>
 		<detonateProjectile>Bullet_120mmCannonShell_HEAT</detonateProjectile>
@@ -62,7 +62,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>188.92</MarketValue>
+			<MarketValue>172.67</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHE</ammoClass>
 		<detonateProjectile>Bullet_120mmCannonShell_HE</detonateProjectile>

--- a/Defs/Ammo/Shell/155mmHowitzer.xml
+++ b/Defs/Ammo/Shell/155mmHowitzer.xml
@@ -64,7 +64,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>427.1</MarketValue>
+			<MarketValue>384.6</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHE</ammoClass>
 		<detonateProjectile>Bullet_155mmHowitzerShell_HE</detonateProjectile>

--- a/Defs/Ammo/Shell/15cmNebelwerfer.xml
+++ b/Defs/Ammo/Shell/15cmNebelwerfer.xml
@@ -46,7 +46,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>298.27</MarketValue>
+			<MarketValue>283.35</MarketValue>
 			<Mass>31.8</Mass>
 			<Bulk>57.59</Bulk>
 		</statBases>

--- a/Defs/Ammo/Shell/28cmSpgr.xml
+++ b/Defs/Ammo/Shell/28cmSpgr.xml
@@ -47,7 +47,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>1688.67</MarketValue>
+			<MarketValue>1513.5</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHE</ammoClass>
 		<detonateProjectile>Bullet_28cmSpgrShell_HE</detonateProjectile>

--- a/Defs/Ammo/Shell/37x223mmR.xml
+++ b/Defs/Ammo/Shell/37x223mmR.xml
@@ -47,7 +47,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>11.54</MarketValue>
+			<MarketValue>9.94</MarketValue>
 			<Mass>1.18</Mass>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
@@ -62,7 +62,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>5.88</MarketValue>
+			<MarketValue>5.92</MarketValue>
 			<Mass>1.47</Mass>
 		</statBases>
 		<ammoClass>ArmorPiercing</ammoClass>

--- a/Defs/Ammo/Shell/40x365mmBofors.xml
+++ b/Defs/Ammo/Shell/40x365mmBofors.xml
@@ -45,7 +45,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>22.21</MarketValue>
+			<MarketValue>15.78</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_40x365mmBofors_HE</cookOffProjectile>
@@ -59,7 +59,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>8.57</MarketValue>
+			<MarketValue>8.64</MarketValue>
 		</statBases>
 		<ammoClass>ArmorPiercing</ammoClass>
 		<cookOffProjectile>Bullet_40x365mmBofors_AP</cookOffProjectile>

--- a/Defs/Ammo/Shell/50mmType89Mortar.xml
+++ b/Defs/Ammo/Shell/50mmType89Mortar.xml
@@ -49,7 +49,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>21.1</MarketValue>
+      <MarketValue>20.1</MarketValue>
     </statBases>
     <ammoClass>GrenadeHE</ammoClass>
 	<detonateProjectile>Bullet_50mmType89MortarShell_HE</detonateProjectile>

--- a/Defs/Ammo/Shell/57x483mmBofors.xml
+++ b/Defs/Ammo/Shell/57x483mmBofors.xml
@@ -46,7 +46,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>43</MarketValue>
+			<MarketValue>39.32</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHE</ammoClass>
 		<detonateProjectile>Bullet_57x483mmBofors_HE</detonateProjectile>

--- a/Defs/Ammo/Shell/60mmMortar.xml
+++ b/Defs/Ammo/Shell/60mmMortar.xml
@@ -53,7 +53,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>29.2</MarketValue>
+      <MarketValue>27.2</MarketValue>
     </statBases>
     <ammoClass>GrenadeHE</ammoClass>
     <detonateProjectile>Bullet_60mmMortarShell_HE</detonateProjectile>

--- a/Defs/Ammo/Shell/762x385mmRCannon.xml
+++ b/Defs/Ammo/Shell/762x385mmRCannon.xml
@@ -49,7 +49,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>61.1</MarketValue>
+			<MarketValue>58.1</MarketValue>
 		</statBases>
 		<ammoClass>RocketHEAT</ammoClass>
 		<detonateProjectile>Bullet_762x385mmRCannonShell_HEAT</detonateProjectile>
@@ -63,7 +63,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>59.04</MarketValue>
+			<MarketValue>56.54</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHE</ammoClass>
 		<detonateProjectile>Bullet_762x385mmRCannonShell_HE</detonateProjectile>

--- a/Defs/Ammo/Shell/81mmMortar.xml
+++ b/Defs/Ammo/Shell/81mmMortar.xml
@@ -57,7 +57,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>55.09</MarketValue>
+      <MarketValue>50.09</MarketValue>
       <Mass>5.27</Mass>
       <Bulk>8.17</Bulk>
     </statBases>

--- a/Defs/Ammo/Shell/90mmCannon.xml
+++ b/Defs/Ammo/Shell/90mmCannon.xml
@@ -53,7 +53,7 @@
     </graphicData>
     <statBases>
       <Mass>15.8</Mass>
-      <MarketValue>93</MarketValue>
+      <MarketValue>89</MarketValue>
     </statBases>
     <ammoClass>RocketHEAT</ammoClass>
 	<detonateProjectile>Bullet_90mmCannonShell_HEAT</detonateProjectile>
@@ -75,7 +75,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>109.83</MarketValue>
+      <MarketValue>104.83</MarketValue>
     </statBases>
     <ammoClass>GrenadeHE</ammoClass>
     <comps>
@@ -102,7 +102,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>139.83</MarketValue>
+      <MarketValue>124.33</MarketValue>
     </statBases>
     <ammoClass>GrenadeHETF</ammoClass>
     <comps>
@@ -392,7 +392,7 @@
             <li>ComponentIndustrial</li>
           </thingDefs>
         </filter>
-        <count>3</count>
+        <count>5</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>

--- a/Defs/ThingDefs_Items/Items_Resource_Ammo.xml
+++ b/Defs/ThingDefs_Items/Items_Resource_Ammo.xml
@@ -18,6 +18,7 @@
       <MaxHitPoints>70</MaxHitPoints>
       <MarketValue>6</MarketValue>
       <Flammability>1.0</Flammability>
+      <DeteriorationRate>1.0</DeteriorationRate>
       <Mass>0.5</Mass>
       <Bulk>1</Bulk>
     </statBases>
@@ -59,6 +60,7 @@
       <MaxHitPoints>70</MaxHitPoints>
       <MarketValue>10</MarketValue>
       <Flammability>1.0</Flammability>
+      <DeteriorationRate>1.0</DeteriorationRate>
       <Mass>0.5</Mass>
       <Bulk>1</Bulk>
     </statBases>

--- a/Defs/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Grenades.xml
@@ -110,7 +110,7 @@
     <statBases>
       <Mass>0.436</Mass>
       <Bulk>1.55</Bulk>
-      <MarketValue>13.65</MarketValue>
+      <MarketValue>12.4</MarketValue>
       <SightsEfficiency>0.65</SightsEfficiency>
       <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
     </statBases>
@@ -263,7 +263,7 @@
     <statBases>
       <Mass>1.5</Mass>
       <Bulk>4.72</Bulk>
-      <MarketValue>25.51</MarketValue>
+      <MarketValue>20.51</MarketValue>
       <SightsEfficiency>0.65</SightsEfficiency>
       <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
     </statBases>

--- a/Patches/Biomes Caverns/ThingDefs_Races/CE_Boommoth.xml
+++ b/Patches/Biomes Caverns/ThingDefs_Races/CE_Boommoth.xml
@@ -26,7 +26,7 @@
 							<compClass>CombatExtended.CompShearableRenameable</compClass>
 							<growthLabel>Secretion level</growthLabel>
 							<shearIntervalDays>3</shearIntervalDays>
-							<woolAmount>3</woolAmount>
+							<woolAmount>2</woolAmount>
 							<woolDef>FSX</woolDef>
 						</li>
 					</value>

--- a/Patches/Biomes Caverns/ThingDefs_Races/CE_ChemSnail.xml
+++ b/Patches/Biomes Caverns/ThingDefs_Races/CE_ChemSnail.xml
@@ -31,7 +31,7 @@
 							<compClass>CombatExtended.CompShearableRenameable</compClass>
 							<growthLabel>Secretion level</growthLabel>
 							<shearIntervalDays>10</shearIntervalDays>
-							<woolAmount>10</woolAmount>
+							<woolAmount>5</woolAmount>
 							<woolDef>FSX</woolDef>
 						</li>
 					</value>

--- a/Patches/Biomes Caverns/ThingDefs_Races/CE_ChemSnail.xml
+++ b/Patches/Biomes Caverns/ThingDefs_Races/CE_ChemSnail.xml
@@ -31,7 +31,7 @@
 							<compClass>CombatExtended.CompShearableRenameable</compClass>
 							<growthLabel>Secretion level</growthLabel>
 							<shearIntervalDays>10</shearIntervalDays>
-							<woolAmount>5</woolAmount>
+							<woolAmount>6</woolAmount>
 							<woolDef>FSX</woolDef>
 						</li>
 					</value>

--- a/Patches/Bori Race/ThingDefs_Misc/Bori_Explosives.xml
+++ b/Patches/Bori Race/ThingDefs_Misc/Bori_Explosives.xml
@@ -144,7 +144,7 @@
 		<defName>BD_GrenadeFrag</defName>
 		<statBases>
 				<Mass>1.08</Mass>
-				<MarketValue>8.25</MarketValue>
+				<MarketValue>7.42</MarketValue>
 				<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 				<SightsEfficiency>1</SightsEfficiency>
 		</statBases>

--- a/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_Ammo_Rocket.xml
+++ b/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_Ammo_Rocket.xml
@@ -54,7 +54,7 @@
 							<graphicClass>Graphic_StackCount</graphicClass>
 						</graphicData>
 						<statBases>
-							<MarketValue>24.42</MarketValue>
+							<MarketValue>22.42</MarketValue>
 							<Mass>0.75</Mass>
 							<Bulk>1.53</Bulk>
 						</statBases>

--- a/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_KitClassic_CE_Patch_Ammo_ClassicRocket.xml
+++ b/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_KitClassic_CE_Patch_Ammo_ClassicRocket.xml
@@ -55,7 +55,7 @@
 							<graphicClass>Graphic_StackCount</graphicClass>
 						</graphicData>
 						<statBases>
-							<MarketValue>37.44</MarketValue>
+							<MarketValue>34.44</MarketValue>
 							<Mass>0.75</Mass>
 							<Bulk>1.53</Bulk>
 						</statBases>

--- a/Patches/Censored Armory/30mm Rifle Grenade.xml
+++ b/Patches/Censored Armory/30mm Rifle Grenade.xml
@@ -55,7 +55,7 @@
             <graphicClass>Graphic_StackCount</graphicClass>
           </graphicData>
           <statBases>
-            <MarketValue>2.85</MarketValue>
+            <MarketValue>2.62</MarketValue>
           </statBases>
           <ammoClass>GrenadeHE</ammoClass>
           <detonateProjectile>Bullet_30mmRifleGrenade_HE</detonateProjectile>

--- a/Patches/Censored Armory/37x249mmR.xml
+++ b/Patches/Censored Armory/37x249mmR.xml
@@ -55,7 +55,7 @@
 						<drawSize>1.50</drawSize>
 					</graphicData>
 					<statBases>
-						<MarketValue>8.25</MarketValue>
+						<MarketValue>7.75</MarketValue>
 					</statBases>
 					<ammoClass>ExplosiveAP</ammoClass>
 					<cookOffProjectile>Bullet_37x249mmR_HE</cookOffProjectile>

--- a/Patches/Censored Armory/75cm leIG18.xml
+++ b/Patches/Censored Armory/75cm leIG18.xml
@@ -57,7 +57,7 @@
 						<graphicClass>Graphic_Single</graphicClass>
 					</graphicData>
 					<statBases>
-						<MarketValue>93.5</MarketValue>
+						<MarketValue>88.82</MarketValue>
 					</statBases>
 					<ammoClass>GrenadeHE</ammoClass>
 					<detonateProjectile>Bullet_75cmleIG18CannonShell_HE</detonateProjectile>

--- a/Patches/Censored Armory/75x714mmR.xml
+++ b/Patches/Censored Armory/75x714mmR.xml
@@ -74,7 +74,7 @@
             <drawSize>1.50</drawSize>
           </graphicData>
           <statBases>
-            <MarketValue>50</MarketValue>
+            <MarketValue>47.5</MarketValue>
           </statBases>
           <ammoClass>GrenadeHE</ammoClass>
           <comps>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
@@ -192,7 +192,7 @@
 		<statBases>
 			<Mass>0.4</Mass>
 			<Bulk>0.87</Bulk>
-			<MarketValue>12.22</MarketValue>
+			<MarketValue>11.22</MarketValue>
 			<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 			<SightsEfficiency>0.65</SightsEfficiency>
 		</statBases>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Tropical.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Tropical.xml
@@ -232,7 +232,7 @@
 				<compClass>CombatExtended.CompShearableRenameable</compClass>
 				<growthLabel>Secretion level</growthLabel>
 				<shearIntervalDays>10</shearIntervalDays>
-				<woolAmount>10</woolAmount>
+				<woolAmount>5</woolAmount>
 				<woolDef>FSX</woolDef>
 			</li>
 		</value>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Tropical.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Tropical.xml
@@ -232,7 +232,7 @@
 				<compClass>CombatExtended.CompShearableRenameable</compClass>
 				<growthLabel>Secretion level</growthLabel>
 				<shearIntervalDays>10</shearIntervalDays>
-				<woolAmount>5</woolAmount>
+				<woolAmount>6</woolAmount>
 				<woolDef>FSX</woolDef>
 			</li>
 		</value>

--- a/Patches/Exotic Arsenal/Exotic_Ammo_Energy.xml
+++ b/Patches/Exotic Arsenal/Exotic_Ammo_Energy.xml
@@ -138,7 +138,7 @@
 		<statBases>
 			<Mass>0.014</Mass>
 			<Bulk>0.014</Bulk>
-			<MarketValue>1</MarketValue>
+			<MarketValue>0.95</MarketValue>
 		</statBases>
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
@@ -162,7 +162,7 @@
 		<statBases>
 			<Mass>0.018</Mass>
 			<Bulk>0.014</Bulk>
-			<MarketValue>1.66</MarketValue>
+			<MarketValue>1.57</MarketValue>
 		</statBases>
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>

--- a/Patches/Exotic Arsenal/Exotic_Ammo_Others.xml
+++ b/Patches/Exotic Arsenal/Exotic_Ammo_Others.xml
@@ -154,7 +154,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.2</MarketValue>
+      <MarketValue>0.18</MarketValue>
     </statBases>
     <ammoClass>Exotic_Buck</ammoClass>
     <generateAllowChance>0.1</generateAllowChance>
@@ -170,7 +170,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.35</MarketValue>
+      <MarketValue>0.32</MarketValue>
     </statBases>
     <ammoClass>Exotic_Cluster</ammoClass>
     <generateAllowChance>0.05</generateAllowChance>
@@ -185,7 +185,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.5</MarketValue>
+      <MarketValue>0.45</MarketValue>
     </statBases>
     <ammoClass>Exotic_Mayhem</ammoClass>
     <generateAllowChance>0</generateAllowChance>

--- a/Patches/Halo - UNSC Armoury/Ammo_UNSC.xml
+++ b/Patches/Halo - UNSC Armoury/Ammo_UNSC.xml
@@ -113,7 +113,7 @@
 						<graphicClass>Graphic_StackCount</graphicClass>
 					</graphicData>
 					<statBases>
-						<MarketValue>0.2</MarketValue>
+						<MarketValue>0.18</MarketValue>
 					</statBases>
 					<ammoClass>ExplosiveAP</ammoClass>
 					<cookOffProjectile>Bullet_95x40mm_HE</cookOffProjectile>

--- a/Patches/Halo Ammo/102mmM41Rockets.xml
+++ b/Patches/Halo Ammo/102mmM41Rockets.xml
@@ -56,7 +56,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>95.37</MarketValue>
+			<MarketValue>90.61</MarketValue>
 			<Mass>5.5</Mass>
 			<Bulk>9.45</Bulk>
 		</statBases>
@@ -73,7 +73,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>104.37</MarketValue>
+			<MarketValue>99.15</MarketValue>
 			<Mass>5.5</Mass>
 			<Bulk>9.45</Bulk>
 		</statBases>

--- a/Patches/Halo Ammo/12.7x99mm.xml
+++ b/Patches/Halo Ammo/12.7x99mm.xml
@@ -86,7 +86,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>1</MarketValue>
+      <MarketValue>0.95</MarketValue>
     </statBases>
     <ammoClass>ExplosiveAP</ammoClass>
     <cookOffProjectile>Bullet_127x99mm_HE</cookOffProjectile>

--- a/Patches/Halo Ammo/14.5x114mmUNSC.xml
+++ b/Patches/Halo Ammo/14.5x114mmUNSC.xml
@@ -87,7 +87,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>1.56</MarketValue>
+      <MarketValue>1.48</MarketValue>
     </statBases>
     <ammoClass>ExplosiveAP</ammoClass>
     <generateAllowChance>0.15</generateAllowChance>

--- a/Patches/Halo Ammo/16x65mm.xml
+++ b/Patches/Halo Ammo/16x65mm.xml
@@ -54,7 +54,7 @@
 		<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-		<MarketValue>12</MarketValue>
+		<MarketValue>11</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_16x65mm_HE</cookOffProjectile>

--- a/Patches/Halo Ammo/40x46mmGrenadesUNSC.xml
+++ b/Patches/Halo Ammo/40x46mmGrenadesUNSC.xml
@@ -51,7 +51,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>6.37</MarketValue>
+      <MarketValue>6.01</MarketValue>
     </statBases>
     <ammoClass>GrenadeHEDP</ammoClass>
 	<detonateProjectile>Bullet_40x46mmGrenade_HE</detonateProjectile>

--- a/Patches/Halo Ammo/7.62x51mmUNSC.xml
+++ b/Patches/Halo Ammo/7.62x51mmUNSC.xml
@@ -168,7 +168,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.23</MarketValue>
+      <MarketValue>0.20</MarketValue>
     </statBases>
     <ammoClass>ExplosiveAP</ammoClass>
 	<generateAllowChance>0.2</generateAllowChance>

--- a/Patches/Halo Ammo/9.5x40mm.xml
+++ b/Patches/Halo Ammo/9.5x40mm.xml
@@ -118,7 +118,7 @@
 		<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-		<MarketValue>0.23</MarketValue>
+		<MarketValue>0.20</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<generateAllowChance>0.2</generateAllowChance>

--- a/Patches/Infinity Rim Ariadna/Ammo/MicroMissile.xml
+++ b/Patches/Infinity Rim Ariadna/Ammo/MicroMissile.xml
@@ -53,7 +53,7 @@
 								<drawSize>0.75</drawSize>
 							</graphicData>
 							<statBases>
-								<MarketValue>14.83</MarketValue>
+								<MarketValue>13.64</MarketValue>
 								<Mass>0.52</Mass>
 								<Bulk>0.88</Bulk>
 							</statBases>

--- a/Patches/K4G Rimworld War 2/AmmoDefs/WW2_RocketAmmo.xml
+++ b/Patches/K4G Rimworld War 2/AmmoDefs/WW2_RocketAmmo.xml
@@ -57,7 +57,7 @@
                   <graphicClass>Graphic_StackCount</graphicClass>
                </graphicData>
                <statBases>
-                  <MarketValue>51.75</MarketValue>
+                  <MarketValue>47.61</MarketValue>
                   <Mass>1.59</Mass>
                   <Bulk>4.66</Bulk>
                </statBases>

--- a/Patches/Kaiser Armory/105x155mmR.xml
+++ b/Patches/Kaiser Armory/105x155mmR.xml
@@ -57,7 +57,7 @@
 			<drawSize>1.30</drawSize>
 		</graphicData>
 		<statBases>
-			<MarketValue>101.44</MarketValue>
+			<MarketValue>96.36</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHE</ammoClass>
 		<detonateProjectile>Bullet_105x155mmRCannonShell_HE</detonateProjectile>

--- a/Patches/Kaiser Armory/77x230mmR.xml
+++ b/Patches/Kaiser Armory/77x230mmR.xml
@@ -58,7 +58,7 @@
 			<drawSize>1.60</drawSize>
 		</graphicData>
 		<statBases>
-			<MarketValue>44.9</MarketValue>
+			<MarketValue>41.3</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHE</ammoClass>
 		<detonateProjectile>Bullet_77x230mmRCannonShell_HE</detonateProjectile>

--- a/Patches/LF Red Dawn/135mm9M113Konkur.xml
+++ b/Patches/LF Red Dawn/135mm9M113Konkur.xml
@@ -53,7 +53,7 @@
 						<drawSize>1.0</drawSize>
 					</graphicData>
 					<statBases>
-						<MarketValue>180</MarketValue>
+						<MarketValue>170</MarketValue>
 						<Mass>14.1</Mass>
 						<Bulk>27.17</Bulk>
 					</statBases>

--- a/Patches/LF Red Dawn/82mmMortar.xml
+++ b/Patches/LF Red Dawn/82mmMortar.xml
@@ -69,7 +69,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>55.09</MarketValue>
+      <MarketValue>50.68</MarketValue>
     </statBases>
     <ammoClass>GrenadeHE</ammoClass>
 	<detonateProjectile>Bullet_82mmMortarShell_HE</detonateProjectile>

--- a/Patches/LF Red Dawn/RD_Grenade.xml
+++ b/Patches/LF Red Dawn/RD_Grenade.xml
@@ -275,7 +275,7 @@
 		<statBases>
 			<Mass>0.31</Mass>
 			<Bulk>1.5</Bulk>
-			<MarketValue>5.05</MarketValue>
+			<MarketValue>4.55</MarketValue>
 			<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 			<SightsEfficiency>0.65</SightsEfficiency>
 		</statBases>
@@ -307,7 +307,7 @@
 		<statBases>
 			<Mass>0.29</Mass>
 			<Bulk>1.5</Bulk>
-			<MarketValue>5.05</MarketValue>
+			<MarketValue>4.55</MarketValue>
 			<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 			<SightsEfficiency>0.65</SightsEfficiency>
 		</statBases>
@@ -339,7 +339,7 @@
 		<statBases>
 			<Mass>0.53</Mass>
 			<Bulk>1.5</Bulk>
-			<MarketValue>5.05</MarketValue>
+			<MarketValue>4.55</MarketValue>
 			<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 			<SightsEfficiency>0.65</SightsEfficiency>
 		</statBases>
@@ -371,7 +371,7 @@
 		<statBases>
 			<Mass>0.31</Mass>
 			<Bulk>1.5</Bulk>
-			<MarketValue>5.05</MarketValue>
+			<MarketValue>4.55</MarketValue>
 			<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 			<SightsEfficiency>0.65</SightsEfficiency>
 		</statBases>
@@ -403,7 +403,7 @@
 		<statBases>
 			<Mass>1.07</Mass>
 			<Bulk>1.5</Bulk>
-			<MarketValue>5.05</MarketValue>
+			<MarketValue>4.55</MarketValue>
 			<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 			<SightsEfficiency>0.65</SightsEfficiency>
 		</statBases>

--- a/Patches/LF Red Dawn/RD_Launchers.xml
+++ b/Patches/LF Red Dawn/RD_Launchers.xml
@@ -13,7 +13,7 @@
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 				<defName>Gun_RPG18D</defName>
 				<statBases>
-      					<MarketValue>35.72</MarketValue>
+      					<MarketValue>33.72</MarketValue>
 					<Mass>2.60</Mass>
 					<RangedWeapon_Cooldown>1.50</RangedWeapon_Cooldown>
 					<SightsEfficiency>1.00</SightsEfficiency>
@@ -60,7 +60,7 @@
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 				<defName>Gun_RPG22D</defName>
 				<statBases>
-      					<MarketValue>35.72</MarketValue>
+      					<MarketValue>33.72</MarketValue>
 					<Mass>2.80</Mass>
 					<RangedWeapon_Cooldown>1.50</RangedWeapon_Cooldown>
 					<SightsEfficiency>1.00</SightsEfficiency>
@@ -107,7 +107,7 @@
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 				<defName>Gun_RPG26D</defName>
 				<statBases>
-      					<MarketValue>35.72</MarketValue>
+      					<MarketValue>33.72</MarketValue>
 					<Mass>2.90</Mass>
 					<RangedWeapon_Cooldown>1.50</RangedWeapon_Cooldown>
 					<SightsEfficiency>1.00</SightsEfficiency>
@@ -154,7 +154,7 @@
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 				<defName>Gun_RPG27D</defName>
 				<statBases>
-      					<MarketValue>35.72</MarketValue>
+      					<MarketValue>33.72</MarketValue>
 					<Mass>7.60</Mass>
 					<RangedWeapon_Cooldown>1.50</RangedWeapon_Cooldown>
 					<SightsEfficiency>1.00</SightsEfficiency>

--- a/Patches/LF Red Dawn/RPG16.xml
+++ b/Patches/LF Red Dawn/RPG16.xml
@@ -54,7 +54,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>57.78</MarketValue>
+      <MarketValue>55.78</MarketValue>
       <Mass>2.8</Mass>
       <Bulk>9.37</Bulk>
     </statBases>
@@ -70,7 +70,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>38.96</MarketValue>
+      <MarketValue>36.96</MarketValue>
       <Mass>2.2</Mass>
       <Bulk>1.89</Bulk>
     </statBases>

--- a/Patches/LF Red Dawn/RPG29.xml
+++ b/Patches/LF Red Dawn/RPG29.xml
@@ -54,7 +54,7 @@
 						<drawSize>1.65</drawSize>
 					</graphicData>
 					<statBases>
-						<MarketValue>100</MarketValue>
+						<MarketValue>95</MarketValue>
 						<Mass>6.7</Mass>
 						<Bulk>9.17</Bulk>
 					</statBases>
@@ -70,7 +70,7 @@
 					<graphicClass>Graphic_StackCount</graphicClass>
 					</graphicData>
 					<statBases>
-					<MarketValue>123.58</MarketValue>
+					<MarketValue>119.58</MarketValue>
 					<Mass>6.7</Mass>
 					<Bulk>9.99</Bulk>
 					</statBases>

--- a/Patches/LTS Military/Weapons.xml
+++ b/Patches/LTS Military/Weapons.xml
@@ -725,7 +725,7 @@
           <statBases>
             <Mass>0.82</Mass>
             <Bulk>0.36</Bulk>
-            <MarketValue>12.22</MarketValue>
+            <MarketValue>11.22</MarketValue>
             <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
             <SightsEfficiency>0.65</SightsEfficiency>
           </statBases>

--- a/Patches/Mass Effect - Playable Geth/Ammo_ME.xml
+++ b/Patches/Mass Effect - Playable Geth/Ammo_ME.xml
@@ -132,7 +132,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>51.78</MarketValue>
+      <MarketValue>49.78</MarketValue>
       <Mass>2.25</Mass>
       <Bulk>3.5</Bulk>
     </statBases>

--- a/Patches/Miho Race/Ammo/Ammo_Miho_Industrial.xml
+++ b/Patches/Miho Race/Ammo/Ammo_Miho_Industrial.xml
@@ -366,7 +366,7 @@
 					<graphicClass>Graphic_StackCount</graphicClass>
 				</graphicData>
 				<statBases>
-					<MarketValue>22.21</MarketValue>
+					<MarketValue>21.21</MarketValue>
 				</statBases>
 				<ammoClass>ExplosiveAP</ammoClass>
 				<cookOffProjectile>Bullet_Miho47x285mm_HE</cookOffProjectile>
@@ -380,7 +380,7 @@
 					<graphicClass>Graphic_StackCount</graphicClass>
 				</graphicData>
 				<statBases>
-					<MarketValue>8.57</MarketValue>
+					<MarketValue>7.57</MarketValue>
 				</statBases>
 				<ammoClass>ArmorPiercing</ammoClass>
 				<cookOffProjectile>Bullet_Miho47x285mm_AP</cookOffProjectile>

--- a/Patches/Morgante WW2 Italian Weapons/Patch_Ammo.xml
+++ b/Patches/Morgante WW2 Italian Weapons/Patch_Ammo.xml
@@ -57,7 +57,7 @@
 		<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-		<MarketValue>36.3</MarketValue>
+		<MarketValue>35.3</MarketValue>
 		</statBases>
 		<ammoClass>RocketHEAT</ammoClass>
 		<detonateProjectile>Bullet_60mmGrenade_HEAT</detonateProjectile>

--- a/Patches/Not Only Just A Cannon/Patch_Cannon_Ammo.xml
+++ b/Patches/Not Only Just A Cannon/Patch_Cannon_Ammo.xml
@@ -47,7 +47,7 @@
 			<statBases>
 				<MaxHitPoints>100</MaxHitPoints>
 				<Mass>19</Mass>
-				<Bulk>22.41</Bulk>
+				<Bulk>21.41</Bulk>
 			</statBases>
 			<cookOffFlashScale>30</cookOffFlashScale>
 			<cookOffSound>MortarBomb_Explode</cookOffSound>
@@ -84,7 +84,7 @@
 				<graphicClass>Graphic_StackCount</graphicClass>
 			</graphicData>
 			<statBases>
-				<MarketValue>1.83</MarketValue>
+				<MarketValue>100.83</MarketValue>
 			</statBases>
 			<ammoClass>GrenadeHE</ammoClass>
 			<comps>

--- a/Patches/Nyaron/Ammo/Ammo_Nyaron.xml
+++ b/Patches/Nyaron/Ammo/Ammo_Nyaron.xml
@@ -312,7 +312,7 @@
 					  <graphicClass>Graphic_StackCount</graphicClass>
 					</graphicData>
 					<statBases>
-					  <MarketValue>1.69</MarketValue>
+					  <MarketValue>1.56</MarketValue>
 					</statBases>
 					<ammoClass>GrenadeHE</ammoClass>
 					<thingCategories Inherit="False">

--- a/Patches/Orassans/Ammo/40x90mmGrenadeOE.xml
+++ b/Patches/Orassans/Ammo/40x90mmGrenadeOE.xml
@@ -56,7 +56,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>3.5</MarketValue>
+      <MarketValue>3.3</MarketValue>
     </statBases>
     <ammoClass>GrenadeHE</ammoClass>
 	<detonateProjectile>Bullet_40x90mmGrenadeOE_HE</detonateProjectile>
@@ -70,7 +70,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>3.9</MarketValue>
+      <MarketValue>3.6</MarketValue>
     </statBases>
     <ammoClass>GrenadeHEAT</ammoClass>
 	<detonateProjectile>Bullet_40x90mmGrenadeOE_HEAT</detonateProjectile>

--- a/Patches/Orassans/Ammo/ChemicalCompoundOE.xml
+++ b/Patches/Orassans/Ammo/ChemicalCompoundOE.xml
@@ -58,7 +58,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>5.2</MarketValue>
+      <MarketValue>5.0</MarketValue>
     </statBases>
     <ammoClass>ChemicalMunitionCompoundCryo</ammoClass>
 	<detonateProjectile>Bullet_ChemicalCompoundOE_Cryo</detonateProjectile>
@@ -72,7 +72,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>3.5</MarketValue>
+      <MarketValue>3.3</MarketValue>
     </statBases>
     <ammoClass>IncendiaryFuel</ammoClass>
 	<detonateProjectile>Bullet_ChemicalCompoundOE_Napalm</detonateProjectile>
@@ -86,7 +86,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>7.5</MarketValue>
+      <MarketValue>7.2</MarketValue>
     </statBases>
     <ammoClass>ChemicalMunitionCompoundAprometheum</ammoClass>
 	<detonateProjectile>Bullet_ChemicalCompoundOE_Aprometheum</detonateProjectile>
@@ -100,7 +100,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>9.5</MarketValue>
+      <MarketValue>8.5</MarketValue>
     </statBases>
     <ammoClass>ChemicalMunitionCompoundThermobaric</ammoClass>
 	<detonateProjectile>Bullet_ChemicalCompoundOE_Thermobaric</detonateProjectile>

--- a/Patches/Orassans/Ammo/MissileAmmo.xml
+++ b/Patches/Orassans/Ammo/MissileAmmo.xml
@@ -57,7 +57,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>151.46</MarketValue>
+			<MarketValue>141.46</MarketValue>
 		</statBases>
 		<ammoClass>RocketHEAT</ammoClass>
 		<detonateProjectile>Bullet_OrassanMissileShell_HEAT</detonateProjectile>
@@ -71,7 +71,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>198.99</MarketValue>
+			<MarketValue>180.99</MarketValue>
 		</statBases>
 		<ammoClass>RocketHE</ammoClass>
 		<detonateProjectile>Bullet_OrassanMissileShell_HE</detonateProjectile>

--- a/Patches/Paniel the Automata/Ammo/Ammo_Paniel.xml
+++ b/Patches/Paniel the Automata/Ammo/Ammo_Paniel.xml
@@ -75,7 +75,7 @@
 						  <li>CE_AutoEnableTrade</li>
 						</tradeTags>
 						<statBases>
-							<MarketValue>233.6</MarketValue>
+							<MarketValue>221.6</MarketValue>
 						</statBases>
 						<ammoClass>GrenadeHE</ammoClass>
 						<detonateProjectile>Bullet_PanielHowitzerShell_HE</detonateProjectile>

--- a/Patches/Pratt WWII Weapons Pack/PWW2_CE_Patch_Weapons_Grenades.xml
+++ b/Patches/Pratt WWII Weapons Pack/PWW2_CE_Patch_Weapons_Grenades.xml
@@ -151,7 +151,7 @@
 				<statBases>
 					<Mass>0.595</Mass>
 					<Bulk>0.91</Bulk>
-					<MarketValue>10.95</MarketValue>
+					<MarketValue>9.95</MarketValue>
 					<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 					<SightsEfficiency>0.45</SightsEfficiency>
 				</statBases>
@@ -286,7 +286,7 @@
 				<statBases>
 					<Mass>0.595</Mass>
 					<Bulk>4.22</Bulk>
-					<MarketValue>13.41</MarketValue>
+					<MarketValue>12.41</MarketValue>
 					<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 					<SightsEfficiency>0.45</SightsEfficiency>
 				</statBases>
@@ -428,7 +428,7 @@
 				<statBases>
 					<Mass>0.45</Mass>
 					<Bulk>0.57</Bulk>
-					<MarketValue>10.55</MarketValue>
+					<MarketValue>9.55</MarketValue>
 					<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 					<SightsEfficiency>0.45</SightsEfficiency>
 				</statBases>
@@ -563,7 +563,7 @@
 				<statBases>
 					<Mass>0.75</Mass>
 					<Bulk>1.31</Bulk>
-					<MarketValue>11.74</MarketValue>
+					<MarketValue>10.74</MarketValue>
 					<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 					<SightsEfficiency>0.45</SightsEfficiency>
 				</statBases>
@@ -698,7 +698,7 @@
 				<statBases>
 					<Mass>0.55</Mass>
 					<Bulk>0.65</Bulk>
-					<MarketValue>10.95</MarketValue>
+					<MarketValue>9.95</MarketValue>
 					<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 					<SightsEfficiency>0.45</SightsEfficiency>
 				</statBases>
@@ -833,7 +833,7 @@
 				<statBases>
 					<Mass>0.765</Mass>
 					<Bulk>0.84</Bulk>
-					<MarketValue>11.74</MarketValue>
+					<MarketValue>10.74</MarketValue>
 					<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 					<SightsEfficiency>0.45</SightsEfficiency>
 				</statBases>

--- a/Patches/RH2 Rimmu-Nation² - Security/152mmBGM71.xml
+++ b/Patches/RH2 Rimmu-Nation² - Security/152mmBGM71.xml
@@ -53,7 +53,7 @@
 						<drawSize>1.65</drawSize>
 					</graphicData>
 					<statBases>
-						<MarketValue>248.27</MarketValue>
+						<MarketValue>232.27</MarketValue>
 						<Mass>21.5</Mass>
 						<Bulk>36.17</Bulk>
 					</statBases>

--- a/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_Grenades.xml
+++ b/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_Grenades.xml
@@ -129,7 +129,7 @@
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 				<defName>RNThrown_C4CSGO</defName>
 				<statBases>
-					<Mass>3.42</Mass>
+					<Mass>2.92</Mass>
 					<Bulk>6.8</Bulk>
 					<MarketValue>184.2</MarketValue>
 					<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>

--- a/Patches/Rimsenal Collection/Core/Weapons_Explosives.xml
+++ b/Patches/Rimsenal Collection/Core/Weapons_Explosives.xml
@@ -318,7 +318,7 @@
 		<defName>YP_BaegYa</defName>
 		<statBases>
 				<Mass>0.4</Mass>
-				<MarketValue>5.25</MarketValue>
+				<MarketValue>4.75</MarketValue>
 				<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 				<SightsEfficiency>1</SightsEfficiency>
 		</statBases>
@@ -366,7 +366,7 @@
 		<defName>JI_Dunder</defName>
 		<statBases>
 				<Mass>2.5</Mass>
-				<MarketValue>8.25</MarketValue>
+				<MarketValue>7.25</MarketValue>
 				<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 				<SightsEfficiency>1</SightsEfficiency>
 		</statBases>
@@ -413,7 +413,7 @@
 		<defName>GD_Bobcat</defName>
 		<statBases>
 				<Mass>0.4</Mass>
-				<MarketValue>5.25</MarketValue>
+				<MarketValue>4.75</MarketValue>
 				<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 				<SightsEfficiency>1</SightsEfficiency>
 				<ShotSpread>1.0</ShotSpread>
@@ -463,7 +463,7 @@
 		<defName>TE_Grief</defName>
 		<statBases>
 				<Mass>0.4</Mass>
-				<MarketValue>5.25</MarketValue>
+				<MarketValue>4.75</MarketValue>
 				<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 				<SightsEfficiency>1</SightsEfficiency>
 		</statBases>

--- a/Patches/Rimsenal Collection/Security/Ammo_Security.xml
+++ b/Patches/Rimsenal Collection/Security/Ammo_Security.xml
@@ -211,7 +211,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 			</graphicData>
 			<statBases>
-			<MarketValue>70</MarketValue>
+			<MarketValue>65</MarketValue>
 			<Mass>10</Mass>
 			<Bulk>10</Bulk>
 			</statBases>
@@ -240,7 +240,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 			</graphicData>
 			<statBases>
-			<MarketValue>70</MarketValue>
+			<MarketValue>65</MarketValue>
 			<Mass>10</Mass>
 			<Bulk>10</Bulk>
 			</statBases>

--- a/Patches/Urbworld Weaponry - Caseless/7.7mmPC.xml
+++ b/Patches/Urbworld Weaponry - Caseless/7.7mmPC.xml
@@ -100,7 +100,7 @@
         <graphicClass>Graphic_StackCount</graphicClass>
       </graphicData>
       <statBases>
-        <MarketValue>0.24</MarketValue>
+        <MarketValue>0.22</MarketValue>
       </statBases>
       <ammoClass>IncendiaryAP</ammoClass>
       <cookOffProjectile>Bullet_77x49mmPC_Incendiary</cookOffProjectile>

--- a/Patches/Vanilla XCOM weapons/MAG weapons/Ammo.xml
+++ b/Patches/Vanilla XCOM weapons/MAG weapons/Ammo.xml
@@ -86,7 +86,7 @@
 							<statBases>
 								<Mass>0.01</Mass>
 								<Bulk>0.008</Bulk>
-								<MarketValue>0.06</MarketValue>
+								<MarketValue>0.05</MarketValue>
 							</statBases>
 							<tradeTags>
 								<li>CE_AutoEnableTrade</li>
@@ -435,7 +435,7 @@
 							<statBases>
 								<Mass>0.01</Mass>
 								<Bulk>0.008</Bulk>
-								<MarketValue>0.06</MarketValue>
+								<MarketValue>0.05</MarketValue>
 							</statBases>
 							<tradeTags>
 								<li>CE_AutoEnableTrade</li>
@@ -743,7 +743,7 @@
 							<statBases>
 								<Mass>0.009</Mass>
 								<Bulk>0.01</Bulk>
-								<MarketValue>0.06</MarketValue>
+								<MarketValue>0.05</MarketValue>
 							</statBases>
 							<tradeTags>
 								<li>CE_AutoEnableTrade</li>

--- a/Patches/Vanilla XCOM weapons/Plasma weapons/Ammo.xml
+++ b/Patches/Vanilla XCOM weapons/Plasma weapons/Ammo.xml
@@ -81,7 +81,7 @@
 							<statBases>
 								<Mass>0.014</Mass>
 								<Bulk>0.01</Bulk>
-								<MarketValue>0.23</MarketValue>
+								<MarketValue>0.2</MarketValue>
 							</statBases>
 							<tradeTags>
 								<li>CE_AutoEnableTrade</li>
@@ -118,7 +118,7 @@
 							<statBases>
 								<Mass>0.014</Mass>
 								<Bulk>0.01</Bulk>
-								<MarketValue>0.23</MarketValue>
+								<MarketValue>0.2</MarketValue>
 							</statBases>
 							<tradeTags>
 								<li>CE_AutoEnableTrade</li>
@@ -155,7 +155,7 @@
 							<statBases>
 								<Mass>0.014</Mass>
 								<Bulk>0.01</Bulk>
-								<MarketValue>0.23</MarketValue>
+								<MarketValue>0.2</MarketValue>
 							</statBases>
 							<tradeTags>
 								<li>CE_AutoEnableTrade</li>


### PR DESCRIPTION
## Changes

- Reduced the amount of FSX being secreted from large animals like boomalopes.
- Reduced the market value of FSX down to 7.5$ along with the necessary changes.
- Made both FSX and Prometheum deteriorate-able like other manufactured resources.

## Reasoning

- 10 FSX per 10 days results in boomalopes being the most profitable animal to keep as each 15 days the yield from their products amount to 530$ (x10 FSX and x165 chemfuel) and something like a muffalo only gives 324$ from its wool. FSX is already easy enough to get, an animal that prints it for very low investment is too much.
- It seemed like both FSX and Prometheum were not deteriorate-able due do a missing node as both make sense to deteriorate like any other manufactured resource.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
