### PR TITLE
Shell ammo tweaks and housekeeping

### DIFF
--- a/Defs/Ammo/Advanced/70mmMechanoidGrenade.xml
+++ b/Defs/Ammo/Advanced/70mmMechanoidGrenade.xml
@@ -62,19 +62,7 @@
 			<MarketValue>39.32</MarketValue><!-- value intentionally decreased to help reduce wealth bloat/free silver -->
 		</statBases>
 		<ammoClass>GrenadeEMP</ammoClass>
-		<comps>
-			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>5</damageAmountBase>
-				<explosiveDamageType>Bomb</explosiveDamageType>
-				<explosiveRadius>2.5</explosiveRadius>
-				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-			</li>
-			<li Class="CombatExtended.CompProperties_Fragments">
-				<fragments>
-					<Fragment_Large>1</Fragment_Large>
-				</fragments>
-			</li>
-		</comps>
+		<detonateProjectile>Bullet_70mmMechanoidGrenade_EMP</detonateProjectile>
 	</ThingDef>
 
 	<!-- ================== Projectiles ================== -->
@@ -104,7 +92,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>3</Fragment_Large>
-					<Fragment_Small>76</Fragment_Small>
+					<Fragment_Small>19</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Grenade/25x40mmGrenade.xml
+++ b/Defs/Ammo/Grenade/25x40mmGrenade.xml
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="25x40mmGrenadeBase">
 		<defName>Ammo_25x40mmGrenade_HE_TFuzed</defName>
-		<label>25x40mm grenade (HE-Airburst)</label>
+		<label>25x40mm grenade (HE Time-Fuzed)</label>
 		<graphicData>
 			<texPath>Things/Ammo/GrenadeLauncher/AIR</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -134,7 +134,7 @@
 
 	<ThingDef ParentName="Base25x40mmGrenadeBullet">
 		<defName>Bullet_25x40mmGrenade_HE_TFuzed</defName>
-		<label>25mm grenade (HE-Airburst)</label>
+		<label>25mm grenade (HE Time-Fuzed)</label>
 		<thingClass>CombatExtended.ProjectileCE_Bursting</thingClass>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bomb</damageDef>
@@ -225,9 +225,9 @@
 
 	<RecipeDef ParentName="LauncherAmmoRecipeBase">
 		<defName>MakeAmmo_25x40mmGrenade_HE_TFuzed</defName>
-		<label>make 25x40mm HE-Airburst grenades x100</label>
-		<description>Craft 100 25x40mm HE-Airburst grenades.</description>
-		<jobString>Making 25x40mm HE-Airburst grenades.</jobString>
+		<label>make 25x40mm HE Time-Fuzed grenades x100</label>
+		<description>Craft 100 25x40mm HE Time-Fuzed grenades.</description>
+		<jobString>Making 25x40mm HE Time-Fuzed grenades.</jobString>
 		<ingredients>
 			<li>
 				<filter>

--- a/Defs/Ammo/Grenade/25x40mmGrenade.xml
+++ b/Defs/Ammo/Grenade/25x40mmGrenade.xml
@@ -126,7 +126,7 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Small>13</Fragment_Small>
+					<Fragment_Small>16</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>
@@ -147,7 +147,7 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Small>39</Fragment_Small>
+					<Fragment_Small>16</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Grenade/25x59mmGrenade.xml
+++ b/Defs/Ammo/Grenade/25x59mmGrenade.xml
@@ -72,7 +72,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="25x59mmGrenadeBase">
 		<defName>Ammo_25x59mmGrenade_HE_TFuzed</defName>
-		<label>25x59mm grenade (HE Time Fuzed)</label>
+		<label>25x59mm grenade (HE Time-Fuzed)</label>
 		<graphicData>
 			<texPath>Things/Ammo/GrenadeLauncher/AIR</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -175,7 +175,7 @@
 	<ThingDef ParentName="Base25x59mmGrenadeBullet">
 		<defName>Bullet_25x59mmGrenade_HE_TFuzed</defName>
 		<thingClass>CombatExtended.ProjectileCE_Bursting</thingClass>
-		<label>25x59mm grenade (HE-Airburst)</label>
+		<label>25x59mm grenade (HE Time-Fuzed)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<explosionRadius>1.0</explosionRadius>
 			<damageDef>Bomb</damageDef>
@@ -310,9 +310,9 @@
 
 	<RecipeDef ParentName="LauncherAmmoRecipeBase">
 		<defName>MakeAmmo_25x59mmGrenade_HE_TFuzed</defName>
-		<label>make 25x59mm HE airburst grenades x100</label>
-		<description>Craft 100 25x59mm HE airburst grenades.</description>
-		<jobString>Making 25x59mm HE airburst grenades.</jobString>
+		<label>make 25x59mm HE Time-Fuzed grenades x100</label>
+		<description>Craft 100 25x59mm HE Time-Fuzed grenades.</description>
+		<jobString>Making 25x59mm HE Time-Fuzed grenades.</jobString>
 		<researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
 		<ingredients>
 			<li>

--- a/Defs/Ammo/Grenade/30x29mmGrenade.xml
+++ b/Defs/Ammo/Grenade/30x29mmGrenade.xml
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="30x29mmGrenadeBase">
 		<defName>Ammo_30x29mmGrenade_HE_TFuzed</defName>
-		<label>30x29mm grenade (HE Airburst)</label>
+		<label>30x29mm grenade (HE Time-Fuzed)</label>
 		<graphicData>
 			<texPath>Things/Ammo/GrenadeLauncher/AIR</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -135,7 +135,7 @@
 	<ThingDef ParentName="Base30x29mmGrenadeBullet">
 		<defName>Bullet_30x29mmGrenade_HE_TFuzed</defName>
 		<thingClass>CombatExtended.ProjectileCE_Bursting</thingClass>
-		<label>30x29mm grenade (HE Airburst)</label>
+		<label>30x29mm grenade (HE Time-Fuzed)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<explosionRadius>1</explosionRadius>
 			<damageDef>Bomb</damageDef>
@@ -225,9 +225,9 @@
 
 	<RecipeDef ParentName="LauncherAmmoRecipeBase">
 		<defName>MakeAmmo_30x29mmGrenade_HE_TFuzed</defName>
-		<label>make 30x29mm HE airburst grenades x100</label>
-		<description>Craft 100 30x29mm HE airburst grenades.</description>
-		<jobString>Making 30x29mm HE airburst grenades.</jobString>
+		<label>make 30x29mm HE Time-Fuzed grenades x100</label>
+		<description>Craft 100 30x29mm HE Time-Fuzed grenades.</description>
+		<jobString>Making 30x29mm HE Time-Fuzed grenades.</jobString>
 		<ingredients>
 			<li>
 				<filter>

--- a/Defs/Ammo/Grenade/40x46mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x46mmGrenade.xml
@@ -58,7 +58,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="40x46mmGrenadeBase">
 		<defName>Ammo_40x46mmGrenade_HE_TFuzed</defName>
-		<label>40x46mm grenade (HE Time Fuzed)</label>
+		<label>40x46mm grenade (HE Time-Fuzed)</label>
 		<graphicData>
 			<texPath>Things/Ammo/GrenadeLauncher/AIR</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -167,7 +167,7 @@
 	<ThingDef ParentName="Base40x46mmGrenadeBullet">
 		<defName>Bullet_40x46mmGrenade_HE_TFuzed</defName>
 		<thingClass>CombatExtended.ProjectileCE_Bursting</thingClass>
-		<label>40x46mm grenade (HE-Airburst)</label>
+		<label>40x46mm grenade (HE Time-Fuzed)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<explosionRadius>1.0</explosionRadius>
 			<damageDef>Bomb</damageDef>
@@ -293,9 +293,9 @@
 
 	<RecipeDef ParentName="LauncherAmmoRecipeBase">
 		<defName>MakeAmmo_40x46mmGrenade_HE_TFuzed</defName>
-		<label>make 40x46mm HE airburst grenades x100</label>
-		<description>Craft 100 40x46mm HE airburst grenades.</description>
-		<jobString>Making 40x46mm HE airburst grenades.</jobString>
+		<label>make 40x46mm HE Time-Fuzed grenades x100</label>
+		<description>Craft 100 40x46mm HE Time-Fuzed grenades.</description>
+		<jobString>Making 40x46mm HE Time-Fuzed grenades.</jobString>
 		<researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
 		<ingredients>
 			<li>

--- a/Defs/Ammo/Grenade/40x46mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x46mmGrenade.xml
@@ -158,7 +158,7 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Small>19</Fragment_Small>
+					<Fragment_Small>20</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>
@@ -179,7 +179,7 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Small>19</Fragment_Small>
+					<Fragment_Small>20</Fragment_Small>
 				</fragments>
 				<fragAngleRange>-89~-5</fragAngleRange>
 			</li>
@@ -205,7 +205,7 @@
 			</li>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Small>9</Fragment_Small>
+					<Fragment_Small>10</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Grenade/40x53mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmGrenade.xml
@@ -58,7 +58,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="40x53mmGrenadeBase">
 		<defName>Ammo_40x53mmGrenade_HE_TFuzed</defName>
