### PR TITLE
Gloomy Dragonian Race Patch

### DIFF
--- a/Patches/Gloomy Dragonian Race/ThingDefs_Bodies/Dragonian_Bodytype.xml
+++ b/Patches/Gloomy Dragonian Race/ThingDefs_Bodies/Dragonian_Bodytype.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
+
 	<Operation Class="PatchOperationSequence">
 		<operations>
 				
@@ -11,134 +12,134 @@
 				</mods>
 				<match Class="PatchOperationSequence">
 					<operations>
-					
+
 						<!--Arm Groups-->
-					
+
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/BodyDef[defName="Dragonian_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[customLabel="Left arm"]/groups</xpath>
 							<value>
-							  <li>LeftArm</li>
+								<li>LeftArm</li>
 							</value>
 						</li>
-						
+
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/BodyDef[defName="Dragonian_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[customLabel="Right arm"]/groups</xpath>
 							<value>
-							  <li>RightArm</li>
+								<li>RightArm</li>
 							</value>
 						</li>
-						
+
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/BodyDef[defName="Dragonian_Body"]/corePart/parts/li[customLabel="Left shoulder"]/groups</xpath>
 							<value>
-							  <li>LeftShoulder</li>
+								<li>LeftShoulder</li>
 							</value>
 						</li>
-						
+
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/BodyDef[defName="Dragonian_Body"]/corePart/parts/li[customLabel="Right shoulder"]/groups</xpath>
 							<value>
-							  <li>RightShoulder</li>
+								<li>RightShoulder</li>
 							</value>
 						</li>
-					
+
 						<!--Natural Armor-->
-						
+
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/BodyDef[defName="Dragonian_Body"]/corePart/groups</xpath>
 							<value>
-									<li>CoveredByNaturalArmor</li>
+								<li>CoveredByNaturalArmor</li>
 							</value>
 						</li>
-						
+
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/BodyDef[defName="Dragonian_Body"]/corePart/parts/li[def="Neck"]/groups</xpath>
 							<value>
-									<li>CoveredByNaturalArmor</li>
+								<li>CoveredByNaturalArmor</li>
 							</value>
 						</li>
-						
+
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/BodyDef[defName="Dragonian_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/groups</xpath>
 							<value>
-									<li>CoveredByNaturalArmor</li>
+								<li>CoveredByNaturalArmor</li>
 							</value>
 						</li>
-						
+
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/BodyDef[defName="Dragonian_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Jaw"]/groups</xpath>
 							<value>
-									<li>CoveredByNaturalArmor</li>
+								<li>CoveredByNaturalArmor</li>
 							</value>
 						</li>
-						
+
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/BodyDef[defName="Dragonian_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]/groups</xpath>
 							<value>
-									<li>CoveredByNaturalArmor</li>
+								<li>CoveredByNaturalArmor</li>
 							</value>
 						</li>
-						
+
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/BodyDef[defName="Dragonian_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Ear"]/groups</xpath>
 							<value>
-									<li>CoveredByNaturalArmor</li>
+								<li>CoveredByNaturalArmor</li>
 							</value>
 						</li>
-						
+
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/BodyDef[defName="Dragonian_Body"]/corePart/parts/li[def="Shoulder"]/groups</xpath>
 							<value>
-									<li>CoveredByNaturalArmor</li>
+								<li>CoveredByNaturalArmor</li>
 							</value>
 						</li>
-						
+
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/BodyDef[defName="Dragonian_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/groups</xpath>
 							<value>
-									<li>CoveredByNaturalArmor</li>
+								<li>CoveredByNaturalArmor</li>
 							</value>
 						</li>
-						
+
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/BodyDef[defName="Dragonian_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Hand"]/groups</xpath>
 							<value>
-									<li>CoveredByNaturalArmor</li>
+								<li>CoveredByNaturalArmor</li>
 							</value>
 						</li>
-						
+
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/BodyDef[defName="Dragonian_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Hand"]/parts/li[def="Finger"]/groups</xpath>
 							<value>
-									<li>CoveredByNaturalArmor</li>
+								<li>CoveredByNaturalArmor</li>
 							</value>
 						</li>
-						
+
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/BodyDef[defName="Dragonian_Body"]/corePart/parts/li[def="Leg"]/groups</xpath>
 							<value>
-									<li>CoveredByNaturalArmor</li>
+								<li>CoveredByNaturalArmor</li>
 							</value>
 						</li>
-						
+
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/BodyDef[defName="Dragonian_Body"]/corePart/parts/li[def="Leg"]/parts/li[def="Foot"]/groups</xpath>
 							<value>
-									<li>CoveredByNaturalArmor</li>
+								<li>CoveredByNaturalArmor</li>
 							</value>
 						</li>
-						
+
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/BodyDef[defName="Dragonian_Body"]/corePart/parts/li[def="Leg"]/parts/li[def="Foot"]/parts/li[def="Toe"]/groups</xpath>
 							<value>
-									<li>CoveredByNaturalArmor</li>
+								<li>CoveredByNaturalArmor</li>
 							</value>
 						</li>
-						
+
 					</operations>
 				</match>
 			</li>
-
 		</operations>
 	</Operation>
+
 </Patch>

--- a/Patches/Gloomy Dragonian Race/ThingDefs_Bodies/Dragonian_Bodytype.xml
+++ b/Patches/Gloomy Dragonian Race/ThingDefs_Bodies/Dragonian_Bodytype.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<operations>
+				
+			<!--Patch Dragonian Bodytype-->
+
+			<li Class="PatchOperationFindMod">
+				<mods>
+					<li>Gloomy Dragonian race</li>
+				</mods>
+				<match Class="PatchOperationSequence">
+					<operations>
+					
+						<!--Arm Groups-->
+					
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/BodyDef[defName="Dragonian_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[customLabel="Left arm"]/groups</xpath>
+							<value>
+							  <li>LeftArm</li>
+							</value>
+						</li>
+						
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/BodyDef[defName="Dragonian_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[customLabel="Right arm"]/groups</xpath>
+							<value>
+							  <li>RightArm</li>
+							</value>
+						</li>
+						
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/BodyDef[defName="Dragonian_Body"]/corePart/parts/li[customLabel="Left shoulder"]/groups</xpath>
+							<value>
+							  <li>LeftShoulder</li>
+							</value>
+						</li>
+						
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/BodyDef[defName="Dragonian_Body"]/corePart/parts/li[customLabel="Right shoulder"]/groups</xpath>
+							<value>
+							  <li>RightShoulder</li>
+							</value>
+						</li>
+					
+						<!--Natural Armor-->
+						
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/BodyDef[defName="Dragonian_Body"]/corePart/groups</xpath>
+							<value>
+									<li>CoveredByNaturalArmor</li>
+							</value>
+						</li>
+						
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/BodyDef[defName="Dragonian_Body"]/corePart/parts/li[def="Neck"]/groups</xpath>
+							<value>
+									<li>CoveredByNaturalArmor</li>
+							</value>
+						</li>
+						
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/BodyDef[defName="Dragonian_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/groups</xpath>
+							<value>
+									<li>CoveredByNaturalArmor</li>
+							</value>
+						</li>
+						
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/BodyDef[defName="Dragonian_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Jaw"]/groups</xpath>
+							<value>
+									<li>CoveredByNaturalArmor</li>
+							</value>
+						</li>
+						
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/BodyDef[defName="Dragonian_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]/groups</xpath>
+							<value>
+									<li>CoveredByNaturalArmor</li>
+							</value>
+						</li>
+						
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/BodyDef[defName="Dragonian_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Ear"]/groups</xpath>
+							<value>
+									<li>CoveredByNaturalArmor</li>
+							</value>
+						</li>
+						
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/BodyDef[defName="Dragonian_Body"]/corePart/parts/li[def="Shoulder"]/groups</xpath>
+							<value>
+									<li>CoveredByNaturalArmor</li>
+							</value>
+						</li>
+						
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/BodyDef[defName="Dragonian_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/groups</xpath>
+							<value>
+									<li>CoveredByNaturalArmor</li>
+							</value>
+						</li>
+						
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/BodyDef[defName="Dragonian_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Hand"]/groups</xpath>
+							<value>
+									<li>CoveredByNaturalArmor</li>
+							</value>
+						</li>
+						
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/BodyDef[defName="Dragonian_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Hand"]/parts/li[def="Finger"]/groups</xpath>
+							<value>
+									<li>CoveredByNaturalArmor</li>
+							</value>
+						</li>
+						
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/BodyDef[defName="Dragonian_Body"]/corePart/parts/li[def="Leg"]/groups</xpath>
+							<value>
+									<li>CoveredByNaturalArmor</li>
+							</value>
+						</li>
+						
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/BodyDef[defName="Dragonian_Body"]/corePart/parts/li[def="Leg"]/parts/li[def="Foot"]/groups</xpath>
+							<value>
+									<li>CoveredByNaturalArmor</li>
+							</value>
+						</li>
+						
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/BodyDef[defName="Dragonian_Body"]/corePart/parts/li[def="Leg"]/parts/li[def="Foot"]/parts/li[def="Toe"]/groups</xpath>
+							<value>
+									<li>CoveredByNaturalArmor</li>
+							</value>
+						</li>
+						
+					</operations>
+				</match>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/Gloomy Dragonian Race/ThingDefs_Items/Items_Resource_Stuff.xml
+++ b/Patches/Gloomy Dragonian Race/ThingDefs_Items/Items_Resource_Stuff.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationSequence">
+	<operations>
+	  <li Class="PatchOperationFindMod">
+			
+		<mods><li>Gloomy Dragonian race</li></mods>
+			
+		<match Class="PatchOperationSequence">
+		<operations>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="WoolDragonian"]/statBases</xpath>
+				<value>
+					<Bulk>0.3</Bulk>
+					<WornBulk>0.3</WornBulk>
+					<StuffPower_Armor_Electric>0.10</StuffPower_Armor_Electric>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="WoolDragonian"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+					<StuffPower_Armor_Sharp>0.675</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="WoolDragonian"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<value>
+					<StuffPower_Armor_Blunt>0.85</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="WoolDragonian"]/statBases/StuffPower_Armor_Heat</xpath>
+				<value>
+					<StuffPower_Armor_Heat>0.15</StuffPower_Armor_Heat>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="WoolDragonian"]/stuffProps/statFactors</xpath>
+				<value>
+					<Mass>0.90</Mass>
+				</value>
+			</li>
+
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="WoolDragonian"]/stuffProps/categories</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="WoolDragonian"]/stuffProps</xpath>
+					<value>
+						<categories>
+						<li>SoftArmor</li>
+						</categories>
+					</value>
+				</nomatch>
+				<match Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="WoolDragonian"]/stuffProps/categories</xpath>
+					<value>
+						<li>SoftArmor</li>
+					</value>
+				</match>
+			</li>
+			
+		</operations>
+		</match>	
+	  </li>
+	</operations>	
+  </Operation>
+</Patch>

--- a/Patches/Gloomy Dragonian Race/ThingDefs_Items/Items_Resource_Stuff.xml
+++ b/Patches/Gloomy Dragonian Race/ThingDefs_Items/Items_Resource_Stuff.xml
@@ -1,72 +1,74 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
-  <Operation Class="PatchOperationSequence">
-	<operations>
-	  <li Class="PatchOperationFindMod">
-			
-		<mods><li>Gloomy Dragonian race</li></mods>
-			
-		<match Class="PatchOperationSequence">
+
+	<Operation Class="PatchOperationSequence">
 		<operations>
+			<li Class="PatchOperationFindMod">
 			
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="WoolDragonian"]/statBases</xpath>
-				<value>
-					<Bulk>0.3</Bulk>
-					<WornBulk>0.3</WornBulk>
-					<StuffPower_Armor_Electric>0.10</StuffPower_Armor_Electric>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="WoolDragonian"]/statBases/StuffPower_Armor_Sharp</xpath>
-				<value>
-					<StuffPower_Armor_Sharp>0.675</StuffPower_Armor_Sharp>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="WoolDragonian"]/statBases/StuffPower_Armor_Blunt</xpath>
-				<value>
-					<StuffPower_Armor_Blunt>0.85</StuffPower_Armor_Blunt>
-				</value>
-			</li>
+				<mods><li>Gloomy Dragonian race</li></mods>
 			
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="WoolDragonian"]/statBases/StuffPower_Armor_Heat</xpath>
-				<value>
-					<StuffPower_Armor_Heat>0.15</StuffPower_Armor_Heat>
-				</value>
-			</li>
+				<match Class="PatchOperationSequence">
+					<operations>
+			
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/ThingDef[defName="WoolDragonian"]/statBases</xpath>
+							<value>
+								<Bulk>0.3</Bulk>
+								<WornBulk>0.3</WornBulk>
+								<StuffPower_Armor_Electric>0.10</StuffPower_Armor_Electric>
+							</value>
+						</li>
 
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="WoolDragonian"]/stuffProps/statFactors</xpath>
-				<value>
-					<Mass>0.90</Mass>
-				</value>
-			</li>
+						<li Class="PatchOperationReplace">
+							<xpath>Defs/ThingDef[defName="WoolDragonian"]/statBases/StuffPower_Armor_Sharp</xpath>
+							<value>
+								<StuffPower_Armor_Sharp>0.675</StuffPower_Armor_Sharp>
+							</value>
+						</li>
 
