### PR TITLE
Biomes Cavern Thrumbungus Shroom Melee Tool Fix

### DIFF
--- a/Patches/Biomes Caverns/Weapons/CE_Thrumbungushroom.xml
+++ b/Patches/Biomes Caverns/Weapons/CE_Thrumbungushroom.xml
@@ -75,6 +75,23 @@
 				  </weaponTags>
 				</li>
 	
+		<li Class="PatchOperationAdd">
+		  <xpath>Defs/ThingDef[defName="BMT_ThrumbungusShroom"]</xpath>
+		  <value>
+			<tools>
+			  <li Class="CombatExtended.ToolCE">
+				<label>Body</label>
+				<capacities>
+				  <li>Blunt</li>
+				</capacities>
+				<power>2</power>
+				<cooldownTime>1.75</cooldownTime>
+				<armorPenetrationBlunt>1.0</armorPenetrationBlunt>
+				<linkedBodyPartsGroup>Base</linkedBodyPartsGroup>
+			  </li>
+			</tools>
+		  </value>
+		</li>
 			
 			</operations>
 		</match>


### PR DESCRIPTION
Add Melee Tools to ThrumbungusShroom

Fix an oversight.


## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [X] (For compatibility patches) ...with and without patched mod loaded
- [X] Playtested a colony (for about 15 seconds to see that I can spawn a thrumbug shroom and thwack people with it)