### PR TITLE
Add missing tech level node for the plate helmet

### DIFF
--- a/Defs/ThingDefs_Misc/Apparel_Headgear.xml
+++ b/Defs/ThingDefs_Misc/Apparel_Headgear.xml
@@ -10,6 +10,7 @@
             <graphicClass>Graphic_Single</graphicClass>
         </graphicData>
         <possessionCount>1</possessionCount>
+        <techLevel>Medieval</techLevel>
         <stuffCategories>
             <li>Metallic</li>
         </stuffCategories>

--- a/Defs/ThingDefs_Misc/Apparel_Headgear.xml
+++ b/Defs/ThingDefs_Misc/Apparel_Headgear.xml
@@ -31,11 +31,11 @@
             <MeleeHitChance>-2</MeleeHitChance>
         </equippedStatOffsets>
         <recipeMaker>
+            <researchPrerequisite>PlateArmor</researchPrerequisite>
             <recipeUsers>
                 <li>ElectricSmithy</li>
                 <li>FueledSmithy</li>
             </recipeUsers>
-            <researchPrerequisite>PlateArmor</researchPrerequisite>
             <skillRequirements>
                 <Crafting>7</Crafting>
             </skillRequirements>


### PR DESCRIPTION
## Changes

- What it says on the tin, the Medieval tech level node was missing.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
