### PR TITLE
Adeptus Astartes Bolter ammo fix

### DIFF
--- a/Patches/Warcaskets - Adeptus Astartes/Ammo/Bolter.xml
+++ b/Patches/Warcaskets - Adeptus Astartes/Ammo/Bolter.xml
@@ -26,7 +26,6 @@
 						<Ammo_Bolter75_MetalStorm>Bullet_Bolter75_MetalStorm</Ammo_Bolter75_MetalStorm>
 						<Ammo_Bolter75_Kraken>Bullet_Bolter75_Kraken</Ammo_Bolter75_Kraken>
 					</ammoTypes>
-					<similarTo>AmmoSet_AntiMateriel</similarTo>
 				</CombatExtended.AmmoSetDef>
 
 				<!-- ==================== Ammo ========================== -->

--- a/Patches/Warcaskets - Adeptus Astartes/Ammo/HeavyBolter.xml
+++ b/Patches/Warcaskets - Adeptus Astartes/Ammo/HeavyBolter.xml
@@ -26,7 +26,6 @@
 						<Ammo_Bolter998_MetalStorm>Bullet_Bolter998_MetalStorm</Ammo_Bolter998_MetalStorm>
 						<Ammo_Bolter998_Kraken>Bullet_Bolter998_Kraken</Ammo_Bolter998_Kraken>
 					</ammoTypes>
-					<similarTo>AmmoSet_Autocannon</similarTo>
 				</CombatExtended.AmmoSetDef>
 
 				<!-- ==================== Ammo ========================== -->


### PR DESCRIPTION
## Changes

- What it says on the tin, the ammo is custom and not conventional like normal firearm ammo so it does not make sense for it to have generic ammo which causes issues without the Bolter ammo having its own custom tailored generic ammo (the generic ammo system does not recognize the ammo types cuz they have custom ammo classes) which in the end would be exactly the same as the existing ammo.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
