### PR TITLE
FSX market value updated

### DIFF
--- a/Defs/ThingDefs_Items/Items_Resource_Ammo.xml
+++ b/Defs/ThingDefs_Items/Items_Resource_Ammo.xml
@@ -58,7 +58,7 @@
 		<stackLimit>25</stackLimit>
 		<statBases>
 			<MaxHitPoints>70</MaxHitPoints>
-			<MarketValue>10</MarketValue>
+			<MarketValue>7.5</MarketValue>
 			<Flammability>1.0</Flammability>
 			<DeteriorationRate>1.0</DeteriorationRate>
 			<Mass>0.5</Mass>


### PR DESCRIPTION
## Changes

- Actually changed FSX's market value to 7.5$, it was left out in #2604.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