-		<label>40x53mm grenade (HE Time Fuzed)</label>
+		<label>40x53mm grenade (HE Time-Fuzed)</label>
 		<graphicData>
 			<texPath>Things/Ammo/GrenadeLauncher/AIR</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -152,7 +152,7 @@
 	<ThingDef ParentName="Base40x53mmGrenadeBullet">
 		<defName>Bullet_40x53mmGrenade_HE_TFuzed</defName>
 		<thingClass>CombatExtended.ProjectileCE_Bursting</thingClass>
-		<label>40x53mm grenade (HE-Airburst)</label>
+		<label>40x53mm grenade (HE Time-Fuzed)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<explosionRadius>1.0</explosionRadius>
 			<damageDef>Bomb</damageDef>
@@ -267,9 +267,9 @@
 
 	<RecipeDef ParentName="LauncherAmmoRecipeBase">
 		<defName>MakeAmmo_40x53mmGrenade_HE_TFuzed</defName>
-		<label>make 40x53mm HE Airburst grenades x100</label>
-		<description>Craft 100 40x53mm HE Airburst grenades.</description>
-		<jobString>Making 40x53mm HE Airburst grenades.</jobString>
+		<label>make 40x53mm HE Time-Fuzed grenades x100</label>
+		<description>Craft 100 40x53mm HE Time-Fuzed grenades.</description>
+		<jobString>Making 40x53mm HE Time-Fuzed grenades.</jobString>
 		<researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
 		<ingredients>
 			<li>

--- a/Defs/Ammo/Grenade/40x53mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmGrenade.xml
@@ -143,7 +143,7 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Small>35</Fragment_Small>
+					<Fragment_Small>36</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>
@@ -164,7 +164,7 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Small>35</Fragment_Small>
+					<Fragment_Small>36</Fragment_Small>
 				</fragments>
 				<fragAngleRange>-89~-5</fragAngleRange>
 			</li>
@@ -190,7 +190,7 @@
 			</li>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Small>17</Fragment_Small>
+					<Fragment_Small>16</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Grenade/40x53mmVOG25Grenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmVOG25Grenade.xml
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="40x53mmVOG25GrenadeBase">
 		<defName>Ammo_40x53mmVOG25Grenade_HE_TFuzed</defName>
-		<label>40x53mm VOG-25 grenade (HE Time Fuzed)</label>
+		<label>40x53mm VOG-25 grenade (HE Time-Fuzed)</label>
 		<graphicData>
 			<texPath>Things/Ammo/GrenadeLauncher/AIR</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -134,7 +134,7 @@
 	<ThingDef ParentName="Base40x53mmVOG25GrenadeBullet">
 		<defName>Bullet_40x53mmVOG25Grenade_HE_TFuzed</defName>
 		<thingClass>CombatExtended.ProjectileCE_Bursting</thingClass>
-		<label>40x53mm VOG-25 grenade (HE-Airburst)</label>
+		<label>40x53mm VOG-25 grenade (HE Time-Fuzed)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<explosionRadius>1.0</explosionRadius>
 			<damageDef>Bomb</damageDef>
@@ -224,9 +224,9 @@
 
 	<RecipeDef ParentName="LauncherAmmoRecipeBase">
 		<defName>MakeAmmo_40x53mmVOG25Grenade_HE_TFuzed</defName>
-		<label>make 40x53mm VOG-25 HE airburst grenades x100</label>
-		<description>Craft 100 40x53mm VOG-25 HE airburst grenades.</description>
-		<jobString>Making 40x53mm VOG-25 HE airburst grenades.</jobString>
+		<label>make 40x53mm VOG-25 HE Time-Fuzed grenades x100</label>
+		<description>Craft 100 40x53mm VOG-25 HE Time-Fuzed grenades.</description>
+		<jobString>Making 40x53mm VOG-25 HE Time-Fuzed grenades.</jobString>
 		<researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
 		<ingredients>
 			<li>

--- a/Defs/Ammo/Grenade/40x53mmVOG25Grenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmVOG25Grenade.xml
@@ -125,7 +125,7 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Small>22</Fragment_Small>
+					<Fragment_Small>24</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>
@@ -146,7 +146,7 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Small>22</Fragment_Small>
+					<Fragment_Small>24</Fragment_Small>
 				</fragments>
 				<fragAngleRange>-89~-5</fragAngleRange>
 			</li>

--- a/Defs/Ammo/Grenade/83mmPIATGrenade.xml
+++ b/Defs/Ammo/Grenade/83mmPIATGrenade.xml
@@ -116,7 +116,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>1</Fragment_Large>
-					<Fragment_Small>42</Fragment_Small>
+					<Fragment_Small>11</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/HighCaliber/40x311mmR.xml
+++ b/Defs/Ammo/HighCaliber/40x311mmR.xml
@@ -118,7 +118,7 @@
 		<label>40x311mmR bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>105</damageAmountBase>
-			<armorPenetrationSharp>100</armorPenetrationSharp>
+			<armorPenetrationSharp>70</armorPenetrationSharp>
 			<armorPenetrationBlunt>6502.5</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -128,7 +128,7 @@
 		<label>40x311mmR bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>105</damageAmountBase>
-			<armorPenetrationSharp>100</armorPenetrationSharp>
+			<armorPenetrationSharp>70</armorPenetrationSharp>
 			<armorPenetrationBlunt>6502.5</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
@@ -144,7 +144,7 @@
 		<label>40x311mmR bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>168</damageAmountBase>
-			<armorPenetrationSharp>50</armorPenetrationSharp>
+			<armorPenetrationSharp>35</armorPenetrationSharp>
 			<armorPenetrationBlunt>6502.5</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
@@ -160,7 +160,7 @@
 		<label>40x311mmR bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>89</damageAmountBase>
-			<armorPenetrationSharp>175</armorPenetrationSharp>
+			<armorPenetrationSharp>123</armorPenetrationSharp>
 			<armorPenetrationBlunt>8339.46</armorPenetrationBlunt>
 			<speed>214</speed>
 		</projectile>

--- a/Defs/Ammo/Medieval/CannonBall.xml
+++ b/Defs/Ammo/Medieval/CannonBall.xml
@@ -77,7 +77,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>53.28</MarketValue>
+			<MarketValue>45.45</MarketValue>
 		</statBases>
 		<ammoClass>BurstingShell</ammoClass>
 		<cookOffProjectile>Bullet_CannonBall_Bursting</cookOffProjectile>
@@ -148,18 +148,18 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<speed>99</speed>
 			<damageDef>Bomb</damageDef>
-			<damageAmountBase>142</damageAmountBase>
+			<damageAmountBase>82</damageAmountBase>
 			<armorPenetrationSharp>0</armorPenetrationSharp>
 			<armorPenetrationBlunt>0</armorPenetrationBlunt>
-			<explosionRadius>2.5</explosionRadius>
+			<explosionRadius>2.0</explosionRadius>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Large>17</Fragment_Large>
-					<Fragment_Small>22</Fragment_Small>
+					<Fragment_Large>9</Fragment_Large>
+					<Fragment_Small>19</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>
@@ -225,16 +225,16 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bomb</damageDef>
-			<damageAmountBase>142</damageAmountBase>
-			<explosionRadius>2.5</explosionRadius>
+			<damageAmountBase>82</damageAmountBase>
+			<explosionRadius>2.0</explosionRadius>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Large>17</Fragment_Large>
-					<Fragment_Small>22</Fragment_Small>
+					<Fragment_Large>9</Fragment_Large>
+					<Fragment_Small>19</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>
@@ -308,7 +308,7 @@
 						<li>FSX</li>
 					</thingDefs>
 				</filter>
-				<count>9</count>
+				<count>4</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -320,7 +320,7 @@
 		<products>
 			<Ammo_CannonBall_Bursting>5</Ammo_CannonBall_Bursting>
 		</products>
-		<workAmount>11400</workAmount>
+		<workAmount>9400</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Medieval/MortarGrenade.xml
+++ b/Defs/Ammo/Medieval/MortarGrenade.xml
@@ -26,7 +26,7 @@
 		</graphicData>
 		<statBases>
 			<Mass>0.95</Mass>
-			<Bulk>0.5</Bulk>
+			<Bulk>0.51</Bulk>
 		</statBases>
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
@@ -36,7 +36,7 @@
 		<thingCategories>
 			<li>MortarGrenade</li>
 		</thingCategories>
-		<stackLimit>100</stackLimit>
+		<stackLimit>150</stackLimit>
 		<cookOffFlashScale>20</cookOffFlashScale>
 		<techLevel>Medieval</techLevel>
 	</ThingDef>
@@ -49,7 +49,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>2.96</MarketValue>
+			<MarketValue>18.54</MarketValue>
 		</statBases>
 		<ammoClass>BurstingShell</ammoClass>
 		<detonateProjectile>Bullet_MortarGrenade</detonateProjectile>
@@ -68,13 +68,13 @@
 			<explosionRadius>1.0</explosionRadius>
 			<damageDef>Bomb</damageDef>
 			<damageAmountBase>30</damageAmountBase>
