### PR TITLE
Mech loadout adjustments and housekeeping

### DIFF
--- a/Patches/Advanced Mechanoid Warfare/Patches/Patch_Loadouts.xml
+++ b/Patches/Advanced Mechanoid Warfare/Patches/Patch_Loadouts.xml
@@ -40,8 +40,8 @@
 			<value>
 			  <li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-				  <min>10</min>
-				  <max>20</max>
+				  <min>6</min>
+				  <max>10</max>
 				</primaryMagazineCount>
 			  </li>
 			</value>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Misc/Weapons.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Misc/Weapons.xml
@@ -120,8 +120,6 @@
 							<defaultProjectile>Bullet_CoilLance</defaultProjectile>
 							<warmupTime>2.4</warmupTime>
 							<range>62</range>
-							<ticksBetweenBurstShots>10</ticksBetweenBurstShots>
-							<burstShotCount>3</burstShotCount>
 							<soundCast>AM_Gauss</soundCast>
 							<soundCastTail>GunTail_Medium</soundCastTail>
 							<muzzleFlashScale>9</muzzleFlashScale>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Bellicor.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Bellicor.xml
@@ -80,8 +80,8 @@
 						<value>
 							<li Class="CombatExtended.LoadoutPropertiesExtension">
 								<primaryMagazineCount>
-									<min>5</min>
-									<max>6</max>
+									<min>3</min>
+									<max>5</max>
 								</primaryMagazineCount>
 							</li>
 						</value>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Bellicor_Mortar.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Bellicor_Mortar.xml
@@ -80,13 +80,12 @@
 						<value>
 							<li Class="CombatExtended.LoadoutPropertiesExtension">
 								<primaryMagazineCount>
-									<min>4</min>
-									<max>6</max>
+									<min>3</min>
+									<max>5</max>
 								</primaryMagazineCount>
 							</li>
 						</value>
 					</li>
-
 
 				</operations>
 			</match>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Legate.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Legate.xml
@@ -89,8 +89,8 @@
 						<value>
 							<li Class="CombatExtended.LoadoutPropertiesExtension">
 								<primaryMagazineCount>
-									<min>6</min>
-									<max>8</max>
+									<min>3</min>
+									<max>5</max>
 								</primaryMagazineCount>
 							</li>
 						</value>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Lux.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Lux.xml
@@ -76,8 +76,8 @@
 						<value>
 							<li Class="CombatExtended.LoadoutPropertiesExtension">
 								<primaryMagazineCount>
-									<min>5</min>
-									<max>8</max>
+									<min>3</min>
+									<max>4</max>
 								</primaryMagazineCount>
 							</li>
 						</value>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Munifex.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Munifex.xml
@@ -76,8 +76,8 @@
 						<value>
 							<li Class="CombatExtended.LoadoutPropertiesExtension">
 								<primaryMagazineCount>
-									<min>9</min>
-									<max>10</max>
+									<min>4</min>
+									<max>5</max>
 								</primaryMagazineCount>
 							</li>
 						</value>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Optio.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Optio.xml
@@ -70,8 +70,8 @@
 						<value>
 							<li Class="CombatExtended.LoadoutPropertiesExtension">
 								<primaryMagazineCount>
-									<min>4</min>
-									<max>6</max>
+									<min>2</min>
+									<max>3</max>
 								</primaryMagazineCount>
 							</li>
 						</value>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Siegemelter.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Siegemelter.xml
@@ -80,8 +80,8 @@
 						<value>
 							<li Class="CombatExtended.LoadoutPropertiesExtension">
 								<primaryMagazineCount>
-									<min>5</min>
-									<max>6</max>
+									<min>4</min>
+									<max>5</max>
 								</primaryMagazineCount>
 							</li>
 						</value>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/VFE_Pawnkinds.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/VFE_Pawnkinds.xml
@@ -20,8 +20,8 @@
 							<modExtensions>
 								<li Class="CombatExtended.LoadoutPropertiesExtension">
 									<primaryMagazineCount>
-										<min>9</min>
-										<max>14</max>
+										<min>4</min>
+										<max>7</max>
 									</primaryMagazineCount>
 								</li>
 							</modExtensions>