-			<li Class="PatchOperationConditional">
-				<xpath>Defs/ThingDef[defName="WoolDragonian"]/stuffProps/categories</xpath>
-				<nomatch Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="WoolDragonian"]/stuffProps</xpath>
-					<value>
-						<categories>
-						<li>SoftArmor</li>
-						</categories>
-					</value>
-				</nomatch>
-				<match Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="WoolDragonian"]/stuffProps/categories</xpath>
-					<value>
-						<li>SoftArmor</li>
-					</value>
+						<li Class="PatchOperationReplace">
+							<xpath>Defs/ThingDef[defName="WoolDragonian"]/statBases/StuffPower_Armor_Blunt</xpath>
+							<value>
+								<StuffPower_Armor_Blunt>0.85</StuffPower_Armor_Blunt>
+							</value>
+						</li>
+
+						<li Class="PatchOperationReplace">
+							<xpath>Defs/ThingDef[defName="WoolDragonian"]/statBases/StuffPower_Armor_Heat</xpath>
+							<value>
+								<StuffPower_Armor_Heat>0.15</StuffPower_Armor_Heat>
+							</value>
+						</li>
+
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/ThingDef[defName="WoolDragonian"]/stuffProps/statFactors</xpath>
+							<value>
+								<Mass>0.90</Mass>
+							</value>
+						</li>
+
+						<li Class="PatchOperationConditional">
+							<xpath>Defs/ThingDef[defName="WoolDragonian"]/stuffProps/categories</xpath>
+							<nomatch Class="PatchOperationAdd">
+								<xpath>Defs/ThingDef[defName="WoolDragonian"]/stuffProps</xpath>
+								<value>
+									<categories>
+										<li>SoftArmor</li>
+									</categories>
+								</value>
+							</nomatch>
+							<match Class="PatchOperationAdd">
+								<xpath>Defs/ThingDef[defName="WoolDragonian"]/stuffProps/categories</xpath>
+								<value>
+									<li>SoftArmor</li>
+								</value>
+							</match>
+						</li>
+
+					</operations>
 				</match>
 			</li>
