### PR TITLE
Expose projectile shadow to XML

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompFragments.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompFragments.cs
@@ -61,7 +61,7 @@ namespace CombatExtended
                     fragSpeedFactor * projectile.def.projectile.speed,
                     projectile
                 );
-                
+
                 projectile.castShadow = (Rand.Value < fragShadowChance); // moved after Launch due to it assigning shadow
 
                 fragSpawnedInTick++;

--- a/Source/CombatExtended/CombatExtended/Comps/CompFragments.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompFragments.cs
@@ -48,7 +48,6 @@ namespace CombatExtended
 
                 projectile.canTargetSelf = canTargetSelf;
                 projectile.minCollisionDistance = minCollisionDistance;
-                projectile.castShadow = (Rand.Value < fragShadowChance);
                 projectile.logMisses = false;
                 float elevAngle = Mathf.Asin(fragAngleSinRange.RandomInRange);
 
@@ -62,6 +61,8 @@ namespace CombatExtended
                     fragSpeedFactor * projectile.def.projectile.speed,
                     projectile
                 );
+                
+                projectile.castShadow = (Rand.Value < fragShadowChance); // moved after Launch due to it assigning shadow
 
                 fragSpawnedInTick++;
                 if (fragSpawnedInTick >= fragPerTick)

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -609,6 +609,10 @@ namespace CombatExtended
             this.shotHeight = shotHeight;
             this.shotRotation = shotRotation;
             this.shotSpeed = Math.Max(shotSpeed, def.projectile.speed);
+            if (def.projectile is ProjectilePropertiesCE props)
+            {
+                this.castShadow = props.castShadow;
+            }
             Launch(launcher, origin, equipment);
             this.ticksToImpact = IntTicksToImpact;
         }

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectilePropertiesCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectilePropertiesCE.cs
@@ -23,6 +23,7 @@ namespace CombatExtended
         public bool damageFalloff = true; // Damage falloff for *instant* projectiles.
         public float armorPenetrationSharp;
         public float armorPenetrationBlunt;
+        public bool castShadow = true;
 
         public float suppressionFactor = 1;
         public float airborneSuppressionFactor = 1;


### PR DESCRIPTION
## Additions

- Allowed to set a `castShadow` node to CE projectiles in XML, defaults to `true`
- Moved the shadow assignment for fragments to keep the original behavior (only 20% chance for frags to have a shadow)

## Reasoning

- The value is only assigned at projectile launch, allowing it to be modified later
- Added on request from GarbageDay, for easier custom projectiles

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] Playtested a colony (specify how long)