@@ -34,8 +34,8 @@
 						<value>
 							<li Class="CombatExtended.LoadoutPropertiesExtension">
 								<primaryMagazineCount>
-									<min>3</min>
-									<max>5</max>
+									<min>2</min>
+									<max>3</max>
 								</primaryMagazineCount>
 							</li>
 						</value>
@@ -47,8 +47,8 @@
 						<value>
 							<li Class="CombatExtended.LoadoutPropertiesExtension">
 								<primaryMagazineCount>
-									<min>9</min>
-									<max>13</max>
+									<min>4</min>
+									<max>6</max>
 								</primaryMagazineCount>
 							</li>
 						</value>

--- a/Patches/Alpha Mechs/PawnKindDefs_Mechanoids/AlphaMechs_PawnKinds.xml
+++ b/Patches/Alpha Mechs/PawnKindDefs_Mechanoids/AlphaMechs_PawnKinds.xml
@@ -9,29 +9,15 @@
 		<match Class="PatchOperationSequence">
 			<operations>
 
-				<!--Siegebreaker-->
+				<!-- Siegebreaker and Demolisher -->
 
 				<li Class="PatchOperationAddModExtension">
-					<xpath>Defs/PawnKindDef[defName="AM_Siegebreaker"]</xpath>
-					<value>
-						<li Class="CombatExtended.LoadoutPropertiesExtension">
-							<primaryMagazineCount>
-								<min>9</min>
-								<max>13</max>
-							</primaryMagazineCount>
-						</li>
-					</value>
-				</li>
-
-				<!--Demolisher-->
-
-				<li Class="PatchOperationAddModExtension">
-					<xpath>Defs/PawnKindDef[defName="AM_Demolisher"]</xpath>
+					<xpath>Defs/PawnKindDef[defName="AM_Siegebreaker" or defName="AM_Demolisher"]</xpath>
 					<value>
 						<li Class="CombatExtended.LoadoutPropertiesExtension">
 							<primaryMagazineCount>
 								<min>4</min>
-								<max>8</max>
+								<max>7</max>
 							</primaryMagazineCount>
 						</li>
 					</value>
@@ -44,8 +30,8 @@
 					<value>
 						<li Class="CombatExtended.LoadoutPropertiesExtension">
 							<primaryMagazineCount>
-								<min>3</min>
-								<max>4</max>
+								<min>2</min>
+								<max>3</max>
 							</primaryMagazineCount>
 						</li>
 					</value>
@@ -58,8 +44,8 @@
 					<value>
 						<li Class="CombatExtended.LoadoutPropertiesExtension">
 							<primaryMagazineCount>
-								<min>9</min>
-								<max>12</max>
+								<min>4</min>
+								<max>6</max>
 							</primaryMagazineCount>
 						</li>
 					</value>

--- a/Patches/Alpha Mechs/ThingDefs_Misc/AlphaMechs_RangedMechanoid.xml
+++ b/Patches/Alpha Mechs/ThingDefs_Misc/AlphaMechs_RangedMechanoid.xml
@@ -257,6 +257,7 @@
 					</Properties>
 					<AmmoUser>
 						<magazineSize>1</magazineSize>
+						<AmmoGenPerMagOverride>2</AmmoGenPerMagOverride>
 						<reloadTime>8</reloadTime>
 						<ammoSet>AmmoSet_90mmCannonShell</ammoSet>
 					</AmmoUser>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -1231,6 +1231,7 @@
     </Properties>
     <AmmoUser>
       <magazineSize>1</magazineSize>
+      <AmmoGenPerMagOverride>2</AmmoGenPerMagOverride>
       <reloadTime>9.8</reloadTime>
       <ammoSet>AmmoSet_80x256mmFuel</ammoSet>
     </AmmoUser>
@@ -1290,6 +1291,7 @@
     </Properties>
     <AmmoUser>
       <magazineSize>1</magazineSize>