-			
 		</operations>
-		</match>	
-	  </li>
-	</operations>	
-  </Operation>
+	</Operation>
+
 </Patch>

--- a/Patches/Gloomy Dragonian Race/ThingDefs_Misc/DR_Apparel.xml
+++ b/Patches/Gloomy Dragonian Race/ThingDefs_Misc/DR_Apparel.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationSequence">
+	<operations>
+	  <li Class="PatchOperationFindMod">
+			
+		<mods><li>Gloomy Dragonian race</li></mods>
+			
+		<match Class="PatchOperationSequence">
+		<operations>
+
+			<!-- ========== Basic Wears ========== -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DR_BasicWear" or defName="DR_BasicDress"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<!-- ========== Regular ========== -->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DR_OpenDress" or
+				defName="DR_SideDress" or 
+				defName="DR_OffshoulderDress" or
+				defName="DR_Seethrough" or
+				defName="DR_MidOff" or
+				defName="DR_SlaveCloth"
+				]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+					<WornBulk>0</WornBulk>
+				</value>
+			</li>
+			
+			<!-- ========== Armor ========== -->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DR_BattleDress"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+					<Bulk>15</Bulk>
+					<WornBulk>7.5</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DR_BattleDress"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>4.05</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DR_BattleDress"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>5.1</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="DR_BattleDress"]/apparel/bodyPartGroups</xpath>
+				<value>
+					<li>Hands</li>
+					<li>Feet</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DR_BattleHelmA"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
+					<Bulk>3</Bulk>
+					<WornBulk>1</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DR_BattleHelmA"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>1</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DR_BattleHelmA"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>1.5</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+		</operations>
+		</match>	
+	  </li>
+	</operations>	
+  </Operation>
+</Patch>

