### PR TITLE
VWE Makeshift patch fix

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -81,6 +81,7 @@
 		<li>sarg.alphamechs</li>
 		<li>Slashandz.MiniMiner</li>
 		<li>Killathon.MechHumanlikes.MechanicalBiomimetics</li>
+		<li>VanillaExpanded.VWEMS</li>
 	</loadAfter>
 
 </ModMetaData>

--- a/About/About.xml
+++ b/About/About.xml
@@ -81,7 +81,6 @@
 		<li>sarg.alphamechs</li>
 		<li>Slashandz.MiniMiner</li>
 		<li>Killathon.MechHumanlikes.MechanicalBiomimetics</li>
-		<li>VanillaExpanded.VWEMS</li>
 	</loadAfter>
 
 </ModMetaData>

--- a/Patches/Vanilla Weapons Expanded - Makeshift/RangedIndustrial.xml
+++ b/Patches/Vanilla Weapons Expanded - Makeshift/RangedIndustrial.xml
@@ -170,7 +170,7 @@
 								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 								<hasStandardCommand>true</hasStandardCommand>
 								<defaultProjectile>Bullet_9x19mmPara_FMJ</defaultProjectile>
-								<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+								<ticksBetweenBurstShots>9</ticksBetweenBurstShots>
 								<burstShotCount>6</burstShotCount>
 								<warmupTime>0.6</warmupTime>
 								<range>22</range>
@@ -216,7 +216,7 @@
 								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 								<hasStandardCommand>true</hasStandardCommand>
 								<defaultProjectile>Bullet_762x39mmSoviet_FMJ</defaultProjectile>
-								<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+								<ticksBetweenBurstShots>9</ticksBetweenBurstShots>
 								<burstShotCount>5</burstShotCount>
 								<warmupTime>1.1</warmupTime>
 								<range>40</range>
@@ -259,7 +259,7 @@
 								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 								<hasStandardCommand>true</hasStandardCommand>
 								<defaultProjectile>Bullet_762x54mmR_FMJ</defaultProjectile>
-								<ticksBetweenBurstShots>7</ticksBetweenBurstShots>
+								<ticksBetweenBurstShots>12</ticksBetweenBurstShots>
 								<burstShotCount>10</burstShotCount>
 								<warmupTime>1.3</warmupTime>
 								<range>58</range>
@@ -305,7 +305,6 @@
 								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 								<hasStandardCommand>true</hasStandardCommand>
 								<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
-								<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
 								<warmupTime>0.6</warmupTime>
 								<range>13</range>
 								<soundCast>Shot_Shotgun</soundCast>

--- a/Patches/Vanilla Weapons Expanded - Makeshift/RangedIndustrial.xml
+++ b/Patches/Vanilla Weapons Expanded - Makeshift/RangedIndustrial.xml
@@ -235,7 +235,7 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 						<SightsEfficiency>0.80</SightsEfficiency>
 						<ShotSpread>0.28</ShotSpread>
-						<SwayFactor>1.78</SwayFactor>
+						<SwayFactor>2.23</SwayFactor>
 						<Bulk>15.7</Bulk>
 					</statBases>
 					<AmmoUser>

--- a/Patches/Vanilla Weapons Expanded - Makeshift/RangedIndustrial.xml
+++ b/Patches/Vanilla Weapons Expanded - Makeshift/RangedIndustrial.xml
@@ -297,7 +297,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VWE_Gun_MakeshiftLMG"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="VWE_Gun_MakeshiftShotgun"]/verbs</xpath>
 					<value>
 						<verbs>
 							<li Class="CombatExtended.VerbPropertiesCE">

--- a/Patches/Vanilla Weapons Expanded - Makeshift/RangedIndustrial.xml
+++ b/Patches/Vanilla Weapons Expanded - Makeshift/RangedIndustrial.xml
@@ -8,6 +8,16 @@
 		<match Class="PatchOperationSequence">
 			<operations>
 
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/ThingDef[
+						defName = "VWE_Gun_MakeshiftPistol" or
+						defName = "VWE_Gun_MakeshiftSMG" or
+						defName = "VWE_Gun_MakeshiftRifle" or
+						defName = "VWE_Gun_MakeshiftLMG" or
+						defName = "VWE_Gun_MakeshiftShotgun"
+						]/modExtensions</xpath>
+				</li>
+
 				<li Class="PatchOperationReplace">
 					<xpath>
 						Defs/ThingDef[defName = "VWE_Gun_MakeshiftPistol"]/tools
@@ -95,17 +105,6 @@
 						<SwayFactor>1.30</SwayFactor>
 						<Bulk>2.62</Bulk>
 					</statBases>
-					<Properties>
-						<recoilAmount>2.75</recoilAmount>
-						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-						<hasStandardCommand>true</hasStandardCommand>
-						<defaultProjectile>Bullet_9x19mmPara_FMJ</defaultProjectile>
-						<warmupTime>0.2</warmupTime>
-						<range>10</range>
-						<soundCast>Shot_Autopistol</soundCast>
-						<soundCastTail>GunTail_Light</soundCastTail>
-						<muzzleFlashScale>9</muzzleFlashScale>
-					</Properties>
 					<AmmoUser>
 						<magazineSize>5</magazineSize>
 						<reloadTime>4</reloadTime>
