### PR TITLE
(Alpha Mechs) Ammo destroy on gun swap fix 

### DIFF
--- a/Source/CombatExtended/Harmony/Compatibility/Harmony_AlphaMechs.cs
+++ b/Source/CombatExtended/Harmony/Compatibility/Harmony_AlphaMechs.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using HarmonyLib;
+using RimWorld;
+using UnityEngine;
+using Verse;
+
+namespace CombatExtended.HarmonyCE.Compatibility
+{
+
+    public static class Harmony_AlphaMechs
+    {
+        private static Type CompSwapWeapons_Patch_HarmonyPatches
+        {
+            get
+            {
+                return AccessTools.TypeByName("AlphaMechs.CompSwapWeapons");
+            }
+        }
+        [HarmonyPatch]
+        public static class Harmony_CompSwapWeapons_Apply
+        {
+            public static bool Prepare()
+            {
+                return CompSwapWeapons_Patch_HarmonyPatches != null;
+            }
+
+            public static MethodBase TargetMethod()
+            {
+                return AccessTools.Method("AlphaMechs.CompSwapWeapons:Apply", new Type[] { typeof(LocalTargetInfo), typeof(LocalTargetInfo) });
+            }
+
+            public static void Prefix(CompAbilityEffect __instance)
+            {
+                __instance?.parent?.pawn?.equipment.Primary?.TryGetComp<CompAmmoUser>()?.TryUnload();
+            }
+        }
+        
+    }
+}

--- a/Source/CombatExtended/Harmony/Compatibility/Harmony_AlphaMechs.cs
+++ b/Source/CombatExtended/Harmony/Compatibility/Harmony_AlphaMechs.cs
@@ -38,6 +38,6 @@ namespace CombatExtended.HarmonyCE.Compatibility
                 __instance?.parent?.pawn?.equipment.Primary?.TryGetComp<CompAmmoUser>()?.TryUnload();
             }
         }
-        
+
     }
 }


### PR DESCRIPTION
## Changes

Pawn unloads ammo before gun swap.
Tried to order (by code) pawn reload after gun swap, but failed.

## Reasoning

Why did you choose to implement things this way, e.g.
- Guns getting destroyed on swap weapons.


## Alternatives

Describe alternative implementations you have considered, e.g.
- Override swap gun code.
## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (opened my colony, swaped few times)
