### PR TITLE
update BiotechExpansion's patch

### DIFF
--- a/Patches/Biotech Expansion - Mythic/BEM_AbilityDefs_Patch.xml
+++ b/Patches/Biotech Expansion - Mythic/BEM_AbilityDefs_Patch.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
+
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>Biotech Expansion - Mythic</li>
@@ -7,27 +8,27 @@
 		<match Class="PatchOperationSequence">
 			<operations>
 
-                <li Class="PatchOperationAdd">
-                    <xpath>Defs/ThingDef[defName="BTEMy_BrilliantBlast"]</xpath>
-                    <value>
-                        <thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
-                    </value>
-                </li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="BTEMy_BrilliantBlast"]</xpath>
+					<value>
+						<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+					</value>
+				</li>
 
-                <li Class="PatchOperationReplace">
-                    <xpath>Defs/ThingDef[defName="BTEMy_BrilliantBlast"]/projectile</xpath>
-                    <value>
-                        <projectile Class="CombatExtended.ProjectilePropertiesCE">
-                            <explosionRadius>3</explosionRadius>
-                            <damageDef>Bomb</damageDef>
-                            <damageAmountBase>56</damageAmountBase>
-                            <explosionDelay>0</explosionDelay>
-                            <dropsCasings>false</dropsCasings>
-                            <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-                            <speed>80</speed>
-                        </projectile>
-                    </value>
-                </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="BTEMy_BrilliantBlast"]/projectile</xpath>
+					<value>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<explosionRadius>3</explosionRadius>
+							<damageDef>Bomb</damageDef>
+							<damageAmountBase>56</damageAmountBase>
+							<explosionDelay>0</explosionDelay>
+							<dropsCasings>false</dropsCasings>
+							<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+							<speed>80</speed>
+						</projectile>
+					</value>
+				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="BTEMy_Punish"]/projectile</xpath>
@@ -59,4 +60,5 @@
 			</operations>
 		</match>
 	</Operation>
+
 </Patch>

--- a/Patches/Biotech Expansion - Mythic/BEM_AbilityDefs_Patch.xml
+++ b/Patches/Biotech Expansion - Mythic/BEM_AbilityDefs_Patch.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Biotech Expansion - Mythic</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs/ThingDef[defName="BTEMy_BrilliantBlast"]</xpath>
+                    <value>
+                        <thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/ThingDef[defName="BTEMy_BrilliantBlast"]/projectile</xpath>
+                    <value>
+                        <projectile Class="CombatExtended.ProjectilePropertiesCE">
+                            <explosionRadius>3</explosionRadius>
+                            <damageDef>Bomb</damageDef>
+                            <damageAmountBase>56</damageAmountBase>
+                            <explosionDelay>0</explosionDelay>
+                            <dropsCasings>false</dropsCasings>
+                            <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+                            <speed>80</speed>
+                        </projectile>
+                    </value>
+                </li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="BTEMy_Punish"]/projectile</xpath>
+					<value>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<damageDef>RangedStab</damageDef>
+							<speed>120</speed>
+							<damageAmountBase>20</damageAmountBase>
+							<armorPenetrationSharp>6</armorPenetrationSharp>
+							<armorPenetrationBlunt>6</armorPenetrationBlunt>
+						</projectile>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/AbilityDef[defName="BTEMy_Punish"]/verbProperties/range</xpath>
+					<value>
+						<range>21</range>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/AbilityDef[defName="BTEMy_BrilliantBlast"]/verbProperties/range</xpath>
+					<value>
+						<range>36</range>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Tribal smoke bombs
- New tribal smoke bomb sprite
- Tribal smoke bomb recipes at smithing bench and crafting spot using prometheum
migrate BiotechExpansion's CE patch to CE side.
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased regular smoke bomb radius
 add patch for BiotechExpansion's abilities, blast range patch may need balancing, considering beside the mana costs it has a 2 hours cooldown.

## References

Links to the associated issues or other related pull requests, e.g.
needs[PR#2657](https://github.com/CombatExtended-Continued/CombatExtended/pull/2657) to work.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