-			<speed>21</speed>
+			<speed>25</speed>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Small>12</Fragment_Small>
+					<Fragment_Medium>6</Fragment_Medium>
 				</fragments>
 			</li>
 		</comps>
@@ -84,8 +84,8 @@
 
 	<RecipeDef ParentName="AmmoRecipeBase">
 		<defName>MakeAmmo_MortarGrenade</defName>
-		<label>Make Mortar Grenade x6</label>
-		<description>Craft 6 Mortar Grenades</description>
+		<label>Make Mortar Grenade x5</label>
+		<description>Craft 5 Mortar Grenades</description>
 		<jobString>Making Mortar Grenades</jobString>
 		<researchPrerequisite>CE_Gunpowder</researchPrerequisite>
 		<ingredients>
@@ -95,7 +95,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>15</count>
+				<count>10</count>
 			</li>
 			<li>
 				<filter>
@@ -103,7 +103,7 @@
 						<li>FSX</li>
 					</thingDefs>
 				</filter>
-				<count>8</count>
+				<count>1</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -113,9 +113,9 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_MortarGrenade>6</Ammo_MortarGrenade>
+			<Ammo_MortarGrenade>5</Ammo_MortarGrenade>
 		</products>
-		<workAmount>8000</workAmount>
+		<workAmount>2600</workAmount>
 	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Rocket/127mmJavelinMissile.xml
+++ b/Defs/Ammo/Rocket/127mmJavelinMissile.xml
@@ -30,7 +30,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>2</Fragment_Large>
-					<Fragment_Small>451</Fragment_Small>
+					<Fragment_Small>80</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Rocket/130mmType63.xml
+++ b/Defs/Ammo/Rocket/130mmType63.xml
@@ -87,8 +87,8 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Large>110</Fragment_Large>
-					<Fragment_Small>226</Fragment_Small>
+					<Fragment_Large>40</Fragment_Large>
+					<Fragment_Small>57</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Rocket/150mmMBTLAWMissile.xml
+++ b/Defs/Ammo/Rocket/150mmMBTLAWMissile.xml
@@ -30,7 +30,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>5</Fragment_Large>
-					<Fragment_Small>301</Fragment_Small>
+					<Fragment_Small>76</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Rocket/20mmFliegerfaust.xml
+++ b/Defs/Ammo/Rocket/20mmFliegerfaust.xml
@@ -82,7 +82,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>1</Fragment_Large>
-					<Fragment_Small>3</Fragment_Small>
+					<Fragment_Small>1</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Rocket/70mmAPKWS.xml
+++ b/Defs/Ammo/Rocket/70mmAPKWS.xml
@@ -97,7 +97,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>26</Fragment_Large>
-					<Fragment_Small>46</Fragment_Small>
+					<Fragment_Small>12</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Rocket/83mmSMAW.xml
+++ b/Defs/Ammo/Rocket/83mmSMAW.xml
@@ -123,7 +123,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>7</Fragment_Large>
-					<Fragment_Small>38</Fragment_Small>
+					<Fragment_Small>10</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>
@@ -147,7 +147,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>12</Fragment_Large>
-					<Fragment_Small>98</Fragment_Small>
+					<Fragment_Small>25</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Rocket/84mmAT4.xml
+++ b/Defs/Ammo/Rocket/84mmAT4.xml
@@ -30,7 +30,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>3</Fragment_Large>
-					<Fragment_Small>27</Fragment_Small>
+					<Fragment_Small>7</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Rocket/84x246mmR.xml
+++ b/Defs/Ammo/Rocket/84x246mmR.xml
@@ -104,7 +104,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>4</Fragment_Large>
-					<Fragment_Small>34</Fragment_Small>
+					<Fragment_Small>9</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>
@@ -125,7 +125,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>5</Fragment_Large>
-					<Fragment_Small>95</Fragment_Small>
+					<Fragment_Small>24</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Rocket/88mmRPzB.xml
+++ b/Defs/Ammo/Rocket/88mmRPzB.xml
@@ -89,7 +89,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>3</Fragment_Large>
-					<Fragment_Small>35</Fragment_Small>
+					<Fragment_Small>9</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Rocket/90mmMATADOR.xml
+++ b/Defs/Ammo/Rocket/90mmMATADOR.xml
@@ -30,7 +30,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>4</Fragment_Large>
-					<Fragment_Small>29</Fragment_Small>
+					<Fragment_Small>8</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Rocket/90mmRecoilless.xml
+++ b/Defs/Ammo/Rocket/90mmRecoilless.xml
@@ -105,8 +105,8 @@
 			</li>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Large>8</Fragment_Large>
-					<Fragment_Small>20</Fragment_Small>
+					<Fragment_Large>5</Fragment_Large>
+					<Fragment_Small>7</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Rocket/M6.xml
+++ b/Defs/Ammo/Rocket/M6.xml
@@ -92,7 +92,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>1</Fragment_Large>
-					<Fragment_Small>43</Fragment_Small>
+					<Fragment_Small>11</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Rocket/M6A1.xml
+++ b/Defs/Ammo/Rocket/M6A1.xml
@@ -81,7 +81,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>1</Fragment_Large>
-					<Fragment_Small>43</Fragment_Small>
+					<Fragment_Small>11</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Rocket/M6A3.xml
+++ b/Defs/Ammo/Rocket/M6A3.xml
@@ -63,7 +63,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>1</Fragment_Large>
-					<Fragment_Small>43</Fragment_Small>
+					<Fragment_Small>11</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Rocket/M72LAW.xml
+++ b/Defs/Ammo/Rocket/M72LAW.xml
@@ -33,7 +33,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>3</Fragment_Large>
-					<Fragment_Small>26</Fragment_Small>
+					<Fragment_Small>7</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Rocket/RPG28.xml
+++ b/Defs/Ammo/Rocket/RPG28.xml
@@ -30,7 +30,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>20</Fragment_Large>
-					<Fragment_Small>49</Fragment_Small>
+					<Fragment_Small>13</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Rocket/RPG32.xml
+++ b/Defs/Ammo/Rocket/RPG32.xml
@@ -106,7 +106,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>6</Fragment_Large>
-					<Fragment_Small>42</Fragment_Small>
+					<Fragment_Small>11</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Rocket/RPG7.xml
+++ b/Defs/Ammo/Rocket/RPG7.xml
@@ -124,7 +124,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>3</Fragment_Large>
-					<Fragment_Small>47</Fragment_Small>
+					<Fragment_Small>12</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>
@@ -147,8 +147,8 @@
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 			<ai_IsIncendiary>true</ai_IsIncendiary>
 			<!-- <fuze_delay>2</fuze_delay>
-      <HP_penetration>true</HP_penetration>
-      <HP_penetration_ratio>300</HP_penetration_ratio> -->
+      		<HP_penetration>true</HP_penetration>
+     		<HP_penetration_ratio>300</HP_penetration_ratio> -->
 		</projectile>
 	</ThingDef>
 
@@ -171,7 +171,7 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Small>200</Fragment_Small>
+					<Fragment_Small>50</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Rocket/SPG9.xml
+++ b/Defs/Ammo/Rocket/SPG9.xml
@@ -141,7 +141,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>9</Fragment_Large>
-					<Fragment_Small>20</Fragment_Small>
+					<Fragment_Small>5</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>
@@ -186,8 +186,7 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Large>16</Fragment_Large>
-					<Fragment_Small>200</Fragment_Small>
+					<Fragment_Small>80</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Rocket/TomahawkLAM.xml
+++ b/Defs/Ammo/Rocket/TomahawkLAM.xml
@@ -88,10 +88,8 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Large>300</Fragment_Large>
-					<!-- Reduced from calculated value of 3729 for performance reasons -->
-					<Fragment_Small>500</Fragment_Small>
-					<!-- Reduced from calculated value of 39576 for performance reasons -->
+					<Fragment_Large>40</Fragment_Large>
+					<Fragment_Small>80</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Shell/100x695mmR.xml
+++ b/Defs/Ammo/Shell/100x695mmR.xml
@@ -77,7 +77,6 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<speed>165</speed>
-			<soundExplode>MortarBomb_Explode</soundExplode>
 			<flyOverhead>false</flyOverhead>
 			<dropsCasings>true</dropsCasings>
 			<casingMoteDefname>Fleck_BigShell</casingMoteDefname>

--- a/Defs/Ammo/Shell/105mmHowitzer.xml
+++ b/Defs/Ammo/Shell/105mmHowitzer.xml
@@ -114,6 +114,7 @@
 			<MarketValue>222</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeEMP</ammoClass>
+		<detonateProjectile>Bullet_105mmHowitzerShell_EMP</detonateProjectile>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="105mmHowitzerShellBase">
@@ -169,8 +170,8 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Large>30</Fragment_Large>
-					<Fragment_Small>50</Fragment_Small>
+					<Fragment_Large>40</Fragment_Large>
+					<Fragment_Small>44</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>
@@ -282,8 +283,8 @@
 			</li>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Large>25</Fragment_Large>
