### PR TITLE
Readjust cannon grapeshot spread

### DIFF
--- a/Defs/Ammo/Medieval/CannonBall.xml
+++ b/Defs/Ammo/Medieval/CannonBall.xml
@@ -194,7 +194,7 @@
 			<armorPenetrationSharp>8.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>420.68</armorPenetrationBlunt>
 			<pelletCount>27</pelletCount>
-			<spreadMult>35.6</spreadMult>
+			<spreadMult>26.7</spreadMult>
 		</projectile>
 	</ThingDef>
 


### PR DESCRIPTION
## Changes

- Lowered the spread to 26.7 (base 17.8*1.5) from 35.6 as it was unrealistically high.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
