### PR TITLE
Patch Recon Mechs Mod

### DIFF
--- a/Patches/Recon Mechanoid/Mech_PawnKinds.xml
+++ b/Patches/Recon Mechanoid/Mech_PawnKinds.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Recon Mechanoid</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[
+					defName="Mech_Recon" or
+					defName="Mech_ReconBlaster" or
+					defName="Mech_Scout" or
+					defName="Mech_ScoutBlaster"
+					]</xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+						<primaryMagazineCount>
+							<min>3</min>
+							<max>5</max>
+						</primaryMagazineCount>
+					</li>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Recon Mechanoid/Mech_PawnKinds.xml
+++ b/Patches/Recon Mechanoid/Mech_PawnKinds.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
+
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>Recon Mechanoid</li>
@@ -7,22 +8,22 @@
 		<match Class="PatchOperationSequence">
 			<operations>
 
-			<li Class="PatchOperationAddModExtension">
-				<xpath>Defs/PawnKindDef[
-					defName="Mech_Recon" or
-					defName="Mech_ReconBlaster" or
-					defName="Mech_Scout" or
-					defName="Mech_ScoutBlaster"
-					]</xpath>
-				<value>
-					<li Class="CombatExtended.LoadoutPropertiesExtension">
-						<primaryMagazineCount>
-							<min>3</min>
-							<max>5</max>
-						</primaryMagazineCount>
-					</li>
-				</value>
-			</li>
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/PawnKindDef[
+						defName="Mech_Recon" or
+						defName="Mech_ReconBlaster" or
+						defName="Mech_Scout" or
+						defName="Mech_ScoutBlaster"
+						]</xpath>
+					<value>
+						<li Class="CombatExtended.LoadoutPropertiesExtension">
+							<primaryMagazineCount>
+								<min>3</min>
+								<max>5</max>
+							</primaryMagazineCount>
+						</li>
+					</value>
+				</li>
 
 			</operations>
 		</match>

--- a/Patches/Recon Mechanoid/Races_Mechanoid.xml
+++ b/Patches/Recon Mechanoid/Races_Mechanoid.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Recon Mechanoid</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[
+				defName="Mech_Recon" or
+				defName="Mech_ReconBlaster" or
+				defName="Mech_Scout" or
+				defName="Mech_ScoutBlaster"
+				]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Humanoid</bodyShape>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="Mech_Recon" or
+				defName="Mech_ReconBlaster" or
+				defName="Mech_Scout" or
+				defName="Mech_ScoutBlaster"				
+				]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>3</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="Mech_Recon" or
+				defName="Mech_ReconBlaster" or
+				defName="Mech_Scout" or
+				defName="Mech_ScoutBlaster"
+				]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>2</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[
+				defName="Mech_Recon" or
+				defName="Mech_ReconBlaster" or
+				defName="Mech_Scout" or
+				defName="Mech_ScoutBlaster"
+				]/statBases</xpath>
+				<value>
+					<AimingAccuracy>1.0</AimingAccuracy>
+					<ShootingAccuracyPawn>1.1</ShootingAccuracyPawn>
+					<MeleeDodgeChance>0.15</MeleeDodgeChance>
+					<MeleeCritChance>0.075</MeleeCritChance>
+					<MeleeParryChance>0.075</MeleeParryChance>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="Mech_Recon" or
+				defName="Mech_ReconBlaster" or
+				defName="Mech_Scout" or
+				defName="Mech_ScoutBlaster"
+				]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>4</power>
+							<cooldownTime>2.0</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+							<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>left fist</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>1.11</cooldownTime>
+							<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>1.2</armorPenetrationBlunt>
+							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right fist</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>1.11</cooldownTime>
+							<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>1.2</armorPenetrationBlunt>
+							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+						</li>					
+					</tools>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Recon Mechanoid/Races_Mechanoid.xml
+++ b/Patches/Recon Mechanoid/Races_Mechanoid.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
+
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>Recon Mechanoid</li>
@@ -7,106 +8,106 @@
 		<match Class="PatchOperationSequence">
 			<operations>
 