+	  <AmmoGenPerMagOverride>2</AmmoGenPerMagOverride>
       <reloadTime>9.8</reloadTime>
       <ammoSet>AmmoSet_164x284mmDemo</ammoSet>
     </AmmoUser>

--- a/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
@@ -25,11 +25,11 @@
   </Operation>
 
   <Operation Class="PatchOperationAddModExtension">
-    <xpath>Defs/PawnKindDef[defName="Mech_Lancer" or defName="Mech_Pikeman" or @Name="MechCentipedeBase"]</xpath>
+    <xpath>Defs/PawnKindDef[defName="Mech_Lancer" or defName="Mech_Pikeman"]</xpath>
     <value>
       <li Class="CombatExtended.LoadoutPropertiesExtension">
         <primaryMagazineCount>
-          <min>9</min>
+          <min>8</min>
           <max>10</max>
         </primaryMagazineCount>
       </li>
@@ -37,12 +37,12 @@
   </Operation>
 
   <Operation Class="PatchOperationAddModExtension">
-    <xpath>Defs/PawnKindDef[defName="Mech_Termite_Breach"]</xpath>
+    <xpath>Defs/PawnKindDef[defName="Mech_Termite_Breach" or @Name="MechCentipedeBase"]</xpath>
     <value>
       <li Class="CombatExtended.LoadoutPropertiesExtension">
         <primaryMagazineCount>
-          <min>8</min>
-          <max>15</max>
+          <min>4</min>
+          <max>6</max>
         </primaryMagazineCount>
       </li>
     </value>

--- a/Patches/MechanoidsExtraordinaire/PawnKindDefs/PawnKinds_MechanoidsExtraordinaire.xml
+++ b/Patches/MechanoidsExtraordinaire/PawnKindDefs/PawnKinds_MechanoidsExtraordinaire.xml
@@ -30,8 +30,8 @@
 				<value>
 					<li Class="CombatExtended.LoadoutPropertiesExtension">
 						<primaryMagazineCount>
-						  <min>8</min>
-						  <max>14</max>
+						  <min>4</min>
+						  <max>6</max>
 					</primaryMagazineCount>
 				  </li>
 				</value>

--- a/Patches/MechanoidsExtraordinaire/ThingDefs_Misc/Weapons_Guns_MechanoidsExtraordinaire.xml
+++ b/Patches/MechanoidsExtraordinaire/ThingDefs_Misc/Weapons_Guns_MechanoidsExtraordinaire.xml
@@ -29,6 +29,7 @@
 				</Properties>
 				<AmmoUser>
 					<magazineSize>1</magazineSize>
+					<AmmoGenPerMagOverride>2</AmmoGenPerMagOverride>
 					<reloadTime>9.8</reloadTime>
 					<ammoSet>AmmoSet_80x256mmFuel</ammoSet>
 				</AmmoUser>

--- a/Patches/MoreMechanoids/PawnKinds/PawnKinds.xml
+++ b/Patches/MoreMechanoids/PawnKinds/PawnKinds.xml
@@ -14,8 +14,8 @@
                     <value>
                         <li Class="CombatExtended.LoadoutPropertiesExtension">
                             <primaryMagazineCount>
-                                <min>4</min>
-                                <max>8</max>
+                                <min>3</min>
+                                <max>5</max>
                             </primaryMagazineCount>
                         </li>
                     </value>

--- a/Patches/Reinforced Mechanoid 2/PawnKindDefs/RM_PawnKinds_Mech.xml
+++ b/Patches/Reinforced Mechanoid 2/PawnKindDefs/RM_PawnKinds_Mech.xml
@@ -106,8 +106,8 @@
           <value>
             <li Class="CombatExtended.LoadoutPropertiesExtension">
               <primaryMagazineCount>
-                <min>7</min>
-                <max>10</max>
+                <min>6</min>
+                <max>8</max>
               </primaryMagazineCount>
             </li>
           </value>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/PawnKindDefs/Pawnkinds_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/PawnKindDefs/Pawnkinds_Mech.xml
@@ -24,9 +24,7 @@
 		  </li>
 
 		  <li Class="PatchOperationAddModExtension">