--- a/Patches/Gloomy Dragonian Race/ThingDefs_Misc/DR_Apparel.xml
+++ b/Patches/Gloomy Dragonian Race/ThingDefs_Misc/DR_Apparel.xml
@@ -1,98 +1,102 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
-  <Operation Class="PatchOperationSequence">
-	<operations>
-	  <li Class="PatchOperationFindMod">
-			
-		<mods><li>Gloomy Dragonian race</li></mods>
-			
-		<match Class="PatchOperationSequence">
+
+	<Operation Class="PatchOperationSequence">
 		<operations>
-
-			<!-- ========== Basic Wears ========== -->
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="DR_BasicWear" or defName="DR_BasicDress"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
-				</value>
-			</li>
-
-			<!-- ========== Regular ========== -->
+			<li Class="PatchOperationFindMod">
 			
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="DR_OpenDress" or
+				<mods>
+					<li>Gloomy Dragonian race</li>
+				</mods>
+			
+				<match Class="PatchOperationSequence">
+					<operations>
+
+						<!-- ========== Basic Wears ========== -->
+
+						<li Class="PatchOperationReplace">
+							<xpath>Defs/ThingDef[defName="DR_BasicWear" or defName="DR_BasicDress"]/statBases/StuffEffectMultiplierArmor</xpath>
+							<value>
+								<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+							</value>
+						</li>
+
+						<!-- ========== Regular ========== -->
+
+						<li Class="PatchOperationReplace">
+							<xpath>Defs/ThingDef[defName="DR_OpenDress" or
 				defName="DR_SideDress" or 
 				defName="DR_OffshoulderDress" or
 				defName="DR_Seethrough" or
 				defName="DR_MidOff" or
 				defName="DR_SlaveCloth"
-				]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
-					<WornBulk>0</WornBulk>
-				</value>
+				]/statBases/StuffEffectMultiplierArmor							</xpath>
+							<value>
+								<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+								<WornBulk>0</WornBulk>
+							</value>
+						</li>
+
+						<!-- ========== Armor ========== -->
+
+						<li Class="PatchOperationReplace">
+							<xpath>Defs/ThingDef[defName="DR_BattleDress"]/statBases/StuffEffectMultiplierArmor</xpath>
+							<value>
+								<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+								<Bulk>15</Bulk>
+								<WornBulk>7.5</WornBulk>
+							</value>
+						</li>
+
+						<li Class="PatchOperationReplace">
+							<xpath>Defs/ThingDef[defName="DR_BattleDress"]/statBases/ArmorRating_Sharp</xpath>
+							<value>
+								<ArmorRating_Sharp>4.05</ArmorRating_Sharp>
+							</value>
+						</li>
+
+						<li Class="PatchOperationReplace">
+							<xpath>Defs/ThingDef[defName="DR_BattleDress"]/statBases/ArmorRating_Blunt</xpath>
+							<value>
+								<ArmorRating_Blunt>5.1</ArmorRating_Blunt>
+							</value>
+						</li>
+
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/ThingDef[defName="DR_BattleDress"]/apparel/bodyPartGroups</xpath>
+							<value>
+								<li>Hands</li>
+								<li>Feet</li>
+							</value>
+						</li>
+
+						<li Class="PatchOperationReplace">
+							<xpath>Defs/ThingDef[defName="DR_BattleHelmA"]/statBases/StuffEffectMultiplierArmor</xpath>
+							<value>
+								<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
+								<Bulk>3</Bulk>
+								<WornBulk>1</WornBulk>
+							</value>
+						</li>
+
+						<li Class="PatchOperationReplace">
+							<xpath>Defs/ThingDef[defName="DR_BattleHelmA"]/statBases/ArmorRating_Sharp</xpath>
+							<value>
+								<ArmorRating_Sharp>1</ArmorRating_Sharp>
+							</value>
+						</li>
+
+						<li Class="PatchOperationReplace">
+							<xpath>Defs/ThingDef[defName="DR_BattleHelmA"]/statBases/ArmorRating_Blunt</xpath>
+							<value>
+								<ArmorRating_Blunt>1.5</ArmorRating_Blunt>
+							</value>
+						</li>
+
+					</operations>
+				</match>
 			</li>