-			<li Class="PatchOperationAddModExtension">
-				<xpath>Defs/ThingDef[
-				defName="Mech_Recon" or
-				defName="Mech_ReconBlaster" or
-				defName="Mech_Scout" or
-				defName="Mech_ScoutBlaster"
-				]</xpath>
-				<value>
-					<li Class="CombatExtended.RacePropertiesExtensionCE">
-						<bodyShape>Humanoid</bodyShape>
-					</li>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[
-				defName="Mech_Recon" or
-				defName="Mech_ReconBlaster" or
-				defName="Mech_Scout" or
-				defName="Mech_ScoutBlaster"				
-				]/statBases/ArmorRating_Blunt</xpath>
-				<value>
-					<ArmorRating_Blunt>3</ArmorRating_Blunt>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[
-				defName="Mech_Recon" or
-				defName="Mech_ReconBlaster" or
-				defName="Mech_Scout" or
-				defName="Mech_ScoutBlaster"
-				]/statBases/ArmorRating_Sharp</xpath>
-				<value>
-					<ArmorRating_Sharp>2</ArmorRating_Sharp>
-				</value>
-			</li>
-
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[
-				defName="Mech_Recon" or
-				defName="Mech_ReconBlaster" or
-				defName="Mech_Scout" or
-				defName="Mech_ScoutBlaster"
-				]/statBases</xpath>
-				<value>
-					<AimingAccuracy>1.0</AimingAccuracy>
-					<ShootingAccuracyPawn>1.1</ShootingAccuracyPawn>
-					<MeleeDodgeChance>0.15</MeleeDodgeChance>
-					<MeleeCritChance>0.075</MeleeCritChance>
-					<MeleeParryChance>0.075</MeleeParryChance>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[
-				defName="Mech_Recon" or
-				defName="Mech_ReconBlaster" or
-				defName="Mech_Scout" or
-				defName="Mech_ScoutBlaster"
-				]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>head</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>4</power>
-							<cooldownTime>2.0</cooldownTime>
-							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-							<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
-							<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
-							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/ThingDef[
+						defName="Mech_Recon" or
+						defName="Mech_ReconBlaster" or
+						defName="Mech_Scout" or
+						defName="Mech_ScoutBlaster"
+						]</xpath>
+					<value>
+						<li Class="CombatExtended.RacePropertiesExtensionCE">
+							<bodyShape>Humanoid</bodyShape>
 						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>left fist</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.11</cooldownTime>
-							<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
-							<armorPenetrationBlunt>1.2</armorPenetrationBlunt>
-							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>right fist</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.11</cooldownTime>
-							<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
-							<armorPenetrationBlunt>1.2</armorPenetrationBlunt>
-							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-						</li>					
-					</tools>
-				</value>
-			</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+						defName="Mech_Recon" or
+						defName="Mech_ReconBlaster" or
+						defName="Mech_Scout" or
+						defName="Mech_ScoutBlaster"
+						]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>3</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+						defName="Mech_Recon" or
+						defName="Mech_ReconBlaster" or
+						defName="Mech_Scout" or
+						defName="Mech_ScoutBlaster"
+						]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>2</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[
+						defName="Mech_Recon" or
+						defName="Mech_ReconBlaster" or
+						defName="Mech_Scout" or
+						defName="Mech_ScoutBlaster"
+						]/statBases</xpath>
+					<value>
+						<AimingAccuracy>1.0</AimingAccuracy>
+						<ShootingAccuracyPawn>1.1</ShootingAccuracyPawn>
+						<MeleeDodgeChance>0.15</MeleeDodgeChance>
+						<MeleeCritChance>0.075</MeleeCritChance>
+						<MeleeParryChance>0.075</MeleeParryChance>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+						defName="Mech_Recon" or
+						defName="Mech_ReconBlaster" or
+						defName="Mech_Scout" or
+						defName="Mech_ScoutBlaster"
+						]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>4</power>
+								<cooldownTime>2.0</cooldownTime>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+								<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+								<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>left fist</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>2</power>
+								<cooldownTime>1.11</cooldownTime>
+								<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>1.2</armorPenetrationBlunt>
+								<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>right fist</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>2</power>
+								<cooldownTime>1.11</cooldownTime>
+								<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>1.2</armorPenetrationBlunt>
+								<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+							</li>
+						</tools>
+					</value>
+				</li>
 
 			</operations>
 		</match>

