### PR TITLE
Add New Shells

### DIFF
--- a/Defs/Ammo/Shell/105x617mmR.xml
+++ b/Defs/Ammo/Shell/105x617mmR.xml
@@ -64,7 +64,7 @@
 		<statBases>
 			<MarketValue>156.72</MarketValue>
 			<Bulk>45.47</Bulk>
-			<Mass>23</Mass>			
+			<Mass>23</Mass>
 		</statBases>
 		<ammoClass>GrenadeHE</ammoClass>
 		<detonateProjectile>Bullet_105x617mmRCannonShell_HE</detonateProjectile>
@@ -94,7 +94,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>235</speed>		
+			<speed>201</speed>
 			<damageAmountBase>316</damageAmountBase>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<armorPenetrationSharp>390</armorPenetrationSharp>
@@ -126,7 +126,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bomb</damageDef>
-			<speed>199</speed>				
+			<speed>134</speed>
 			<damageAmountBase>199</damageAmountBase>
 			<explosionRadius>3</explosionRadius>
 			<soundExplode>MortarBomb_Explode</soundExplode>

--- a/Defs/Ammo/Shell/105x617mmR.xml
+++ b/Defs/Ammo/Shell/105x617mmR.xml
@@ -2,8 +2,8 @@
 <Defs>
 
 	<ThingCategoryDef>
-		<defName>Ammo105x607mmRCannonShells</defName>
-		<label>105x607mmR cannon shell</label>
+		<defName>Ammo105x617mmRCannonShells</defName>
+		<label>105x617mmR cannon shell</label>
 		<parent>AmmoShells</parent>
 		<iconPath>UI/Icons/ThingCategories/CaliberCannon</iconPath>
 	</ThingCategoryDef>
@@ -11,20 +11,20 @@
 	<!-- ==================== AmmoSet ========================== -->
 
 	<CombatExtended.AmmoSetDef>
-		<defName>AmmoSet_105x607mmRCannonShell</defName>
-		<label>105x607mmR recoilless rifle shells</label>
+		<defName>AmmoSet_105x617mmRCannonShell</defName>
+		<label>105x617mmR shells</label>
 		<ammoTypes>
-			<Ammo_105x607mmRCannonShell_HEAT>Bullet_105x607mmRCannonShell_HEAT</Ammo_105x607mmRCannonShell_HEAT>
-			<Ammo_105x607mmRCannonShell_HE>Bullet_105x607mmRCannonShell_HE</Ammo_105x607mmRCannonShell_HE>
+			<Ammo_105x617mmRCannonShell_HEAT>Bullet_105x617mmRCannonShell_HEAT</Ammo_105x617mmRCannonShell_HEAT>
+			<Ammo_105x617mmRCannonShell_HE>Bullet_105x617mmRCannonShell_HE</Ammo_105x617mmRCannonShell_HE>
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="105x607mmRCannonShellBase" ParentName="HeavyAmmoBase" Abstract="True">
-		<description>High-caliber recoilless rifle shells, typically used by large recoilless rifles.</description>
+	<ThingDef Class="CombatExtended.AmmoDef" Name="105x617mmRCannonShellBase" ParentName="HeavyAmmoBase" Abstract="True">
+		<description>High-caliber tank shell, typically used by heavily armored vehicles.</description>
 		<thingCategories>
-			<li>Ammo105x607mmRCannonShells</li>
+			<li>Ammo105x617mmRCannonShells</li>
 		</thingCategories>
 		<stackLimit>25</stackLimit>
 		<tradeTags>
@@ -33,49 +33,50 @@
 		</tradeTags>
 		<statBases>
 			<MaxHitPoints>200</MaxHitPoints>
-			<Bulk>22.09</Bulk>
-			<Mass>11</Mass>
 		</statBases>
 		<cookOffFlashScale>30</cookOffFlashScale>
 		<cookOffSound>MortarBomb_Explode</cookOffSound>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="105x607mmRCannonShellBase">
-		<defName>Ammo_105x607mmRCannonShell_HEAT</defName>
-		<label>105x607mmR cannon shell (HEAT)</label>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="105x617mmRCannonShellBase">
+		<defName>Ammo_105x617mmRCannonShell_HEAT</defName>
+		<label>105x617mmR cannon shell (HEAT)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Cannon/Flak/HEAT</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>101.62</MarketValue>
+			<MarketValue>142.42</MarketValue>
+			<Bulk>44.48</Bulk>
+			<Mass>22.2</Mass>
 		</statBases>
 		<ammoClass>RocketHEAT</ammoClass>
