### PR TITLE
Move tuque back to overhead

### DIFF
--- a/Patches/Core/ThingDefs_Misc/Apparel_Hats.xml
+++ b/Patches/Core/ThingDefs_Misc/Apparel_Hats.xml
@@ -9,16 +9,7 @@
 			<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Apparel_Tuque"]/apparel/layers</xpath>
-		<value>
-			<layers>
-				<li>OnHead</li>
-			</layers>
-		</value>
-	</Operation>
-
+  
 	<!-- ========== Tribal Headdress ========== -->
 
 	<Operation Class="PatchOperationReplace">

--- a/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Apparel.xml
+++ b/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Apparel.xml
@@ -102,7 +102,6 @@
 								defName="Moyo_BowlerHat"]/apparel/layers </xpath>
 							<value>
 								<layers>
-									<li>OnHead</li>
 									<li>Overhead</li>
 								</layers>
 							</value>

--- a/Patches/Rimmu-Nation - Clothing/RNC_CE_Patch_Apparel_Headgear.xml
+++ b/Patches/Rimmu-Nation - Clothing/RNC_CE_Patch_Apparel_Headgear.xml
@@ -167,17 +167,6 @@
 						defName="RNApparel_Beanie" or
 						defName="RNApparel_M81Tuque" or
 						defName="RNApparel_MulticamTuque"
-						]/apparel/layers/li[.="Overhead"] </xpath>
-					<value>
-						<li>OnHead</li>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[
-						defName="RNApparel_Beanie" or
-						defName="RNApparel_M81Tuque" or
-						defName="RNApparel_MulticamTuque"
 						]/statBases/StuffEffectMultiplierArmor </xpath>
 					<value>
 						<!-- Equivalent to vanilla tuque -->
@@ -207,13 +196,6 @@
 					<xpath>Defs/ThingDef[defName="RNApparel_BeanieDivision"]/equippedStatOffsets</xpath>
 					<value>
 						<SmokeSensitivity>-1</SmokeSensitivity>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="RNApparel_BeanieDivision"]/apparel/layers/li[.="Overhead"]</xpath>
-					<value>
-						<li>OnHead</li>
 					</value>
 				</li>
 

--- a/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Headgear_Industrial.xml
+++ b/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Headgear_Industrial.xml
@@ -100,7 +100,7 @@
 					<xpath>Defs/ThingDef[defName="VAE_Headgear_Sunglasses" or defName="VAE_Headgear_Glasses"]/apparel/layers</xpath>
 					<value>
 						<layers>
-							<li>OnHead</li>
+							<li>StrappedHead</li>
 						</layers>
 					</value>
 				</li>

--- a/Patches/Vanilla Ideology Expanded - Hats and Rags/Apparel_Headgear.xml
+++ b/Patches/Vanilla Ideology Expanded - Hats and Rags/Apparel_Headgear.xml
@@ -66,24 +66,6 @@
 					</value>
 				</li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VIEHAR_Apparel_HorseMask"]/apparel/layers</xpath>
-					<value>
-						<layers>
-							<li>OnHead</li>
-						</layers>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VIEHAR_Apparel_Headbag"]/apparel/layers</xpath>
-					<value>
-						<layers>
-							<li>OnHead</li>
-						</layers>
-					</value>
-				</li>
-
 			</operations>
 		</match>
 	</Operation>


### PR DESCRIPTION
Tuque texture(s) clip with a whole bunch of helmet textures, many people were comlaining about this before, and now that we actually have balaclavas there's no point keeping them thisway.