--- a/Patches/Recon Mechanoid/RangedRecon.xml
+++ b/Patches/Recon Mechanoid/RangedRecon.xml
@@ -1,0 +1,208 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Recon Mechanoid</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- Melee Tools -->
+			<li Class="PatchOperationReplace">
+				<xpath>
+					Defs/ThingDef[
+					defName="Gun_ReconSMG" or
+					defName="Gun_MechScoutGun" or
+					defName="Gun_ReconBlaster" or
+					defName="Gun_ScoutLancer"
+					]/tools
+				</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>stock</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
+							<chanceFactor>1.5</chanceFactor>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>barrel</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>5</power>
+							<cooldownTime>2.02</cooldownTime>
+							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>muzzle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<!-- Recon SMG -->
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>Gun_ReconSMG</defName>
+				<statBases>
+					<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.00</SightsEfficiency>
+					<ShotSpread>0.19</ShotSpread>
+					<SwayFactor>0.98</SwayFactor>
+					<Bulk>3</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>1.79</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
+					<warmupTime>0.6</warmupTime>
+					<range>20.9</range>
+					<burstShotCount>5</burstShotCount>
+					<ticksBetweenBurstShots>8</ticksBetweenBurstShots>
+					<soundCast>Shot_Slugthrower</soundCast>
+					<soundCastTail>GunTail_Light</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>20</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_45ACP</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aimedBurstShotCount>2</aimedBurstShotCount>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>Snapshot</aiAimMode>
+				</FireModes>
+				<weaponTags>
+					<li>CE_SMG</li>
+					<li>CE_AI_BROOM</li>
+				</weaponTags>
+			</li>
+
+			<!-- Recon Blaster  -->
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>Gun_ReconBlaster</defName>
+				<statBases>
+					<SightsEfficiency>1.1</SightsEfficiency>
+					<ShotSpread>0.15</ShotSpread>
+					<SwayFactor>0.78</SwayFactor>
+					<Bulk>4.50</Bulk>
+					<Mass>2.0</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+				</statBases>
+				<Properties>
+					<recoilAmount>1.42</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_6x18mmCharged</defaultProjectile>
+					<burstShotCount>4</burstShotCount>
+					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+					<warmupTime>0.5</warmupTime>
+					<range>28</range>
+					<soundCast>Shot_ChargeBlaster</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>28</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_6x18mmCharged</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aimedBurstShotCount>2</aimedBurstShotCount>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>Snapshot</aiAimMode>
+				</FireModes>
+			</li>
+
+			<!-- Scout Gun -->
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>Gun_MechScoutGun</defName>
+				<statBases>
+					<Mass>3.26</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>1</SightsEfficiency>
+					<ShotSpread>0.09</ShotSpread>
+					<SwayFactor>1.35</SwayFactor>
+					<Bulk>5</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>1.54</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+					<warmupTime>1.1</warmupTime>
+					<range>46</range>
+					<soundCast>Shot_Slugthrower</soundCast>
+					<soundCastTail>GunTail_Light</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>10</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+				<weaponTags>
+					<li>CE_AI_AR</li>
+				</weaponTags>
+			</li>
+
+			<!-- Scout Lancer -->
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>Gun_ScoutLancer</defName>
+				<statBases>
+					<Mass>3.26</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.1</SightsEfficiency>
+					<ShotSpread>0.09</ShotSpread>
+					<SwayFactor>1.35</SwayFactor>
+					<Bulk>5</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>1.54</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_6x24mmCharged</defaultProjectile>
+					<warmupTime>1.1</warmupTime>
+					<range>52</range>
+					<soundCast>Shot_ChargeBlaster</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>10</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_6x24mmCharged</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+				<weaponTags>
+					<li>CE_AI_AR</li>
+				</weaponTags>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Recon Mechanoid/RangedRecon.xml
+++ b/Patches/Recon Mechanoid/RangedRecon.xml
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Patch>
+
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>Recon Mechanoid</li>
@@ -7,199 +8,199 @@
 		<match Class="PatchOperationSequence">
 			<operations>
 
-			<!-- Melee Tools -->
-			<li Class="PatchOperationReplace">
-				<xpath>
-					Defs/ThingDef[
-					defName="Gun_ReconSMG" or
-					defName="Gun_MechScoutGun" or
-					defName="Gun_ReconBlaster" or
-					defName="Gun_ScoutLancer"
-					]/tools
-				</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
+				<!-- Melee Tools -->
+				<li Class="PatchOperationReplace">
+					<xpath>
+						Defs/ThingDef[
+						defName="Gun_ReconSMG" or
+						defName="Gun_MechScoutGun" or
+						defName="Gun_ReconBlaster" or
+						defName="Gun_ScoutLancer"
+						]/tools
+					</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>stock</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>8</power>
+								<cooldownTime>1.55</cooldownTime>
+								<chanceFactor>1.5</chanceFactor>
+								<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>barrel</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>5</power>
+								<cooldownTime>2.02</cooldownTime>
+								<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>muzzle</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>8</power>
+								<cooldownTime>1.55</cooldownTime>
+								<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+							</li>
+						</tools>
+					</value>
+				</li>
 