-			
-			<!-- ========== Armor ========== -->
-			
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="DR_BattleDress"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
-					<Bulk>15</Bulk>
-					<WornBulk>7.5</WornBulk>
-				</value>
-			</li>
-			
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="DR_BattleDress"]/statBases/ArmorRating_Sharp</xpath>
-				<value>
-					<ArmorRating_Sharp>4.05</ArmorRating_Sharp>
-				</value>
-			</li>
-			
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="DR_BattleDress"]/statBases/ArmorRating_Blunt</xpath>
-				<value>
-					<ArmorRating_Blunt>5.1</ArmorRating_Blunt>
-				</value>
-			</li>
-			
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="DR_BattleDress"]/apparel/bodyPartGroups</xpath>
-				<value>
-					<li>Hands</li>
-					<li>Feet</li>
-				</value>
-			</li>
-			
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="DR_BattleHelmA"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
-					<Bulk>3</Bulk>
-					<WornBulk>1</WornBulk>
-				</value>
-			</li>
-			
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="DR_BattleHelmA"]/statBases/ArmorRating_Sharp</xpath>
-				<value>
-					<ArmorRating_Sharp>1</ArmorRating_Sharp>
-				</value>
-			</li>
-			
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="DR_BattleHelmA"]/statBases/ArmorRating_Blunt</xpath>
-				<value>
-					<ArmorRating_Blunt>1.5</ArmorRating_Blunt>
-				</value>
-			</li>
-			
 		</operations>
-		</match>	
-	  </li>
-	</operations>	
-  </Operation>
+	</Operation>
+
 </Patch>

--- a/Patches/Gloomy Dragonian Race/ThingDefs_Misc/DR_Weapon.xml
+++ b/Patches/Gloomy Dragonian Race/ThingDefs_Misc/DR_Weapon.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationSequence">
+	<operations>
+	  <li Class="PatchOperationFindMod">
+			
+		<mods><li>Gloomy Dragonian race</li></mods>
+			
+		<match Class="PatchOperationSequence">
+		<operations>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DR_BattleMace"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>handle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>5</power>
+							<cooldownTime>1.37</cooldownTime>
+							<armorPenetrationBlunt>0.87</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+								<li>Demolish</li>
+							</capacities>
+							<power>32</power>
+							<extraMeleeDamages>
+							<li>
+								<def>EMP</def>
+								<amount>15</amount>
+							</li>
+							</extraMeleeDamages>					
+							<cooldownTime>2.57</cooldownTime>
+							<armorPenetrationBlunt>11.5</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+						</li>				
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="DR_BattleMace"]/statBases</xpath>
+				<value>
+					<Bulk>8</Bulk>
+					<MeleeCounterParryBonus>0.40</MeleeCounterParryBonus>
+				</value>
+			</li>
+
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName = "DR_BattleMace"]/equippedStatOffsets</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName = "DR_BattleMace"]</xpath>
+					<value>
+						<equippedStatOffsets />
+					</value>
+				</nomatch>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="DR_BattleMace"]/equippedStatOffsets</xpath>
+				<value>
+					<MeleeCritChance>1.50</MeleeCritChance>
+					<MeleeParryChance>0.30</MeleeParryChance>
+					<MeleeDodgeChance>0.30</MeleeDodgeChance>	
+				</value>	
+			</li>
+			
+		</operations>
+		</match>	
+	  </li>
+	  
+	</operations>	
+  </Operation>
+</Patch>

--- a/Patches/Gloomy Dragonian Race/ThingDefs_Misc/DR_Weapon.xml
+++ b/Patches/Gloomy Dragonian Race/ThingDefs_Misc/DR_Weapon.xml
@@ -1,79 +1,82 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
-  <Operation Class="PatchOperationSequence">
-	<operations>
-	  <li Class="PatchOperationFindMod">
-			
-		<mods><li>Gloomy Dragonian race</li></mods>
-			
-		<match Class="PatchOperationSequence">
-		<operations>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="DR_BattleMace"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>handle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>1.37</cooldownTime>
-							<armorPenetrationBlunt>0.87</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>head</label>
-							<capacities>
-								<li>Blunt</li>
-								<li>Demolish</li>
-							</capacities>
-							<power>32</power>
-							<extraMeleeDamages>
-							<li>
-								<def>EMP</def>
-								<amount>15</amount>
-							</li>
-							</extraMeleeDamages>					
-							<cooldownTime>2.57</cooldownTime>
-							<armorPenetrationBlunt>11.5</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
-						</li>				
-					</tools>
-				</value>
-			</li>
-			
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="DR_BattleMace"]/statBases</xpath>
-				<value>
-					<Bulk>8</Bulk>
-					<MeleeCounterParryBonus>0.40</MeleeCounterParryBonus>
-				</value>
-			</li>
 
