### PR TITLE
Fix Spartan Foundry Patch NV

### DIFF
--- a/Patches/Spartan Foundry/Apparel_Headgear.xml
+++ b/Patches/Spartan Foundry/Apparel_Headgear.xml
@@ -15,6 +15,7 @@
 						<Bulk>5</Bulk>
 						<WornBulk>1</WornBulk>
 						<MaxHitPoints>240</MaxHitPoints>
+						<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>						
 					</value>
 				</li>
 				<li Class="PatchOperationConditional">
@@ -34,7 +35,6 @@
 							<ToxicEnvironmentResistance>0.5</ToxicEnvironmentResistance>
 							<PainShockThreshold>0.2</PainShockThreshold>
 							<SmokeSensitivity>-1</SmokeSensitivity>
-							<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
 						</equippedStatOffsets>
 					</value>
 				</li>
@@ -77,6 +77,7 @@
 						<Bulk>4.5</Bulk>
 						<WornBulk>0.9</WornBulk>
 						<MaxHitPoints>240</MaxHitPoints>
+						<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
 					</value>
 				</li>
 				<li Class="PatchOperationConditional">
@@ -98,7 +99,6 @@
 							<FixBrokenDownBuildingSuccessChance>0.1</FixBrokenDownBuildingSuccessChance>
 							<ConstructionSpeed>0.1</ConstructionSpeed>
 							<SmokeSensitivity>-1</SmokeSensitivity>
-							<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
 						</equippedStatOffsets>
 					</value>
 				</li>
@@ -141,6 +141,7 @@
 						<Bulk>5</Bulk>
 						<WornBulk>1</WornBulk>
 						<MaxHitPoints>240</MaxHitPoints>
+						<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>						
 					</value>
 				</li>
 				<li Class="PatchOperationConditional">
@@ -162,7 +163,6 @@
 							<PlantHarvestYield>0.1</PlantHarvestYield>
 							<TameAnimalChance>0.1</TameAnimalChance>
 							<SmokeSensitivity>-1</SmokeSensitivity>
-							<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
 						</equippedStatOffsets>
 					</value>
 				</li>
@@ -205,6 +205,7 @@
 						<Bulk>5.6</Bulk>
 						<WornBulk>1.1</WornBulk>
 						<MaxHitPoints>240</MaxHitPoints>
+						<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>						
 					</value>
 				</li>
 				<li Class="PatchOperationConditional">
@@ -223,7 +224,6 @@
 							<AimingAccuracy>0.35</AimingAccuracy>
 							<ToxicEnvironmentResistance>0.5</ToxicEnvironmentResistance>
 							<SmokeSensitivity>-1</SmokeSensitivity>
-							<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
 						</equippedStatOffsets>
 					</value>
 				</li>
@@ -266,6 +266,7 @@
 						<Bulk>5</Bulk>
 						<WornBulk>1</WornBulk>
 						<MaxHitPoints>240</MaxHitPoints>
+						<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
 					</value>
 				</li>
 				<li Class="PatchOperationConditional">
@@ -285,7 +286,6 @@
 							<ToxicEnvironmentResistance>0.5</ToxicEnvironmentResistance>
 							<AimingDelayFactor>-0.15</AimingDelayFactor>
 							<SmokeSensitivity>-1</SmokeSensitivity>
-							<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
 						</equippedStatOffsets>
 					</value>
 				</li>
@@ -328,6 +328,7 @@
 						<Bulk>5.6</Bulk>
 						<WornBulk>1.1</WornBulk>
 						<MaxHitPoints>240</MaxHitPoints>
+						<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
 					</value>
 				</li>
 				<li Class="PatchOperationConditional">
@@ -348,7 +349,6 @@
 							<ToxicEnvironmentResistance>1</ToxicEnvironmentResistance>
 							<ImmunityGainSpeed>0.1</ImmunityGainSpeed>
 							<SmokeSensitivity>-1</SmokeSensitivity>
-							<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
 						</equippedStatOffsets>
 					</value>
 				</li>