-			<!-- Recon SMG -->
-			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
-				<defName>Gun_ReconSMG</defName>
-				<statBases>
-					<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
-					<SightsEfficiency>1.00</SightsEfficiency>
-					<ShotSpread>0.19</ShotSpread>
-					<SwayFactor>0.98</SwayFactor>
-					<Bulk>3</Bulk>
-				</statBases>
-				<Properties>
-					<recoilAmount>1.79</recoilAmount>
-					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-					<hasStandardCommand>true</hasStandardCommand>
-					<defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
-					<warmupTime>0.6</warmupTime>
-					<range>20.9</range>
-					<burstShotCount>4</burstShotCount>
-					<ticksBetweenBurstShots>8</ticksBetweenBurstShots>
-					<soundCast>Shot_Slugthrower</soundCast>
-					<soundCastTail>GunTail_Light</soundCastTail>
-					<muzzleFlashScale>9</muzzleFlashScale>
-				</Properties>
-				<AmmoUser>
-					<magazineSize>20</magazineSize>
-					<reloadTime>4</reloadTime>
-					<ammoSet>AmmoSet_45ACP</ammoSet>
-				</AmmoUser>
-				<FireModes>
-					<aimedBurstShotCount>2</aimedBurstShotCount>
-					<aiUseBurstMode>FALSE</aiUseBurstMode>
-					<aiAimMode>Snapshot</aiAimMode>
-				</FireModes>
-				<weaponTags>
-					<li>CE_SMG</li>
-					<li>CE_AI_BROOM</li>
-				</weaponTags>
-			</li>
+				<!-- Recon SMG -->
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>Gun_ReconSMG</defName>
+					<statBases>
+						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+						<SightsEfficiency>1.00</SightsEfficiency>
+						<ShotSpread>0.19</ShotSpread>
+						<SwayFactor>0.98</SwayFactor>
+						<Bulk>3</Bulk>
+					</statBases>
+					<Properties>
+						<recoilAmount>1.79</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
+						<warmupTime>0.6</warmupTime>
+						<range>20.9</range>
+						<burstShotCount>4</burstShotCount>
+						<ticksBetweenBurstShots>8</ticksBetweenBurstShots>
+						<soundCast>Shot_Slugthrower</soundCast>
+						<soundCastTail>GunTail_Light</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+					<AmmoUser>
+						<magazineSize>20</magazineSize>
+						<reloadTime>4</reloadTime>
+						<ammoSet>AmmoSet_45ACP</ammoSet>
+					</AmmoUser>
+					<FireModes>
+						<aimedBurstShotCount>2</aimedBurstShotCount>
+						<aiUseBurstMode>FALSE</aiUseBurstMode>
+						<aiAimMode>Snapshot</aiAimMode>
+					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_BROOM</li>
+					</weaponTags>
+				</li>
 