-			<li Class="PatchOperationConditional">
-				<xpath>Defs/ThingDef[defName = "DR_BattleMace"]/equippedStatOffsets</xpath>
-				<nomatch Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName = "DR_BattleMace"]</xpath>
-					<value>
-						<equippedStatOffsets />
-					</value>
-				</nomatch>
-			</li>
+	<Operation Class="PatchOperationSequence">
+		<operations>
+			<li Class="PatchOperationFindMod">
+
+				<mods>
+					<li>Gloomy Dragonian race</li>
+				</mods>
+
+				<match Class="PatchOperationSequence">
+					<operations>
+						<li Class="PatchOperationReplace">
+							<xpath>Defs/ThingDef[defName="DR_BattleMace"]/tools</xpath>
+							<value>
+								<tools>
+									<li Class="CombatExtended.ToolCE">
+										<label>handle</label>
+										<capacities>
+											<li>Poke</li>
+										</capacities>
+										<power>5</power>
+										<cooldownTime>1.37</cooldownTime>
+										<armorPenetrationBlunt>0.87</armorPenetrationBlunt>
+										<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+									</li>
+									<li Class="CombatExtended.ToolCE">
+										<label>head</label>
+										<capacities>
+											<li>Blunt</li>
+											<li>Demolish</li>
+										</capacities>
+										<power>32</power>
+										<extraMeleeDamages>
+											<li>
+												<def>EMP</def>
+												<amount>15</amount>
+											</li>
+										</extraMeleeDamages>
+										<cooldownTime>2.57</cooldownTime>
+										<armorPenetrationBlunt>11.5</armorPenetrationBlunt>
+										<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+									</li>
+								</tools>
+							</value>
+						</li>
+
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/ThingDef[defName="DR_BattleMace"]/statBases</xpath>
+							<value>
+								<Bulk>8</Bulk>
+								<MeleeCounterParryBonus>0.40</MeleeCounterParryBonus>
+							</value>
+						</li>
+
+						<li Class="PatchOperationConditional">
+							<xpath>Defs/ThingDef[defName = "DR_BattleMace"]/equippedStatOffsets</xpath>
+							<nomatch Class="PatchOperationAdd">
+								<xpath>Defs/ThingDef[defName = "DR_BattleMace"]</xpath>
+								<value>
+									<equippedStatOffsets/>
+								</value>
+							</nomatch>
+						</li>
+
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/ThingDef[defName="DR_BattleMace"]/equippedStatOffsets</xpath>
+							<value>
+								<MeleeCritChance>1.50</MeleeCritChance>
+								<MeleeParryChance>0.30</MeleeParryChance>
+								<MeleeDodgeChance>0.30</MeleeDodgeChance>
+							</value>
+						</li>
 			
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="DR_BattleMace"]/equippedStatOffsets</xpath>
-				<value>
-					<MeleeCritChance>1.50</MeleeCritChance>
-					<MeleeParryChance>0.30</MeleeParryChance>
-					<MeleeDodgeChance>0.30</MeleeDodgeChance>	
-				</value>	
+					</operations>
+				</match>
 			</li>
-			
 		</operations>
-		</match>	
-	  </li>
-	  
-	</operations>	
-  </Operation>
+	</Operation>
+
 </Patch>

--- a/Patches/Gloomy Dragonian Race/ThingDefs_Races/Race_Dragonian.xml
+++ b/Patches/Gloomy Dragonian Race/ThingDefs_Races/Race_Dragonian.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationSequence">
+	<operations>
+	  <li Class="PatchOperationFindMod">
+		<mods>
+			<li>Gloomy Dragonian race</li>
+		</mods>			
+		<match Class="PatchOperationSequence">
+		<operations>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Dragonian_Race"]/comps</xpath>
+				<value>
+					<li>
+						<compClass>CombatExtended.CompPawnGizmo</compClass>
+					</li>
+					<li Class="CombatExtended.CompProperties_Suppressable" />
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Dragonian_Race"]/comps</xpath>
+				<value>
+					<li>
+						<compClass>CombatExtended.CompPawnGizmo</compClass>
+					</li>
+					<li Class="CombatExtended.CompProperties_Suppressable" />
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Dragonian_Race"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Humanoid</bodyShape>
+					</li>
+				</value>
+			</li>
+			
+			<!-- 5.2 Speed/0.8 Size/60 kg -->
+			
+			<li Class="PatchOperationAdd">
+			 <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Dragonian_Race"]/statBases</xpath>
+				<value>
+				<MeleeCritChance>1.08</MeleeCritChance>
+				<MeleeParryChance>1.06</MeleeParryChance>
+				<Suppressability>1</Suppressability>
+				<!--Innate toxic resistance of 0.6-->
+				<SmokeSensitivity>0.6</SmokeSensitivity>
+				</value>
+			</li>
+	
+			<li Class="PatchOperationReplace">
+			 <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Dragonian_Race"]/statBases/MeleeDodgeChance</xpath>
+				<value>
+					<MeleeDodgeChance>1.18</MeleeDodgeChance>
+				</value>
+			</li>
+
+			<!--4mm Wool (skin+scales), their vanilla armor is thrumbo level-->
+		
+			<li Class="PatchOperationReplace">
+			 <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Dragonian_Race"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>2.7</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+			 <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Dragonian_Race"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>3.4</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+			 <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Dragonian_Race"]/statBases/ArmorRating_Heat</xpath>
+				<value>
+					<ArmorRating_Heat>0.6</ArmorRating_Heat>
+				</value>
+			</li>
+
+			<!--Their vanilla melee is very strong (18 verus 8.2 for humanlike)-->
+		
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Dragonian_Race"]/tools</xpath> 
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left fist</label>
+							<capacities>
+								<li>Scratch</li>
+							</capacities>
+							<power>7</power>
+							<cooldownTime>0.89</cooldownTime>
+							<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.47</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right fist</label>
+							<capacities>
+								<li>Scratch</li>
+							</capacities>
+							<power>7</power>
+							<cooldownTime>0.89</cooldownTime>
+							<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.47</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>tail</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>20</power>
+							<cooldownTime>2.28</cooldownTime>
+							<linkedBodyPartsGroup>Dragonian_Tail</linkedBodyPartsGroup>
+							<chanceFactor>0.2</chanceFactor>
+							<armorPenetrationBlunt>7.875</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+			 <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Dragonian_Race"]/alienRace/raceRestriction/whiteApparelList</xpath>
+				<value>
+				<li>CE_Apparel_TacVest</li>
+				<li>CE_Apparel_Backpack</li>
+				<li>CE_Apparel_TribalBackpack</li>
+				<li>CE_Apparel_BallisticShield</li>
+				<li>CE_Apparel_MeleeShield</li>
+				<li>CE_Apparel_GasMask</li>
+				<li>CE_Apparel_ImprovGasMask</li>
+				</value>
+			</li>
+	
+		</operations>
+		</match>	
+	  </li>
+	</operations>	
+  </Operation>
+</Patch>

