### PR TITLE
Patched damageDef tweaks

### DIFF
--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Misc/Weapons.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Misc/Weapons.xml
@@ -549,14 +549,14 @@
 					<li Class="PatchOperationReplace">
 						<xpath>Defs/ThingDef[defName="AM_Bullet_Tesla"]/projectile/damageAmountBase</xpath>
 						<value>
-							<damageAmountBase>10</damageAmountBase>
+							<damageAmountBase>5</damageAmountBase>
 						</value>
 					</li>
 
 					<li Class="PatchOperationReplace">
 						<xpath>Defs/ThingDef[defName="AM_Bullet_Tesla"]/modExtensions/li[@Class="VFEMech.TeslaChainingProps"]/damageDef</xpath>
 						<value>
-							<damageDef>Electrical</damageDef>
+							<damageDef>EMP</damageDef>
 						</value>
 					</li>
 

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Misc/Weapons.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Misc/Weapons.xml
@@ -549,7 +549,7 @@
 					<li Class="PatchOperationReplace">
 						<xpath>Defs/ThingDef[defName="AM_Bullet_Tesla"]/projectile/damageAmountBase</xpath>
 						<value>
-							<damageAmountBase>5</damageAmountBase>
+							<damageAmountBase>10</damageAmountBase>
 						</value>
 					</li>
 
@@ -557,6 +557,13 @@
 						<xpath>Defs/ThingDef[defName="AM_Bullet_Tesla"]/modExtensions/li[@Class="VFEMech.TeslaChainingProps"]/damageDef</xpath>
 						<value>
 							<damageDef>EMP</damageDef>
+						</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+						<xpath>Defs/ThingDef[defName="AM_Bullet_Tesla"]/modExtensions/li[@Class="VFEMech.TeslaChainingProps"]/maxLifetime</xpath>
+						<value>
+							<maxLifetime>6</maxLifetime>
 						</value>
 					</li>
 
@@ -668,7 +675,7 @@
 					<li Class="PatchOperationReplace">
 						<xpath>Defs/ThingDef[defName="AM_BeamGraserCannon"]/verbs/li/burstShotCount</xpath>
 						<value>
-							<burstShotCount>10</burstShotCount>
+							<burstShotCount>20</burstShotCount>
 						</value>
 					</li>
 

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Security_Turrets.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Security_Turrets.xml
@@ -530,7 +530,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VFE_Bullet_TeslaProjectile"]/projectile/damageAmountBase</xpath>
 					<value>
-						<damageAmountBase>10</damageAmountBase>
+						<damageAmountBase>15</damageAmountBase>
 					</value>
 				</li>
  
@@ -538,6 +538,13 @@
 					<xpath>Defs/ThingDef[defName="VFE_Bullet_TeslaProjectile"]/modExtensions/li[@Class="VFEMech.TeslaChainingProps"]/damageDef</xpath>
 					<value>
 						<damageDef>EMP</damageDef>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VFE_Bullet_TeslaProjectile"]/modExtensions/li[@Class="VFEMech.TeslaChainingProps"]/maxLifetime</xpath>
+					<value>
+						<maxLifetime>10</maxLifetime>
 					</value>
 				</li>
 

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Security_Turrets.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Security_Turrets.xml
@@ -537,7 +537,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VFE_Bullet_TeslaProjectile"]/modExtensions/li[@Class="VFEMech.TeslaChainingProps"]/damageDef</xpath>
 					<value>
-						<damageDef>Electrical</damageDef>
+						<damageDef>EMP</damageDef>
 					</value>
 				</li>
 


### PR DESCRIPTION
## Changes

- Changed the Electrical damageDef on Tesla weapons from VFE-M and Alpha Mechs, also tweaked and rebalanced some numbers on the patches.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