-			<!-- Recon Blaster  -->
-			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
-				<defName>Gun_ReconBlaster</defName>
-				<statBases>
-					<SightsEfficiency>1.1</SightsEfficiency>
-					<ShotSpread>0.15</ShotSpread>
-					<SwayFactor>0.78</SwayFactor>
-					<Bulk>4.50</Bulk>
-					<Mass>2.0</Mass>
-					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-				</statBases>
-				<Properties>
-					<recoilAmount>1.42</recoilAmount>
-					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-					<hasStandardCommand>true</hasStandardCommand>
-					<defaultProjectile>Bullet_6x18mmCharged</defaultProjectile>
-					<burstShotCount>4</burstShotCount>
-					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
-					<warmupTime>0.5</warmupTime>
-					<range>28</range>
-					<soundCast>Shot_ChargeBlaster</soundCast>
-					<soundCastTail>GunTail_Heavy</soundCastTail>
-					<muzzleFlashScale>9</muzzleFlashScale>
-				</Properties>
-				<AmmoUser>
-					<magazineSize>28</magazineSize>
-					<reloadTime>4</reloadTime>
-					<ammoSet>AmmoSet_6x18mmCharged</ammoSet>
-				</AmmoUser>
-				<FireModes>
-					<aimedBurstShotCount>2</aimedBurstShotCount>
-					<aiUseBurstMode>FALSE</aiUseBurstMode>
-					<aiAimMode>Snapshot</aiAimMode>
-				</FireModes>
-			</li>
+				<!-- Recon Blaster  -->
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>Gun_ReconBlaster</defName>
+					<statBases>
+						<SightsEfficiency>1.1</SightsEfficiency>
+						<ShotSpread>0.15</ShotSpread>
+						<SwayFactor>0.78</SwayFactor>
+						<Bulk>4.50</Bulk>
+						<Mass>2.0</Mass>
+						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					</statBases>
+					<Properties>
+						<recoilAmount>1.42</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_6x18mmCharged</defaultProjectile>
+						<burstShotCount>4</burstShotCount>
+						<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+						<warmupTime>0.5</warmupTime>
+						<range>28</range>
+						<soundCast>Shot_ChargeBlaster</soundCast>
+						<soundCastTail>GunTail_Heavy</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+					<AmmoUser>
+						<magazineSize>28</magazineSize>
+						<reloadTime>4</reloadTime>
+						<ammoSet>AmmoSet_6x18mmCharged</ammoSet>
+					</AmmoUser>
+					<FireModes>
+						<aimedBurstShotCount>2</aimedBurstShotCount>
+						<aiUseBurstMode>FALSE</aiUseBurstMode>
+						<aiAimMode>Snapshot</aiAimMode>
+					</FireModes>
+				</li>
 
-			<!-- Scout Gun -->
-			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
-				<defName>Gun_MechScoutGun</defName>
-				<statBases>
-					<Mass>3.26</Mass>
-					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-					<SightsEfficiency>1</SightsEfficiency>
-					<ShotSpread>0.09</ShotSpread>
-					<SwayFactor>1.35</SwayFactor>
-					<Bulk>5</Bulk>
-				</statBases>
-				<Properties>
-					<recoilAmount>1.54</recoilAmount>
-					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-					<hasStandardCommand>true</hasStandardCommand>
-					<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
-					<warmupTime>1.1</warmupTime>
-					<range>46</range>
-					<soundCast>Shot_Slugthrower</soundCast>
-					<soundCastTail>GunTail_Light</soundCastTail>
-					<muzzleFlashScale>9</muzzleFlashScale>
-				</Properties>
-				<AmmoUser>
-					<magazineSize>10</magazineSize>
-					<reloadTime>4</reloadTime>
-					<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
-				</AmmoUser>
-				<FireModes>
-					<aiUseBurstMode>TRUE</aiUseBurstMode>
-					<aiAimMode>AimedShot</aiAimMode>
-				</FireModes>
-				<weaponTags>
-					<li>CE_AI_AR</li>
-				</weaponTags>
-			</li>
+				<!-- Scout Gun -->
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>Gun_MechScoutGun</defName>
+					<statBases>
+						<Mass>3.26</Mass>
+						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+						<SightsEfficiency>1</SightsEfficiency>
+						<ShotSpread>0.09</ShotSpread>
+						<SwayFactor>1.35</SwayFactor>
+						<Bulk>5</Bulk>
+					</statBases>
+					<Properties>
+						<recoilAmount>1.54</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+						<warmupTime>1.1</warmupTime>
+						<range>46</range>
+						<soundCast>Shot_Slugthrower</soundCast>
+						<soundCastTail>GunTail_Light</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+					<AmmoUser>
+						<magazineSize>10</magazineSize>
+						<reloadTime>4</reloadTime>
+						<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+					</AmmoUser>
+					<FireModes>
+						<aiUseBurstMode>TRUE</aiUseBurstMode>
+						<aiAimMode>AimedShot</aiAimMode>
+					</FireModes>
+					<weaponTags>
+						<li>CE_AI_AR</li>
+					</weaponTags>
+				</li>
 