--- a/Patches/Gloomy Dragonian Race/ThingDefs_Races/Race_Dragonian.xml
+++ b/Patches/Gloomy Dragonian Race/ThingDefs_Races/Race_Dragonian.xml
@@ -1,145 +1,147 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
-  <Operation Class="PatchOperationSequence">
-	<operations>
-	  <li Class="PatchOperationFindMod">
-		<mods>
-			<li>Gloomy Dragonian race</li>
-		</mods>			
-		<match Class="PatchOperationSequence">
+
+	<Operation Class="PatchOperationSequence">
 		<operations>
+			<li Class="PatchOperationFindMod">
+				<mods>
+					<li>Gloomy Dragonian race</li>
+				</mods>
+				<match Class="PatchOperationSequence">
+					<operations>
 
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Dragonian_Race"]/comps</xpath>
-				<value>
-					<li>
-						<compClass>CombatExtended.CompPawnGizmo</compClass>
-					</li>
-					<li Class="CombatExtended.CompProperties_Suppressable" />
-				</value>
-			</li>
-			
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Dragonian_Race"]/comps</xpath>
-				<value>
-					<li>
-						<compClass>CombatExtended.CompPawnGizmo</compClass>
-					</li>
-					<li Class="CombatExtended.CompProperties_Suppressable" />
-				</value>
-			</li>
-
-			<li Class="PatchOperationAddModExtension">
-				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Dragonian_Race"]</xpath>
-				<value>
-					<li Class="CombatExtended.RacePropertiesExtensionCE">
-						<bodyShape>Humanoid</bodyShape>
-					</li>
-				</value>
-			</li>
-			
-			<!-- 5.2 Speed/0.8 Size/60 kg -->
-			
-			<li Class="PatchOperationAdd">
-			 <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Dragonian_Race"]/statBases</xpath>
-				<value>
-				<MeleeCritChance>1.08</MeleeCritChance>
-				<MeleeParryChance>1.06</MeleeParryChance>
-				<Suppressability>1</Suppressability>
-				<!--Innate toxic resistance of 0.6-->
-				<SmokeSensitivity>0.6</SmokeSensitivity>
-				</value>
-			</li>
-	
-			<li Class="PatchOperationReplace">
-			 <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Dragonian_Race"]/statBases/MeleeDodgeChance</xpath>
-				<value>
-					<MeleeDodgeChance>1.18</MeleeDodgeChance>
-				</value>
-			</li>
-
-			<!--4mm Wool (skin+scales), their vanilla armor is thrumbo level-->
-		
-			<li Class="PatchOperationReplace">
-			 <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Dragonian_Race"]/statBases/ArmorRating_Sharp</xpath>
-				<value>
-					<ArmorRating_Sharp>2.7</ArmorRating_Sharp>
-				</value>
-			</li>
-			
-			<li Class="PatchOperationReplace">
-			 <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Dragonian_Race"]/statBases/ArmorRating_Blunt</xpath>
-				<value>
-					<ArmorRating_Blunt>3.4</ArmorRating_Blunt>
-				</value>
-			</li>
-			
-			<li Class="PatchOperationReplace">
-			 <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Dragonian_Race"]/statBases/ArmorRating_Heat</xpath>
-				<value>
-					<ArmorRating_Heat>0.6</ArmorRating_Heat>
-				</value>
-			</li>
-
-			<!--Their vanilla melee is very strong (18 verus 8.2 for humanlike)-->
-		
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Dragonian_Race"]/tools</xpath> 
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>left fist</label>
-							<capacities>
-								<li>Scratch</li>
-							</capacities>
-							<power>7</power>
-							<cooldownTime>0.89</cooldownTime>
-							<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
-							<armorPenetrationSharp>0.47</armorPenetrationSharp>
-							<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Dragonian_Race"]/comps</xpath>
+							<value>
+								<li>
+									<compClass>CombatExtended.CompPawnGizmo</compClass>
+								</li>
+								<li Class="CombatExtended.CompProperties_Suppressable"/>
+							</value>
 						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>right fist</label>
-							<capacities>
-								<li>Scratch</li>
-							</capacities>
-							<power>7</power>
-							<cooldownTime>0.89</cooldownTime>
-							<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
-							<armorPenetrationSharp>0.47</armorPenetrationSharp>
-							<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Dragonian_Race"]/comps</xpath>
+							<value>
+								<li>
+									<compClass>CombatExtended.CompPawnGizmo</compClass>
+								</li>
+								<li Class="CombatExtended.CompProperties_Suppressable"/>
+							</value>
 						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>tail</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>20</power>