-			<xpath>Defs/PawnKindDef[
-			defName="VFE_Mech_Centipede" or
-			defName="VFE_Mech_AdvancedCentipede" or			 
+			<xpath>Defs/PawnKindDef[		 
 			defName="VFE_Mech_AdvancedLancer" or
 			defName="VFE_Mech_Lancer" or
 			defName="VFE_Mech_Pikeman" or
@@ -35,13 +33,13 @@
 			<value>
 			  <li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-				  <min>10</min>
+				  <min>8</min>
 				  <max>10</max>
 				</primaryMagazineCount>
 			  </li>
 			</value>
 		  </li>
-		  
+
 		  <li Class="PatchOperationAddModExtension">
 			<xpath>Defs/PawnKindDef[
 			defName="VFE_Mech_Knight" or 
@@ -51,7 +49,7 @@
 			  <li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
 				  <min>3</min>
-				  <max>5</max>
+				  <max>4</max>
 				</primaryMagazineCount>
 			  </li>
 			</value>
@@ -73,12 +71,17 @@
 		  </li>
 		  
 		  <li Class="PatchOperationAddModExtension">
-			<xpath>Defs/PawnKindDef[defName="VFE_Mech_Termite" or defName="VFE_Mech_AdvTermite"]</xpath>
+			<xpath>Defs/PawnKindDef[
+			defName="VFE_Mech_Centipede" or
+			defName="VFE_Mech_AdvancedCentipede" or
+			defName="VFE_Mech_Termite" or
+			defName="VFE_Mech_AdvTermite"
+			]</xpath>
 			<value>
 			  <li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-				  <min>8</min>
-				  <max>15</max>
+				  <min>4</min>
+				  <max>6</max>
 				</primaryMagazineCount>
 			  </li>
 			</value>
@@ -110,6 +113,92 @@
 					</weaponTags>
 				</value>
 			</nomatch>
+		</li>
+
+		<li Class="PatchOperationFindMod">
+			<mods>
+				<li>Biotech</li>
+			</mods>
+			<match Class="PatchOperationSequence">
+			  <operations>
+
+				  <li Class="PatchOperationReplace">
+					<xpath>Defs/PawnKindDef[defName="VFE_Mech_AdvancedCentipede_PlayerControlled"]/combatPower</xpath>
+					<value>
+						<combatPower>580</combatPower>
+					</value>
+				  </li>
+
+				  <li Class="PatchOperationReplace">
+					<xpath>Defs/PawnKindDef[defName="VFE_Mech_AdvancedPikeman_PlayerControlled"]/combatPower</xpath>
+					<value>
+						<combatPower>180</combatPower>
+					</value>
+				  </li>
+
+				  <li Class="PatchOperationAddModExtension">
+					<xpath>Defs/PawnKindDef[		 
+					defName="VFE_Mech_AdvancedLancer_PlayerControlled" or
+					defName="VFE_Mech_AdvancedPikeman_PlayerControlled"
+					]</xpath>
+					<value>
+					  <li Class="CombatExtended.LoadoutPropertiesExtension">
+						<primaryMagazineCount>
+						  <min>8</min>
+						  <max>10</max>
+						</primaryMagazineCount>
+					  </li>
+					</value>
+				  </li>
+
+				  <li Class="PatchOperationAddModExtension">
+					<xpath>Defs/PawnKindDef[
+					defName="VFE_Mech_Knight_PlayerControlled" or 
+					defName="VFE_Mech_AdvancedKnight_PlayerControlled"
+					]</xpath>
+					<value>
+					  <li Class="CombatExtended.LoadoutPropertiesExtension">
+						<primaryMagazineCount>
+						  <min>3</min>
+						  <max>4</max>
+						</primaryMagazineCount>
+					  </li>
+					</value>
+				  </li>
+
+				  <li Class="PatchOperationAddModExtension">
+					<xpath>Defs/PawnKindDef[
+					defName="VFE_Mech_Inquisitor_PlayerControlled" or
+					defName="VFE_Mech_AdvancedInquisitor_PlayerControlled"
+					]</xpath>
+					<value>
+					  <li Class="CombatExtended.LoadoutPropertiesExtension">
+						<primaryMagazineCount>
+						  <min>2</min>
+						  <max>3</max>
+						</primaryMagazineCount>
+					  </li>
+					</value>
+				  </li>
+				  
+				  <li Class="PatchOperationAddModExtension">
+					<xpath>Defs/PawnKindDef[
+					defName="VFE_Mech_AdvancedCentipede_PlayerControlled" or
+					defName="VFE_Mech_Termite_PlayerControlled" or
+					defName="VFE_Mech_AdvTermite_PlayerControlled"
+					]</xpath>
+					<value>
+					  <li Class="CombatExtended.LoadoutPropertiesExtension">
+						<primaryMagazineCount>
+						  <min>4</min>
+						  <max>6</max>
+						</primaryMagazineCount>
+					  </li>
+					</value>
+				  </li>
+
+			  </operations>
+			</match>
 		</li>
 
       </operations>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
@@ -505,15 +505,6 @@
         </tools>
       </value>
     </li>
-	
-	<!--CE's blast is way too strong for them dying. Switching it to boomalope-->
-	
-    <li Class="PatchOperationReplace">
-      <xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedInquisitor"]/race/deathActionWorkerClass</xpath>
-      <value>
-        <deathActionWorkerClass>DeathActionWorker_BigExplosion</deathActionWorkerClass>
-      </value>
-    </li>
 
     <!-- ========== VFE Advanced Carpenter ========== -->
 

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid_PlayerControlled.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid_PlayerControlled.xml
@@ -13,50 +13,6 @@
       <match Class="PatchOperationSequence">
         <operations>
 
-          <!--<li Class="PatchOperationConditional">
-		<xpath>Defs/ThingDef[@Name="VFE_AdvancedMechanoid"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[@Name="VFE_AdvancedMechanoid"]</xpath>
-			<value>
-				<comps />
-			</value>
-		</nomatch>
-	</li>-->
-
-          <!--<li Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[@Name="VFE_AdvancedMechanoid"]/comps</xpath>
-		<value>
-			<li>
-				<compClass>CombatExtended.CompPawnGizmo</compClass>
-			</li>
-			<li>
-				<compClass>CombatExtended.CompAmmoGiver</compClass>
-			</li>
-			<li Class="CombatExtended.CompProperties_MechAmmo">
-				<gizmoIconSetMagCount>UI/Buttons/SetMagCount</gizmoIconSetMagCount>
-				<gizmoIconTakeAmmoNow>UI/Buttons/TakeAmmoNow</gizmoIconTakeAmmoNow>
-			</li>
-		</value>
-	</li>-->
-
-          <!-- Advanced mechs retain some heat armor to represent sealing of sensitive electronics. Minor improvement to EMP resistance as well-->
-
-          <!--<li Class="PatchOperationReplace">
-      <xpath>Defs/ThingDef[@Name="VFE_AdvancedMechanoid"]/statBases/ArmorRating_Heat</xpath>
-      <value>
-        <ArmorRating_Heat>0.5</ArmorRating_Heat>
-      </value>
-    </li>-->
-
-          <!--<li Class="PatchOperationAdd">
-    <xpath>Defs/ThingDef[@Name="VFE_AdvancedMechanoid"]/statBases</xpath>
-      <value>
-        <SmokeSensitivity>0</SmokeSensitivity>
-        <ArmorRating_Electric>0.10</ArmorRating_Electric>
-        <NightVisionEfficiency>0.85</NightVisionEfficiency>
-      </value>
-    </li>-->
-
           <!-- ========== VFE Advanced Centipede ========== -->
 
           <li Class="PatchOperationAddModExtension">
@@ -525,78 +481,6 @@
             </value>
           </li>
 
-          <!--CE's blast is way too strong for them dying. Switching it to boomalope-->
-
-
-          <li Class="PatchOperationReplace">
-            <xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedInquisitor_PlayerControlled"]/race/deathActionWorkerClass</xpath>
-            <value>
-              <deathActionWorkerClass>DeathActionWorker_BigExplosion</deathActionWorkerClass>
-            </value>
-          </li>
-
-
-          <!-- ========== VFE Advanced Carpenter ========== -->
-          <!--
-
-    -->
-          <!--<li Class="PatchOperationAddModExtension">
-      <xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedCarpenter"]</xpath>
-      <value>
-        <li Class="CombatExtended.RacePropertiesExtensionCE">
-          <bodyShape>Quadruped</bodyShape>
-        </li>
-      </value>
-    </li>
-
-    <li Class="PatchOperationAdd">
-      <xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedCarpenter"]/statBases</xpath>
-      <value>
-        <CarryWeight>400</CarryWeight>
-        <CarryBulk>80</CarryBulk>
-        <MeleeDodgeChance>0.04</MeleeDodgeChance>
-        <MeleeCritChance>0.47</MeleeCritChance>
-        <MeleeParryChance>0.52</MeleeParryChance>
-        <MaxHitPoints>500</MaxHitPoints>
-      </value>
-    </li>
-
-    <li Class="PatchOperationReplace">
-      <xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedCarpenter"]/statBases/ArmorRating_Blunt</xpath>
-      <value>
-        <ArmorRating_Blunt>48</ArmorRating_Blunt>
-      </value>
-    </li>
-
-    <li Class="PatchOperationReplace">
-      <xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedCarpenter"]/statBases/ArmorRating_Sharp</xpath>
-      <value>
-        <ArmorRating_Sharp>22</ArmorRating_Sharp>
-      </value>
-    </li>
-
-    <li Class="PatchOperationReplace">
-      <xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedCarpenter"]/tools</xpath>
-      <value>
-        <tools>
-          <li Class="CombatExtended.ToolCE">
-            <label>head</label>
-            <capacities>
-              <li>Blunt</li>
-            </capacities>
-            <power>35</power>
-            <cooldownTime>3.51</cooldownTime>
-            <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-            <armorPenetrationSharp>0</armorPenetrationSharp>
-            <armorPenetrationBlunt>15</armorPenetrationBlunt>
-            <alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-          </li>
-        </tools>
-      </value>
-    </li>-->
-          <!--
-
-    -->
           <!-- ==========VFE Advanced Termite ========== -->
 
           <li Class="PatchOperationAddModExtension">

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -501,15 +501,6 @@
         </tools>
       </value>
     </li>
-	
-	<!--CE's blast is way too strong for them dying. Switching it to boomalope-->
-	
-    <li Class="PatchOperationReplace">
-      <xpath>Defs/ThingDef[defName="VFE_Mech_Inquisitor"]/race/deathActionWorkerClass</xpath>
-      <value>
-        <deathActionWorkerClass>DeathActionWorker_BigExplosion</deathActionWorkerClass>
-      </value>
-    </li>
 
     <!-- ========== VFE Carpenter and Ancient Carpenter ========== -->
 

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid_PlayerControlled.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid_PlayerControlled.xml
@@ -238,16 +238,9 @@
             </value>
           </li>
 
-          <!--CE's blast is way too strong for them dying. Switching it to boomalope-->
-
-          <li Class="PatchOperationReplace">
-            <xpath>Defs/ThingDef[defName="VFE_Mech_Inquisitor_PlayerControlled"]/race/deathActionWorkerClass</xpath>
-            <value>
-              <deathActionWorkerClass>DeathActionWorker_BigExplosion</deathActionWorkerClass>
-            </value>
-          </li>
         </operations>
       </match>
     </match>
   </Operation>
+
 </Patch>


### PR DESCRIPTION
## Changes

- Decreased the ammo mechs carry in their loadout.
- Added some missing patches and adjusted some others.
- Added the `AmmoGenPerMagOverride` node where necessary.
- Removed the patches that changed the explosion effect of the Inquisitor mechs from VFE-M as the intended explosion is not longer absurdly strong in CE.

## Reasoning

- Certain mechs especially the large ones carry too much ammo that almost always they don't even get to use more than half of it resulting in a ton of ammo being dropped upon their death which results in a wealth spike and too much ammo in general to be sold and smelted down for free. The new loadouts brings the mag counts to a reasonable amount.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
