### PR TITLE
Fix mech death on down

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_Pawn_HealthTracker.cs
+++ b/Source/CombatExtended/Harmony/Harmony_Pawn_HealthTracker.cs
@@ -26,8 +26,6 @@ namespace CombatExtended.HarmonyCE
 
             bool flag = false;
 
-            Log.Message("Combat Extended :: Harmony_Pawn_HealthTracker_CheckForStateChange transpiler called");
-
             List<CodeInstruction> codes = instructions.ToList();
             for (int i = 0; i < codes.Count; i++)
             {
@@ -35,7 +33,6 @@ namespace CombatExtended.HarmonyCE
                 if (codes[i].opcode == OpCodes.Callvirt && codes[i].OperandIs(mGet_IsMechanoid))
                 {
                     flag = true;
-                    Log.Message("Combat Extended :: Found Get_IsMecchanoid call");
                 }
                 //take the next unconditional branch
                 else if (flag == true && codes[i].opcode == OpCodes.Br_S)
@@ -43,7 +40,6 @@ namespace CombatExtended.HarmonyCE
                     // point branch at the down on death code, instead of the random chance check blocking it
                     codes[i] = new CodeInstruction(OpCodes.Br_S, deathOnDownLabel);
                     flag = false;
-                    Log.Message("Combat Extended :: Branch at " + i.ToString("X") + " replaced");
                 }
                 // find instruction calling Verse.DebugViewSettings::logCauseOfDeath and label it
                 else if (codes[i].opcode == OpCodes.Ldsfld && ReferenceEquals(codes[i].operand, AccessTools.Field(typeof(DebugViewSettings), "logCauseOfDeath")))
@@ -52,7 +48,6 @@ namespace CombatExtended.HarmonyCE
                         {
                             deathOnDownLabel
                         };
-                    Log.Message("Combat Extended :: logCauseOfDeath label placed");
                 }
             }
             return Transpilers.MethodReplacer(
@@ -64,7 +59,6 @@ namespace CombatExtended.HarmonyCE
 
         static bool NoChance(float unusedChance)
         {
-            Log.Message("Combat Extended :: Random Death on down bypassed");
             return false;
         }
     }

--- a/Source/CombatExtended/Harmony/Harmony_Pawn_HealthTracker.cs
+++ b/Source/CombatExtended/Harmony/Harmony_Pawn_HealthTracker.cs
@@ -15,12 +15,48 @@ namespace CombatExtended.HarmonyCE
     [HarmonyPatch(typeof(Pawn_HealthTracker), "CheckForStateChange")]
     static class Harmony_Pawn_HealthTracker_CheckForStateChange
     {
+        private static MethodBase mGet_IsMechanoid = AccessTools.Method(typeof(RaceProperties), "get_IsMechanoid");
 
-
-        static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
         {
+            //Code handling automatically killing mechs on down.  Stock code has the random death on down code in a Rand.Chance block, and would pass a 1 to Rand.Chance if the pawn is a mech.
+            //We replace the Rand.Chance check with a method that returns false to remove random death on down.  Thus we need to re-route the branch statement after the get_IsMechanoid() call.
+            //Note this is a brittle method, and changes in core code may change where what is effectively a goto call needs to point.
+            Label deathOnDownLabel = generator.DefineLabel();
+
+            bool flag = false;
+
+            Log.Message("Combat Extended :: Harmony_Pawn_HealthTracker_CheckForStateChange transpiler called");
+
+            List<CodeInstruction> codes = instructions.ToList();
+            for (int i = 0; i < codes.Count; i++)
+            {
+                //Find the get_IsMechanoid() check
+                if (codes[i].opcode == OpCodes.Callvirt && codes[i].OperandIs(mGet_IsMechanoid))
+                {
+                    flag = true;
+                    Log.Message("Combat Extended :: Found Get_IsMecchanoid call");
+                }
+                //take the next unconditional branch
+                else if (flag == true && codes[i].opcode == OpCodes.Br_S)
+                {
+                    // point branch at the down on death code, instead of the random chance check blocking it
+                    codes[i] = new CodeInstruction(OpCodes.Br_S, deathOnDownLabel);
+                    flag = false;
+                    Log.Message("Combat Extended :: Branch at " + i.ToString("X") + " replaced");
+                }
+                // find instruction calling Verse.DebugViewSettings::logCauseOfDeath and label it
+                else if (codes[i].opcode == OpCodes.Ldsfld && ReferenceEquals(codes[i].operand, AccessTools.Field(typeof(DebugViewSettings), "logCauseOfDeath")))
+                {
+                    codes[i].labels = new List<Label>()
+                        {
+                            deathOnDownLabel
+                        };
+                    Log.Message("Combat Extended :: logCauseOfDeath label placed");
+                }
+            }
             return Transpilers.MethodReplacer(
-                       instructions,
+                       codes,
                        AccessTools.Method(typeof(Rand), nameof(Rand.Chance)),
                        AccessTools.Method(typeof(Harmony_Pawn_HealthTracker_CheckForStateChange), nameof(Harmony_Pawn_HealthTracker_CheckForStateChange.NoChance))
                    );
@@ -28,6 +64,7 @@ namespace CombatExtended.HarmonyCE
 
         static bool NoChance(float unusedChance)
         {
+            Log.Message("Combat Extended :: Random Death on down bypassed");
             return false;
         }
     }


### PR DESCRIPTION
## Changes

- Transpiler changes to kill mechs when downed.

## Reasoning

- Recreate the vanilla behavior of mechanoids automatically dying when downed, removing the need to manually finish them off.

## Alternatives

 - Manually kill every downed mechanoid

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
