### PR TITLE
Bloodloss hediff hidden label renamed

### DIFF
--- a/Patches/Core/HediffDefs/BloodLoss.xml
+++ b/Patches/Core/HediffDefs/BloodLoss.xml
@@ -5,7 +5,7 @@
 		<value>
 			<stages>
 				<li>
-					<label>hidden</label>
+					<label>minor</label>
 					<becomeVisible>false</becomeVisible>
 				</li>
 				<li>


### PR DESCRIPTION
## Changes

- Relabeled the "hidden" stage back to the vanilla "minor" as it's not actually hidden and seeing it labeled as hidden in-game is really odd.
![image](https://github.com/CombatExtended-Continued/CombatExtended/assets/56392968/aec86c46-2ca3-4e95-8825-044a08f904f1)

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