-					<Fragment_Small>40</Fragment_Small>
+					<Fragment_Large>26</Fragment_Large>
+					<Fragment_Small>13</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>
@@ -307,8 +308,8 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Large>30</Fragment_Large>
-					<Fragment_Small>50</Fragment_Small>
+					<Fragment_Large>40</Fragment_Large>
+					<Fragment_Small>44</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Shell/105x607mmR.xml
+++ b/Defs/Ammo/Shell/105x607mmR.xml
@@ -162,7 +162,7 @@
 						<li>FSX</li>
 					</thingDefs>
 				</filter>
-				<count>7</count>
+				<count>6</count>
 			</li>
 			<li>
 				<filter>

--- a/Defs/Ammo/Shell/105x607mmR.xml
+++ b/Defs/Ammo/Shell/105x607mmR.xml
@@ -34,7 +34,7 @@
 		<statBases>
 			<MaxHitPoints>200</MaxHitPoints>
 			<Bulk>22.09</Bulk>
-			<Mass>11</Mass>
+			<Mass>18.96</Mass>
 		</statBases>
 		<cookOffFlashScale>30</cookOffFlashScale>
 		<cookOffSound>MortarBomb_Explode</cookOffSound>
@@ -48,7 +48,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>101.62</MarketValue>
+			<MarketValue>131.37</MarketValue>
 		</statBases>
 		<ammoClass>RocketHEAT</ammoClass>
 		<detonateProjectile>Bullet_105x607mmRCannonShell_HEAT</detonateProjectile>
@@ -62,7 +62,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>132.95</MarketValue>
+			<MarketValue>162.7</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHE</ammoClass>
 		<detonateProjectile>Bullet_105x607mmRCannonShell_HE</detonateProjectile>
@@ -107,8 +107,8 @@
 			</li>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Large>22</Fragment_Large>
-					<Fragment_Small>50</Fragment_Small>
+					<Fragment_Large>12</Fragment_Large>
+					<Fragment_Small>16</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>
@@ -132,7 +132,7 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Large>40</Fragment_Large>
+					<Fragment_Large>16</Fragment_Large>
 					<Fragment_Small>80</Fragment_Small>
 				</fragments>
 			</li>
@@ -146,7 +146,7 @@
 		<label>make 105x607mmR HEAT cannon shells x2</label>
 		<description>Craft 2 105x607mmR HEAT cannon shells.</description>
 		<jobString>Making 105x607mmR HEAT cannon shells.</jobString>
-		<workAmount>8200</workAmount>
+		<workAmount>11200</workAmount>
 		<ingredients>
 			<li>
 				<filter>
@@ -154,7 +154,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>46</count>
+				<count>76</count>
 			</li>
 			<li>
 				<filter>
@@ -193,7 +193,7 @@
 		<label>make 105x607mmR HE cannon shells x2</label>
 		<description>Craft 5 105x607mmR HE cannon shells.</description>
 		<jobString>Making 105x607mmR HE cannon shells.</jobString>
-		<workAmount>11400</workAmount>
+		<workAmount>14400</workAmount>
 		<ingredients>
 			<li>
 				<filter>
@@ -201,7 +201,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>46</count>
+				<count>76</count>
 			</li>
 			<li>
 				<filter>

--- a/Defs/Ammo/Shell/120mmCannon.xml
+++ b/Defs/Ammo/Shell/120mmCannon.xml
@@ -76,7 +76,6 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<speed>229</speed>
-			<soundExplode>MortarBomb_Explode</soundExplode>
 			<flyOverhead>false</flyOverhead>
 			<dropsCasings>true</dropsCasings>
 			<casingMoteDefname>Fleck_BigShell</casingMoteDefname>

--- a/Defs/Ammo/Shell/120mmCannon.xml
+++ b/Defs/Ammo/Shell/120mmCannon.xml
@@ -108,7 +108,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>18</Fragment_Large>
-					<Fragment_Small>81</Fragment_Small>
+					<Fragment_Small>21</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>
@@ -133,7 +133,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>30</Fragment_Large>
-					<Fragment_Small>323</Fragment_Small>
+					<Fragment_Small>80</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Shell/155mmHowitzer.xml
+++ b/Defs/Ammo/Shell/155mmHowitzer.xml
@@ -95,6 +95,7 @@
 			<MarketValue>673.94</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeEMP</ammoClass>
+		<detonateProjectile>Bullet_155mmHowitzerShell_EMP</detonateProjectile>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="155mmHowitzerShellBase">
@@ -150,7 +151,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>40</Fragment_Large>
-					<Fragment_Small>60</Fragment_Small>
+					<Fragment_Small>80</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>
@@ -255,7 +256,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>40</Fragment_Large>
-					<Fragment_Small>60</Fragment_Small>
+					<Fragment_Small>80</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Shell/28cmSpgr.xml
+++ b/Defs/Ammo/Shell/28cmSpgr.xml
@@ -105,7 +105,7 @@
 		<label>make 28cm Spgr. HE cannon shells x5</label>
 		<description>Craft 5 28cm Spgr. HE cannon shells.</description>
 		<jobString>Making 28cm Spgr. HE cannon shells.</jobString>
-		<workAmount>395200</workAmount>
+		<workAmount>74400</workAmount>
 		<ingredients>
 			<li>
 				<filter>
@@ -113,7 +113,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>3000</count>
+				<count>600</count>
 			</li>
 			<li>
 				<filter>
@@ -129,7 +129,7 @@
 						<li>FSX</li>
 					</thingDefs>
 				</filter>
-				<count>235</count>
+				<count>33</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>