-			<!-- Scout Lancer -->
-			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
-				<defName>Gun_ScoutLancer</defName>
-				<statBases>
-					<Mass>3.26</Mass>
-					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-					<SightsEfficiency>1.1</SightsEfficiency>
-					<ShotSpread>0.09</ShotSpread>
-					<SwayFactor>1.35</SwayFactor>
-					<Bulk>5</Bulk>
-				</statBases>
-				<Properties>
-					<recoilAmount>1.54</recoilAmount>
-					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-					<hasStandardCommand>true</hasStandardCommand>
-					<defaultProjectile>Bullet_6x24mmCharged</defaultProjectile>
-					<warmupTime>1.1</warmupTime>
-					<range>52</range>
-					<soundCast>Shot_ChargeBlaster</soundCast>
-					<soundCastTail>GunTail_Heavy</soundCastTail>
-					<muzzleFlashScale>9</muzzleFlashScale>
-				</Properties>
-				<AmmoUser>
-					<magazineSize>10</magazineSize>
-					<reloadTime>4</reloadTime>
-					<ammoSet>AmmoSet_6x24mmCharged</ammoSet>
-				</AmmoUser>
-				<FireModes>
-					<aiUseBurstMode>TRUE</aiUseBurstMode>
-					<aiAimMode>AimedShot</aiAimMode>
-				</FireModes>
-				<weaponTags>
-					<li>CE_AI_AR</li>
-				</weaponTags>
-			</li>
+				<!-- Scout Lancer -->
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>Gun_ScoutLancer</defName>
+					<statBases>
+						<Mass>3.26</Mass>
+						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+						<SightsEfficiency>1.1</SightsEfficiency>
+						<ShotSpread>0.09</ShotSpread>
+						<SwayFactor>1.35</SwayFactor>
+						<Bulk>5</Bulk>
+					</statBases>
+					<Properties>
+						<recoilAmount>1.54</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_6x24mmCharged</defaultProjectile>
+						<warmupTime>1.1</warmupTime>
+						<range>52</range>
+						<soundCast>Shot_ChargeBlaster</soundCast>
+						<soundCastTail>GunTail_Heavy</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+					<AmmoUser>
+						<magazineSize>10</magazineSize>
+						<reloadTime>4</reloadTime>
+						<ammoSet>AmmoSet_6x24mmCharged</ammoSet>
+					</AmmoUser>
+					<FireModes>
+						<aiUseBurstMode>TRUE</aiUseBurstMode>
+						<aiAimMode>AimedShot</aiAimMode>
+					</FireModes>
+					<weaponTags>
+						<li>CE_AI_AR</li>
+					</weaponTags>
+				</li>
 
 			</operations>
 		</match>

--- a/Patches/Recon Mechanoid/RangedRecon.xml
+++ b/Patches/Recon Mechanoid/RangedRecon.xml
@@ -71,7 +71,7 @@
 					<defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
 					<warmupTime>0.6</warmupTime>
 					<range>20.9</range>
-					<burstShotCount>5</burstShotCount>
+					<burstShotCount>4</burstShotCount>
 					<ticksBetweenBurstShots>8</ticksBetweenBurstShots>
 					<soundCast>Shot_Slugthrower</soundCast>
 					<soundCastTail>GunTail_Light</soundCastTail>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -366,6 +366,7 @@ Ratkin Apparel+ |
 Ratnik-3 Prototype Armor    |
 Red Army (Continued) |
 Redcoat Apparel	|
+Recon Mechanoid |
 ReGrowth: Extinct Animals |
 Reinforced Mechanoid 2 |
 Remote Detonator	|
@@ -426,11 +427,11 @@ Spartan Foundry	|
 Spidercamp's Horses     |
 SRTS Expanded	|
 Stalingrad – Uniforms   |
-Steamworld Uniforms |
 Star Crafters Armory  |
 Star Wars - Droids |
 Star Wars - Factions |
 Starship Troopers Aracnids  |
+Steamworld Uniforms |
 Swords (Continued)  |
 Tactical Extremity Protection [BAL] |
 Textiles+ (continued)   |


### PR DESCRIPTION
## Additions
- Patch Recon Mechanoid.
  - Mechs have light armor and limited bulk capacity.
  - Weapons a inferior variants (more sway, lower rate of fire, more recoil) of industrial and spacer rifles and SMGs. SMGs use pistol caliber (.45 ACP and 6x18mm Charged) while rifles are semi-auto in 5.56 NATO and 6x24mm Charged.
  
## Changes
- Fix a listed mod on the SupportedModList that wasn't in alphabetical order.

## References
Close #2511 

## Reasoning
The mod notes these mechs as light, frontline models, only a small step up from militors. As such, their weapon options are more effective than the militor's shotgun--with the option of automatic SMGs or decent-ranged semi-auto rifles--but are still nothing special.

## Alternatives
Could stat the weapons differently.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
