### PR TITLE
medieval explosive recipe tweak

### DIFF
--- a/Defs/Ammo/Medieval/CannonBall.xml
+++ b/Defs/Ammo/Medieval/CannonBall.xml
@@ -77,7 +77,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>45.45</MarketValue>
+			<MarketValue>32.45</MarketValue>
 		</statBases>
 		<ammoClass>BurstingShell</ammoClass>
 		<cookOffProjectile>Bullet_CannonBall_Bursting</cookOffProjectile>
@@ -92,7 +92,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>41.72</MarketValue>
+			<MarketValue>28.72</MarketValue>
 		</statBases>
 		<ammoClass>FireShell</ammoClass>
 		<cookOffProjectile>Bullet_CannonBall_Incendiary</cookOffProjectile>
@@ -320,7 +320,7 @@
 		<products>
 			<Ammo_CannonBall_Bursting>5</Ammo_CannonBall_Bursting>
 		</products>
-		<workAmount>9400</workAmount>
+		<workAmount>8200</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
@@ -356,7 +356,7 @@
 		<products>
 			<Ammo_CannonBall_Incendiary>5</Ammo_CannonBall_Incendiary>
 		</products>
-		<workAmount>8600</workAmount>
+		<workAmount>7400</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Medieval/MortarGrenade.xml
+++ b/Defs/Ammo/Medieval/MortarGrenade.xml
@@ -49,7 +49,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>18.54</MarketValue>
+			<MarketValue>7.67</MarketValue>
 		</statBases>
 		<ammoClass>BurstingShell</ammoClass>
 		<detonateProjectile>Bullet_MortarGrenade</detonateProjectile>
@@ -84,8 +84,8 @@
 
 	<RecipeDef ParentName="AmmoRecipeBase">
 		<defName>MakeAmmo_MortarGrenade</defName>
-		<label>Make Mortar Grenade x5</label>
-		<description>Craft 5 Mortar Grenades</description>
+		<label>Make Mortar Grenade x25</label>
+		<description>Craft 25 Mortar Grenades</description>
 		<jobString>Making Mortar Grenades</jobString>
 		<researchPrerequisite>CE_Gunpowder</researchPrerequisite>
 		<ingredients>
@@ -95,7 +95,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>10</count>
+				<count>48</count>
 			</li>
 			<li>
 				<filter>
@@ -103,7 +103,7 @@
 						<li>FSX</li>
 					</thingDefs>
 				</filter>
-				<count>1</count>
+				<count>4</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -113,9 +113,9 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_MortarGrenade>5</Ammo_MortarGrenade>
+			<Ammo_MortarGrenade>25</Ammo_MortarGrenade>
 		</products>
-		<workAmount>2600</workAmount>
+		<workAmount>7600</workAmount>
 	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Medieval/MortarGrenade.xml
+++ b/Defs/Ammo/Medieval/MortarGrenade.xml
@@ -49,7 +49,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>7.67</MarketValue>
+			<MarketValue>5.07</MarketValue>
 		</statBases>
 		<ammoClass>BurstingShell</ammoClass>
 		<detonateProjectile>Bullet_MortarGrenade</detonateProjectile>
@@ -115,7 +115,7 @@
 		<products>
 			<Ammo_MortarGrenade>25</Ammo_MortarGrenade>
 		</products>
-		<workAmount>7600</workAmount>
+		<workAmount>6400</workAmount>
 	</RecipeDef>
 
 </Defs>


### PR DESCRIPTION
## Changes

- Altered the projectile spreadsheet manually and set the component cost of HE and Incendiary medieval ammo to 0.
- Adjusted the batch size of mortar grenade crafting recipe from x5 to x25 to reduce its market value.

## Reasoning

- The recipe and market values were not accurate with the component cost being accounted for automatically by the sheet.
- Mortar grenades had become too expensive cuz of the small crafting batch size.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