--- a/Defs/Ammo/Shell/28cmSpgr.xml
+++ b/Defs/Ammo/Shell/28cmSpgr.xml
@@ -91,8 +91,8 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Large>1013</Fragment_Large>
-					<Fragment_Small>1640</Fragment_Small>
+					<Fragment_Large>40</Fragment_Large>
+					<Fragment_Small>80</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Shell/37x223mmR.xml
+++ b/Defs/Ammo/Shell/37x223mmR.xml
@@ -71,7 +71,7 @@
 
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef Name="Base37x223mmRBullet" ParentName="BaseBulletCE" Abstract="true">
+	<ThingDef Name="Base37x223mmRBullet" ParentName="BaseExplosiveBullet" Abstract="true">
 		<graphicData>
 			<texPath>Things/Projectile/Bullet_Big</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -89,6 +89,7 @@
 		<defName>Bullet_37x223mmR_AP</defName>
 		<label>37x223mmR shell (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
 			<damageAmountBase>82</damageAmountBase>
 			<armorPenetrationSharp>71</armorPenetrationSharp>
 			<armorPenetrationBlunt>3398.44</armorPenetrationBlunt>
@@ -99,15 +100,10 @@
 		<defName>Bullet_37x223mmR_HE</defName>
 		<label>37x223mmR shell (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<flyOverhead>false</flyOverhead>
 			<speed>150</speed>
 			<damageDef>Bomb</damageDef>
 			<damageAmountBase>33</damageAmountBase>
 			<explosionRadius>1</explosionRadius>
-			<soundExplode>MortarBomb_Explode</soundExplode>
-			<dropsCasings>true</dropsCasings>
-			<casingMoteDefname>Fleck_BigShell</casingMoteDefname>
-			<casingFilthDefname>Filth_CannonAmmoCasings</casingFilthDefname>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">

--- a/Defs/Ammo/Shell/37x223mmR.xml
+++ b/Defs/Ammo/Shell/37x223mmR.xml
@@ -77,8 +77,8 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>Bullet</damageDef>
 			<speed>125</speed>
+			<flyOverhead>false</flyOverhead>
 			<dropsCasings>true</dropsCasings>
 			<casingMoteDefname>Fleck_BigShell</casingMoteDefname>
 			<casingFilthDefname>Filth_CannonAmmoCasings</casingFilthDefname>
@@ -96,7 +96,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef ParentName="BaseExplosiveBullet">
+	<ThingDef ParentName="Base37x223mmRBullet">
 		<defName>Bullet_37x223mmR_HE</defName>
 		<label>37x223mmR shell (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/Shell/37x223mmR.xml
+++ b/Defs/Ammo/Shell/37x223mmR.xml
@@ -108,8 +108,8 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Large>3</Fragment_Large>
-					<Fragment_Small>15</Fragment_Small>
+					<Fragment_Large>2</Fragment_Large>
+					<Fragment_Small>2</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Shell/37x223mmR.xml
+++ b/Defs/Ammo/Shell/37x223mmR.xml
@@ -41,7 +41,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo37x223mmRBase">
 		<defName>Ammo_37x223mmR_HE</defName>
-		<label>37x223mmR cartridge (APHE)</label>
+		<label>37x223mmR cartridge (HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Cannon/HE</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -71,32 +71,52 @@
 
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef ParentName="Base40x365mmBoforsBullet">
-		<defName>Bullet_37x223mmR_HE</defName>
-		<label>37x223mmR shell (APHE)</label>
+	<ThingDef Name="Base37x223mmRBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_Big</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>150</speed>
-			<damageAmountBase>136</damageAmountBase>
-			<armorPenetrationSharp>54</armorPenetrationSharp>
-			<armorPenetrationBlunt>3826.32</armorPenetrationBlunt>
-			<secondaryDamage>
-				<li>
-					<def>Bomb_Secondary</def>
-					<amount>81</amount>
-				</li>
-			</secondaryDamage>
+			<damageDef>Bullet</damageDef>
+			<speed>125</speed>
+			<dropsCasings>true</dropsCasings>
+			<casingMoteDefname>Fleck_BigShell</casingMoteDefname>
+			<casingFilthDefname>Filth_CannonAmmoCasings</casingFilthDefname>
 		</projectile>
 	</ThingDef>
 
-	<ThingDef ParentName="Base40x365mmBoforsBullet">
+	<ThingDef ParentName="Base37x223mmRBullet">
 		<defName>Bullet_37x223mmR_AP</defName>
 		<label>37x223mmR shell (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>125</speed>
 			<damageAmountBase>82</damageAmountBase>
 			<armorPenetrationSharp>77</armorPenetrationSharp>
 			<armorPenetrationBlunt>3398.44</armorPenetrationBlunt>
 		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="BaseExplosiveBullet">
+		<defName>Bullet_37x223mmR_HE</defName>
+		<label>37x223mmR shell (HE)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<flyOverhead>false</flyOverhead>
+			<speed>150</speed>
+			<damageDef>Bomb</damageDef>
+			<damageAmountBase>33</damageAmountBase>
+			<explosionRadius>1</explosionRadius>
+			<soundExplode>MortarBomb_Explode</soundExplode>
+			<dropsCasings>true</dropsCasings>
+			<casingMoteDefname>Fleck_BigShell</casingMoteDefname>
+			<casingFilthDefname>Filth_CannonAmmoCasings</casingFilthDefname>
+		</projectile>
+		<comps>
+			<li Class="CombatExtended.CompProperties_Fragments">
+				<fragments>
+					<Fragment_Large>3</Fragment_Large>
+					<Fragment_Small>15</Fragment_Small>
+				</fragments>
+			</li>
+		</comps>
 	</ThingDef>
 
 	<!-- ==================== Recipes ========================== -->

--- a/Defs/Ammo/Shell/37x223mmR.xml
+++ b/Defs/Ammo/Shell/37x223mmR.xml
@@ -104,6 +104,7 @@
 			<damageDef>Bomb</damageDef>
 			<damageAmountBase>33</damageAmountBase>
 			<explosionRadius>1</explosionRadius>
+			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 		</projectile>
 		<comps>

--- a/Defs/Ammo/Shell/37x223mmR.xml
+++ b/Defs/Ammo/Shell/37x223mmR.xml
@@ -104,6 +104,7 @@
 			<damageDef>Bomb</damageDef>
 			<damageAmountBase>33</damageAmountBase>
 			<explosionRadius>1</explosionRadius>
+			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">

--- a/Defs/Ammo/Shell/37x223mmR.xml
+++ b/Defs/Ammo/Shell/37x223mmR.xml
@@ -90,7 +90,7 @@
 		<label>37x223mmR shell (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>82</damageAmountBase>
-			<armorPenetrationSharp>77</armorPenetrationSharp>
+			<armorPenetrationSharp>71</armorPenetrationSharp>
 			<armorPenetrationBlunt>3398.44</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Shell/37x223mmR.xml
+++ b/Defs/Ammo/Shell/37x223mmR.xml
@@ -14,8 +14,8 @@
 		<defName>AmmoSet_37x223mmR</defName>
 		<label>37x223mmR</label>
 		<ammoTypes>
-			<Ammo_37x223mmR_HE>Bullet_37x223mmR_HE</Ammo_37x223mmR_HE>
 			<Ammo_37x223mmR_AP>Bullet_37x223mmR_AP</Ammo_37x223mmR_AP>
+			<Ammo_37x223mmR_HE>Bullet_37x223mmR_HE</Ammo_37x223mmR_HE>
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
 
@@ -40,21 +40,6 @@
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo37x223mmRBase">
-		<defName>Ammo_37x223mmR_HE</defName>
-		<label>37x223mmR cartridge (HE)</label>
-		<graphicData>
-			<texPath>Things/Ammo/Cannon/HE</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<statBases>
-			<MarketValue>9.94</MarketValue>
-			<Mass>1.18</Mass>
-		</statBases>
-		<ammoClass>ExplosiveAP</ammoClass>
-		<cookOffProjectile>Bullet_37x223mmR_HE</cookOffProjectile>
-	</ThingDef>
-
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo37x223mmRBase">
 		<defName>Ammo_37x223mmR_AP</defName>
 		<label>37x223mmR cartridge (AP)</label>
 		<graphicData>
@@ -67,6 +52,21 @@
 		</statBases>
 		<ammoClass>ArmorPiercing</ammoClass>
 		<cookOffProjectile>Bullet_37x223mmR_AP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo37x223mmRBase">
+		<defName>Ammo_37x223mmR_HE</defName>
+		<label>37x223mmR cartridge (HE)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Cannon/HE</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>8.87</MarketValue>
+			<Mass>1.18</Mass>
+		</statBases>
+		<ammoClass>GrenadeHE</ammoClass>
+		<cookOffProjectile>Bullet_37x223mmR_HE</cookOffProjectile>
 	</ThingDef>
 
 	<!-- ================== Projectiles ================== -->
@@ -122,6 +122,35 @@
 	<!-- ==================== Recipes ========================== -->
 
 	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_37x223mmR_AP</defName>
+		<label>make 37x223mmR (AP) cartridge x25</label>
+		<description>Craft 25 37x223mmR (AP) cartridges.</description>
+		<jobString>Making 37x223mmR (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>74</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_37x223mmR_AP>25</Ammo_37x223mmR_AP>
+		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
+		<workAmount>8880</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
 		<defName>MakeAmmo_37x223mmR_HE</defName>
 		<label>make 37x223mmR (HE) cartridge x25</label>
 		<description>Craft 25 37x223mmR (HE) cartridges.</description>
@@ -138,15 +167,24 @@
 			<li>
 				<filter>
 					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>2</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
 						<li>FSX</li>
 					</thingDefs>
 				</filter>
-				<count>16</count>
+				<count>4</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
 			<thingDefs>
 				<li>Steel</li>
+				<li>ComponentIndustrial</li>
 				<li>FSX</li>
 			</thingDefs>
 		</fixedIngredientFilter>
@@ -156,36 +194,7 @@
 		<skillRequirements>
 			<Crafting>4</Crafting>
 		</skillRequirements>
-		<workAmount>12600</workAmount>
-	</RecipeDef>
-
-	<RecipeDef ParentName="AmmoRecipeBase">
-		<defName>MakeAmmo_37x223mmR_AP</defName>
-		<label>make 37x223mmR (AP) cartridge x25</label>
-		<description>Craft 25 37x223mmR (AP) cartridges.</description>
-		<jobString>Making 37x223mmR (AP) cartridges.</jobString>
-		<ingredients>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>Steel</li>
-					</thingDefs>
-				</filter>
-				<count>66</count>
-			</li>
-		</ingredients>
-		<fixedIngredientFilter>
-			<thingDefs>
-				<li>Steel</li>
-			</thingDefs>
-		</fixedIngredientFilter>
-		<products>
-			<Ammo_37x223mmR_AP>25</Ammo_37x223mmR_AP>
-		</products>
-		<skillRequirements>
-			<Crafting>4</Crafting>
-		</skillRequirements>
-		<workAmount>10800</workAmount>
+		<workAmount>9000</workAmount>
 	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Shell/40x365mmBofors.xml
+++ b/Defs/Ammo/Shell/40x365mmBofors.xml
@@ -16,6 +16,7 @@
 		<ammoTypes>
 			<Ammo_40x365mmBofors_AP>Bullet_40x365mmBofors_AP</Ammo_40x365mmBofors_AP>
 			<Ammo_40x365mmBofors_HE>Bullet_40x365mmBofors_HE</Ammo_40x365mmBofors_HE>
+			<Ammo_40x365mmBofors_HE_TFuzed>Bullet_40x365mmBofors_HE_TFuzed</Ammo_40x365mmBofors_HE_TFuzed>
 			<Ammo_40x365mmBofors_Sabot>Bullet_40x365mmBofors_Sabot</Ammo_40x365mmBofors_Sabot>
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
@@ -61,6 +62,20 @@
 		</graphicData>
 		<statBases>
 			<MarketValue>16.36</MarketValue>
+		</statBases>
+		<ammoClass>GrenadeHE</ammoClass>
+		<cookOffProjectile>Bullet_40x365mmBofors_HE</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo40x365mmBoforsBase">
+		<defName>Ammo_40x365mmBofors_HE_TFuzed</defName>
+		<label>40x365mm Bofors cartridge (HE Time Fuzed)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/Bofors/HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>17.66</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHE</ammoClass>
 		<cookOffProjectile>Bullet_40x365mmBofors_HE</cookOffProjectile>
@@ -216,6 +231,54 @@
 			<Crafting>4</Crafting>
 		</skillRequirements>
 		<workAmount>18600</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_40x365mmBofors_HE_TFuzed</defName>
+		<label>make 40x365mm Bofors airburst cartridge x25</label>
+		<description>Craft 25 40x365mm Bofors airburst cartridges.</description>
+		<jobString>Making 40x365mm Bofors airburst cartridges.</jobString>
+		<researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>126</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>5</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>FSX</li>
+					</thingDefs>
+				</filter>
+				<count>12</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>ComponentIndustrial</li>
+				<li>FSX</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_40x365mmBofors_HE_TFuzed>25</Ammo_40x365mmBofors_HE_TFuzed>
+		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
+		<workAmount>20400</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/Shell/40x365mmBofors.xml
+++ b/Defs/Ammo/Shell/40x365mmBofors.xml
@@ -76,22 +76,8 @@
 			<damageDef>Bullet</damageDef>
 			<speed>181</speed>
 			<dropsCasings>true</dropsCasings>
-		</projectile>
-	</ThingDef>
-
-	<ThingDef ParentName="Base40x365mmBoforsBullet">
-		<defName>Bullet_40x365mmBofors_HE</defName>
-		<label>40x365mm Bofors bullet (HE)</label>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>195</damageAmountBase>
-			<armorPenetrationSharp>33</armorPenetrationSharp>
-			<armorPenetrationBlunt>10007.440</armorPenetrationBlunt>
-			<secondaryDamage>
-				<li>
-					<def>Bomb_Secondary</def>
-					<amount>117</amount>
-				</li>
-			</secondaryDamage>
+			<casingMoteDefname>Fleck_BigShell</casingMoteDefname>
+			<casingFilthDefname>Filth_CannonAmmoCasings</casingFilthDefname>
 		</projectile>
 	</ThingDef>
 
@@ -103,6 +89,30 @@
 			<armorPenetrationSharp>65</armorPenetrationSharp>
 			<armorPenetrationBlunt>10007.440</armorPenetrationBlunt>
 		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="BaseExplosiveBullet">
+		<defName>Bullet_40x365mmBofors_HE</defName>
+		<label>40x365mm Bofors bullet (HE)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<flyOverhead>false</flyOverhead>
+			<speed>181</speed>
+			<damageDef>Bomb</damageDef>
+			<damageAmountBase>64</damageAmountBase>
+			<explosionRadius>1.5</explosionRadius>
+			<soundExplode>MortarBomb_Explode</soundExplode>
+			<dropsCasings>true</dropsCasings>
+			<casingMoteDefname>Fleck_BigShell</casingMoteDefname>
+			<casingFilthDefname>Filth_CannonAmmoCasings</casingFilthDefname>
+		</projectile>
+		<comps>
+			<li Class="CombatExtended.CompProperties_Fragments">
+				<fragments>
+					<Fragment_Large>4</Fragment_Large>
+					<Fragment_Small>25</Fragment_Small>
+				</fragments>
+			</li>
+		</comps>
 	</ThingDef>
 
 	<!-- ==================== Recipes ========================== -->

--- a/Defs/Ammo/Shell/40x365mmBofors.xml
+++ b/Defs/Ammo/Shell/40x365mmBofors.xml
@@ -143,6 +143,29 @@
 		</comps>
 	</ThingDef>
 
+	<ThingDef ParentName="BaseExplosiveBullet">
+		<defName>Bullet_40x365mmBofors_HE_TFuzed</defName>
+		<label>40x365mm Bofors bullet (HE Time-Fuzed)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bomb</damageDef>
+			<damageAmountBase>64</damageAmountBase>
+			<explosionRadius>1.5</explosionRadius>
+			<soundExplode>MortarBomb_Explode</soundExplode>
+			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			<aimHeightOffset>2</aimHeightOffset>
+			<armingDelay>2</armingDelay>
+		</projectile>
+		<comps>
+			<li Class="CombatExtended.CompProperties_Fragments">
+				<fragments>
+					<Fragment_Large>3</Fragment_Large>
+					<Fragment_Small>6</Fragment_Small>
+				</fragments>
+				<fragAngleRange>-89~-5</fragAngleRange>
+			</li>
+		</comps>
+	</ThingDef>
+
 	<ThingDef ParentName="Base40x365mmBoforsBullet">
 		<defName>Bullet_40x365mmBofors_Sabot</defName>
 		<label>40x365mm Bofors bullet (Sabot)</label>
@@ -235,9 +258,9 @@
 
 	<RecipeDef ParentName="AmmoRecipeBase">
 		<defName>MakeAmmo_40x365mmBofors_HE_TFuzed</defName>
-		<label>make 40x365mm Bofors airburst cartridge x25</label>
-		<description>Craft 25 40x365mm Bofors airburst cartridges.</description>
-		<jobString>Making 40x365mm Bofors airburst cartridges.</jobString>
+		<label>make 40x365mm Bofors Time-Fuzed cartridge x25</label>
+		<description>Craft 25 40x365mm Bofors Time-Fuzed cartridges.</description>
+		<jobString>Making 40x365mm Bofors Time-Fuzed cartridges.</jobString>
 		<researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
 		<ingredients>
 			<li>

--- a/Defs/Ammo/Shell/40x365mmBofors.xml
+++ b/Defs/Ammo/Shell/40x365mmBofors.xml
@@ -14,8 +14,8 @@
 		<defName>AmmoSet_40x365mmBofors</defName>
 		<label>40x365mm Bofors</label>
 		<ammoTypes>
-			<Ammo_40x365mmBofors_HE>Bullet_40x365mmBofors_HE</Ammo_40x365mmBofors_HE>
 			<Ammo_40x365mmBofors_AP>Bullet_40x365mmBofors_AP</Ammo_40x365mmBofors_AP>
+			<Ammo_40x365mmBofors_HE>Bullet_40x365mmBofors_HE</Ammo_40x365mmBofors_HE>
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
 
@@ -38,20 +38,6 @@
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo40x365mmBoforsBase">
-		<defName>Ammo_40x365mmBofors_HE</defName>
-		<label>40x365mm Bofors cartridge (HE)</label>
-		<graphicData>
-			<texPath>Things/Ammo/HighCaliber/Bofors/HE</texPath>
-			<graphicClass>Graphic_StackCount</graphicClass>
-		</graphicData>
-		<statBases>
-			<MarketValue>15.78</MarketValue>
-		</statBases>
-		<ammoClass>ExplosiveAP</ammoClass>
-		<cookOffProjectile>Bullet_40x365mmBofors_HE</cookOffProjectile>
-	</ThingDef>
-
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo40x365mmBoforsBase">
 		<defName>Ammo_40x365mmBofors_AP</defName>
 		<label>40x365mm Bofors cartridge (AP)</label>
 		<graphicData>
@@ -63,6 +49,20 @@
 		</statBases>
 		<ammoClass>ArmorPiercing</ammoClass>
 		<cookOffProjectile>Bullet_40x365mmBofors_AP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo40x365mmBoforsBase">
+		<defName>Ammo_40x365mmBofors_HE</defName>
+		<label>40x365mm Bofors cartridge (HE)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/Bofors/HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>14.93</MarketValue>
+		</statBases>
+		<ammoClass>GrenadeHE</ammoClass>
+		<cookOffProjectile>Bullet_40x365mmBofors_HE</cookOffProjectile>
 	</ThingDef>
 
 	<!-- ================== Projectiles ================== -->
@@ -118,44 +118,6 @@
 	<!-- ==================== Recipes ========================== -->
 
 	<RecipeDef ParentName="AmmoRecipeBase">
-		<defName>MakeAmmo_40x365mmBofors_HE</defName>
-		<label>make 40x365mm Bofors (HE) cartridge x25</label>
-		<description>Craft 25 40x365mm Bofors (HE) cartridges.</description>
-		<jobString>Making 40x365mm Bofors (HE) cartridges.</jobString>
-		<ingredients>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>Steel</li>
-					</thingDefs>
-				</filter>
-				<count>108</count>
-			</li>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>FSX</li>
-					</thingDefs>
-				</filter>
-				<count>33</count>
-			</li>
-		</ingredients>
-		<fixedIngredientFilter>
-			<thingDefs>
-				<li>Steel</li>
-				<li>FSX</li>
-			</thingDefs>
-		</fixedIngredientFilter>
-		<products>
-			<Ammo_40x365mmBofors_HE>25</Ammo_40x365mmBofors_HE>
-		</products>
-		<skillRequirements>
-			<Crafting>4</Crafting>
-		</skillRequirements>
-		<workAmount>24000</workAmount>
-	</RecipeDef>
-
-	<RecipeDef ParentName="AmmoRecipeBase">
 		<defName>MakeAmmo_40x365mmBofors_AP</defName>
 		<label>make 40x365mm Bofors (AP) cartridge x25</label>
 		<description>Craft 25 40x365mm Bofors (AP) cartridges.</description>
@@ -181,7 +143,54 @@
 		<skillRequirements>
 			<Crafting>4</Crafting>
 		</skillRequirements>
-		<workAmount>10800</workAmount>
+		<workAmount>12960</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_40x365mmBofors_HE</defName>
+		<label>make 40x365mm Bofors (HE) cartridge x25</label>
+		<description>Craft 25 40x365mm Bofors (HE) cartridges.</description>
+		<jobString>Making 40x365mm Bofors (HE) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>108</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>2</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>FSX</li>
+					</thingDefs>
+				</filter>
+				<count>12</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>ComponentIndustrial</li>
+				<li>FSX</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_40x365mmBofors_HE>25</Ammo_40x365mmBofors_HE>
+		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
+		<workAmount>16800</workAmount>
 	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Shell/40x365mmBofors.xml
+++ b/Defs/Ammo/Shell/40x365mmBofors.xml
@@ -123,7 +123,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef ParentName="BaseExplosiveBullet">
+	<ThingDef ParentName="Base40x365mmBoforsBullet">
 		<defName>Bullet_40x365mmBofors_HE</defName>
 		<label>40x365mm Bofors bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -143,7 +143,7 @@
 		</comps>
 	</ThingDef>
 
-	<ThingDef ParentName="BaseExplosiveBullet">
+	<ThingDef ParentName="Base40x365mmBoforsBullet">
 		<defName>Bullet_40x365mmBofors_HE_TFuzed</defName>
 		<label>40x365mm Bofors bullet (HE Time-Fuzed)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/Shell/40x365mmBofors.xml
+++ b/Defs/Ammo/Shell/40x365mmBofors.xml
@@ -16,6 +16,7 @@
 		<ammoTypes>
 			<Ammo_40x365mmBofors_AP>Bullet_40x365mmBofors_AP</Ammo_40x365mmBofors_AP>
 			<Ammo_40x365mmBofors_HE>Bullet_40x365mmBofors_HE</Ammo_40x365mmBofors_HE>
+			<Ammo_40x365mmBofors_Sabot>Bullet_40x365mmBofors_Sabot</Ammo_40x365mmBofors_Sabot>
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
 
@@ -24,7 +25,7 @@
 	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo40x365mmBoforsBase" ParentName="HeavyAmmoBase" Abstract="True">
 		<description>Large caliber cartridge used by autocannons and anti-aircraft cannons.</description>
 		<statBases>
-			<Mass>2.15</Mass>
+			<Mass>2.5</Mass>
 			<Bulk>4.69</Bulk>
 		</statBases>
 		<tradeTags>
@@ -45,7 +46,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>8.64</MarketValue>
+			<MarketValue>10.08</MarketValue>
 		</statBases>
 		<ammoClass>ArmorPiercing</ammoClass>
 		<cookOffProjectile>Bullet_40x365mmBofors_AP</cookOffProjectile>
@@ -59,10 +60,25 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>14.93</MarketValue>
+			<MarketValue>16.36</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHE</ammoClass>
 		<cookOffProjectile>Bullet_40x365mmBofors_HE</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo40x365mmBoforsBase">
+		<defName>Ammo_40x365mmBofors_Sabot</defName>
+		<label>40x365mm Bofors cartridge (Sabot)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/Bofors/Sabot</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<Mass>2.088</Mass>
+			<MarketValue>11.12</MarketValue>
+		</statBases>
+		<ammoClass>Sabot</ammoClass>
+		<cookOffProjectile>Bullet_40x365mmBofors_Sabot</cookOffProjectile>
 	</ThingDef>
 
 	<!-- ================== Projectiles ================== -->
@@ -89,7 +105,7 @@
 			<damageDef>Bullet</damageDef>
 			<damageAmountBase>122</damageAmountBase>
 			<armorPenetrationSharp>100</armorPenetrationSharp>
-			<armorPenetrationBlunt>10007.440</armorPenetrationBlunt>
+			<armorPenetrationBlunt>10007.44</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -111,6 +127,18 @@
 		</comps>
 	</ThingDef>
 
+	<ThingDef ParentName="Base40x365mmBoforsBullet">
+		<defName>Bullet_40x365mmBofors_Sabot</defName>
+		<label>40x365mm Bofors bullet (Sabot)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<damageAmountBase>117</damageAmountBase>
+			<armorPenetrationSharp>175</armorPenetrationSharp>
+			<armorPenetrationBlunt>12861.7</armorPenetrationBlunt>
+			<speed>245</speed>
+		</projectile>
+	</ThingDef>
+
 	<!-- ==================== Recipes ========================== -->
 
 	<RecipeDef ParentName="AmmoRecipeBase">
@@ -125,7 +153,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>108</count>
+				<count>126</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -139,7 +167,7 @@
 		<skillRequirements>
 			<Crafting>4</Crafting>
 		</skillRequirements>
-		<workAmount>12960</workAmount>
+		<workAmount>15120</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
@@ -154,7 +182,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>108</count>
+				<count>126</count>
 			</li>
 			<li>
 				<filter>
@@ -186,7 +214,54 @@
 		<skillRequirements>
 			<Crafting>4</Crafting>
 		</skillRequirements>
-		<workAmount>16800</workAmount>
+		<workAmount>18600</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_40x365mmBofors_Sabot</defName>
+		<label>make 40x365mm Bofors (Sabot) cartridge x25</label>
+		<description>Craft 25 40x365mm Bofors (Sabot) cartridges.</description>
+		<jobString>Making 40x365mm Bofors (Sabot) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>78</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Uranium</li>
+					</thingDefs>
+				</filter>
+				<count>14</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Chemfuel</li>
+					</thingDefs>
+				</filter>
+				<count>14</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Uranium</li>
+				<li>Chemfuel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_40x365mmBofors_Sabot>25</Ammo_40x365mmBofors_Sabot>
+		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
+		<workAmount>16200</workAmount>
 	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Shell/40x365mmBofors.xml
+++ b/Defs/Ammo/Shell/40x365mmBofors.xml
@@ -67,14 +67,15 @@
 
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef Name="Base40x365mmBoforsBullet" ParentName="BaseBulletCE" Abstract="true">
+	<ThingDef Name="Base40x365mmBoforsBullet" ParentName="BaseExplosiveBullet" Abstract="true">
 		<graphicData>
 			<texPath>Things/Projectile/Bullet_Big</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>Bullet</damageDef>
 			<speed>181</speed>
+			<soundExplode>MortarBomb_Explode</soundExplode>
+			<flyOverhead>false</flyOverhead>
 			<dropsCasings>true</dropsCasings>
 			<casingMoteDefname>Fleck_BigShell</casingMoteDefname>
 			<casingFilthDefname>Filth_CannonAmmoCasings</casingFilthDefname>
@@ -85,8 +86,9 @@
 		<defName>Bullet_40x365mmBofors_AP</defName>
 		<label>40x365mm Bofors bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
 			<damageAmountBase>122</damageAmountBase>
-			<armorPenetrationSharp>65</armorPenetrationSharp>
+			<armorPenetrationSharp>100</armorPenetrationSharp>
 			<armorPenetrationBlunt>10007.440</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -95,15 +97,9 @@
 		<defName>Bullet_40x365mmBofors_HE</defName>
 		<label>40x365mm Bofors bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<flyOverhead>false</flyOverhead>
-			<speed>181</speed>
 			<damageDef>Bomb</damageDef>
 			<damageAmountBase>64</damageAmountBase>
 			<explosionRadius>1.5</explosionRadius>
-			<soundExplode>MortarBomb_Explode</soundExplode>
-			<dropsCasings>true</dropsCasings>
-			<casingMoteDefname>Fleck_BigShell</casingMoteDefname>
-			<casingFilthDefname>Filth_CannonAmmoCasings</casingFilthDefname>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">

--- a/Defs/Ammo/Shell/40x365mmBofors.xml
+++ b/Defs/Ammo/Shell/40x365mmBofors.xml
@@ -116,6 +116,7 @@
 			<damageDef>Bomb</damageDef>
 			<damageAmountBase>64</damageAmountBase>
 			<explosionRadius>1.5</explosionRadius>
+			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">

--- a/Defs/Ammo/Shell/40x365mmBofors.xml
+++ b/Defs/Ammo/Shell/40x365mmBofors.xml
@@ -90,7 +90,6 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<speed>181</speed>
-			<soundExplode>MortarBomb_Explode</soundExplode>
 			<flyOverhead>false</flyOverhead>
 			<dropsCasings>true</dropsCasings>
 			<casingMoteDefname>Fleck_BigShell</casingMoteDefname>
@@ -116,6 +115,7 @@
 			<damageDef>Bomb</damageDef>
 			<damageAmountBase>64</damageAmountBase>
 			<explosionRadius>1.5</explosionRadius>
+			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 		</projectile>
 		<comps>

--- a/Defs/Ammo/Shell/40x365mmBofors.xml
+++ b/Defs/Ammo/Shell/40x365mmBofors.xml
@@ -104,8 +104,8 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Large>4</Fragment_Large>
-					<Fragment_Small>25</Fragment_Small>
+					<Fragment_Large>3</Fragment_Large>
+					<Fragment_Small>6</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Shell/50mmType89Mortar.xml
+++ b/Defs/Ammo/Shell/50mmType89Mortar.xml
@@ -133,7 +133,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>3</Fragment_Large>
-					<Fragment_Small>12</Fragment_Small>
+					<Fragment_Small>3</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Shell/57x483mmBofors.xml
+++ b/Defs/Ammo/Shell/57x483mmBofors.xml
@@ -101,7 +101,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>306</count>
+				<count>122</count>
 			</li>
 			<li>
 				<filter>
@@ -117,7 +117,7 @@
 						<li>FSX</li>
 					</thingDefs>
 				</filter>
-				<count>39</count>
+				<count>11</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -133,7 +133,7 @@
 		<skillRequirements>
 			<Crafting>4</Crafting>
 		</skillRequirements>
-		<workAmount>47400</workAmount>
+		<workAmount>17800</workAmount>
 	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Shell/57x483mmBofors.xml
+++ b/Defs/Ammo/Shell/57x483mmBofors.xml
@@ -76,7 +76,6 @@
 			<damageDef>Bomb</damageDef>
 			<damageAmountBase>108</damageAmountBase>
 			<explosionRadius>2</explosionRadius>
-			<soundExplode>MortarBomb_Explode</soundExplode>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">

--- a/Defs/Ammo/Shell/57x483mmBofors.xml
+++ b/Defs/Ammo/Shell/57x483mmBofors.xml
@@ -81,7 +81,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>7</Fragment_Large>
-					<Fragment_Small>55</Fragment_Small>
+					<Fragment_Small>14</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Shell/57x483mmBofors.xml
+++ b/Defs/Ammo/Shell/57x483mmBofors.xml
@@ -76,6 +76,7 @@
 			<damageDef>Bomb</damageDef>
 			<damageAmountBase>108</damageAmountBase>
 			<explosionRadius>2</explosionRadius>
+			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">

--- a/Defs/Ammo/Shell/60mmMortar.xml
+++ b/Defs/Ammo/Shell/60mmMortar.xml
@@ -155,7 +155,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>6</Fragment_Large>
-					<Fragment_Small>31</Fragment_Small>
+					<Fragment_Small>8</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Shell/762x385mmRCannon.xml
+++ b/Defs/Ammo/Shell/762x385mmRCannon.xml
@@ -91,7 +91,6 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<speed>134</speed>
-			<soundExplode>MortarBomb_Explode</soundExplode>
 			<flyOverhead>false</flyOverhead>
 			<dropsCasings>true</dropsCasings>
 			<casingMoteDefname>Fleck_BigShell</casingMoteDefname>

--- a/Defs/Ammo/Shell/762x385mmRCannon.xml
+++ b/Defs/Ammo/Shell/762x385mmRCannon.xml
@@ -80,18 +80,7 @@
 			<MarketValue>87.70</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeEMP</ammoClass>
-		<comps>
-			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>99</damageAmountBase>
-				<explosiveDamageType>Bomb</explosiveDamageType>
-				<explosiveRadius>2</explosiveRadius>
-			</li>
-			<li Class="CombatExtended.CompProperties_Fragments">
-				<fragments>
-					<Fragment_Large>22</Fragment_Large>
-				</fragments>
-			</li>
-		</comps>
+		<detonateProjectile>Bullet_762x385mmRCannonShell_EMP</detonateProjectile>
 	</ThingDef>
 
 	<!-- ================== Projectiles ================== -->
@@ -133,8 +122,8 @@
 			</li>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Large>12</Fragment_Large>
-					<Fragment_Small>36</Fragment_Small>
+					<Fragment_Large>11</Fragment_Large>
+					<Fragment_Small>7</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>
@@ -159,7 +148,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>21</Fragment_Large>
-					<Fragment_Small>47</Fragment_Small>
+					<Fragment_Small>12</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Shell/81mmMortar.xml
+++ b/Defs/Ammo/Shell/81mmMortar.xml
@@ -282,7 +282,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>16</Fragment_Large>
-					<Fragment_Small>100</Fragment_Small>
+					<Fragment_Small>25</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Shell/90mmCannon.xml
+++ b/Defs/Ammo/Shell/90mmCannon.xml
@@ -57,14 +57,6 @@
 		</statBases>
 		<ammoClass>RocketHEAT</ammoClass>
 		<detonateProjectile>Bullet_90mmCannonShell_HEAT</detonateProjectile>
-		<comps>
-			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>258</damageAmountBase>
-				<explosiveDamageType>Bomb</explosiveDamageType>
-				<explosiveRadius>1</explosiveRadius>
-				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-			</li>
-		</comps>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="90mmCannonShellBase">
@@ -78,20 +70,7 @@
 			<MarketValue>104.83</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHE</ammoClass>
-		<comps>
-			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>285</damageAmountBase>
-				<explosiveDamageType>Bomb</explosiveDamageType>
-				<explosiveRadius>2.5</explosiveRadius>
-				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-			</li>
-			<li Class="CombatExtended.CompProperties_Fragments">
-				<fragments>
-					<Fragment_Large>53</Fragment_Large>
-					<Fragment_Small>96</Fragment_Small>
-				</fragments>
-			</li>
-		</comps>
+		<detonateProjectile>Bullet_90mmCannonShell_HE</detonateProjectile>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="90mmCannonShellBase">
@@ -105,20 +84,7 @@
 			<MarketValue>124.33</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHETF</ammoClass>
-		<comps>
-			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>285</damageAmountBase>
-				<explosiveDamageType>Bomb</explosiveDamageType>
-				<explosiveRadius>2.5</explosiveRadius>
-				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-			</li>
-			<li Class="CombatExtended.CompProperties_Fragments">
-				<fragments>
-					<Fragment_Large>53</Fragment_Large>
-					<Fragment_Small>96</Fragment_Small>
-				</fragments>
-			</li>
-		</comps>
+		<detonateProjectile>Bullet_90mmCannonShell_HE</detonateProjectile>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="90mmCannonShellBase">
@@ -132,18 +98,7 @@
 			<MarketValue>160.66</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeEMP</ammoClass>
-		<comps>
-			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>142</damageAmountBase>
-				<explosiveDamageType>Bomb</explosiveDamageType>
-				<explosiveRadius>5</explosiveRadius>
-			</li>
-			<li Class="CombatExtended.CompProperties_Fragments">
-				<fragments>
-					<Fragment_Large>22</Fragment_Large>
-				</fragments>
-			</li>
-		</comps>
+		<detonateProjectile>Bullet_90mmCannonShell_EMP</detonateProjectile>
 	</ThingDef>
 
 	<!-- ================== Projectiles ================== -->
@@ -186,7 +141,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>22</Fragment_Large>
-					<Fragment_Small>36</Fragment_Small>
+					<Fragment_Small>9</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>
@@ -212,8 +167,8 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Large>53</Fragment_Large>
-					<Fragment_Small>96</Fragment_Small>
+					<Fragment_Large>40</Fragment_Large>
+					<Fragment_Small>24</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>
@@ -241,8 +196,8 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Large>53</Fragment_Large>
-					<Fragment_Small>96</Fragment_Small>
+					<Fragment_Large>40</Fragment_Large>
+					<Fragment_Small>24</Fragment_Small>
 				</fragments>
 				<fragAngleRange>-89~-10</fragAngleRange>
 			</li>

--- a/Defs/Ammo/Shell/90mmCannon.xml
+++ b/Defs/Ammo/Shell/90mmCannon.xml
@@ -75,7 +75,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="90mmCannonShellBase">
 		<defName>Ammo_90mmCannonShell_HE_TFuzed</defName>
-		<label>90mm cannon shell (HE Time Fuzed)</label>
+		<label>90mm cannon shell (HE Time-Fuzed)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Cannon/Flak/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -176,7 +176,7 @@
 
 	<ThingDef ParentName="Base90mmCannonShell">
 		<defName>Bullet_90mmCannonShell_HE_TFuzed</defName>
-		<label>90mm cannon shell (HE Time Fuse)</label>
+		<label>90mm cannon shell (HE Time-Fuzed)</label>
 		<thingClass>CombatExtended.ProjectileCE_Bursting</thingClass>
 		<graphicData>
 			<texPath>Things/Projectile/Cannon/HE</texPath>
@@ -319,9 +319,9 @@
 
 	<RecipeDef ParentName="AmmoRecipeBase">
 		<defName>MakeAmmo_90mmCannonShell_HE_TFuzed</defName>
-		<label>make 90mm HE airburst cannon shells x5</label>
-		<description>Craft 5 90mm HE airburst cannon shells.</description>
-		<jobString>Making 90mm HE airburst cannon shells.</jobString>
+		<label>make 90mm HE Time-Fuzed cannon shells x5</label>
+		<description>Craft 5 90mm HE Time-Fuzed cannon shells.</description>
+		<jobString>Making 90mm HE Time-Fuzed cannon shells.</jobString>
 		<workAmount>26400</workAmount>
 		<researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
 		<ingredients>


### PR DESCRIPTION
## Changes

- Fixed the sharp armor penetration of the two 40mm Bofors shells, they were in reverse.
- Replaced the 37mm and 40mm AP-HE shells with true HE as both have HE shells and not AP-HE. Also added airburst ammo to 40mm Bofors as it's the actual HE shell that is normally used.
- Updated and fixed several shell recipes.
- Fixed the 105x607mmR shell's stats.
- Ran a consistency check on all fragment counts among ammo types, everything is adjusted according to the sheet except thrown and launched grenades which still have x4 small frags than what they should.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070

## Reasoning

- The sources used for the 40mm shells are accurate but the values inputted into the sheet was in reverse, 40x365mm shells have the higher sharp AP values, not 40x311mm ones.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
