### PR TITLE
Flashbang overhaul

### DIFF
--- a/Defs/DamageDefs/Damages_LocalInjury.xml
+++ b/Defs/DamageDefs/Damages_LocalInjury.xml
@@ -124,4 +124,12 @@
 		</additionalHediffs>
 	</DamageDef>
 
+	<DamageDef ParentName="StunBase">
+		<defName>Flashbang</defName>
+		<label>flashbang</label>
+		<workerClass>DamageWorker_AddGlobal</workerClass>
+		<soundExplosion>Explosion_Stun</soundExplosion>
+		<hediff>Flashbanged</hediff>
+	</DamageDef>
+
 </Defs>

--- a/Defs/HediffDefs/Hediffs_CE.xml
+++ b/Defs/HediffDefs/Hediffs_CE.xml
@@ -378,8 +378,6 @@
 		</stages>
 	</HediffDef>
 
-	<!-- For Project Red Horse: Militaires Sans Frontieres -->
-
 	<HediffDef>
 		<defName>Tranquilizer</defName>
 		<label>tranquilizer</label>
@@ -402,6 +400,61 @@
 					<li>
 						<capacity>Consciousness</capacity>
 						<setMax>0.1</setMax>
+					</li>
+				</capMods>
+			</li>
+		</stages>
+	</HediffDef>
+
+	<HediffDef>
+		<defName>Flashbanged</defName>
+		<label>blinded by a flash</label>
+		<description>Vision and hearing temporarily compromised due to a bright flash.</description>
+		<hediffClass>HediffWithComps</hediffClass>
+		<maxSeverity>1</maxSeverity>
+		<displayWound>true</displayWound>
+		<makesAlert>false</makesAlert>
+		<comps>
+			<li Class="HediffCompProperties_SeverityPerDay">
+				<severityPerDay>-60</severityPerDay>
+			</li>
+		</comps>
+		<stages>
+			<li>
+				<minSeverity>0</minSeverity>
+				<label>irritated</label>
+				<capMods>
+					<li>
+						<capacity>Sight</capacity>
+						<offset>-0.1</offset>
+					</li>
+				</capMods>
+			</li>
+			<li>
+				<minSeverity>0.2</minSeverity>
+				<label>disoriented</label>
+				<capMods>
+					<li>
+						<capacity>Sight</capacity>
+						<offset>-0.5</offset>
+					</li>
+					<li>
+						<capacity>Hearing</capacity>
+						<offset>-0.4</offset>
+					</li>
+				</capMods>
+			</li>
+			<li>
+				<minSeverity>0.4</minSeverity>
+				<label>blinded</label>
+				<capMods>
+					<li>
+						<capacity>Sight</capacity>
+						<setMax>0</setMax>
+					</li>
+					<li>
+						<capacity>Hearing</capacity>
+						<setMax>0.2</setMax>
 					</li>
 				</capMods>
 			</li>

--- a/Defs/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Grenades.xml
@@ -157,7 +157,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<explosionRadius>4</explosionRadius>
 			<damageDef>Stun</damageDef>
-			<damageAmountBase>55</damageAmountBase>
+			<damageAmountBase>10</damageAmountBase>
 			<explosionDelay>30</explosionDelay>
 			<soundExplode>Explosion_Stun</soundExplode>
 			<dropsCasings>true</dropsCasings>
@@ -169,6 +169,14 @@
 			<dangerFactor>1.5</dangerFactor>
 			<airborneSuppressionFactor>0.25</airborneSuppressionFactor>
 		</projectile>
+		<comps>
+			<li Class="CombatExtended.CompProperties_ExplosiveCE">
+				<damageAmountBase>1</damageAmountBase>
+				<explosiveDamageType>Flashbang</explosiveDamageType>
+				<explosiveRadius>4</explosiveRadius>
+				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			</li>
+		</comps>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseGrenadeEquipment">
@@ -218,7 +226,7 @@
 		</verbs>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>25</damageAmountBase>
+				<damageAmountBase>5</damageAmountBase>
 				<explosiveDamageType>Stun</explosiveDamageType>
 				<explosiveRadius>4</explosiveRadius>
 				<explosionSound>Explosion_Stun</explosionSound>


### PR DESCRIPTION
## Changes

- Changed flashbang grenades in two different ways, firstly instead of a long stun duration they now stun for 5 seconds and secondly for the remaining time they apply a blindness hediff that is gradual. Around 10s of complete blindness and a hearing penalty which 5 seconds of it overlaps with the stun duration, and the remaining time is the gradual reduction in the stat penalties which the hediff lasts 16.8 seconds in total.

## Reasoning

- Realism, the current implementation of flashbang nades is very OP and not how they behave in real life. The change keeps some of the old behavior to not make them obsolete and adds the realistic part of their flash and bang behavior to them which blinds and deafens the pawns on the receiving end of them.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Threw a couple nades at various targets)
