### PR TITLE
Make CE load after VTE

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -80,5 +80,6 @@
 		<li>sarg.alphamechs</li>
 		<li>Slashandz.MiniMiner</li>
 		<li>Killathon.MechHumanlikes.MechanicalBiomimetics</li>
+		<li>VanillaExpanded.VTEXE</li>
 	</loadAfter>
 </ModMetaData>


### PR DESCRIPTION
## Changes

- VTE overrides the glorious textures in CE, it's time we ended that.

## Reasoning

- Most people don't know that CE retextures the vanilla ranged weapons and when coupled with CE Guns' renaming of the guns, it can lead to weird situations like mismatching guns and names.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
