### PR TITLE
Compatibility patch for Possessed Weapons

### DIFF
--- a/Patches/Possesed Weapons/PossessedWeapons_MeleePatch.xml
+++ b/Patches/Possesed Weapons/PossessedWeapons_MeleePatch.xml
@@ -1,0 +1,613 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Table of contents
+
+        BotchJob_PossessedScourgeBlade
+		BotchJob_PossessedGlacialCleaver
+		BotchJob_PossessedSanctifiedSword
+		BotchJob_PossessedVolcanicMaul
+		BotchJob_PossessedCraghammer
+		BotchJob_PossessedDragonfireGreatbow
+		BotchJob_PossessedLightningJavelin
+		BotchJob_PossessedArchmageStaff
+		BotchJob_PossessedAutomatonCrossbow
+		BotchJob_PossessedVerdantBow
+		BotchJob_PossessedGildedArquebus
+		BotchJob_PossessedShroudedDagger
+		BotchJob_PossessedAcolyteStaff
+		
+		BotchJob_ScourgeBlade
+		BotchJob_GlacialCleaver
+		BotchJob_SanctifiedSword
+		BotchJob_VolcanicMaul
+		BotchJob_Craghammer
+		BotchJob_DragonfireGreatbow
+		BotchJob_LightningJavelin
+		BotchJob_ArchmageStaff
+		BotchJob_AutomatonCrossbow
+		BotchJob_VerdantBow
+		BotchJob_GildedArquebus
+		BotchJob_ShroudedDagger
+		BotchJob_AcolyteStaff
+		
+		
+-->
+
+<Patch>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Possessed Weapons</li>
+    </mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+			
+			<!--=============================== Melee ================================-->
+
+			<!--=============================== Scourge Blade ================================-->
+			
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="BotchJob_ScourgeBlade"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>handle</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>3</power>
+								<chanceFactor>0.1</chanceFactor>
+								<cooldownTime>1.69</cooldownTime>
+								<armorPenetrationBlunt>0.8</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>edge</label>
+								<capacities>
+									<li>BotchJob_ToxicCut</li>
+								</capacities>
+								<power>40</power>
+								<cooldownTime>2.06</cooldownTime>
+								<armorPenetrationBlunt>3.2</armorPenetrationBlunt>
+								<armorPenetrationSharp>16</armorPenetrationSharp>
+								<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>point</label>
+								<capacities>
+									<li>BotchJob_ToxicStab</li>
+								</capacities>
+								<power>17</power>					
+								<cooldownTime>0.99</cooldownTime>
+								<armorPenetrationBlunt>3.24</armorPenetrationBlunt>
+								<armorPenetrationSharp>32.4</armorPenetrationSharp>
+							</li>					
+						</tools>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="BotchJob_ScourgeBlade"]/statBases</xpath>
+					<value>
+						<Bulk>8.5</Bulk>
+						<MeleeCounterParryBonus>0.80</MeleeCounterParryBonus>				
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="BotchJob_ScourgeBlade"]/equippedStatOffsets</xpath>
+					<value>
+							<MeleeCritChance>1.00</MeleeCritChance>
+							<MeleeParryChance>0.60</MeleeParryChance>
+							<MeleeDodgeChance>0.4</MeleeDodgeChance>
+					</value>
+				</li>
+
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[defName="BotchJob_ScourgeBlade"]/weaponTags</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="BotchJob_ScourgeBlade"]</xpath>
+						<value>
+							<weaponTags />
+						</value>
+					</nomatch>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="BotchJob_ScourgeBlade"]/weaponTags</xpath>
+					<value>
+						<li>CE_OneHandedWeapon</li>
+					</value>
+				</li>
+		
+		
+			<!--=============================== Possessed Scourge Blade ================================-->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="BotchJob_PossessedScourgeBlade"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>handle</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>3</power>
+								<chanceFactor>0.1</chanceFactor>
+								<cooldownTime>1.52</cooldownTime>
+								<armorPenetrationBlunt>0.97</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>edge</label>
+								<capacities>
+									<li>BotchJob_ToxicCut</li>
+								</capacities>
+								<power>40</power>
+								<cooldownTime>1.85</cooldownTime>
+								<armorPenetrationBlunt>3.87</armorPenetrationBlunt>
+								<armorPenetrationSharp>19.36</armorPenetrationSharp>
+								<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>point</label>
+								<capacities>
+									<li>BotchJob_ToxicStab</li>
+								</capacities>
+								<power>17</power>					
+								<cooldownTime>0.89</cooldownTime>
+								<armorPenetrationBlunt>3.92</armorPenetrationBlunt>
+								<armorPenetrationSharp>39.2</armorPenetrationSharp>
+							</li>					
+						</tools>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="BotchJob_PossessedScourgeBlade"]/statBases</xpath>
+					<value>
+						<Bulk>8.5</Bulk>
+						<MeleeCounterParryBonus>1.2</MeleeCounterParryBonus>				
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="BotchJob_PossessedScourgeBlade"]/equippedStatOffsets</xpath>
+					<value>
+							<MeleeCritChance>1.00</MeleeCritChance>
+							<MeleeParryChance>0.69</MeleeParryChance>
+							<MeleeDodgeChance>0.46</MeleeDodgeChance>
+					</value>
+				</li>
+				
+			<!--=============================== Glacial Cleaver ================================-->	
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="BotchJob_GlacialCleaver"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>handle</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>9</power>
+								<chanceFactor>0.1</chanceFactor>
+								<cooldownTime>0.99</cooldownTime>
+								<armorPenetrationBlunt>6</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>edge</label>
+								<capacities>
+									<li>BotchJob_FrostCut</li>
+								</capacities>
+								<power>46</power>
+								<extraMeleeDamages>
+								<li>
+								<def>Frostbite</def>
+								<amount>8</amount>
+								<chance>0.3</chance>
+								</li>
+								</extraMeleeDamages>
+								<cooldownTime>1.92</cooldownTime>
+								<armorPenetrationBlunt>6.48</armorPenetrationBlunt>
+								<armorPenetrationSharp>19.24</armorPenetrationSharp>
+								<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+							</li>				
+						</tools>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="BotchJob_GlacialCleaver"]/statBases</xpath>
+					<value>
+						<Bulk>10</Bulk>
+						<MeleeCounterParryBonus>0.13</MeleeCounterParryBonus>				
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="BotchJob_GlacialCleaver"]/equippedStatOffsets</xpath>
+					<value>
+						<MeleeCritChance>1</MeleeCritChance>
+						<MeleeParryChance>0.1</MeleeParryChance>
+						<MeleeDodgeChance>0.20</MeleeDodgeChance>
+					</value>
+				</li>		
+		
+			<!--=============================== Possessed Glaciar Cleaver ================================-->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="BotchJob_PossessedGlacialCleaver"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>handle</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>9</power>
+								<chanceFactor>0.1</chanceFactor>
+								<cooldownTime>0.89</cooldownTime>
+								<armorPenetrationBlunt>7.26</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>edge</label>
+								<capacities>
+									<li>BotchJob_FrostCut</li>
+								</capacities>
+								<power>46</power>
+								<extraMeleeDamages>
+								<li>
+								<def>Frostbite</def>
+								<amount>9</amount>
+								<chance>0.3</chance>
+								</li>
+								</extraMeleeDamages>
+								<cooldownTime>1.73</cooldownTime>
+								<armorPenetrationBlunt>7.84</armorPenetrationBlunt>
+								<armorPenetrationSharp>23.28</armorPenetrationSharp>
+								<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+							</li>				
+						</tools>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="BotchJob_PossessedGlacialCleaver"]/statBases</xpath>
+					<value>
+						<Bulk>10</Bulk>
+						<MeleeCounterParryBonus>0.15</MeleeCounterParryBonus>				
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="BotchJob_PossessedGlacialCleaver"]/equippedStatOffsets</xpath>
+					<value>
+							<MeleeCritChance>1</MeleeCritChance>
+							<MeleeParryChance>0.12</MeleeParryChance>
+							<MeleeDodgeChance>0.23</MeleeDodgeChance>	
+					</value>
+				</li>
+				
+			<!--=============================== Sanctified Sword ================================-->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="BotchJob_SanctifiedSword"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>handle</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>3</power>
+								<chanceFactor>0.1</chanceFactor>
+								<cooldownTime>1.6</cooldownTime>
+								<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>edge</label>
+								<capacities>
+									<li>Cut</li>
+								</capacities>
+								<power>40</power>
+								<cooldownTime>2.4</cooldownTime>
+								<armorPenetrationBlunt>2.88</armorPenetrationBlunt>
+								<armorPenetrationSharp>18</armorPenetrationSharp>
+								<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>point</label>
+								<capacities>
+									<li>Stab</li>
+								</capacities>
+								<power>17</power>					
+								<cooldownTime>2.4</cooldownTime>
+								<armorPenetrationBlunt>1.28</armorPenetrationBlunt>
+								<armorPenetrationSharp>25</armorPenetrationSharp>
+							</li>					
+						</tools>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="BotchJob_SanctifiedSword"]/statBases</xpath>
+					<value>
+						<Bulk>10</Bulk>
+						<MeleeCounterParryBonus>0.8</MeleeCounterParryBonus>				
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="BotchJob_SanctifiedSword"]/equippedStatOffsets</xpath>
+					<value>
+						<MeleeCritChance>1</MeleeCritChance>
+						<MeleeParryChance>0.6</MeleeParryChance>
+						<MeleeDodgeChance>0.4</MeleeDodgeChance>
+					</value>
+				</li>
+				
+				<!--=============================== Possessed Sanctified Sword ================================-->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="BotchJob_PossessedSanctifiedSword"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>handle</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>3</power>
+								<chanceFactor>0.1</chanceFactor>
+								<cooldownTime>1.44</cooldownTime>
+								<armorPenetrationBlunt>0.61</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>edge</label>
+								<capacities>
+									<li>Cut</li>
+								</capacities>
+								<power>40</power>
+								<cooldownTime>2.16</cooldownTime>
+								<armorPenetrationBlunt>3.48</armorPenetrationBlunt>
+								<armorPenetrationSharp>21.78</armorPenetrationSharp>
+								<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>point</label>
+								<capacities>
+									<li>Stab</li>
+								</capacities>
+								<power>17</power>					
+								<cooldownTime>2.16</cooldownTime>
+								<armorPenetrationBlunt>1.55</armorPenetrationBlunt>
+								<armorPenetrationSharp>30.25</armorPenetrationSharp>
+							</li>					
+						</tools>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="BotchJob_PossessedSanctifiedSword"]/statBases</xpath>
+					<value>
+						<Bulk>10</Bulk>
+						<MeleeCounterParryBonus>0.92</MeleeCounterParryBonus>				
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="BotchJob_PossessedSanctifiedSword"]/equippedStatOffsets</xpath>
+					<value>
+						<MeleeCritChance>1</MeleeCritChance>
+						<MeleeParryChance>0.69</MeleeParryChance>
+						<MeleeDodgeChance>0.46</MeleeDodgeChance>
+					</value>
+				</li>
+		
+					<!--=============================== Volcanic Maul ================================-->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="BotchJob_VolcanicMaul"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>handle</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>13</power>
+								<chanceFactor>0.1</chanceFactor>
+								<cooldownTime>2.67</cooldownTime>
+								<armorPenetrationBlunt>5</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>93</power>
+								<extraMeleeDamages>
+								<li>
+								<def>Flame</def>
+								<amount>8</amount>
+								<chance>0.3</chance>
+								</li>
+								</extraMeleeDamages>
+								<cooldownTime>3.47</cooldownTime>
+								<armorPenetrationBlunt>45</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+							</li>			
+						</tools>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="BotchJob_VolcanicMaul"]/statBases</xpath>
+					<value>
+						<Bulk>10</Bulk>
+						<MeleeCounterParryBonus>0.4</MeleeCounterParryBonus>				
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="BotchJob_VolcanicMaul"]</xpath>
+					<value>
+						<equippedStatOffsets>
+						<MeleeCritChance>1.5</MeleeCritChance>
+						<MeleeParryChance>0.3</MeleeParryChance>
+						<MeleeDodgeChance>0.3</MeleeDodgeChance>
+						</equippedStatOffsets>
+					</value>
+				</li>
+				
+				<!--=============================== Possessed Volcanic Sword ================================-->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="BotchJob_PossessedVolcanicMaul"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>handle</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>13</power>
+								<chanceFactor>0.1</chanceFactor>
+								<cooldownTime>2.4</cooldownTime>
+								<armorPenetrationBlunt>6.05</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>93</power>
+								<extraMeleeDamages>
+								<li>
+								<def>Flame</def>
+								<amount>8</amount>
+								<chance>0.3</chance>
+								</li>
+								</extraMeleeDamages>
+								<cooldownTime>3.12</cooldownTime>
+								<armorPenetrationBlunt>54.45</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+							</li>			
+						</tools>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="BotchJob_PossessedVolcanicMaul"]/statBases</xpath>
+					<value>
+						<Bulk>10</Bulk>
+						<MeleeCounterParryBonus>0.46</MeleeCounterParryBonus>				
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="BotchJob_PossessedVolcanicMaul"]/equippedStatOffsets</xpath>
+					<value>
+						<MeleeCritChance>1.5</MeleeCritChance>
+						<MeleeParryChance>0.35</MeleeParryChance>
+						<MeleeDodgeChance>0.35</MeleeDodgeChance>
+					</value>
+				</li>
+		
+							<!--=============================== Craghammer ================================-->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="BotchJob_Craghammer"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>handle</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>11</power>
+								<chanceFactor>0.1</chanceFactor>
+								<cooldownTime>2.52</cooldownTime>
+								<armorPenetrationBlunt>4</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Demolish</li>
+								</capacities>
+								<power>76</power>
+								<cooldownTime>3.28</cooldownTime>
+								<armorPenetrationBlunt>36</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+							</li>			
+						</tools>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="BotchJob_Craghammer"]/statBases</xpath>
+					<value>
+						<Bulk>10</Bulk>
+						<MeleeCounterParryBonus>0.4</MeleeCounterParryBonus>				
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="BotchJob_Craghammer"]/equippedStatOffsets</xpath>
+					<value>
+						<MeleeCritChance>1.5</MeleeCritChance>
+						<MeleeParryChance>0.3</MeleeParryChance>
+						<MeleeDodgeChance>0.3</MeleeDodgeChance>
+					</value>
+				</li>
+				
+				<!--=============================== Possessed Sanctified Sword ================================-->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="BotchJob_PossessedCraghammer"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>handle</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>11</power>
+								<chanceFactor>0.1</chanceFactor>
+								<cooldownTime>2.27</cooldownTime>
+								<armorPenetrationBlunt>4.84</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Demolish</li>
+								</capacities>
+								<power>76</power>
+								<cooldownTime>2.95</cooldownTime>
+								<armorPenetrationBlunt>43.56</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+							</li>			
+						</tools>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="BotchJob_PossessedCraghammer"]/statBases</xpath>
+					<value>
+						<Bulk>10</Bulk>
+						<MeleeCounterParryBonus>0.46</MeleeCounterParryBonus>				
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="BotchJob_PossessedCraghammer"]/equippedStatOffsets</xpath>
+					<value>
+						<MeleeCritChance>1.5</MeleeCritChance>
+						<MeleeParryChance>0.35</MeleeParryChance>
+						<MeleeDodgeChance>0.35</MeleeDodgeChance>
+					</value>
+				</li>		
+			
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Possesed Weapons/PossessedWeapons_RangedPatch.xml
+++ b/Patches/Possesed Weapons/PossessedWeapons_RangedPatch.xml
@@ -1,0 +1,1474 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Table of contents
+
+     	BotchJob_PossessedDragonfireGreatbow
+		BotchJob_PossessedLightningJavelin
+		BotchJob_PossessedArchmageStaff
+		BotchJob_PossessedAutomatonCrossbow
+		BotchJob_PossessedVerdantBow
+		BotchJob_PossessedGildedArquebus
+		BotchJob_PossessedShroudedDagger
+		BotchJob_PossessedAcolyteStaff
+		
+		BotchJob_DragonfireGreatbow
+		BotchJob_LightningJavelin
+		BotchJob_ArchmageStaff
+		BotchJob_AutomatonCrossbow
+		BotchJob_VerdantBow
+		BotchJob_GildedArquebus
+		BotchJob_ShroudedDagger
+		BotchJob_AcolyteStaff
+		
+		
+-->
+
+<Patch>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Possessed Weapons</li>
+    </mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+			
+			<!--=============================== Ranged ================================-->
+
+			<!--=============================== Dragonfire Greatbow ================================-->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>BotchJob_DragonfireGreatbow</defName>
+				<statBases>
+					<SightsEfficiency>0.6</SightsEfficiency>
+					<ShotSpread>1</ShotSpread>
+					<SwayFactor>2</SwayFactor>
+					<Bulk>10.00</Bulk>
+					<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+				</statBases>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Projectile_LesserDragonFireArrow</defaultProjectile>
+					<warmupTime>4</warmupTime>
+					<range>30</range>
+					<soundCast>Bow_Large</soundCast>
+					<muzzleFlashScale>14</muzzleFlashScale>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+				</Properties>
+				<AmmoUser>
+					<ammoSet>AmmoSet_LesserDragonFireArrow</ammoSet>
+				</AmmoUser>
+				<FireModes />
+				<weaponTags>
+					<li>BotchJob_DragonfireGreatbow</li>
+				</weaponTags>
+				<AllowWithRunAndGun>false</AllowWithRunAndGun>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="BotchJob_DragonfireGreatbow"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>7</power>
+							<cooldownTime>1.6</cooldownTime>
+							<armorPenetrationBlunt>0.65</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<!-- Possessed Dragonfire Bow -->
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>BotchJob_PossessedDragonfireGreatbow</defName>
+				<statBases>
+					<SightsEfficiency>0.6</SightsEfficiency>
+					<ShotSpread>1</ShotSpread>
+					<SwayFactor>2</SwayFactor>
+					<Bulk>10.00</Bulk>
+					<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+				</statBases>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Projectile_DragonFireArrow</defaultProjectile>
+					<warmupTime>4</warmupTime>
+					<range>30</range>
+					<soundCast>Bow_Large</soundCast>
+					<muzzleFlashScale>14</muzzleFlashScale>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+				</Properties>
+				<AmmoUser>
+					<ammoSet>AmmoSet_DragonFireArrow</ammoSet>
+				</AmmoUser>
+				<FireModes />
+				<weaponTags>
+					<li>BotchJob_PossessedDragonfireGreatbow</li>
+				</weaponTags>
+				<AllowWithRunAndGun>false</AllowWithRunAndGun>
+			</li>
+
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="BotchJob_PossessedDragonfireGreatbow"]/equippedStatOffsets</xpath>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="BotchJob_PossessedDragonfireGreatbow"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>7</power>
+							<cooldownTime>1.44</cooldownTime>
+							<armorPenetrationBlunt>0.79</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<!-- Dragonfire Ammo Sets -->
+			<li Class="PatchOperationAdd">
+					<xpath>Defs</xpath>
+					<value>
+
+						<CombatExtended.AmmoSetDef>
+							<defName>AmmoSet_LesserDragonFireArrow</defName>
+							<label>great arrows</label>
+							<ammoTypes>
+								<Ammo_GreatArrow_Stone>Projectile_LesserDragonFireArrow</Ammo_GreatArrow_Stone>
+								<Ammo_GreatArrow_Steel>Projectile_LesserDragonFireArrow</Ammo_GreatArrow_Steel>
+								<Ammo_GreatArrow_Venom>Projectile_LesserDragonFireArrow</Ammo_GreatArrow_Venom>
+								<Ammo_GreatArrow_Flame>Projectile_LesserDragonFireArrow</Ammo_GreatArrow_Flame>
+							</ammoTypes>
+						</CombatExtended.AmmoSetDef>
+						
+						<CombatExtended.AmmoSetDef>
+							<defName>AmmoSet_DragonFireArrow</defName>
+							<label>great arrows</label>
+							<ammoTypes>
+								<Ammo_GreatArrow_Stone>Projectile_DragonFireArrow</Ammo_GreatArrow_Stone>
+								<Ammo_GreatArrow_Steel>Projectile_DragonFireArrow</Ammo_GreatArrow_Steel>
+								<Ammo_GreatArrow_Venom>Projectile_DragonFireArrow</Ammo_GreatArrow_Venom>
+								<Ammo_GreatArrow_Flame>Projectile_DragonFireArrow</Ammo_GreatArrow_Flame>
+							</ammoTypes>
+						</CombatExtended.AmmoSetDef>
+
+						<ThingDef ParentName="BaseGreatArrowProjectile">
+							<defName>Projectile_LesserDragonFireArrow</defName>
+							<label>dragon fire arrow</label>
+							<graphicData>
+								<texPath>Things/Projectile/DragonfireArrow</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+							</graphicData>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<speed>30</speed>
+								<damageDef>BotchJob_LesserDragonfireArrow</damageDef>
+								<damageAmountBase>7</damageAmountBase>
+								<explosionRadius>2</explosionRadius>
+								<ai_IsIncendiary>true</ai_IsIncendiary>
+								<preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
+								<preExplosionSpawnChance>0.33</preExplosionSpawnChance>
+							</projectile>
+						</ThingDef>
+						
+						<ThingDef ParentName="BaseGreatArrowProjectile">
+							<defName>Projectile_DragonFireArrow</defName>
+							<label>dragon fire arrow</label>
+							<graphicData>
+								<texPath>Things/Projectile/DragonfireArrow</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+							</graphicData>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<speed>30</speed>
+								<damageDef>BotchJob_DragonfireArrow</damageDef>
+								<damageAmountBase>15</damageAmountBase>
+								<explosionRadius>3</explosionRadius>
+								<ai_IsIncendiary>true</ai_IsIncendiary>
+								<preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
+								<preExplosionSpawnChance>0.33</preExplosionSpawnChance>
+							</projectile>
+						</ThingDef>
+
+					</value>
+				</li>
+			
+			<!--=============================== Lightning Javelin ================================-->			
+			<li Class="PatchOperationAttributeSet">
+			<xpath>Defs/ThingDef[defName="BotchJob_LightningJavelin"]</xpath>
+			<attribute>ParentName</attribute>
+			<value>BaseWeapon</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="BotchJob_LightningJavelin"]</xpath>
+				<value>
+				<thingClass>CombatExtended.AmmoThing</thingClass>
+				<stackLimit>5</stackLimit>
+				<resourceReadoutPriority>First</resourceReadoutPriority>
+				<techLevel>Medieval</techLevel>
+				<tradeNeverStack>true</tradeNeverStack>
+				<relicChance>3</relicChance>
+				<burnableByRecipe>true</burnableByRecipe>
+				<thingSetMakerTags>
+					<li>RewardStandardMidFreq</li>
+				</thingSetMakerTags>
+			</value>
+			</li>
+			
+			<li Class="PatchOperationAttributeSet">
+				<xpath>Defs/ThingDef[defName="BotchJob_LightningJavelin"]</xpath>
+				<attribute>Class</attribute>
+				<value>CombatExtended.AmmoDef</value>
+			</li>
+	
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>BotchJob_LightningJavelin</defName>
+				<statBases>
+					<SightsEfficiency>1</SightsEfficiency>
+					<Bulk>2</Bulk>
+					<Mass>2</Mass>
+					<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+					<MeleeCounterParryBonus>0.36</MeleeCounterParryBonus>
+				</statBases>
+				<Properties>
+				<label>Throw lightning javelin</label>
+				<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+				<hasStandardCommand>True</hasStandardCommand>
+				<defaultProjectile>Projectile_ThrownLightningJavelin</defaultProjectile>
+				<warmupTime>1</warmupTime>
+				<range>25</range>
+				<soundCast>Power_OnSmall</soundCast>
+				<ai_IsBuildingDestroyer>false</ai_IsBuildingDestroyer>
+				<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+				</targetParams>
+				</Properties>
+				<weaponTags>
+				<li>CE_OneHandedWeapon</li>
+				</weaponTags>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="BotchJob_ShroudedDagger"]/equippedStatOffsets</xpath>
+					<value>
+						<MeleeCritChance>0.17</MeleeCritChance>
+						<MeleeDodgeChance>0.6</MeleeDodgeChance>
+						<MeleeParryChance>0.5</MeleeParryChance>
+					</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="BotchJob_LightningJavelin"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>handle</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>11</power>
+								<cooldownTime>2.52</cooldownTime>
+								<armorPenetrationBlunt>4</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>point</label>
+								<capacities>
+									<li>Stab</li>
+								</capacities>
+								<power>26</power>
+								<cooldownTime>2.52</cooldownTime>
+								<chanceFactor>1.33</chanceFactor>
+								<armorPenetrationBlunt>4</armorPenetrationBlunt>
+								<armorPenetrationSharp>3.34</armorPenetrationSharp>
+								<extraMeleeDamages>
+									<li>
+										<def>EMP</def>
+										<amount>9</amount>
+									</li>
+								</extraMeleeDamages>
+								<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+							</li>					
+						</tools>
+					</value>
+				</li>
+						
+			<!--=============================== Possessed Lightning Javelin ================================-->				
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+               <defName>BotchJob_PossessedLightningJavelin</defName>
+			   <statBases>
+					<SightsEfficiency>1</SightsEfficiency>
+					<Bulk>8</Bulk>
+					<Mass>4</Mass>
+					<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+				</statBases>
+               <Properties>
+                  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+                  <hasStandardCommand>true</hasStandardCommand>
+                  <defaultProjectile>Projectile_ThrownPossessedLightningJavelin</defaultProjectile>
+                  <warmupTime>3</warmupTime>
+                  <range>25</range>
+                  <soundCast>Power_OnSmall</soundCast>
+                  <ai_IsBuildingDestroyer>false</ai_IsBuildingDestroyer>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+               </Properties>
+               <FireModes>
+                  <aiAimMode>AimedShot</aiAimMode>
+               </FireModes>
+            </li>
+			
+			<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="BotchJob_PossessedLightningJavelin"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>handle</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>11</power>
+								<cooldownTime>2.26</cooldownTime>
+								<armorPenetrationBlunt>4.84</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>point</label>
+								<capacities>
+									<li>Stab</li>
+								</capacities>
+								<power>26</power>
+								<cooldownTime>2.26</cooldownTime>
+								<chanceFactor>1.33</chanceFactor>
+								<armorPenetrationBlunt>4.84</armorPenetrationBlunt>
+								<armorPenetrationSharp>4.04</armorPenetrationSharp>
+								<extraMeleeDamages>
+									<li>
+										<def>EMP</def>
+										<amount>9</amount>
+									</li>
+								</extraMeleeDamages>
+								<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+							</li>					
+						</tools>
+					</value>
+			</li> 
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="BotchJob_PossessedLightningJavelin"]/description</xpath>
+					<value>
+			 <description>A large, lightning infused spear that is deadly in close quarters but can also be thrown to produce an EMP burst on impact.\n\nThe electricity coursing through this weapon will energize its wielder, increasing their movement speed. The downside of this is that being constantly energized makes it difficult to sleep and as such, the wielder's rest rate will be slower.\n\nThis weapon is possessed by an ancient spirit and will exhibit some of their traits. The spirit will bond with the first person to wield it and thereafter, refuse to be wielded by anyone else.\n\nWhen wielded by the bonded person, the spirit will augment their combat abilities, allowing them to attack with greater ferocity, speed and accuracy than ever before. The spirit of the lightning javelin is temperamental and will depart once thrown.</description>
+				</value>
+			</li>
+			<!-- Projectile -->
+			<li Class="PatchOperationAdd">
+					<xpath>Defs</xpath>
+					<value>			
+					<ThingDef ParentName="BasePilumProjectile">
+					<defName>Projectile_ThrownPossessedLightningJavelin</defName>
+					<label>lightning javelin</label>
+					<graphicData>
+						<texPath>Things/Projectile/LightningJavelinThrown</texPath>
+						<graphicClass>Graphic_Single</graphicClass>
+					</graphicData>	
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<damageAmountBase>36</damageAmountBase>
+						<flyOverhead>false</flyOverhead>
+						<speed>20</speed>
+						<damageDef>EMP</damageDef>
+						<armorPenetrationBlunt>10</armorPenetrationBlunt>
+						<armorPenetrationSharp>8.34	</armorPenetrationSharp>
+						<preExplosionSpawnChance>1</preExplosionSpawnChance>
+						<preExplosionSpawnThingDef>BotchJob_LightningJavelin</preExplosionSpawnThingDef>
+					</projectile>
+						<comps>
+						<li Class="CombatExtended.CompProperties_ExplosiveCE">
+							<damageAmountBase>30</damageAmountBase>
+							<explosiveDamageType>EMP</explosiveDamageType>
+							<explosiveRadius>4</explosiveRadius>
+							<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+						</li>
+					</comps>	
+					</ThingDef>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+					<xpath>Defs</xpath>
+					<value>			
+					<ThingDef ParentName="BasePilumProjectile">
+					<defName>Projectile_ThrownLightningJavelin</defName>
+					<label>lightning javelin</label>
+					<graphicData>
+						<texPath>Things/Projectile/LightningJavelinThrown</texPath>
+						<graphicClass>Graphic_Single</graphicClass>
+					</graphicData>	
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<damageAmountBase>26</damageAmountBase>
+						<flyOverhead>false</flyOverhead>
+						<speed>20</speed>
+						<damageDef>EMP</damageDef>
+						<armorPenetrationBlunt>4.84</armorPenetrationBlunt>
+						<armorPenetrationSharp>4.04</armorPenetrationSharp>
+						<preExplosionSpawnChance>1</preExplosionSpawnChance>
+						<preExplosionSpawnThingDef>BotchJob_LightningJavelin</preExplosionSpawnThingDef>
+						</projectile>
+						<comps>
+						<li Class="CombatExtended.CompProperties_ExplosiveCE">
+							<damageAmountBase>20</damageAmountBase>
+							<explosiveDamageType>EMP</explosiveDamageType>
+							<explosiveRadius>2</explosiveRadius>
+							<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+						</li>
+					</comps>	
+					</ThingDef>
+				</value>
+			</li>
+			
+			<!--=============================== Archmage Staff ================================-->
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>BotchJob_ArchmageStaff</defName>
+				<statBases>
+					<SightsEfficiency>0.3</SightsEfficiency>
+					<ShotSpread>3</ShotSpread>
+					<SwayFactor>1</SwayFactor>
+					<Bulk>10.00</Bulk>
+					<RangedWeapon_Cooldown>2</RangedWeapon_Cooldown>
+				</statBases>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Projectile_ArchmageStaffBolt</defaultProjectile>
+					<warmupTime>6</warmupTime>
+					<range>30</range>
+					<ticksBetweenBurstShots>10</ticksBetweenBurstShots>
+					<burstShotCount>8</burstShotCount>
+					<soundAiming>BotchJob_ArchmageStaffCharge</soundAiming>
+					<soundCast>BotchJob_ArchmageStaffCast</soundCast>
+					<stopBurstWithoutLos>false</stopBurstWithoutLos>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+					<muzzleFlashScale>14</muzzleFlashScale>
+					<ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
+				</Properties>
+				<FireModes>
+                  <aiAimMode>AimedShot</aiAimMode>
+               </FireModes>
+				<weaponTags>
+					<li>BotchJob_ArchmageStaff</li>
+				</weaponTags>
+				<AllowWithRunAndGun>false</AllowWithRunAndGun>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="BotchJob_ArchmageStaff"]/tools</xpath>
+               <value>
+                  <tools>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>limb</label>
+                        <capacities>
+                           <li>Blunt</li>
+                           <li>Poke</li>
+                        </capacities>
+                        <power>6</power>
+                        <cooldownTime>1.2</cooldownTime>
+                        <armorPenetrationBlunt>0.4</armorPenetrationBlunt>
+                     </li>
+                  </tools>
+               </value>
+            </li>
+		
+			<!--=============================== Possessed Archmage Staff ================================-->
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>BotchJob_PossessedArchmageStaff</defName>
+				<statBases>
+					<SightsEfficiency>0.3</SightsEfficiency>
+					<ShotSpread>3</ShotSpread>
+					<SwayFactor>1</SwayFactor>
+					<Bulk>10.00</Bulk>
+					<RangedWeapon_Cooldown>2</RangedWeapon_Cooldown>
+				</statBases>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Projectile_ArchmageStaffBolt</defaultProjectile>
+					<warmupTime>5.4</warmupTime>
+					<range>30</range>
+					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+					<burstShotCount>10</burstShotCount>
+					<soundAiming>BotchJob_ArchmageStaffCharge</soundAiming>
+					<soundCast>BotchJob_ArchmageStaffCast</soundCast>
+					<stopBurstWithoutLos>false</stopBurstWithoutLos>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+					<muzzleFlashScale>14</muzzleFlashScale>
+					<ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
+				</Properties>
+				<FireModes>
+                  <aiAimMode>AimedShot</aiAimMode>
+               </FireModes>
+				<weaponTags>
+					<li>BotchJob_PossessedArchmageStaff</li>
+				</weaponTags>
+				<AllowWithRunAndGun>false</AllowWithRunAndGun>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="BotchJob_PossessedArchmageStaff"]/tools</xpath>
+               <value>
+                  <tools>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>limb</label>
+                        <capacities>
+                           <li>Blunt</li>
+                           <li>Poke</li>
+                        </capacities>
+                        <power>6</power>
+                        <cooldownTime>1.2</cooldownTime>
+                        <armorPenetrationBlunt>0.4</armorPenetrationBlunt>
+                     </li>
+                  </tools>
+               </value>
+            </li>
+				
+			<!-- Archmage Staff Projectiles  -->
+			<li Class="PatchOperationAdd">
+					<xpath>Defs</xpath>
+					<value>			
+					<ThingDef ParentName="BasePilumProjectile">
+					<defName>Projectile_ArchmageStaffBolt</defName>
+					<label>archmage staff bolt</label>
+					<graphicData>
+						<texPath>Things/Projectile/ArchmageStaffBolt</texPath>
+						<graphicClass>Graphic_Single</graphicClass>
+					</graphicData>	
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<flyOverhead>false</flyOverhead>
+						<speed>20</speed>
+						<damageDef>BotchJob_ArchmageStaffBolt</damageDef>
+						<explosionRadius>1</explosionRadius>
+						<ai_IsIncendiary>true</ai_IsIncendiary>
+						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+						</projectile>
+						<comps>
+						<li Class="CombatExtended.CompProperties_ExplosiveCE">
+							<explosiveDamageType>Flame</explosiveDamageType>
+							<explosiveRadius>1</explosiveRadius>
+						</li>
+					</comps>	
+					</ThingDef>
+				</value>
+			</li>
+			
+			<!--=============================== Automaton Crossbow ================================-->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>BotchJob_AutomatonCrossbow</defName>
+				<statBases>
+					<SightsEfficiency>1</SightsEfficiency>
+					<ShotSpread>0.2</ShotSpread>
+					<SwayFactor>1</SwayFactor>
+					<Bulk>8</Bulk>
+					<RangedWeapon_Cooldown>0.2</RangedWeapon_Cooldown>
+				</statBases>
+				<Properties>
+					<recoilAmount>1.39</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Projectile_CrossbowBolt_Steel</defaultProjectile>
+					<warmupTime>1</warmupTime>
+					<ticksBetweenBurstShots>10</ticksBetweenBurstShots>
+					<burstShotCount>3</burstShotCount>
+					<range>26</range>
+					<soundCast>Bow_Large</soundCast>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+				</Properties>
+				<AmmoUser>
+                  <magazineSize>3</magazineSize>
+                  <reloadTime>5.5</reloadTime>
+                  <ammoSet>AmmoSet_CrossbowBolt</ammoSet>
+               </AmmoUser>
+				<FireModes>
+						<aiUseBurstMode>FALSE</aiUseBurstMode>
+						<aiAimMode>Snapshot</aiAimMode>
+						<aimedBurstShotCount>3</aimedBurstShotCount>
+				</FireModes>
+				<weaponTags>
+					<li>BotchJob_AutomatonCrossbow</li>
+				</weaponTags>
+			</li>
+			
+			<!-- Patch to Make it Utilize Heavy Crossbow Ammo from MO when loaded -->
+			<li Class="PatchOperationFindMod">
+				<mods>
+					<li>Medieval Overhaul</li>
+				</mods>
+				<match Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="BotchJob_AutomatonCrossbow"]/comps</xpath>
+					<value>
+						<comps>
+							<li Class="CombatExtended.CompProperties_AmmoUser">
+								<magazineSize>3</magazineSize>
+								<reloadTime>5.5</reloadTime>
+								<ammoSet>AmmoSet_ArbalestBolt</ammoSet>
+							</li>
+							<li Class="CombatExtended.CompProperties_FireModes">
+								<aiUseBurstMode>FALSE</aiUseBurstMode>
+								<aiAimMode>Snapshot</aiAimMode>
+								<aimedBurstShotCount>3</aimedBurstShotCount>
+							</li>
+						</comps>
+					</value>
+				</match>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="BotchJob_AutomatonCrossbow"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>7</power>
+							<cooldownTime>1.6</cooldownTime>
+							<armorPenetrationBlunt>0.85</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<!--=============================== Possessed Automaton Crossbow ================================-->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>BotchJob_PossessedAutomatonCrossbow</defName>
+				<statBases>
+					<SightsEfficiency>1</SightsEfficiency>
+					<ShotSpread>0.2</ShotSpread>
+					<SwayFactor>1</SwayFactor>
+					<Bulk>8</Bulk>
+					<RangedWeapon_Cooldown>0.2</RangedWeapon_Cooldown>
+				</statBases>
+				<Properties>
+					<recoilAmount>1.39</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Projectile_CrossbowBolt_Steel</defaultProjectile>
+					<warmupTime>1</warmupTime>
+					<ticksBetweenBurstShots>10</ticksBetweenBurstShots>
+					<burstShotCount>3</burstShotCount>
+					<range>26</range>
+					<soundCast>Bow_Large</soundCast>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+				</Properties>
+				<AmmoUser>
+                  <magazineSize>3</magazineSize>
+                  <reloadTime>5</reloadTime>
+                  <ammoSet>AmmoSet_CrossbowBolt</ammoSet>
+               </AmmoUser>
+				<FireModes>
+						<aiUseBurstMode>FALSE</aiUseBurstMode>
+						<aiAimMode>Snapshot</aiAimMode>
+						<aimedBurstShotCount>3</aimedBurstShotCount>
+				</FireModes>
+				<weaponTags>
+					<li>BotchJob_PossessedAutomatonCrossbow</li>
+				</weaponTags>
+			</li>
+			
+			<!-- Patch to Make it Utilize Heavy Crossbow Ammo from MO when loaded -->
+			<li Class="PatchOperationFindMod">
+				<mods>
+					<li>Medieval Overhaul</li>
+				</mods>
+				<match Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="BotchJob_PossessedAutomatonCrossbow"]/comps</xpath>
+					<value>
+						<comps>
+							<li Class="CombatExtended.CompProperties_AmmoUser">
+								<magazineSize>3</magazineSize>
+								<reloadTime>5</reloadTime>
+								<ammoSet>AmmoSet_ArbalestBolt</ammoSet>
+							</li>
+							<li Class="CombatExtended.CompProperties_FireModes">
+								<aiUseBurstMode>FALSE</aiUseBurstMode>
+								<aiAimMode>Snapshot</aiAimMode>
+								<aimedBurstShotCount>3</aimedBurstShotCount>
+							</li>
+						</comps>
+					</value>
+				</match>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="BotchJob_PossessedAutomatonCrossbow"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>7</power>
+							<cooldownTime>1.44</cooldownTime>
+							<armorPenetrationBlunt>1.03</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<!--=============================== Verdant Bow ================================-->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>BotchJob_VerdantBow</defName>
+				<statBases>
+					<SightsEfficiency>0.8</SightsEfficiency>
+                  <ShotSpread>1</ShotSpread>
+                  <SwayFactor>2</SwayFactor>
+                  <Bulk>4.00</Bulk>
+                  <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+				</statBases>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Projectile_VerdantArrow_Steel</defaultProjectile>
+					<warmupTime>1.2</warmupTime>
+					<range>22</range>
+					<soundCast>Bow_Recurve</soundCast>
+					<muzzleFlashScale>14</muzzleFlashScale>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+				</Properties>
+				<AmmoUser>
+					<ammoSet>AmmoSet_VerdantArrow</ammoSet>
+				</AmmoUser>
+				<FireModes />
+				<weaponTags>
+					<li>BotchJob_VerdantBow</li>
+				</weaponTags>
+				<AllowWithRunAndGun>false</AllowWithRunAndGun>
+			</li>
+			
+			<!-- Patch to Make it Utilize Heavy Crossbow Ammo from MO when loaded -->
+			<li Class="PatchOperationFindMod">
+				<mods>
+					<li>Medieval Overhaul</li>
+				</mods>
+				<match Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="BotchJob_VerdantBow"]/comps</xpath>
+					<value>
+						<comps>
+							<li Class="CombatExtended.CompProperties_AmmoUser">
+								<ammoSet>AmmoSet_VerdantMOArrow</ammoSet>
+							</li>
+						</comps>
+					</value>
+				</match>
+			</li>
+
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="BotchJob_VerdantBow"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>7</power>
+							<cooldownTime>1.6</cooldownTime>
+							<armorPenetrationBlunt>0.65</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<!--=============================== Possessed Verdant Bow ================================-->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>BotchJob_VerdantBow</defName>
+				<statBases>
+				  <SightsEfficiency>1</SightsEfficiency>
+                  <ShotSpread>0.8</ShotSpread>
+                  <SwayFactor>1.</SwayFactor>
+                  <Bulk>4.00</Bulk>
+                  <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+				</statBases>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Projectile_VerdantArrow_Steel</defaultProjectile>
+					<warmupTime>1.2</warmupTime>
+					<range>22</range>
+					<soundCast>Bow_Recurve</soundCast>
+					<muzzleFlashScale>14</muzzleFlashScale>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+				</Properties>
+				<AmmoUser>
+					<ammoSet>AmmoSet_VerdantArrow</ammoSet>
+				</AmmoUser>
+				<FireModes />
+				<weaponTags>
+					<li>BotchJob_VerdantBow</li>
+				</weaponTags>
+				<AllowWithRunAndGun>false</AllowWithRunAndGun>
+			</li>
+			
+			<!-- Patch to Make it Utilize Heavy Crossbow Ammo from MO when loaded -->
+			<li Class="PatchOperationFindMod">
+				<mods>
+					<li>Medieval Overhaul</li>
+				</mods>
+				<match Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="BotchJob_VerdantBow"]/comps</xpath>
+					<value>
+						<comps>
+							<li Class="CombatExtended.CompProperties_AmmoUser">
+								<ammoSet>AmmoSet_VerdantMOArrow</ammoSet>
+							</li>
+						</comps>
+					</value>
+				</match>
+			</li>
+
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="BotchJob_VerdantBow"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>7</power>
+							<cooldownTime>1.6</cooldownTime>
+							<armorPenetrationBlunt>0.65</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<!-- Ammo for Verdant Bow -->
+			<li Class="PatchOperationAdd">
+					<xpath>Defs</xpath>
+					<value>
+			
+			
+						<!-- Verdant Bow -->
+						<CombatExtended.AmmoSetDef>
+							<defName>AmmoSet_VerdantArrow</defName>
+							<label>verdant arrows</label>
+							<ammoTypes>
+								<Ammo_Arrow_Stone>Projectile_VerdantArrow_Stone</Ammo_Arrow_Stone>
+								<Ammo_Arrow_Steel>Projectile_VerdantArrow_Steel</Ammo_Arrow_Steel>
+								<Ammo_Arrow_Plasteel>Projectile_VerdantArrow_Plasteel</Ammo_Arrow_Plasteel>
+								<Ammo_Arrow_Venom>Projectile_VerdantArrow_Venom</Ammo_Arrow_Venom>
+							</ammoTypes>
+						</CombatExtended.AmmoSetDef>
+						
+						<CombatExtended.AmmoSetDef>
+							<defName>AmmoSet_VerdantMOArrow</defName>
+							<label>verdant arrows</label>
+							<ammoTypes>
+								<Ammo_Arrow_Stone>Projectile_VerdantArrow_Stone</Ammo_Arrow_Stone>
+								<Ammo_Arrow_Steel>Projectile_VerdantArrow_Steel</Ammo_Arrow_Steel>
+								<Ammo_Arrow_Venom>Projectile_VerdantArrow_Venom</Ammo_Arrow_Venom>
+							</ammoTypes>
+						</CombatExtended.AmmoSetDef>
+			
+						<ThingDef ParentName="BaseStreamlinedArrowProjectile">
+							<defName>Projectile_VerdantArrow_Stone</defName>
+							<label>verdant arrow (stone)</label>
+							<graphicData>
+								<texPath>Things/Projectile/VerdantBowArrow</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+							</graphicData>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<speed>40</speed>
+								<damageAmountBase>9</damageAmountBase>
+								<armorPenetrationSharp>0.6</armorPenetrationSharp>
+								<armorPenetrationBlunt>1.9</armorPenetrationBlunt>
+								<preExplosionSpawnChance>0.2</preExplosionSpawnChance>
+								<preExplosionSpawnThingDef>Ammo_Arrow_Stone</preExplosionSpawnThingDef>
+							</projectile>
+						</ThingDef>
+
+						<ThingDef ParentName="BaseStreamlinedArrowProjectile">
+							<defName>Projectile_VerdantArrow_Steel</defName>
+							<label>verdant arrow (steel)</label>
+							<graphicData>
+								<texPath>Things/Projectile/VerdantBowArrow</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+							</graphicData>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<damageAmountBase>10</damageAmountBase>
+								<armorPenetrationSharp>1.5</armorPenetrationSharp>
+								<armorPenetrationBlunt>6.4</armorPenetrationBlunt>
+								<preExplosionSpawnChance>0.6</preExplosionSpawnChance>
+								<preExplosionSpawnThingDef>Ammo_Arrow_Steel</preExplosionSpawnThingDef>
+							</projectile>
+						</ThingDef>
+
+						<ThingDef ParentName="BaseStreamlinedArrowProjectile">
+							<defName>Projectile_VerdantArrow_Plasteel</defName>
+							<label>verdant arrow (plasteel)</label>
+							<graphicData>
+								<texPath>Things/Projectile/VerdantBowArrow</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+							</graphicData>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<speed>50</speed>
+								<damageAmountBase>9</damageAmountBase>
+								<armorPenetrationSharp>2</armorPenetrationSharp>
+								<armorPenetrationBlunt>5.54</armorPenetrationBlunt>
+								<preExplosionSpawnChance>0.75</preExplosionSpawnChance>
+								<preExplosionSpawnThingDef>Ammo_Arrow_Plasteel</preExplosionSpawnThingDef>
+							</projectile>
+						</ThingDef>
+  
+						<ThingDef ParentName="BaseStreamlinedArrowProjectile">
+							<defName>Projectile_VerdantArrow_Venom</defName>
+							<label>verdant arrow (venom)</label>
+							<graphicData>
+								<texPath>Things/Projectile/VerdantBowArrow</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+							</graphicData>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<damageDef>ArrowVenom</damageDef>
+								<damageAmountBase>10</damageAmountBase>	  
+								<armorPenetrationSharp>1.5</armorPenetrationSharp>
+								<armorPenetrationBlunt>6.4</armorPenetrationBlunt>
+								<preExplosionSpawnChance>0.6</preExplosionSpawnChance>
+								<preExplosionSpawnThingDef>Ammo_Arrow_Steel</preExplosionSpawnThingDef>
+							</projectile>
+						</ThingDef>
+					</value>
+			</li>
+			
+			<!--=============================== Gilded Arquebus ================================-->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>BotchJob_GildedArquebus</defName>
+				<statBases>
+				  <SightsEfficiency>0.8</SightsEfficiency>
+                  <ShotSpread>0.03</ShotSpread>
+                  <SwayFactor>1.85</SwayFactor>
+				  <Mass>4.5</Mass>
+                  <Bulk>14.00</Bulk>
+                  <RangedWeapon_Cooldown>0.93</RangedWeapon_Cooldown>
+				</statBases>
+				<Properties>
+					<recoilAmount>2.53</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_FastMusketBall</defaultProjectile>
+					<warmupTime>1.26</warmupTime>
+					<range>35</range>
+					<soundCast>Shot_CE_Musket</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>12</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>1</magazineSize>
+					<AmmoGenPerMagOverride>4</AmmoGenPerMagOverride>
+					<reloadTime>7.11</reloadTime>
+					<ammoSet>AmmoSet_FastMusketBall</ammoSet>
+				</AmmoUser>
+				<FireModes>
+				 <aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+				<weaponTags>
+					<li>BotchJob_GildedArquebus</li>
+				</weaponTags>
+				<AllowWithRunAndGun>false</AllowWithRunAndGun>
+			</li>
+			
+			<!--=============================== Possessed Gilded Arquebus ================================-->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>BotchJob_PossessedGildedArquebus</defName>
+				<statBases>
+				  <SightsEfficiency>0.8</SightsEfficiency>
+                  <ShotSpread>0.03</ShotSpread>
+                  <SwayFactor>1.85</SwayFactor>
+				  <Mass>4.5</Mass>
+                  <Bulk>14.00</Bulk>
+                  <RangedWeapon_Cooldown>0.84</RangedWeapon_Cooldown>
+				</statBases>
+				<Properties>
+					<recoilAmount>2.53</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_FastMusketBall</defaultProjectile>
+					<warmupTime>1.11</warmupTime>
+					<range>35</range>
+					<soundCast>Shot_CE_Musket</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>12</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>1</magazineSize>
+					<AmmoGenPerMagOverride>4</AmmoGenPerMagOverride>
+					<reloadTime>6.4</reloadTime>
+					<ammoSet>AmmoSet_FastMusketBall</ammoSet>
+				</AmmoUser>
+				<FireModes>
+				 <aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+				<weaponTags>
+					<li>BotchJob_GildedArquebus</li>
+				</weaponTags>
+				<AllowWithRunAndGun>false</AllowWithRunAndGun>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="BotchJob_GildedArquebus" or defName="BotchJob_PossessedGildedArquebus"]/tools</xpath>
+				<value>
+					    <tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>stock</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>8</power>
+								<cooldownTime>1.55</cooldownTime>
+								<chanceFactor>1.5</chanceFactor>
+								<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+						        <label>barrel</label>
+								<capacities>
+									<li>Blunt</li>
+ 								</capacities>
+ 								<power>5</power>
+ 								<cooldownTime>2.02</cooldownTime>
+ 								<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+  							</li>
+   							<li Class="CombatExtended.ToolCE">
+    							<label>muzzle</label>
+    						    <capacities>
+    						      <li>Stab</li>
+    						    </capacities>
+    						    <power>13</power>
+    						    <cooldownTime>1.55</cooldownTime>
+								<armorPenetrationSharp>1.3</armorPenetrationSharp>
+								<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+    						</li>
+   						</tools>
+				</value>
+			</li>
+			
+			<!--=============================== Shrouded Dagger ================================-->
+			<li Class="PatchOperationAttributeSet">
+			<xpath>Defs/ThingDef[defName="BotchJob_ShroudedDagger"]</xpath>
+			<attribute>ParentName</attribute>
+			<value>BaseWeapon</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="BotchJob_ShroudedDagger"]</xpath>
+				<value>
+				<thingClass>CombatExtended.AmmoThing</thingClass>
+				<stackLimit>5</stackLimit>
+				<resourceReadoutPriority>First</resourceReadoutPriority>
+				<techLevel>Medieval</techLevel>
+				<tradeNeverStack>true</tradeNeverStack>
+				<relicChance>3</relicChance>
+				<burnableByRecipe>true</burnableByRecipe>
+				<thingSetMakerTags>
+					<li>RewardStandardMidFreq</li>
+				</thingSetMakerTags>
+			</value>
+			</li>
+			
+			<li Class="PatchOperationAttributeSet">
+				<xpath>Defs/ThingDef[defName="BotchJob_ShroudedDagger"]</xpath>
+				<attribute>Class</attribute>
+				<value>CombatExtended.AmmoDef</value>
+			</li>
+	
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>BotchJob_ShroudedDagger</defName>
+				<statBases>
+					<SightsEfficiency>1</SightsEfficiency>
+					<Bulk>1</Bulk>
+					<Mass>1</Mass>
+					<MeleeCounterParryBonus>0.15</MeleeCounterParryBonus>
+					<RangedWeapon_Cooldown>0.3</RangedWeapon_Cooldown>
+				</statBases>
+				<Properties>
+				<label>Throw shrouded dagger</label>
+				<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+				<hasStandardCommand>True</hasStandardCommand>
+				<defaultProjectile>Projectile_ThrownShroudedDagger</defaultProjectile>
+				<warmupTime>0.2</warmupTime>
+				<range>15</range>
+				<soundCast>ThrowGrenade</soundCast>
+				<ai_IsBuildingDestroyer>false</ai_IsBuildingDestroyer>
+				</Properties>
+				<weaponTags>
+				<li>CE_OneHandedWeapon</li>
+				</weaponTags>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="BotchJob_ShroudedDagger"]/equippedStatOffsets</xpath>
+					<value>
+						<equippedStatOffsets>
+						<PawnTrapSpringChance>-0.15</PawnTrapSpringChance>
+						<MeleeDodgeChance>0.15</MeleeDodgeChance>
+						<MeleeCritChance>0.5</MeleeCritChance>
+						<MeleeParryChance>0.15</MeleeParryChance>
+						</equippedStatOffsets>
+					</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="BotchJob_ShroudedDagger"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>handle</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>4</power>
+								<cooldownTime>1</cooldownTime>
+								<armorPenetrationBlunt>1.13</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>stab</label>
+								<capacities>
+									<li>Stab</li>
+								</capacities>
+								<power>17</power>
+								<cooldownTime>1</cooldownTime>
+								<chanceFactor>1.33</chanceFactor>
+								<armorPenetrationBlunt>1.13</armorPenetrationBlunt>
+								<armorPenetrationSharp>1.88</armorPenetrationSharp>
+								<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>slash</label>
+								<capacities>
+									<li>Cut</li>
+								</capacities>
+								<power>15</power>
+								<cooldownTime>1.41</cooldownTime>
+								<chanceFactor>1.33</chanceFactor>
+								<armorPenetrationBlunt>0.72</armorPenetrationBlunt>
+								<armorPenetrationSharp>0.64</armorPenetrationSharp>
+							</li>		
+						</tools>
+					</value>
+				</li>
+			
+			<li Class="PatchOperationAdd">
+					<xpath>Defs</xpath>
+					<value>			
+					<ThingDef ParentName="BasePilumProjectile">
+					<defName>Projectile_ThrownShroudedDagger</defName>
+					<label>shrouded dagger</label>
+					<graphicData>
+						<texPath>Things/Projectile/ShroudedDaggerThrown</texPath>
+						<graphicClass>Graphic_Single</graphicClass>
+					</graphicData>	
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<damageAmountBase>16</damageAmountBase>
+						<flyOverhead>false</flyOverhead>
+						<speed>26</speed>
+						<damageDef>RangedStab</damageDef>
+						<armorPenetrationBlunt>2.26</armorPenetrationBlunt>
+						<armorPenetrationSharp>3.76</armorPenetrationSharp>
+						<preExplosionSpawnChance>1</preExplosionSpawnChance>
+						<preExplosionSpawnThingDef>BotchJob_ShroudedDagger</preExplosionSpawnThingDef>
+						</projectile>					
+					</ThingDef>
+				</value>
+			</li>
+			
+			<!--=============================== Possessed Shrouded Dagger ================================-->
+			<li Class="PatchOperationAttributeSet">
+			<xpath>Defs/ThingDef[defName="BotchJob_PossessedShroudedDagger"]</xpath>
+			<attribute>ParentName</attribute>
+			<value>BaseWeapon</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="BotchJob_PossessedShroudedDagger"]/description</xpath>
+				<value>
+				<description>A deadly dagger favoured by assassins and rogues.\n\nIn skilled hands it can deliver a lightning fast flurry of stabs and slashes and can also be thrown short distances, ideal for finishing off fleeing opponents.\n\nIt allows the wielder to remain light on their feet, increasing their melee dodge chance and reducing the chances of them triggering hidden traps.\n\nThis weapon is possessed by an ancient spirit and will exhibit some of their traits. The spirit will bond with the first person to wield it and thereafter, refuse to be wielded by anyone else.\n\nWhen wielded by the bonded person, the spirit will augment their combat abilities, allowing them to attack with greater ferocity, speed and accuracy than ever before. When thrown the spirit will enhance the dagger one last time before departing.</description>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="BotchJob_PossessedShroudedDagger"]</xpath>
+				<value>
+				<thingClass>CombatExtended.AmmoThing</thingClass>
+				<stackLimit>5</stackLimit>
+				<resourceReadoutPriority>First</resourceReadoutPriority>
+				<techLevel>Medieval</techLevel>
+				<tradeNeverStack>true</tradeNeverStack>
+				<relicChance>3</relicChance>
+				<burnableByRecipe>true</burnableByRecipe>
+				<thingSetMakerTags>
+					<li>RewardStandardLowFreq</li>
+				</thingSetMakerTags>
+			</value>
+			</li>
+			
+			<li Class="PatchOperationAttributeSet">
+				<xpath>Defs/ThingDef[defName="BotchJob_PossessedShroudedDagger"]</xpath>
+				<attribute>Class</attribute>
+				<value>CombatExtended.AmmoDef</value>
+			</li>
+	
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>BotchJob_PossessedShroudedDagger</defName>
+				<statBases>
+					<SightsEfficiency>1</SightsEfficiency>
+					<Bulk>1</Bulk>
+					<Mass>1</Mass>
+					<MeleeCounterParryBonus>0.15</MeleeCounterParryBonus>
+					<RangedWeapon_Cooldown>0.3</RangedWeapon_Cooldown>
+				</statBases>
+				<Properties>
+				<label>Throw shrouded dagger</label>
+				<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+				<hasStandardCommand>True</hasStandardCommand>
+				<defaultProjectile>Projectile_ThrownShroudedDagger</defaultProjectile>
+				<warmupTime>0.2</warmupTime>
+				<range>15</range>
+				<soundCast>ThrowGrenade</soundCast>
+				<ai_IsBuildingDestroyer>false</ai_IsBuildingDestroyer>
+				</Properties>
+				<weaponTags>
+				<li>CE_OneHandedWeapon</li>
+				</weaponTags>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="BotchJob_PossessedShroudedDagger"]/equippedStatOffsets</xpath>
+					<value>
+						<equippedStatOffsets>
+						<PawnTrapSpringChance>-0.15</PawnTrapSpringChance>
+						<MeleeDodgeChance>0.15</MeleeDodgeChance>
+						<MeleeCritChance>0.5</MeleeCritChance>
+						<MeleeParryChance>0.15</MeleeParryChance>
+						</equippedStatOffsets>
+					</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="BotchJob_PossessedShroudedDagger"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>handle</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>4</power>
+								<cooldownTime>0.9</cooldownTime>
+								<armorPenetrationBlunt>1.37</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>stab</label>
+								<capacities>
+									<li>Stab</li>
+								</capacities>
+								<power>17</power>
+								<cooldownTime>0.9</cooldownTime>
+								<chanceFactor>1.2</chanceFactor>
+								<armorPenetrationBlunt>1.37</armorPenetrationBlunt>
+								<armorPenetrationSharp>2.27</armorPenetrationSharp>
+								<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>slash</label>
+								<capacities>
+									<li>Cut</li>
+								</capacities>
+								<power>15</power>
+								<cooldownTime>1.27</cooldownTime>
+								<chanceFactor>1.20</chanceFactor>
+								<armorPenetrationBlunt>0.87</armorPenetrationBlunt>
+								<armorPenetrationSharp>0.77</armorPenetrationSharp>
+							</li>		
+						</tools>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs</xpath>
+					<value>			
+					<ThingDef ParentName="BasePilumProjectile">
+					<defName>Projectile_ThrownShroudedDagger</defName>
+					<label>shrouded dagger</label>
+					<graphicData>
+						<texPath>Things/Projectile/ShroudedDaggerThrown</texPath>
+						<graphicClass>Graphic_Single</graphicClass>
+					</graphicData>	
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<damageAmountBase>32</damageAmountBase>
+						<flyOverhead>false</flyOverhead>
+						<speed>26</speed>
+						<damageDef>RangedStab</damageDef>
+						<armorPenetrationBlunt>4.52</armorPenetrationBlunt>
+						<armorPenetrationSharp>7.52</armorPenetrationSharp>
+						<preExplosionSpawnChance>1</preExplosionSpawnChance>
+						<preExplosionSpawnThingDef>BotchJob_ShroudedDagger</preExplosionSpawnThingDef>
+						</projectile>					
+					</ThingDef>
+				</value>
+			</li>
+			
+			
+			<!--=============================== Acolyte Staff ================================-->
+			<li Class="PatchOperationFindMod">
+				<mods>
+					<li>Biotech</li>
+				</mods>
+				<match Class="PatchOperationSequence">
+					<operations>
+					
+						<li Class="PatchOperationReplace">
+						<xpath>Defs/ThingDef[defName="BotchJob_AcolyteStaff"]/statBases</xpath>
+							<value>
+								<Bulk>10.00</Bulk>
+							</value>
+					
+						<li Class="PatchOperationReplace">
+							<xpath>Defs/ThingDef[defName="BotchJob_AcolyteStaff"]/verbs/li/warmupTime</xpath>
+							<value>
+								<warmupTime>3.2</warmupTime>
+							</value>
+						</li>
+						
+						 <li Class="PatchOperationReplace">
+							<xpath>Defs/ThingDef[defName="BotchJob_AcolyteStaff"]/verbs/li/range</xpath>
+							<value>
+								<range>30</range>
+							</value>
+						</li>
+						
+						<li Class="PatchOperationReplace">
+							<xpath>Defs/ThingDef[defName="BotchJob_AcolyteStaff"]/verbs/li/burstShotCount</xpath>
+							<value>
+								<burstShotCount>10</burstShotCount>
+							</value>
+						</li>
+
+						<li Class="PatchOperationReplace">
+							<xpath>Defs/ThingDef[defName="BotchJob_AcolyteStaff"]/verbs/li/ticksBetweenBurstShots</xpath>
+							<value>
+								<ticksBetweenBurstShots>10</ticksBetweenBurstShots>
+							</value>
+						</li>
+						
+						<li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="BotchJob_ArchmageStaff"]/tools</xpath>
+               <value>
+                  <tools>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>limb</label>
+                        <capacities>
+                           <li>Blunt</li>
+                           <li>Poke</li>
+                        </capacities>
+                        <power>6</power>
+                        <cooldownTime>1.2</cooldownTime>
+                        <armorPenetrationBlunt>0.4</armorPenetrationBlunt>
+                     </li>
+                  </tools>
+               </value>
+            </li>
+					
+						<!--=============================== Possessed Acolyte Staff ================================-->
+						<li Class="PatchOperationReplace">
+						<xpath>Defs/ThingDef[defName="BotchJob_PossessedAcolyteStaff"]/statBases</xpath>
+							<value>
+								<Bulk>10.00</Bulk>
+							</value>
+							
+						<li Class="PatchOperationReplace">
+						<xpath>Defs/ThingDef[defName="BotchJob_PossessedAcolyteStaff"]/statBases/RangedWeapon_Cooldown</xpath>
+							<value>
+								<RangedWeapon_Cooldown>1.53</RangedWeapon_Cooldown>
+							</value>
+							</li>
+						<li Class="PatchOperationReplace">
+							<xpath>Defs/ThingDef[defName="BotchJob_PossessedAcolyteStaff"]/verbs/li/warmupTime</xpath>
+							<value>
+								<warmupTime>2.7</warmupTime>
+							</value>
+						</li>
+						
+						 <li Class="PatchOperationReplace">
+							<xpath>Defs/ThingDef[defName="BotchJob_PossessedAcolyteStaff"]/verbs/li/range</xpath>
+							<value>
+								<range>30</range>
+							</value>
+						</li>
+						
+						<li Class="PatchOperationReplace">
+							<xpath>Defs/ThingDef[defName="BotchJob_PossessedAcolyteStaff"]/verbs/li/burstShotCount</xpath>
+							<value>
+								<burstShotCount>14</burstShotCount>
+							</value>
+						</li>
+
+						<li Class="PatchOperationReplace">
+							<xpath>Defs/ThingDef[defName="BotchJob_PossessedAcolyteStaff"]/verbs/li/ticksBetweenBurstShots</xpath>
+							<value>
+								<ticksBetweenBurstShots>10</ticksBetweenBurstShots>
+							</value>
+						</li>
+						
+						<li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="BotchJob_ArchmageStaff"]/tools</xpath>
+               <value>
+                  <tools>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>limb</label>
+                        <capacities>
+                           <li>Blunt</li>
+                           <li>Poke</li>
+                        </capacities>
+                        <power>6</power>
+                        <cooldownTime>1.2</cooldownTime>
+                        <armorPenetrationBlunt>0.4</armorPenetrationBlunt>
+                     </li>
+                  </tools>
+               </value>
+            </li>
+					
+					
+					</operations>
+				</match>
+				</li>
+			
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -286,6 +286,7 @@ Mechanoid Master Blaser |
 Medieval Medicines 1.4 Medieval Overhaul Edition |
 Medical System Expansion	|
 Medieval Overhaul   |
+Medieval Tailor   |
 Medieval Quest Rewards  |
 Megafauna	|
 MH: Android Tiers	|
@@ -345,6 +346,7 @@ Paniel the Automata |
 Pawnbold Race   |
 Polarisbloc - Security Force	|
 Poleepkwa Race	|
+Possessed Weapons	|
 Prestige Specialist Armours	|
 Project RimFactory - Materials |
 Prostheses+ |


### PR DESCRIPTION
Compatibility patch for Possessed Weapons

## Additions

Describe new functionality added by your code, e.g.
- Compatibility Patch for Possessed Weapons mod

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Update to Support Third Party Mod page to include Medieval Tailor (Already merged PR [#2600](https://github.com/CombatExtended-Continued/CombatExtended/pull/2600)) and Possessed Weapons

## Reasoning

Why did you choose to implement things this way, e.g.
- Thrown weapons changed to no quality
- Slight weirdness with thrown persona weapons. Forced to spawn regular version on impact


## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
