### PR TITLE
Add Alpha Mythology to the list of supported mods

### DIFF
--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -74,6 +74,7 @@ Alpha Genes |
 Alpha Genes - Insectoid Mutations |
 Alpha Mechs |
 Alpha Memes |
+Alpha Mythology |
 Alpha Ships |
 Altered Carbon |
 Ancient Blade Cyborg  |

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -272,7 +272,6 @@ Let's Have a Cat!	|
 Littluna Race |
 Logann Race	|
 Logistics_Mechanoid |
-Magical Menagerie	|
 Magic Wands |
 Makeshift Melee Weapons |
 Marilyn the Mincho Worshipper Witch |


### PR DESCRIPTION
## Additions

None

## Changes

Small PR to add Alpha Mythology to the list of supported mods



## Reasoning

It seems to have an up to date patch [here](https://github.com/CombatExtended-Continued/CombatExtended/blob/Development/Patches/Alpha%20Mythology/AM_CE_Patch_Races.xml) so it must have been an oversight not to include it


## Testing

Haven't tested it since this is just a markdown change