@@ -391,6 +391,7 @@
 						<Bulk>5</Bulk>
 						<WornBulk>1</WornBulk>
 						<MaxHitPoints>240</MaxHitPoints>
+						<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>						
 					</value>
 				</li>
 				<li Class="PatchOperationConditional">
@@ -412,7 +413,6 @@
 							<NegotiationAbility>0.15</NegotiationAbility>
 							<SocialImpact>0.25</SocialImpact>
 							<SmokeSensitivity>-1</SmokeSensitivity>
-							<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
 						</equippedStatOffsets>
 					</value>
 				</li>
@@ -455,6 +455,7 @@
 						<Bulk>4.5</Bulk>
 						<WornBulk>0.9</WornBulk>
 						<MaxHitPoints>240</MaxHitPoints>
+						<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>						
 					</value>
 				</li>
 				<li Class="PatchOperationConditional">
@@ -476,7 +477,6 @@
 							<MedicalOperationSpeed>0.15</MedicalOperationSpeed>
 							<SurgerySuccessChanceFactor>0.15</SurgerySuccessChanceFactor>
 							<SmokeSensitivity>-1</SmokeSensitivity>
-							<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
 						</equippedStatOffsets>
 					</value>
 				</li>
@@ -519,6 +519,7 @@
 						<Bulk>5</Bulk>
 						<WornBulk>1</WornBulk>
 						<MaxHitPoints>240</MaxHitPoints>
+						<NightVisionEfficiency_Apparel>0.7</NightVisionEfficiency_Apparel>
 					</value>
 				</li>
 				<li Class="PatchOperationConditional">
@@ -538,7 +539,6 @@
 							<ToxicEnvironmentResistance>0.5</ToxicEnvironmentResistance>
 							<AimingDelayFactor>0.2</AimingDelayFactor>
 							<SmokeSensitivity>-1</SmokeSensitivity>
-							<NightVisionEfficiency_Apparel>0.7</NightVisionEfficiency_Apparel>
 						</equippedStatOffsets>
 					</value>
 				</li>
@@ -581,6 +581,7 @@
 						<Bulk>5</Bulk>
 						<WornBulk>1</WornBulk>
 						<MaxHitPoints>240</MaxHitPoints>
+						<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>						
 					</value>
 				</li>
 				<li Class="PatchOperationConditional">
@@ -603,7 +604,6 @@
 							<MeleeDodgeChance>0.05</MeleeDodgeChance>
 							<MeleeParryChance>0.1</MeleeParryChance>
 							<SmokeSensitivity>-1</SmokeSensitivity>
-							<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
 						</equippedStatOffsets>
 					</value>
 				</li>
@@ -646,6 +646,7 @@
 						<Bulk>5</Bulk>
 						<WornBulk>1</WornBulk>
 						<MaxHitPoints>240</MaxHitPoints>
+						<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>						
 					</value>
 				</li>
 				<li Class="PatchOperationConditional">
@@ -668,7 +669,6 @@
 							<MeleeDodgeChance>0.025</MeleeDodgeChance>
 							<MeleeParryChance>0.05</MeleeParryChance>
 							<SmokeSensitivity>-1</SmokeSensitivity>
-							<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
 						</equippedStatOffsets>
 					</value>
 				</li>
@@ -711,6 +711,7 @@
 						<Bulk>4.5</Bulk>
 						<WornBulk>0.9</WornBulk>
 						<MaxHitPoints>240</MaxHitPoints>
+						<NightVisionEfficiency_Apparel>0.7</NightVisionEfficiency_Apparel>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
@@ -724,7 +725,6 @@
 							<SmoothingSpeed>0.05</SmoothingSpeed>
 							<ForagedNutritionPerDay>6</ForagedNutritionPerDay>
 							<SmokeSensitivity>-1</SmokeSensitivity>
-							<NightVisionEfficiency_Apparel>0.7</NightVisionEfficiency_Apparel>
 						</equippedStatOffsets>
 					</value>
 				</li>


### PR DESCRIPTION
## Changes
- Fix the helmet night vision. NightVision stats were incorrectly being patched into the worn offsets, instead of the statbases. As was, these stats were appearing on the helmet but not actually applying.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