@@ -121,6 +120,25 @@
 					</weaponTags>
 				</li>
 
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VWE_Gun_MakeshiftPistol"]/verbs</xpath>
+					<value>
+						<verbs>
+							<li Class="CombatExtended.VerbPropertiesCE">
+								<recoilAmount>2.75</recoilAmount>
+								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+								<hasStandardCommand>true</hasStandardCommand>
+								<defaultProjectile>Bullet_9x19mmPara_FMJ</defaultProjectile>
+								<warmupTime>0.5</warmupTime>
+								<range>10</range>
+								<soundCast>Shot_Autopistol</soundCast>
+								<soundCastTail>GunTail_Light</soundCastTail>
+								<muzzleFlashScale>9</muzzleFlashScale>
+							</li>
+						</verbs>
+					</value>
+				</li>
+
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>VWE_Gun_MakeshiftSMG</defName>
 					<statBases>
@@ -131,19 +149,6 @@
 						<SwayFactor>1.18</SwayFactor>
 						<Bulk>5.62</Bulk>
 					</statBases>
-					<Properties>
-						<recoilAmount>2.02</recoilAmount>
-						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-						<hasStandardCommand>true</hasStandardCommand>
-						<defaultProjectile>Bullet_9x19mmPara_FMJ</defaultProjectile>
-						<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
-						<burstShotCount>6</burstShotCount>
-						<warmupTime>0.6</warmupTime>
-						<range>22</range>
-						<soundCast>Shot_MachinePistol</soundCast>
-						<soundCastTail>GunTail_Light</soundCastTail>
-						<muzzleFlashScale>9</muzzleFlashScale>
-					</Properties>
 					<AmmoUser>
 						<magazineSize>24</magazineSize>
 						<reloadTime>4.4</reloadTime>
@@ -152,11 +157,29 @@
 					<FireModes>
 						<aiUseBurstMode>FALSE</aiUseBurstMode>
 						<aiAimMode>SuppressFire</aiAimMode>
-						<aimedBurstShotCount>4</aimedBurstShotCount>
+						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
-					<weaponTags>
-						<li>CE_MachineGun</li>
-					</weaponTags>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VWE_Gun_MakeshiftSMG"]/verbs</xpath>
+					<value>
+						<verbs>
+							<li Class="CombatExtended.VerbPropertiesCE">
+								<recoilAmount>2.02</recoilAmount>
+								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+								<hasStandardCommand>true</hasStandardCommand>
+								<defaultProjectile>Bullet_9x19mmPara_FMJ</defaultProjectile>
+								<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+								<burstShotCount>6</burstShotCount>
+								<warmupTime>0.6</warmupTime>
+								<range>22</range>
+								<soundCast>Shot_MachinePistol</soundCast>
+								<soundCastTail>GunTail_Light</soundCastTail>
+								<muzzleFlashScale>9</muzzleFlashScale>
+							</li>
+						</verbs>
+					</value>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -169,19 +192,6 @@
 						<SwayFactor>1.68</SwayFactor>
 						<Bulk>11.62</Bulk>
 					</statBases>
-					<Properties>
-						<recoilAmount>1.73</recoilAmount>
-						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-						<hasStandardCommand>true</hasStandardCommand>
-						<defaultProjectile>Bullet_762x39mmSoviet_FMJ</defaultProjectile>
-						<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
-						<burstShotCount>5</burstShotCount>
-						<warmupTime>1.1</warmupTime>
-						<range>44</range>
-						<soundCast>Shot_AssaultRifle</soundCast>
-						<soundCastTail>GunTail_Medium</soundCastTail>
-						<muzzleFlashScale>9</muzzleFlashScale>
-					</Properties>
 					<AmmoUser>
 						<magazineSize>30</magazineSize>
 						<reloadTime>4.6</reloadTime>
@@ -190,11 +200,32 @@
 					<FireModes>
 						<aiUseBurstMode>FALSE</aiUseBurstMode>
 						<aiAimMode>SuppressFire</aiAimMode>
-						<aimedBurstShotCount>4</aimedBurstShotCount>
+						<aimedBurstShotCount>2</aimedBurstShotCount>
 					</FireModes>
 					<weaponTags>
 						<li>CE_AI_AR</li>
 					</weaponTags>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VWE_Gun_MakeshiftRifle"]/verbs</xpath>
