### PR TITLE
VE Psycast Overshield: Projectile wont be intercepted if interceptor = launcher

### DIFF
--- a/Source/CombatExtended/Compatibility/VanillaPsycastExpanded.cs
+++ b/Source/CombatExtended/Compatibility/VanillaPsycastExpanded.cs
@@ -67,7 +67,7 @@ namespace CombatExtended.Compatibility
                 var newExactPos = projectile.ExactPosition;
                 if (interceptor.GetType() == typeof(Hediff_Overshield))
                 {
-                    var result = interceptor.pawn.Position == cell || PreventTryColideWithPawn(projectile, interceptor.pawn, newExactPos);
+                    var result = interceptor.pawn != launcher && (interceptor.pawn.Position == cell || PreventTryColideWithPawn(projectile, interceptor.pawn, newExactPos));
                     if (result)
                     {
                         projectile.ExactPosition = IntersectionPoint(projectile.OriginIV3.ToVector3(), projectile.ExactPosition, interceptor.pawn.DrawPos, interceptor.OverlaySize).OrderBy(x => (projectile.OriginIV3.ToVector3() - x).sqrMagnitude).First();


### PR DESCRIPTION

## Fixes

Fixed shots interception (pawn with overshield was not able to shoot using some guns, e.g. chain shotgun)

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (few minutes)