-							<cooldownTime>2.28</cooldownTime>
-							<linkedBodyPartsGroup>Dragonian_Tail</linkedBodyPartsGroup>
-							<chanceFactor>0.2</chanceFactor>
-							<armorPenetrationBlunt>7.875</armorPenetrationBlunt>
+
+						<li Class="PatchOperationAddModExtension">
+							<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Dragonian_Race"]</xpath>
+							<value>
+								<li Class="CombatExtended.RacePropertiesExtensionCE">
+									<bodyShape>Humanoid</bodyShape>
+								</li>
+							</value>
 						</li>
-					</tools>
-				</value>
+
+						<!-- 5.2 Speed/0.8 Size/60 kg -->
+
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Dragonian_Race"]/statBases</xpath>
+							<value>
+								<MeleeCritChance>1.08</MeleeCritChance>
+								<MeleeParryChance>1.06</MeleeParryChance>
+								<Suppressability>1</Suppressability>
+								<!--Innate toxic resistance of 0.6-->
+								<SmokeSensitivity>0.6</SmokeSensitivity>
+							</value>
+						</li>
+
+						<li Class="PatchOperationReplace">
+							<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Dragonian_Race"]/statBases/MeleeDodgeChance</xpath>
+							<value>
+								<MeleeDodgeChance>1.18</MeleeDodgeChance>
+							</value>
+						</li>
+
+						<!--4mm Wool (skin+scales), their vanilla armor is thrumbo level-->
+
+						<li Class="PatchOperationReplace">
+							<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Dragonian_Race"]/statBases/ArmorRating_Sharp</xpath>
+							<value>
+								<ArmorRating_Sharp>2.7</ArmorRating_Sharp>
+							</value>
+						</li>
+
+						<li Class="PatchOperationReplace">
+							<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Dragonian_Race"]/statBases/ArmorRating_Blunt</xpath>
+							<value>
+								<ArmorRating_Blunt>3.4</ArmorRating_Blunt>
+							</value>
+						</li>
+
+						<li Class="PatchOperationReplace">
+							<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Dragonian_Race"]/statBases/ArmorRating_Heat</xpath>
+							<value>
+								<ArmorRating_Heat>0.6</ArmorRating_Heat>
+							</value>
+						</li>
+
+						<!--Their vanilla melee is very strong (18 verus 8.2 for humanlike)-->
+
+						<li Class="PatchOperationReplace">
+							<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Dragonian_Race"]/tools</xpath>
+							<value>
+								<tools>
+									<li Class="CombatExtended.ToolCE">
+										<label>left fist</label>
+										<capacities>
+											<li>Scratch</li>
+										</capacities>
+										<power>7</power>
+										<cooldownTime>0.89</cooldownTime>
+										<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+										<armorPenetrationSharp>0.47</armorPenetrationSharp>
+										<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+									</li>
+									<li Class="CombatExtended.ToolCE">
+										<label>right fist</label>
+										<capacities>
+											<li>Scratch</li>
+										</capacities>
+										<power>7</power>
+										<cooldownTime>0.89</cooldownTime>
+										<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+										<armorPenetrationSharp>0.47</armorPenetrationSharp>
+										<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+									</li>
+									<li Class="CombatExtended.ToolCE">
+										<label>tail</label>
+										<capacities>
+											<li>Blunt</li>
+										</capacities>
+										<power>20</power>
+										<cooldownTime>2.28</cooldownTime>
+										<linkedBodyPartsGroup>Dragonian_Tail</linkedBodyPartsGroup>
+										<chanceFactor>0.2</chanceFactor>
+										<armorPenetrationBlunt>7.875</armorPenetrationBlunt>
+									</li>
+								</tools>
+							</value>
+						</li>
+
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Dragonian_Race"]/alienRace/raceRestriction/whiteApparelList</xpath>
+							<value>
+								<li>CE_Apparel_TacVest</li>
+								<li>CE_Apparel_Backpack</li>
+								<li>CE_Apparel_TribalBackpack</li>
+								<li>CE_Apparel_BallisticShield</li>
+								<li>CE_Apparel_MeleeShield</li>
+								<li>CE_Apparel_GasMask</li>
+								<li>CE_Apparel_ImprovGasMask</li>
+							</value>
+						</li>
+
+					</operations>
+				</match>
 			</li>
-			
-			<li Class="PatchOperationAdd">
-			 <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Dragonian_Race"]/alienRace/raceRestriction/whiteApparelList</xpath>
-				<value>
-				<li>CE_Apparel_TacVest</li>
-				<li>CE_Apparel_Backpack</li>
-				<li>CE_Apparel_TribalBackpack</li>
-				<li>CE_Apparel_BallisticShield</li>
-				<li>CE_Apparel_MeleeShield</li>
-				<li>CE_Apparel_GasMask</li>
-				<li>CE_Apparel_ImprovGasMask</li>
-				</value>
-			</li>
-	
 		</operations>
-		</match>	
-	  </li>
-	</operations>	
-  </Operation>
+	</Operation>
+
 </Patch>


### PR DESCRIPTION
## Additions

Patch for gloomy dragopnian race, which is a distinct mod from dragonian. Seperated folder as there are a lot of different defs, enough that it isn't really worth sharing the patches with the old version.

## Changes

Hammer no longer has augmented EMP in vanilla, so removed from the mace here.

## Reasoning

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

We could try and merge the patch with the alternatiave version of the mod, but there's a lot of differnt defnames and the bodydef is different.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