+					<value>
+						<verbs>
+							<li Class="CombatExtended.VerbPropertiesCE">
+								<recoilAmount>1.73</recoilAmount>
+								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+								<hasStandardCommand>true</hasStandardCommand>
+								<defaultProjectile>Bullet_762x39mmSoviet_FMJ</defaultProjectile>
+								<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+								<burstShotCount>5</burstShotCount>
+								<warmupTime>1.1</warmupTime>
+								<range>40</range>
+								<soundCast>Shot_AssaultRifle</soundCast>
+								<soundCastTail>GunTail_Medium</soundCastTail>
+								<muzzleFlashScale>9</muzzleFlashScale>
+							</li>
+						</verbs>
+					</value>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -207,22 +238,6 @@
 						<SwayFactor>1.78</SwayFactor>
 						<Bulk>15.7</Bulk>
 					</statBases>
-					<Properties>
-						<recoilAmount>1.32</recoilAmount>
-						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-						<hasStandardCommand>true</hasStandardCommand>
-						<defaultProjectile>Bullet_762x54mmR_FMJ</defaultProjectile>
-						<ticksBetweenBurstShots>7</ticksBetweenBurstShots>
-						<burstShotCount>19</burstShotCount>
-						<warmupTime>1.3</warmupTime>
-						<range>58</range>
-						<soundCast>Shot_Minigun</soundCast>
-						<soundCastTail>GunTail_Medium</soundCastTail>
-						<muzzleFlashScale>9</muzzleFlashScale>
-						<targetParams>
-							<canTargetLocations>true</canTargetLocations>
-						</targetParams>
-					</Properties>
 					<AmmoUser>
 						<magazineSize>50</magazineSize>
 						<reloadTime>5.2</reloadTime>
@@ -231,11 +246,32 @@
 					<FireModes>
 						<aiUseBurstMode>FALSE</aiUseBurstMode>
 						<aiAimMode>SuppressFire</aiAimMode>
-						<aimedBurstShotCount>19</aimedBurstShotCount>
+						<aimedBurstShotCount>5</aimedBurstShotCount>
 					</FireModes>
-					<weaponTags>
-						<li>CE_MachineGun</li>
-					</weaponTags>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VWE_Gun_MakeshiftLMG"]/verbs</xpath>
+					<value>
+						<verbs>
+							<li Class="CombatExtended.VerbPropertiesCE">
+								<recoilAmount>1.32</recoilAmount>
+								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+								<hasStandardCommand>true</hasStandardCommand>
+								<defaultProjectile>Bullet_762x54mmR_FMJ</defaultProjectile>
+								<ticksBetweenBurstShots>7</ticksBetweenBurstShots>
+								<burstShotCount>10</burstShotCount>
+								<warmupTime>1.3</warmupTime>
+								<range>58</range>
+								<soundCast>Shot_Minigun</soundCast>
+								<soundCastTail>GunTail_Medium</soundCastTail>
+								<muzzleFlashScale>9</muzzleFlashScale>
+								<targetParams>
+									<canTargetLocations>true</canTargetLocations>
+								</targetParams>
+							</li>
+						</verbs>
+					</value>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -248,22 +284,11 @@
 						<SwayFactor>1.48</SwayFactor>
 						<Bulk>9.6</Bulk>
 					</statBases>
-					<Properties>
-						<recoilAmount>1.69</recoilAmount>
-						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-						<hasStandardCommand>true</hasStandardCommand>
-						<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
-						<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
-						<burstShotCount>2</burstShotCount>
-						<warmupTime>0.6</warmupTime>
-						<range>14</range>
-						<soundCast>Shot_Shotgun</soundCast>
-						<soundCastTail>GunTail_Heavy</soundCastTail>
-						<muzzleFlashScale>9</muzzleFlashScale>
-					</Properties>
 					<AmmoUser>
 						<magazineSize>2</magazineSize>
-						<reloadTime>2</reloadTime>
+						<AmmoGenPerMagOverride>4</AmmoGenPerMagOverride>
+						<reloadTime>1.0</reloadTime>
+						<reloadOneAtATime>true</reloadOneAtATime>
 						<ammoSet>AmmoSet_12Gauge</ammoSet>
 					</AmmoUser>
 					<weaponTags>
@@ -271,7 +296,28 @@
 					</weaponTags>
 				</li>
 
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VWE_Gun_MakeshiftLMG"]/verbs</xpath>
+					<value>
+						<verbs>
+							<li Class="CombatExtended.VerbPropertiesCE">
+								<recoilAmount>1.69</recoilAmount>
+								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+								<hasStandardCommand>true</hasStandardCommand>
+								<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
+								<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+								<warmupTime>0.6</warmupTime>
+								<range>13</range>
+								<soundCast>Shot_Shotgun</soundCast>
+								<soundCastTail>GunTail_Heavy</soundCastTail>
+								<muzzleFlashScale>9</muzzleFlashScale>
+							</li>
+						</verbs>
+					</value>
+				</li>
+
 			</operations>
 		</match>
 	</Operation>
+
 </Patch>


### PR DESCRIPTION
## Changes

- What it says on the tin, no more special gimmicks, no more extra gizmos, no more headaches... (Makeshift ammo does not exist, scavenge or trade for it.)

## Alternatives

- The alternatives are dead.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
