### PR TITLE
Alpha Mechs abilities patch

### DIFF
--- a/Patches/Alpha Mechs/Mods/Biotech/AbilityDefs/Abilities_Biotech.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/AbilityDefs/Abilities_Biotech.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Alpha Mechs</li>
+		</mods>
+
+		<match Class="PatchOperationFindMod">
+			<mods>
+				<li>Biotech</li>
+			</mods>
+
+			<match Class="PatchOperationSequence">
+				<operations>
+
+					<li Class="PatchOperationReplace">
+						<xpath>Defs/AbilityDef[defName="AM_Detonate"]/comps/li[@Class="AlphaMechs.CompProperties_Detonate"]/damageAmount</xpath>
+						<value>
+							<damageAmount>94</damageAmount>
+						</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+						<xpath>Defs/AbilityDef[defName="AM_LongjumpMech"]/verbProperties/range</xpath>
+						<value>
+							<range>22.9</range>
+						</value>
+					</li>
+
+				</operations>
+			</match>
+		</match>
+	</Operation>
+
+</Patch>


### PR DESCRIPTION
## Changes

- Patched the detonate and mech jump ability that were unpatched.

## Reasoning

- The detonate ability deals x0.6 the default bomb damage which results in 0.6*156.
- The jump ability is patch according to the biotech jump abilities.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
