### PR TITLE
Limit the automatic ammo pickup to 4 magazines

### DIFF
--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_TakeAndEquip.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_TakeAndEquip.cs
@@ -489,7 +489,8 @@ namespace CombatExtended
                                                 if (inventory.CanFitInInventory(th, out numToCarry))
                                                 {
                                                     Job job = JobMaker.MakeJob(JobDefOf.TakeInventory, th);
-                                                    job.count = numToCarry;
+                                                    int maxAmmoToPickup = (primaryAmmoUserWithInventoryCheck.MagSizeOverride > 0) ? primaryAmmoUserWithInventoryCheck.MagSizeOverride * 4 : primaryAmmoUserWithInventoryCheck.MagSize * 4;
+                                                    job.count = Mathf.Min(numToCarry, maxAmmoToPickup);
                                                     return job;
                                                 }
                                             }


### PR DESCRIPTION
## Changes

- Limits the amount of ammo that pawns without loadouts pick up to 4 magazines of their held weapon, respecting the mag override
- Requirements to initiate the pickup are unchanged (less than 2 mags held and no enemies nearby)
- Enemy ammo pickup amount is unchanged
- Pawns pick up in 4 magazine size batches, but don't try to drop excess from that amount (still allowing to manually pick up more ammo)
- **Loadout behavior remains unchanged**

## Reasoning

- Previously pawns without loadouts tried to pick up as much ammo as their inventory allowed, which resulted in the pawns hoarding ammo from other colonists or carrying unreasanable amounts of ammo themselves.
- Limiting the pickup to 4 magazines lets them carry a reasonable amount without any setup.

## Alternatives

- Leave the behavior unchanged - previous reasonings still apply
- Change the amount to be picked up for the total to match the 4 magazine limit - additional complexity for not much tangible benefit

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