-		<detonateProjectile>Bullet_105x607mmRCannonShell_HEAT</detonateProjectile>
+		<detonateProjectile>Bullet_105x617mmRCannonShell_HEAT</detonateProjectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="105x607mmRCannonShellBase">
-		<defName>Ammo_105x607mmRCannonShell_HE</defName>
-		<label>105x607mmR cannon shell (HE)</label>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="105x617mmRCannonShellBase">
+		<defName>Ammo_105x617mmRCannonShell_HE</defName>
+		<label>105x617mmR cannon shell (HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Cannon/Flak/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>132.95</MarketValue>
+			<MarketValue>156.72</MarketValue>
+			<Bulk>45.47</Bulk>
+			<Mass>23</Mass>			
 		</statBases>
 		<ammoClass>GrenadeHE</ammoClass>
-		<detonateProjectile>Bullet_105x607mmRCannonShell_HE</detonateProjectile>
+		<detonateProjectile>Bullet_105x617mmRCannonShell_HE</detonateProjectile>
 	</ThingDef>
 
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef Name="Base105x607mmRCannonShell" ParentName="BaseExplosiveBullet" Abstract="true">
+	<ThingDef Name="Base105x617mmRCannonShell" ParentName="BaseExplosiveBullet" Abstract="true">
 		<graphicData>
 			<shaderType>TransparentPostLight</shaderType>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>107</speed>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<flyOverhead>false</flyOverhead>
 			<dropsCasings>true</dropsCasings>
@@ -84,39 +85,40 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef ParentName="Base105x607mmRCannonShell">
-		<defName>Bullet_105x607mmRCannonShell_HEAT</defName>
-		<label>105x607mmR shell (HEAT)</label>
+	<ThingDef ParentName="Base105x617mmRCannonShell">
+		<defName>Bullet_105x617mmRCannonShell_HEAT</defName>
+		<label>105x617mmR cannon shell (HEAT)</label>
 		<graphicData>
 			<texPath>Things/Projectile/Cannon/HEAT</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<damageAmountBase>341</damageAmountBase>
+			<speed>235</speed>		
+			<damageAmountBase>316</damageAmountBase>
 			<soundExplode>MortarBomb_Explode</soundExplode>
-			<armorPenetrationSharp>410</armorPenetrationSharp>
-			<armorPenetrationBlunt>53.916</armorPenetrationBlunt>
+			<armorPenetrationSharp>390</armorPenetrationSharp>
+			<armorPenetrationBlunt>46.013</armorPenetrationBlunt>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>180</damageAmountBase>
+				<damageAmountBase>153</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
 				<explosiveRadius>1.5</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 			</li>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Large>22</Fragment_Large>
-					<Fragment_Small>50</Fragment_Small>
+					<Fragment_Large>17</Fragment_Large>
+					<Fragment_Small>13</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>
 	</ThingDef>
 
-	<ThingDef ParentName="Base105x607mmRCannonShell">
-		<defName>Bullet_105x607mmRCannonShell_HE</defName>
-		<label>105x607mmR shell (HE)</label>
+	<ThingDef ParentName="Base105x617mmRCannonShell">
+		<defName>Bullet_105x617mmRCannonShell_HE</defName>
+		<label>105x617mmR cannon shell (HE)</label>
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		<graphicData>
 			<texPath>Things/Projectile/Cannon/HE</texPath>
@@ -124,16 +126,17 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bomb</damageDef>
-			<damageAmountBase>331</damageAmountBase>
-			<explosionRadius>4</explosionRadius>
+			<speed>199</speed>				
+			<damageAmountBase>199</damageAmountBase>
+			<explosionRadius>3</explosionRadius>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Large>40</Fragment_Large>
-					<Fragment_Small>80</Fragment_Small>
+					<Fragment_Large>38</Fragment_Large>
+					<Fragment_Small>38</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>
@@ -142,11 +145,11 @@
 	<!-- ==================== Recipes ========================== -->
 
 	<RecipeDef ParentName="AmmoRecipeBase">
-		<defName>MakeAmmo_105x607mmRCannonShell_HEAT</defName>
-		<label>make 105x607mmR HEAT cannon shells x2</label>
-		<description>Craft 2 105x607mmR HEAT cannon shells.</description>
-		<jobString>Making 105x607mmR HEAT cannon shells.</jobString>
-		<workAmount>8200</workAmount>
+		<defName>MakeAmmo_105x617mmRCannonShell_HEAT</defName>
+		<label>make 105x617mmR HEAT cannon shells x2</label>
+		<description>Craft 2 105x617mmR HEAT cannon shells.</description>
+		<jobString>Making 105x617mmR HEAT cannon shells.</jobString>
+		<workAmount>11800</workAmount>
 		<ingredients>
 			<li>
 				<filter>
@@ -154,7 +157,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>46</count>
+				<count>90</count>
 			</li>
 			<li>
 				<filter>
@@ -162,7 +165,7 @@
 						<li>FSX</li>
 					</thingDefs>
 				</filter>
-				<count>7</count>
+				<count>4</count>
 			</li>
 			<li>
 				<filter>
@@ -181,7 +184,7 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_105x607mmRCannonShell_HEAT>2</Ammo_105x607mmRCannonShell_HEAT>
+			<Ammo_105x617mmRCannonShell_HEAT>2</Ammo_105x617mmRCannonShell_HEAT>
 		</products>
 		<skillRequirements>
 			<Crafting>4</Crafting>
@@ -189,11 +192,11 @@
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
-		<defName>MakeAmmo_105x607mmRCannonShell_HE</defName>
-		<label>make 105x607mmR HE cannon shells x2</label>
-		<description>Craft 2 105x607mmR HE cannon shells.</description>
-		<jobString>Making 105x607mmR HE cannon shells.</jobString>
-		<workAmount>11400</workAmount>
+		<defName>MakeAmmo_105x617mmRCannonShell_HE</defName>
+		<label>make 105x617mmR HE cannon shells x2</label>
+		<description>Craft 2 105x617mmR HE cannon shells.</description>
+		<jobString>Making 105x617mmR HE cannon shells.</jobString>
+		<workAmount>13000</workAmount>
 		<ingredients>
 			<li>
 				<filter>
@@ -201,7 +204,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>46</count>
+				<count>94</count>
 			</li>
 			<li>
 				<filter>
@@ -209,7 +212,7 @@
 						<li>FSX</li>
 					</thingDefs>
 				</filter>
-				<count>14</count>
+				<count>6</count>
 			</li>
 			<li>
 				<filter>
@@ -228,7 +231,7 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_105x607mmRCannonShell_HE>2</Ammo_105x607mmRCannonShell_HE>
+			<Ammo_105x617mmRCannonShell_HE>2</Ammo_105x617mmRCannonShell_HE>
 		</products>
 		<skillRequirements>
 			<Crafting>4</Crafting>

--- a/Defs/Ammo/Shell/105x617mmR.xml
+++ b/Defs/Ammo/Shell/105x617mmR.xml
@@ -43,7 +43,7 @@
 		<label>105x617mmR cannon shell (HEAT)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Cannon/120mmTank/HEAT</texPath>
-			<graphicClass>Graphic_StackCount</graphicClass>
+			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>142.42</MarketValue>
@@ -59,7 +59,7 @@
 		<label>105x617mmR cannon shell (HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Cannon/120mmTank/HE</texPath>
-			<graphicClass>Graphic_StackCount</graphicClass>
+			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>156.72</MarketValue>

--- a/Defs/Ammo/Shell/105x617mmR.xml
+++ b/Defs/Ammo/Shell/105x617mmR.xml
@@ -77,7 +77,6 @@
 			<shaderType>TransparentPostLight</shaderType>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<soundExplode>MortarBomb_Explode</soundExplode>
 			<flyOverhead>false</flyOverhead>
 			<dropsCasings>true</dropsCasings>
 			<casingMoteDefname>Fleck_BigShell</casingMoteDefname>

--- a/Defs/Ammo/Shell/105x617mmR.xml
+++ b/Defs/Ammo/Shell/105x617mmR.xml
@@ -42,7 +42,7 @@
 		<defName>Ammo_105x617mmRCannonShell_HEAT</defName>
 		<label>105x617mmR cannon shell (HEAT)</label>
 		<graphicData>
-			<texPath>Things/Ammo/Cannon/Flak/HEAT</texPath>
+			<texPath>Things/Ammo/Cannon/120mmTank/HEAT</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
@@ -58,7 +58,7 @@
 		<defName>Ammo_105x617mmRCannonShell_HE</defName>
 		<label>105x617mmR cannon shell (HE)</label>
 		<graphicData>
-			<texPath>Things/Ammo/Cannon/Flak/HE</texPath>
+			<texPath>Things/Ammo/Cannon/120mmTank/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>

--- a/Defs/Ammo/Shell/57x307mmR.xml
+++ b/Defs/Ammo/Shell/57x307mmR.xml
@@ -108,8 +108,8 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Large>2</Fragment_Large>
-					<Fragment_Small>10</Fragment_Small>
+					<Fragment_Large>10</Fragment_Large>
+					<Fragment_Small>2</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Shell/57x307mmR.xml
+++ b/Defs/Ammo/Shell/57x307mmR.xml
@@ -43,7 +43,7 @@
 		<defName>Ammo_57x307mmR_AP</defName>
 		<label>57x307mmR cartridge (AP)</label>
 		<graphicData>
-			<texPath>Things/Ammo/HighCaliber//HE</texPath>
+			<texPath>Things/Ammo/Cannon/Flak/APHE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
@@ -57,7 +57,7 @@
 		<defName>Ammo_57x307mmR_HE</defName>
 		<label>57x307mmR cartridge (HE)</label>
 		<graphicData>
-			<texPath>Things/Ammo/HighCaliber//HE</texPath>
+			<texPath>Things/Ammo/Cannon/Flak/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>

--- a/Defs/Ammo/Shell/57x307mmR.xml
+++ b/Defs/Ammo/Shell/57x307mmR.xml
@@ -76,7 +76,6 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<speed>92</speed>
-			<soundExplode>MortarBomb_Explode</soundExplode>
 			<flyOverhead>false</flyOverhead>
 			<dropsCasings>true</dropsCasings>
 			<casingMoteDefname>Fleck_BigShell</casingMoteDefname>
@@ -90,7 +89,6 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<damageAmountBase>105</damageAmountBase>
-			<soundExplode>MortarBomb_Explode</soundExplode>
 			<armorPenetrationSharp>32</armorPenetrationSharp>
 			<armorPenetrationBlunt>4560.86</armorPenetrationBlunt>
 		</projectile>
@@ -104,6 +102,7 @@
 			<damageAmountBase>33</damageAmountBase>
 			<explosionRadius>1</explosionRadius>
 			<soundExplode>MortarBomb_Explode</soundExplode>
+			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">

--- a/Defs/Ammo/Shell/57x307mmR.xml
+++ b/Defs/Ammo/Shell/57x307mmR.xml
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+	<ThingCategoryDef>
+		<defName>Ammo57x307mmR</defName>
+		<label>57x307mmR</label>
+		<parent>AmmoShells</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberAutocannonLarge</iconPath>
+	</ThingCategoryDef>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_57x307mmR</defName>
+		<label>57x307mmR</label>
+		<ammoTypes>
+			<Ammo_57x307mmR_AP>Bullet_57x307mmR_AP</Ammo_57x307mmR_AP>
+			<Ammo_57x307mmR_HE>Bullet_57x307mmR_HE</Ammo_57x307mmR_HE>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo57x307mmRBase" ParentName="HeavyAmmoBase" Abstract="True">
+		<description>Large caliber cartridge used by naval artillery cannons.</description>
+		<thingCategories>
+			<li>Ammo57x307mmR</li>
+		</thingCategories>
+		<stackLimit>25</stackLimit>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting_TableMachining</li>
+		</tradeTags>
+		<statBases>
+			<Mass>4.3</Mass>
+			<Bulk>2.79</Bulk>
+		</statBases>
+		<cookOffFlashScale>20</cookOffFlashScale>
+		<cookOffSound>MortarBomb_Explode</cookOffSound>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo57x307mmRBase">
+		<defName>Ammo_57x307mmR_AP</defName>
+		<label>57x307mmR cartridge (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber//HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>17.6</MarketValue>
+		</statBases>
+		<ammoClass>AP</ammoClass>
+		<detonateProjectile>Bullet_57x307mmR_AP</detonateProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo57x307mmRBase">
+		<defName>Ammo_57x307mmR_HE</defName>
+		<label>57x307mmR cartridge (HE)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber//HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>32.52</MarketValue>
+		</statBases>
+		<ammoClass>GrenadeHE</ammoClass>
+		<detonateProjectile>Bullet_57x307mmR_HE</detonateProjectile>
+	</ThingDef>
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef Name="Base57x307mmRBullet" ParentName="BaseExplosiveBullet" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_Big</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<speed>83</speed>
+			<soundExplode>MortarBomb_Explode</soundExplode>
+			<flyOverhead>false</flyOverhead>
+			<dropsCasings>true</dropsCasings>
+			<casingMoteDefname>Fleck_BigShell</casingMoteDefname>
+			<casingFilthDefname>Filth_CannonAmmoCasings</casingFilthDefname>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base57x307mmRBullet">
+		<defName>Bullet_57x307mmR_AP</defName>
+		<label>57x307mmR bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<damageAmountBase>105</damageAmountBase>
+			<soundExplode>MortarBomb_Explode</soundExplode>
+			<armorPenetrationSharp>32</armorPenetrationSharp>
+			<armorPenetrationBlunt>4560.86</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base57x307mmRBullet">
+		<defName>Bullet_57x307mmR_HE</defName>
+		<label>57x307mmR bullet (HE)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bomb</damageDef>
+			<damageAmountBase>33</damageAmountBase>
+			<explosionRadius>1</explosionRadius>
+			<soundExplode>MortarBomb_Explode</soundExplode>
+		</projectile>
+		<comps>
+			<li Class="CombatExtended.CompProperties_Fragments">
+				<fragments>
+					<Fragment_Large>7</Fragment_Large>
+					<Fragment_Small>55</Fragment_Small>
+				</fragments>
+			</li>
+		</comps>
+	</ThingDef>
+
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_57x307mmR_AP</defName>
+		<label>make 57x307mmR (AP) shells x5</label>
+		<description>Craft 5 57x307mmR (AP) shells.</description>
+		<jobString>Making 57x307mmR (AP) shells.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>44</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_57x307mmR_AP>5</Ammo_57x307mmR_AP>
+		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
+		<workAmount>5280</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_57x307mmR_HE</defName>
+		<label>make 57x307mmR (HE) cartridge x25</label>
+		<description>Craft 25 57x307mmR (HE) cartridges.</description>
+		<jobString>Making 57x307mmR (HE) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>44</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>2</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>FSX</li>
+					</thingDefs>
+				</filter>
+				<count>1</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>ComponentIndustrial</li>
+				<li>FSX</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_57x307mmR_HE>25</Ammo_57x307mmR_HE>
+		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
+		<workAmount>47400</workAmount>
+	</RecipeDef>
+
+</Defs>

--- a/Defs/Ammo/Shell/57x307mmR.xml
+++ b/Defs/Ammo/Shell/57x307mmR.xml
@@ -49,7 +49,7 @@
 		<statBases>
 			<MarketValue>17.6</MarketValue>
 		</statBases>
-		<ammoClass>AP</ammoClass>
+		<ammoClass>ArmorPiercing</ammoClass>
 		<detonateProjectile>Bullet_57x307mmR_AP</detonateProjectile>
 	</ThingDef>
 
@@ -108,8 +108,8 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Large>7</Fragment_Large>
-					<Fragment_Small>55</Fragment_Small>
+					<Fragment_Large>2</Fragment_Large>
+					<Fragment_Small>10</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>
@@ -119,8 +119,8 @@
 
 	<RecipeDef ParentName="AmmoRecipeBase">
 		<defName>MakeAmmo_57x307mmR_AP</defName>
-		<label>make 57x307mmR (AP) shells x5</label>
-		<description>Craft 5 57x307mmR (AP) shells.</description>
+		<label>make 57x307mmR (AP) shells x10</label>
+		<description>Craft 10 57x307mmR (AP) shells.</description>
 		<jobString>Making 57x307mmR (AP) shells.</jobString>
 		<ingredients>
 			<li>
@@ -129,7 +129,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>44</count>
+				<count>86</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -138,18 +138,18 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_57x307mmR_AP>5</Ammo_57x307mmR_AP>
+			<Ammo_57x307mmR_AP>10</Ammo_57x307mmR_AP>
 		</products>
 		<skillRequirements>
 			<Crafting>4</Crafting>
 		</skillRequirements>
-		<workAmount>5280</workAmount>
+		<workAmount>10320</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
 		<defName>MakeAmmo_57x307mmR_HE</defName>
-		<label>make 57x307mmR (HE) cartridge x25</label>
-		<description>Craft 25 57x307mmR (HE) cartridges.</description>
+		<label>make 57x307mmR (HE) cartridge x10</label>
+		<description>Craft 10 57x307mmR (HE) cartridges.</description>
 		<jobString>Making 57x307mmR (HE) cartridges.</jobString>
 		<ingredients>
 			<li>
@@ -174,7 +174,7 @@
 						<li>FSX</li>
 					</thingDefs>
 				</filter>
-				<count>1</count>
+				<count>2</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -185,12 +185,12 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_57x307mmR_HE>25</Ammo_57x307mmR_HE>
+			<Ammo_57x307mmR_HE>10</Ammo_57x307mmR_HE>
 		</products>
 		<skillRequirements>
 			<Crafting>4</Crafting>
 		</skillRequirements>
-		<workAmount>47400</workAmount>
+		<workAmount>10600</workAmount>
 	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Shell/57x307mmR.xml
+++ b/Defs/Ammo/Shell/57x307mmR.xml
@@ -47,7 +47,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>17.6</MarketValue>
+			<MarketValue>17.2</MarketValue>
 		</statBases>
 		<ammoClass>ArmorPiercing</ammoClass>
 		<detonateProjectile>Bullet_57x307mmR_AP</detonateProjectile>
@@ -61,7 +61,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>32.52</MarketValue>
+			<MarketValue>25.63</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHE</ammoClass>
 		<detonateProjectile>Bullet_57x307mmR_HE</detonateProjectile>
@@ -75,7 +75,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>83</speed>
+			<speed>92</speed>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<flyOverhead>false</flyOverhead>
 			<dropsCasings>true</dropsCasings>

--- a/Defs/Ammo/Shell/75x350mmR.xml
+++ b/Defs/Ammo/Shell/75x350mmR.xml
@@ -42,7 +42,7 @@
 		<defName>Ammo_75x350mmR_AP</defName>
 		<label>75x350mmR cartridge (AP)</label>
 		<graphicData>
-			<texPath>Things/Ammo/HighCaliber//HE</texPath>
+			<texPath>Things/Ammo/Cannon/Flak/APHE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
@@ -57,7 +57,7 @@
 		<defName>Ammo_75x350mmR_HE</defName>
 		<label>75x350mmR cartridge (HE)</label>
 		<graphicData>
-			<texPath>Things/Ammo/HighCaliber//HE</texPath>
+			<texPath>Things/Ammo/Cannon/Flak/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>

--- a/Defs/Ammo/Shell/75x350mmR.xml
+++ b/Defs/Ammo/Shell/75x350mmR.xml
@@ -76,7 +76,6 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<soundExplode>MortarBomb_Explode</soundExplode>
 			<flyOverhead>false</flyOverhead>
 			<dropsCasings>true</dropsCasings>
 			<casingMoteDefname>Fleck_BigShell</casingMoteDefname>
@@ -91,7 +90,6 @@
 			<damageDef>Bullet</damageDef>
 			<speed>124</speed>
 			<damageAmountBase>206</damageAmountBase>
-			<soundExplode>MortarBomb_Explode</soundExplode>
 			<armorPenetrationSharp>88</armorPenetrationSharp>
 			<armorPenetrationBlunt>24149.06</armorPenetrationBlunt>
 		</projectile>
@@ -106,6 +104,7 @@
 			<damageAmountBase>104</damageAmountBase>
 			<explosionRadius>2</explosionRadius>
 			<soundExplode>MortarBomb_Explode</soundExplode>
+			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">

--- a/Defs/Ammo/Shell/77x350mmR.xml
+++ b/Defs/Ammo/Shell/77x350mmR.xml
@@ -2,8 +2,8 @@
 <Defs>
 
 	<ThingCategoryDef>
-		<defName>Ammo57x307mmR</defName>
-		<label>57x307mmR</label>
+		<defName>Ammo75x350mmR</defName>
+		<label>75x350mmR</label>
 		<parent>AmmoShells</parent>
 		<iconPath>UI/Icons/ThingCategories/CaliberAutocannonLarge</iconPath>
 	</ThingCategoryDef>
@@ -11,20 +11,20 @@
 	<!-- ==================== AmmoSet ========================== -->
 
 	<CombatExtended.AmmoSetDef>
-		<defName>AmmoSet_57x307mmR</defName>
-		<label>57x307mmR</label>
+		<defName>AmmoSet_75x350mmR</defName>
+		<label>75x350mmR</label>
 		<ammoTypes>
-			<Ammo_57x307mmR_AP>Bullet_57x307mmR_AP</Ammo_57x307mmR_AP>
-			<Ammo_57x307mmR_HE>Bullet_57x307mmR_HE</Ammo_57x307mmR_HE>
+			<Ammo_75x350mmR_AP>Bullet_75x350mmR_AP</Ammo_75x350mmR_AP>
+			<Ammo_75x350mmR_HE>Bullet_75x350mmR_HE</Ammo_75x350mmR_HE>
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo57x307mmRBase" ParentName="HeavyAmmoBase" Abstract="True">
-		<description>Large caliber shell used by naval artillery guns.</description>
+	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo75x350mmRBase" ParentName="HeavyAmmoBase" Abstract="True">
+		<description>Large caliber shell used by tank cannons.</description>
 		<thingCategories>
-			<li>Ammo57x307mmR</li>
+			<li>Ammo75x350mmR</li>
 		</thingCategories>
 		<stackLimit>25</stackLimit>
 		<tradeTags>
@@ -32,50 +32,50 @@
 			<li>CE_AutoEnableCrafting_TableMachining</li>
 		</tradeTags>
 		<statBases>
-			<Mass>4.3</Mass>
-			<Bulk>2.79</Bulk>
+			<Mass>8.527</Mass>
 		</statBases>
 		<cookOffFlashScale>20</cookOffFlashScale>
 		<cookOffSound>MortarBomb_Explode</cookOffSound>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo57x307mmRBase">
-		<defName>Ammo_57x307mmR_AP</defName>
-		<label>57x307mmR cartridge (AP)</label>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo75x350mmRBase">
+		<defName>Ammo_75x350mmR_AP</defName>
+		<label>75x350mmR cartridge (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber//HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>17.6</MarketValue>
+			<MarketValue>35.2</MarketValue>
+			<Bulk>9.28</Bulk>
 		</statBases>
 		<ammoClass>ArmorPiercing</ammoClass>
-		<detonateProjectile>Bullet_57x307mmR_AP</detonateProjectile>
+		<detonateProjectile>Bullet_75x350mmR_AP</detonateProjectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo57x307mmRBase">
-		<defName>Ammo_57x307mmR_HE</defName>
-		<label>57x307mmR cartridge (HE)</label>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo75x350mmRBase">
+		<defName>Ammo_75x350mmR_HE</defName>
+		<label>75x350mmR cartridge (HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber//HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>32.52</MarketValue>
+			<MarketValue>60.31</MarketValue>
+			<Bulk>11.86</Bulk>
 		</statBases>
 		<ammoClass>GrenadeHE</ammoClass>
-		<detonateProjectile>Bullet_57x307mmR_HE</detonateProjectile>
+		<detonateProjectile>Bullet_75x350mmR_HE</detonateProjectile>
 	</ThingDef>
 
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef Name="Base57x307mmRBullet" ParentName="BaseExplosiveBullet" Abstract="true">
+	<ThingDef Name="Base75x350mmRBullet" ParentName="BaseExplosiveBullet" Abstract="true">
 		<graphicData>
 			<texPath>Things/Projectile/Bullet_Big</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>83</speed>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<flyOverhead>false</flyOverhead>
 			<dropsCasings>true</dropsCasings>
@@ -84,32 +84,34 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef ParentName="Base57x307mmRBullet">
-		<defName>Bullet_57x307mmR_AP</defName>
-		<label>57x307mmR bullet (AP)</label>
+	<ThingDef ParentName="Base75x350mmRBullet">
+		<defName>Bullet_75x350mmR_AP</defName>
+		<label>75x350mmR bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<damageAmountBase>105</damageAmountBase>
+			<speed>124</speed>
+			<damageAmountBase>206</damageAmountBase>
 			<soundExplode>MortarBomb_Explode</soundExplode>
-			<armorPenetrationSharp>32</armorPenetrationSharp>
-			<armorPenetrationBlunt>4560.86</armorPenetrationBlunt>
+			<armorPenetrationSharp>88</armorPenetrationSharp>
+			<armorPenetrationBlunt>24149.06</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
-	<ThingDef ParentName="Base57x307mmRBullet">
-		<defName>Bullet_57x307mmR_HE</defName>
-		<label>57x307mmR bullet (HE)</label>
+	<ThingDef ParentName="Base75x350mmRBullet">
+		<defName>Bullet_75x350mmR_HE</defName>
+		<label>75x350mmR bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bomb</damageDef>
-			<damageAmountBase>33</damageAmountBase>
-			<explosionRadius>1</explosionRadius>
+			<speed>93</speed>
+			<damageAmountBase>104</damageAmountBase>
+			<explosionRadius>2</explosionRadius>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Large>2</Fragment_Large>
-					<Fragment_Small>10</Fragment_Small>
+					<Fragment_Large>22</Fragment_Large>
+					<Fragment_Small>13</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>
@@ -118,10 +120,10 @@
 	<!-- ==================== Recipes ========================== -->
 
 	<RecipeDef ParentName="AmmoRecipeBase">
-		<defName>MakeAmmo_57x307mmR_AP</defName>
-		<label>make 57x307mmR (AP) shells x10</label>
-		<description>Craft 10 57x307mmR (AP) shells.</description>
-		<jobString>Making 57x307mmR (AP) shells.</jobString>
+		<defName>MakeAmmo_75x350mmR_AP</defName>
+		<label>make 75x350mmR (AP) shells x10</label>
+		<description>Craft 10 75x350mmR (AP) shells.</description>
+		<jobString>Making 75x350mmR (AP) shells.</jobString>
 		<ingredients>
 			<li>
 				<filter>
@@ -129,7 +131,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>86</count>
+				<count>88</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -138,19 +140,19 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_57x307mmR_AP>10</Ammo_57x307mmR_AP>
+			<Ammo_75x350mmR_AP>10</Ammo_75x350mmR_AP>
 		</products>
 		<skillRequirements>
 			<Crafting>4</Crafting>
 		</skillRequirements>
-		<workAmount>10320</workAmount>
+		<workAmount>10560</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
-		<defName>MakeAmmo_57x307mmR_HE</defName>
-		<label>make 57x307mmR (HE) cartridge x10</label>
-		<description>Craft 10 57x307mmR (HE) cartridges.</description>
-		<jobString>Making 57x307mmR (HE) cartridges.</jobString>
+		<defName>MakeAmmo_75x350mmR_HE</defName>
+		<label>make 75x350mmR (HE) cartridge x10</label>
+		<description>Craft 10 75x350mmR (HE) cartridges.</description>
+		<jobString>Making 75x350mmR (HE) cartridges.</jobString>
 		<ingredients>
 			<li>
 				<filter>
@@ -158,7 +160,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>86</count>
+				<count>88</count>
 			</li>
 			<li>
 				<filter>
@@ -174,7 +176,7 @@
 						<li>FSX</li>
 					</thingDefs>
 				</filter>
-				<count>2</count>
+				<count>6</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -185,12 +187,12 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_57x307mmR_HE>10</Ammo_57x307mmR_HE>
+			<Ammo_75x350mmR_HE>10</Ammo_75x350mmR_HE>
 		</products>
 		<skillRequirements>
 			<Crafting>4</Crafting>
 		</skillRequirements>
-		<workAmount>10600</workAmount>
+		<workAmount>12400</workAmount>
 	</RecipeDef>
 
 </Defs>


### PR DESCRIPTION
## Additions
Some new shells for the upcoming vehicles. All have been added to the main sheet.
- 105x607mmR (105mm gun on the Abrams)
- 57x307mmR (British Naval 6 Pounder, used on the Mark IV male)
- 75x350mmR (M4 Sherman's 75mm gun.)

## Changes
- Fixed an incorrect recipe label amount and revised some labels.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
