### PR TITLE
Fix ammo pickup error for mag-less weapons

### DIFF
--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_TakeAndEquip.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_TakeAndEquip.cs
@@ -490,7 +490,7 @@ namespace CombatExtended
                                                 {
                                                     Job job = JobMaker.MakeJob(JobDefOf.TakeInventory, th);
                                                     int maxAmmoToPickup = (primaryAmmoUserWithInventoryCheck.MagSizeOverride > 0) ? primaryAmmoUserWithInventoryCheck.MagSizeOverride * 4 : primaryAmmoUserWithInventoryCheck.MagSize * 4;
-                                                    job.count = (maxAmmoToPickup > 0) ? Mathf.Min(numToCarry, maxAmmoToPickup) : numToCarry / 4;
+                                                    job.count = (maxAmmoToPickup > 0) ? Mathf.Min(numToCarry, maxAmmoToPickup) : Mathf.CeilToInt(numToCarry / 4);
                                                     return job;
                                                 }
                                             }

--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_TakeAndEquip.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_TakeAndEquip.cs
@@ -490,7 +490,7 @@ namespace CombatExtended
                                                 {
                                                     Job job = JobMaker.MakeJob(JobDefOf.TakeInventory, th);
                                                     int maxAmmoToPickup = (primaryAmmoUserWithInventoryCheck.MagSizeOverride > 0) ? primaryAmmoUserWithInventoryCheck.MagSizeOverride * 4 : primaryAmmoUserWithInventoryCheck.MagSize * 4;
-                                                    job.count = Mathf.Min(numToCarry, maxAmmoToPickup);
+                                                    job.count = (maxAmmoToPickup > 0) ? Mathf.Min(numToCarry, maxAmmoToPickup) : numToCarry / 4;
                                                     return job;
                                                 }
                                             }


### PR DESCRIPTION
## Additions

- Added a new check to default ammo pickup to not error out when trying to get ammo for a mag-less weapon (like bows)
- Defaults to 25% of available inventory space per pickup job, but will currently pick up more than that (currently pawns with mag-less weapons try to fill 2/3 of available bulk with ammo, as the mag check to initiate the pickup skips mag-less weapons, will look for a more graceful solution in a later PR)

## References

- Closes #2661

## Alternatives

- Could potentially do different fallback values, other than 25%
- Could add a mag override to all mag-less weapons to prevent the situation from happening in the first place, but would require the initial check to respect the override as well

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
