### PR TITLE
Degradable natural armor tweaks and housekeeping

### DIFF
--- a/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Heavy.xml
+++ b/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Heavy.xml
@@ -95,7 +95,7 @@
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="Mech_Tunneler"]</xpath>
 			<value>
-				<comps/>
+				<comps />
 			</value>
 		</nomatch>
 	</Operation>
@@ -118,10 +118,6 @@
 				<CanOverHeal>true</CanOverHeal>
 				<MaxOverHeal>250</MaxOverHeal>
 				<MinArmorPct>0.75</MinArmorPct>
-				<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-				<MinArmorValueBlunt>22</MinArmorValueBlunt>
-				<MinArmorValueHeat>0.2</MinArmorValueHeat>
-				<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 			</li>
 		</value>
 	</Operation>

--- a/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Light.xml
+++ b/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Light.xml
@@ -144,10 +144,6 @@
 				<CanOverHeal>true</CanOverHeal>
 				<MaxOverHeal>70</MaxOverHeal>
 				<MinArmorPct>0.75</MinArmorPct>
-				<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-				<MinArmorValueBlunt>22</MinArmorValueBlunt>
-				<MinArmorValueHeat>0.2</MinArmorValueHeat>
-				<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 			</li>
 		</value>
 	</Operation>
@@ -319,10 +315,6 @@
 				<CanOverHeal>true</CanOverHeal>
 				<MaxOverHeal>50</MaxOverHeal>
 				<MinArmorPct>0.75</MinArmorPct>
-				<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-				<MinArmorValueBlunt>22</MinArmorValueBlunt>
-				<MinArmorValueHeat>0.2</MinArmorValueHeat>
-				<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 			</li>
 		</value>
 	</Operation>
@@ -379,10 +371,6 @@
 				<CanOverHeal>true</CanOverHeal>
 				<MaxOverHeal>100</MaxOverHeal>
 				<MinArmorPct>0.75</MinArmorPct>
-				<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-				<MinArmorValueBlunt>22</MinArmorValueBlunt>
-				<MinArmorValueHeat>0.2</MinArmorValueHeat>
-				<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 			</li>
 		</value>
 	</Operation>

--- a/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Medium.xml
+++ b/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Medium.xml
@@ -121,7 +121,7 @@
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="Mech_Legionary" or defName="Mech_Tesseron"]</xpath>
 			<value>
-				<comps/>
+				<comps />
 			</value>
 		</nomatch>
 	</Operation>
@@ -144,10 +144,6 @@
 				<CanOverHeal>true</CanOverHeal>
 				<MaxOverHeal>100</MaxOverHeal>
 				<MinArmorPct>0.75</MinArmorPct>
-				<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-				<MinArmorValueBlunt>22</MinArmorValueBlunt>
-				<MinArmorValueHeat>0.2</MinArmorValueHeat>
-				<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 			</li>
 		</value>
 	</Operation>
@@ -219,7 +215,7 @@
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="Mech_Scorcher"]</xpath>
 			<value>
-				<comps/>
+				<comps />
 			</value>
 		</nomatch>
 	</Operation>
@@ -242,10 +238,6 @@
 				<CanOverHeal>true</CanOverHeal>
 				<MaxOverHeal>85</MaxOverHeal>
 				<MinArmorPct>0.75</MinArmorPct>
-				<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-				<MinArmorValueBlunt>22</MinArmorValueBlunt>
-				<MinArmorValueHeat>0.2</MinArmorValueHeat>
-				<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 			</li>
 		</value>
 	</Operation>
@@ -325,7 +317,7 @@
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="Mech_Apocriton"]</xpath>
 			<value>
-				<comps/>
+				<comps />
 			</value>
 		</nomatch>
 	</Operation>
@@ -350,8 +342,6 @@
 				<MinArmorPct>0.5</MinArmorPct>
 				<MinArmorValueSharp>14</MinArmorValueSharp>
 				<MinArmorValueBlunt>35</MinArmorValueBlunt>
-				<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-				<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 			</li>
 		</value>
 	</Operation>

--- a/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_SuperHeavy.xml
+++ b/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_SuperHeavy.xml
@@ -133,8 +133,6 @@
 				<MinArmorPct>0.5</MinArmorPct>
 				<MinArmorValueSharp>14</MinArmorValueSharp>
 				<MinArmorValueBlunt>35</MinArmorValueBlunt>
-				<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-				<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 			</li>
 		</value>
 	</Operation>
@@ -228,8 +226,6 @@
 				<MinArmorPct>0.5</MinArmorPct>
 				<MinArmorValueSharp>14</MinArmorValueSharp>
 				<MinArmorValueBlunt>35</MinArmorValueBlunt>
-				<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-				<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 			</li>
 		</value>
 	</Operation>
@@ -309,8 +305,6 @@
 				<MinArmorPct>0.5</MinArmorPct>
 				<MinArmorValueSharp>14</MinArmorValueSharp>
 				<MinArmorValueBlunt>35</MinArmorValueBlunt>
-				<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-				<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 			</li>
 		</value>
 	</Operation>

--- a/Ideology/Patches/ThingDefs_Misc/Race_Animal_Dryads.xml
+++ b/Ideology/Patches/ThingDefs_Misc/Race_Animal_Dryads.xml
@@ -211,7 +211,7 @@
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="Dryad_Barkskin"]</xpath>
 			<value>
-				<comps/>
+				<comps />
 			</value>
 		</nomatch>
 	</Operation>
@@ -224,20 +224,7 @@
 				<Regenerates>true</Regenerates>
 				<RegenInterval>600</RegenInterval>
 				<RegenValue>5</RegenValue>
-				<!-- <Repairable>true</Repairable>
-				<RepairIngredients>
-					<Steel>5</Steel>
-					<Plasteel>5</Plasteel>
-				</RepairIngredients>
-				<RepairTime>300</RepairTime>
-				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>310</MaxOverHeal> -->
 				<MinArmorPct>0.75</MinArmorPct>
-				<!-- <MinArmorValueSharp>14</MinArmorValueSharp>
-				<MinArmorValueBlunt>35</MinArmorValueBlunt>
- 				<MinArmorValueHeat>0.2</MinArmorValueHeat>
-				<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 			</li>
 		</value>
 	</Operation>

--- a/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_BlackHive_Psycasts.xml
+++ b/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_BlackHive_Psycasts.xml
@@ -109,20 +109,7 @@
 								<Regenerates>true</Regenerates>
 								<RegenInterval>600</RegenInterval>
 								<RegenValue>5</RegenValue>
-								<!-- <Repairable>true</Repairable>
-								<RepairIngredients>
-									<Steel>5</Steel>
-									<Plasteel>5</Plasteel>
-								</RepairIngredients>
-								<RepairTime>300</RepairTime>
-								<RepairValue>200</RepairValue>
-								<CanOverHeal>true</CanOverHeal>
-								<MaxOverHeal>75</MaxOverHeal> -->
 								<MinArmorPct>0.5</MinArmorPct>
-								<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-								<MinArmorValueBlunt>22</MinArmorValueBlunt>
-								<MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>
@@ -265,20 +252,7 @@
 								<Regenerates>true</Regenerates>
 								<RegenInterval>600</RegenInterval>
 								<RegenValue>5</RegenValue>
-								<!-- <Repairable>true</Repairable>
-								<RepairIngredients>
-									<Steel>5</Steel>
-									<Plasteel>5</Plasteel>
-								</RepairIngredients>
-								<RepairTime>300</RepairTime>
-								<RepairValue>200</RepairValue>
-								<CanOverHeal>true</CanOverHeal>
-								<MaxOverHeal>75</MaxOverHeal> -->
 								<MinArmorPct>0.5</MinArmorPct>
-								<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-								<MinArmorValueBlunt>22</MinArmorValueBlunt>
-								<MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>
@@ -421,20 +395,7 @@
 								<Regenerates>true</Regenerates>
 								<RegenInterval>600</RegenInterval>
 								<RegenValue>5</RegenValue>
-								<!-- <Repairable>true</Repairable>
-								<RepairIngredients>
-									<Steel>5</Steel>
-									<Plasteel>5</Plasteel>
-								</RepairIngredients>
-								<RepairTime>300</RepairTime>
-								<RepairValue>200</RepairValue>
-								<CanOverHeal>true</CanOverHeal>
-								<MaxOverHeal>75</MaxOverHeal> -->
 								<MinArmorPct>0.5</MinArmorPct>
-								<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-								<MinArmorValueBlunt>22</MinArmorValueBlunt>
-								<MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>
@@ -532,20 +493,7 @@
 								<Regenerates>true</Regenerates>
 								<RegenInterval>600</RegenInterval>
 								<RegenValue>5</RegenValue>
-								<!-- <Repairable>true</Repairable>
-								<RepairIngredients>
-									<Steel>5</Steel>
-									<Plasteel>5</Plasteel>
-								</RepairIngredients>
-								<RepairTime>300</RepairTime>
-								<RepairValue>200</RepairValue>
-								<CanOverHeal>true</CanOverHeal>
-								<MaxOverHeal>75</MaxOverHeal> -->
 								<MinArmorPct>0.5</MinArmorPct>
-								<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-								<MinArmorValueBlunt>22</MinArmorValueBlunt>
-								<MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_BlackQueen.xml
+++ b/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_BlackQueen.xml
@@ -96,20 +96,7 @@
 								<Regenerates>true</Regenerates>
 								<RegenInterval>400</RegenInterval>
 								<RegenValue>5</RegenValue>
-								<!-- <Repairable>true</Repairable>
-								<RepairIngredients>
-									<Steel>5</Steel>
-									<Plasteel>5</Plasteel>
-								</RepairIngredients>
-								<RepairTime>300</RepairTime>
-								<RepairValue>200</RepairValue>
-								<CanOverHeal>true</CanOverHeal>
-								<MaxOverHeal>75</MaxOverHeal> -->
 								<MinArmorPct>0.5</MinArmorPct>
-								<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-								<MinArmorValueBlunt>22</MinArmorValueBlunt>
-								<MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_AngelaMorthal.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_AngelaMorthal.xml
@@ -8,7 +8,7 @@
 		<match Class="PatchOperationSequence">
 			<operations>
 
-				<!-- Larval Atispec -->
+				<!-- Larval Angle Moth -->
 
 				<li Class="PatchOperationAddModExtension">
 					<xpath>Defs/ThingDef[defName="AA_AngelMothLarva"]</xpath>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Animalisk.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Animalisk.xml
@@ -117,20 +117,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-						<RepairIngredients>
-							<Steel>5</Steel>
-							<Plasteel>5</Plasteel>
-						</RepairIngredients>
-						<RepairTime>300</RepairTime>
-						<RepairValue>200</RepairValue>
-						<CanOverHeal>true</CanOverHeal>
-						<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-						<MinArmorValueBlunt>22</MinArmorValueBlunt>
-						<MinArmorValueHeat>0.2</MinArmorValueHeat>
-						<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Atispec.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Atispec.xml
@@ -164,20 +164,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Barb_Slinger.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Barb_Slinger.xml
@@ -136,20 +136,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Bed_Bug.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Bed_Bug.xml
@@ -90,20 +90,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Behemoth.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Behemoth.xml
@@ -158,20 +158,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>400</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Black_Hive.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Black_Hive.xml
@@ -104,20 +104,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -238,20 +225,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -372,20 +346,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Blizzarisk.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Blizzarisk.xml
@@ -118,20 +118,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -254,20 +241,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Bloodshrimp.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Bloodshrimp.xml
@@ -121,20 +121,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>300</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Boulder_Mit.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Boulder_Mit.xml
@@ -88,20 +88,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Boulder_Mit.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Boulder_Mit.xml
@@ -181,20 +181,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_ChemfuelMyrmidon.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_ChemfuelMyrmidon.xml
@@ -97,20 +97,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Cinderlisk.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Cinderlisk.xml
@@ -126,20 +126,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_CrepuscularBeetle.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_CrepuscularBeetle.xml
@@ -89,20 +89,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_CrystalMit.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_CrystalMit.xml
@@ -88,20 +88,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_DarkBeast.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_DarkBeast.xml
@@ -97,20 +97,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Dunealisk.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Dunealisk.xml
@@ -118,20 +118,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -244,20 +231,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_DuskProwler.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_DuskProwler.xml
@@ -132,20 +132,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Feralisk.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Feralisk.xml
@@ -231,20 +231,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Feralisk.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Feralisk.xml
@@ -118,20 +118,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_FrostboundBehemoth.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_FrostboundBehemoth.xml
@@ -84,20 +84,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Frostling.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Frostling.xml
@@ -110,20 +110,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Frostmite.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Frostmite.xml
@@ -99,20 +99,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Gallatross.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Gallatross.xml
@@ -87,20 +87,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Great_Devourer.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Great_Devourer.xml
@@ -95,20 +95,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>400</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Groundrunner.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Groundrunner.xml
@@ -128,20 +128,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Ironhusk_Beetle.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Ironhusk_Beetle.xml
@@ -96,20 +96,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Junglelisk.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Junglelisk.xml
@@ -118,20 +118,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Luciferbug.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Luciferbug.xml
@@ -88,20 +88,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Mammoth_Worm.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Mammoth_Worm.xml
@@ -102,20 +102,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Mantrap.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Mantrap.xml
@@ -93,20 +93,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_MegaLouse.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_MegaLouse.xml
@@ -102,20 +102,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_MoribundGallatross.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_MoribundGallatross.xml
@@ -87,20 +87,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Needlepost.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Needlepost.xml
@@ -92,20 +92,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Needleroll.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Needleroll.xml
@@ -80,20 +80,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Pebble_Mit.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Pebble_Mit.xml
@@ -86,20 +86,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Plasmorph.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Plasmorph.xml
@@ -86,20 +86,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Raptor_Shrimp.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Raptor_Shrimp.xml
@@ -121,20 +121,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>200</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Ravager.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Ravager.xml
@@ -96,20 +96,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Rayhound.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Rayhound.xml
@@ -109,20 +109,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_RipperHound.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_RipperHound.xml
@@ -110,20 +110,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_RoughPlatedMonitor.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_RoughPlatedMonitor.xml
@@ -129,20 +129,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Sand_Squid.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Sand_Squid.xml
@@ -85,20 +85,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Skyeel.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Skyeel.xml
@@ -87,20 +87,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>450</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Slurrypede.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Slurrypede.xml
@@ -87,8 +87,6 @@
 							<MinArmorPct>0.5</MinArmorPct>
 							<MinArmorValueSharp>6</MinArmorValueSharp>
 							<MinArmorValueBlunt>12</MinArmorValueBlunt>
-							<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_SpitterDryad.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_SpitterDryad.xml
@@ -51,20 +51,7 @@
 								<Regenerates>true</Regenerates>
 								<RegenInterval>600</RegenInterval>
 								<RegenValue>5</RegenValue>
-								<!-- <Repairable>true</Repairable>
-								<RepairIngredients>
-									<Steel>5</Steel>
-									<Plasteel>5</Plasteel>
-								</RepairIngredients>
-								<RepairTime>300</RepairTime>
-								<RepairValue>200</RepairValue>
-								<CanOverHeal>true</CanOverHeal>
-								<MaxOverHeal>48</MaxOverHeal> -->
 								<MinArmorPct>0.75</MinArmorPct>
-								<!-- <MinArmorValueSharp>14</MinArmorValueSharp>
-								<MinArmorValueBlunt>35</MinArmorValueBlunt>
-								 <MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Terramorph.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Terramorph.xml
@@ -96,20 +96,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Thermadon.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Thermadon.xml
@@ -117,20 +117,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Thunderbeast.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Thunderbeast.xml
@@ -98,20 +98,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_UnblinkingEye.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_UnblinkingEye.xml
@@ -102,20 +102,7 @@
 								<Regenerates>true</Regenerates>
 								<RegenInterval>450</RegenInterval>
 								<RegenValue>5</RegenValue>
-								<!-- <Repairable>true</Repairable>
-								<RepairIngredients>
-									<Steel>5</Steel>
-									<Plasteel>5</Plasteel>
-								</RepairIngredients>
-								<RepairTime>300</RepairTime>
-								<RepairValue>200</RepairValue>
-								<CanOverHeal>true</CanOverHeal>
-								<MaxOverHeal>75</MaxOverHeal> -->
 								<MinArmorPct>0.5</MinArmorPct>
-								<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-								<MinArmorValueBlunt>22</MinArmorValueBlunt>
-								<MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_WaywardAssembler.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_WaywardAssembler.xml
@@ -95,8 +95,6 @@
 							<MinArmorPct>0.5</MinArmorPct>
 							<MinArmorValueSharp>4</MinArmorValueSharp>
 							<MinArmorValueBlunt>10</MinArmorValueBlunt>
-							<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Windbeast.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Windbeast.xml
@@ -97,20 +97,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Animals/VFE_Mechs/VFESlurrymaster.xml
+++ b/Patches/Alpha Animals/VFE_Mechs/VFESlurrymaster.xml
@@ -94,8 +94,6 @@
 								<MinArmorPct>0.5</MinArmorPct>
 								<MinArmorValueSharp>6</MinArmorValueSharp>
 								<MinArmorValueBlunt>12</MinArmorValueBlunt>
-								<!--	<MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Genes/ThingDefs_Races/Races_OcularSlinger.xml
+++ b/Patches/Alpha Genes/ThingDefs_Races/Races_OcularSlinger.xml
@@ -219,20 +219,7 @@
 								<Regenerates>true</Regenerates>
 								<RegenInterval>600</RegenInterval>
 								<RegenValue>5</RegenValue>
-								<!-- <Repairable>true</Repairable>
-								<RepairIngredients>
-									<Steel>5</Steel>
-									<Plasteel>5</Plasteel>
-								</RepairIngredients>
-								<RepairTime>300</RepairTime>
-								<RepairValue>200</RepairValue>
-								<CanOverHeal>true</CanOverHeal>
-								<MaxOverHeal>112</MaxOverHeal> -->
 								<MinArmorPct>0.5</MinArmorPct>
-								<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-								<MinArmorValueBlunt>22</MinArmorValueBlunt>
-								<MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/AlphaBees/Apiarist.xml
+++ b/Patches/Alpha Mechs/Mods/AlphaBees/Apiarist.xml
@@ -70,10 +70,6 @@
 								<CanOverHeal>true</CanOverHeal>
 								<MaxOverHeal>70</MaxOverHeal>
 								<MinArmorPct>0.75</MinArmorPct>
-								<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-								<MinArmorValueBlunt>22</MinArmorValueBlunt>
-								<MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Apoptosis.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Apoptosis.xml
@@ -136,8 +136,6 @@
 								<MinArmorPct>0.5</MinArmorPct>
 								<MinArmorValueSharp>14</MinArmorValueSharp>
 								<MinArmorValueBlunt>35</MinArmorValueBlunt>
-								<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Bellicor.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Bellicor.xml
@@ -98,10 +98,6 @@
 								<CanOverHeal>true</CanOverHeal>
 								<MaxOverHeal>100</MaxOverHeal>
 								<MinArmorPct>0.75</MinArmorPct>
-								<!-- <MinArmorValueSharp>14</MinArmorValueSharp>
-								<MinArmorValueBlunt>35</MinArmorValueBlunt>
-								<MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Bellicor_Mortar.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Bellicor_Mortar.xml
@@ -98,10 +98,6 @@
 								<CanOverHeal>true</CanOverHeal>
 								<MaxOverHeal>525</MaxOverHeal>
 								<MinArmorPct>0.75</MinArmorPct>
-								<!-- <MinArmorValueSharp>14</MinArmorValueSharp>
-								<MinArmorValueBlunt>35</MinArmorValueBlunt>
-								<MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Blitzkrieg.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Blitzkrieg.xml
@@ -69,10 +69,6 @@
 								<CanOverHeal>true</CanOverHeal>
 								<MaxOverHeal>70</MaxOverHeal>
 								<MinArmorPct>0.75</MinArmorPct>
-								<!-- <MinArmorValueSharp>14</MinArmorValueSharp>
-								<MinArmorValueBlunt>35</MinArmorValueBlunt>
-								<MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Guttersnipe.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Guttersnipe.xml
@@ -107,10 +107,6 @@
 								<CanOverHeal>true</CanOverHeal>
 								<MaxOverHeal>160</MaxOverHeal>
 								<MinArmorPct>0.75</MinArmorPct>
-								<!-- <MinArmorValueSharp>14</MinArmorValueSharp>
-								<MinArmorValueBlunt>35</MinArmorValueBlunt>
-								<MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Infernus.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Infernus.xml
@@ -87,8 +87,6 @@
 								<MinArmorPct>0.5</MinArmorPct>
 								<MinArmorValueSharp>14</MinArmorValueSharp>
 								<MinArmorValueBlunt>35</MinArmorValueBlunt>
-								<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Legate.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Legate.xml
@@ -107,8 +107,6 @@
 								<MinArmorPct>0.5</MinArmorPct>
 								<MinArmorValueSharp>14</MinArmorValueSharp>
 								<MinArmorValueBlunt>35</MinArmorValueBlunt>
-								<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Lux.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Lux.xml
@@ -92,10 +92,6 @@
 								<CanOverHeal>true</CanOverHeal>
 								<MaxOverHeal>100</MaxOverHeal>
 								<MinArmorPct>0.75</MinArmorPct>
-								<!-- <MinArmorValueSharp>14</MinArmorValueSharp>
-								<MinArmorValueBlunt>35</MinArmorValueBlunt>
-								<MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_MasterChef.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_MasterChef.xml
@@ -51,10 +51,6 @@
 								<CanOverHeal>true</CanOverHeal>
 								<MaxOverHeal>70</MaxOverHeal>
 								<MinArmorPct>0.75</MinArmorPct>
-								<!-- <MinArmorValueSharp>14</MinArmorValueSharp>
-								<MinArmorValueBlunt>35</MinArmorValueBlunt>
-								<MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Munifex.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Munifex.xml
@@ -92,10 +92,6 @@
 								<CanOverHeal>true</CanOverHeal>
 								<MaxOverHeal>100</MaxOverHeal>
 								<MinArmorPct>0.75</MinArmorPct>
-								<!-- <MinArmorValueSharp>14</MinArmorValueSharp>
-								<MinArmorValueBlunt>35</MinArmorValueBlunt>
-								<MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Optio.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Optio.xml
@@ -86,10 +86,6 @@
 								<CanOverHeal>true</CanOverHeal>
 								<MaxOverHeal>86</MaxOverHeal>
 								<MinArmorPct>0.75</MinArmorPct>
-								<!-- <MinArmorValueSharp>14</MinArmorValueSharp>
-								<MinArmorValueBlunt>35</MinArmorValueBlunt>
-								<MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Polychoron.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Polychoron.xml
@@ -65,10 +65,6 @@
 								<CanOverHeal>true</CanOverHeal>
 								<MaxOverHeal>135</MaxOverHeal>
 								<MinArmorPct>0.75</MinArmorPct>
-								<!-- <MinArmorValueSharp>14</MinArmorValueSharp>
-								<MinArmorValueBlunt>35</MinArmorValueBlunt>
-								<MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_PristineAssembler.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_PristineAssembler.xml
@@ -101,8 +101,6 @@
 								<MinArmorPct>0.5</MinArmorPct>
 								<MinArmorValueSharp>4</MinArmorValueSharp>
 								<MinArmorValueBlunt>10</MinArmorValueBlunt>
-								<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_PristineSlurrypede.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_PristineSlurrypede.xml
@@ -93,8 +93,6 @@
 								<MinArmorPct>0.5</MinArmorPct>
 								<MinArmorValueSharp>6</MinArmorValueSharp>
 								<MinArmorValueBlunt>12</MinArmorValueBlunt>
-								<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_PristineStrider.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_PristineStrider.xml
@@ -55,6 +55,38 @@
 						</value>
 					</li>
 
+					<li Class="PatchOperationConditional">
+						<xpath>Defs/ThingDef[defName="AM_PristineStrider"]/comps</xpath>
+						<nomatch Class="PatchOperationAdd">
+							<xpath>Defs/ThingDef[defName="AM_PristineStrider"]</xpath>
+							<value>
+								<comps />
+							</value>
+						</nomatch>
+					</li>
+
+					<li Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="AM_PristineStrider"]/comps</xpath>
+						<value>
+							<li Class="CombatExtended.CompProperties_ArmorDurability">
+								<Durability>1000</Durability>
+								<Regenerates>true</Regenerates>
+								<RegenInterval>1250</RegenInterval>
+								<RegenValue>5</RegenValue>
+								<Repairable>true</Repairable>
+								<RepairIngredients>
+									<Steel>5</Steel>
+									<Plasteel>5</Plasteel>
+								</RepairIngredients>
+								<RepairTime>300</RepairTime>
+								<RepairValue>200</RepairValue>
+								<CanOverHeal>true</CanOverHeal>
+								<MaxOverHeal>100</MaxOverHeal>
+								<MinArmorPct>0.75</MinArmorPct>
+							</li>
+						</value>
+					</li>
+
 				</operations>
 			</match>
 		</match>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Sagittarius.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Sagittarius.xml
@@ -92,10 +92,6 @@
 								<CanOverHeal>true</CanOverHeal>
 								<MaxOverHeal>100</MaxOverHeal>
 								<MinArmorPct>0.75</MinArmorPct>
-								<!-- <MinArmorValueSharp>14</MinArmorValueSharp>
-								<MinArmorValueBlunt>35</MinArmorValueBlunt>
-								<MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Siegemelter.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Siegemelter.xml
@@ -99,8 +99,6 @@
 								<MinArmorPct>0.5</MinArmorPct>
 								<MinArmorValueSharp>14</MinArmorValueSharp>
 								<MinArmorValueBlunt>35</MinArmorValueBlunt>
-								<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Starfire.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Starfire.xml
@@ -99,8 +99,6 @@
 								<MinArmorPct>0.5</MinArmorPct>
 								<MinArmorValueSharp>16</MinArmorValueSharp>
 								<MinArmorValueBlunt>40</MinArmorValueBlunt>
-								<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_TurboCleaner.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_TurboCleaner.xml
@@ -68,11 +68,7 @@
 								<RepairValue>200</RepairValue>
 								<CanOverHeal>true</CanOverHeal>
 								<MaxOverHeal>60</MaxOverHeal>
-								<MinArmorPct>0.5</MinArmorPct>
-								<!-- <MinArmorValueSharp>16</MinArmorValueSharp>
-								<MinArmorValueBlunt>40</MinArmorValueBlunt>
-								<MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
+								<MinArmorPct>0.75</MinArmorPct>
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_WarEmpress.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_WarEmpress.xml
@@ -123,8 +123,6 @@
 								<MinArmorPct>0.5</MinArmorPct>
 								<MinArmorValueSharp>14</MinArmorValueSharp>
 								<MinArmorValueBlunt>35</MinArmorValueBlunt>
-								<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/Rimatomics/Nucleotron.xml
+++ b/Patches/Alpha Mechs/Mods/Rimatomics/Nucleotron.xml
@@ -51,10 +51,6 @@
 								<CanOverHeal>true</CanOverHeal>
 								<MaxOverHeal>70</MaxOverHeal>
 								<MinArmorPct>0.75</MinArmorPct>
-								<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-								<MinArmorValueBlunt>22</MinArmorValueBlunt>
-								<MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/VE_Books/Librarian.xml
+++ b/Patches/Alpha Mechs/Mods/VE_Books/Librarian.xml
@@ -51,10 +51,6 @@
 								<CanOverHeal>true</CanOverHeal>
 								<MaxOverHeal>70</MaxOverHeal>
 								<MinArmorPct>0.75</MinArmorPct>
-								<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-								<MinArmorValueBlunt>22</MinArmorValueBlunt>
-								<MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/VE_Fishing/Angler.xml
+++ b/Patches/Alpha Mechs/Mods/VE_Fishing/Angler.xml
@@ -69,10 +69,6 @@
 								<CanOverHeal>true</CanOverHeal>
 								<MaxOverHeal>70</MaxOverHeal>
 								<MinArmorPct>0.75</MinArmorPct>
-								<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-								<MinArmorValueBlunt>22</MinArmorValueBlunt>
-								<MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/VE_Genetics/Geneticor.xml
+++ b/Patches/Alpha Mechs/Mods/VE_Genetics/Geneticor.xml
@@ -51,10 +51,6 @@
 								<CanOverHeal>true</CanOverHeal>
 								<MaxOverHeal>70</MaxOverHeal>
 								<MinArmorPct>0.75</MinArmorPct>
-								<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-								<MinArmorValueBlunt>22</MinArmorValueBlunt>
-								<MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvAura.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvAura.xml
@@ -109,10 +109,6 @@
 								<CanOverHeal>true</CanOverHeal>
 								<MaxOverHeal>142</MaxOverHeal>
 								<MinArmorPct>0.75</MinArmorPct>
-								<!-- <MinArmorValueSharp>12</MinArmorValueSharp>
-								<MinArmorValueBlunt>27</MinArmorValueBlunt>
-								<MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvDaggersnout.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvDaggersnout.xml
@@ -118,10 +118,6 @@
 								<CanOverHeal>true</CanOverHeal>
 								<MaxOverHeal>100</MaxOverHeal>
 								<MinArmorPct>0.75</MinArmorPct>
-								<!-- <MinArmorValueSharp>8</MinArmorValueSharp>
-								<MinArmorValueBlunt>16</MinArmorValueBlunt>
-								<MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvFireworm.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvFireworm.xml
@@ -98,8 +98,6 @@
 								<MinArmorPct>0.5</MinArmorPct>
 								<MinArmorValueSharp>8</MinArmorValueSharp>
 								<MinArmorValueBlunt>16</MinArmorValueBlunt>
-								<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvGoliath.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvGoliath.xml
@@ -100,8 +100,6 @@
 								<MinArmorPct>0.5</MinArmorPct>
 								<MinArmorValueSharp>12</MinArmorValueSharp>
 								<MinArmorValueBlunt>27</MinArmorValueBlunt>
-								<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvPhalanx.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvPhalanx.xml
@@ -98,8 +98,6 @@
 								<MinArmorPct>0.5</MinArmorPct>
 								<MinArmorValueSharp>7</MinArmorValueSharp>
 								<MinArmorValueBlunt>16</MinArmorValueBlunt>
-								<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvSiegebreaker.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvSiegebreaker.xml
@@ -100,8 +100,6 @@
 								<MinArmorPct>0.5</MinArmorPct>
 								<MinArmorValueSharp>14</MinArmorValueSharp>
 								<MinArmorValueBlunt>35</MinArmorValueBlunt>
-								<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEAura.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEAura.xml
@@ -107,10 +107,6 @@
 								<CanOverHeal>true</CanOverHeal>
 								<MaxOverHeal>142</MaxOverHeal>
 								<MinArmorPct>0.75</MinArmorPct>
-								<!-- <MinArmorValueSharp>12</MinArmorValueSharp>
-								<MinArmorValueBlunt>27</MinArmorValueBlunt>
-								<MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEDaggersnout.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEDaggersnout.xml
@@ -117,10 +117,6 @@
 								<CanOverHeal>true</CanOverHeal>
 								<MaxOverHeal>90</MaxOverHeal>
 								<MinArmorPct>0.75</MinArmorPct>
-								<!-- <MinArmorValueSharp>8</MinArmorValueSharp>
-								<MinArmorValueBlunt>16</MinArmorValueBlunt>
-								<MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEFireworm.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEFireworm.xml
@@ -97,8 +97,6 @@
 								<MinArmorPct>0.5</MinArmorPct>
 								<MinArmorValueSharp>8</MinArmorValueSharp>
 								<MinArmorValueBlunt>16</MinArmorValueBlunt>
-								<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEGoliath.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEGoliath.xml
@@ -99,8 +99,6 @@
 								<MinArmorPct>0.5</MinArmorPct>
 								<MinArmorValueSharp>12</MinArmorValueSharp>
 								<MinArmorValueBlunt>27</MinArmorValueBlunt>
-								<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEPhalanx.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEPhalanx.xml
@@ -96,8 +96,6 @@
 								<MinArmorPct>0.5</MinArmorPct>
 								<MinArmorValueSharp>7</MinArmorValueSharp>
 								<MinArmorValueBlunt>16</MinArmorValueBlunt>
-								<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFESiegebreaker.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFESiegebreaker.xml
@@ -99,8 +99,6 @@
 								<MinArmorPct>0.5</MinArmorPct>
 								<MinArmorValueSharp>14</MinArmorValueSharp>
 								<MinArmorValueBlunt>35</MinArmorValueBlunt>
-								<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Aura.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Aura.xml
@@ -112,10 +112,6 @@
 									<CanOverHeal>true</CanOverHeal>
 									<MaxOverHeal>142</MaxOverHeal>
 									<MinArmorPct>0.75</MinArmorPct>
-									<!-- <MinArmorValueSharp>12</MinArmorValueSharp>
-									<MinArmorValueBlunt>27</MinArmorValueBlunt>
-									<MinArmorValueHeat>0.2</MinArmorValueHeat>
-									<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 								</li>
 							</value>
 						</li>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Daggersnout.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Daggersnout.xml
@@ -123,10 +123,6 @@
 									<CanOverHeal>true</CanOverHeal>
 									<MaxOverHeal>100</MaxOverHeal>
 									<MinArmorPct>0.75</MinArmorPct>
-									<!-- <MinArmorValueSharp>8</MinArmorValueSharp>
-									<MinArmorValueBlunt>16</MinArmorValueBlunt>
-									<MinArmorValueHeat>0.2</MinArmorValueHeat>
-									<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 								</li>
 							</value>
 						</li>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Fireworm.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Fireworm.xml
@@ -103,8 +103,6 @@
 									<MinArmorPct>0.5</MinArmorPct>
 									<MinArmorValueSharp>8</MinArmorValueSharp>
 									<MinArmorValueBlunt>16</MinArmorValueBlunt>
-									<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-									<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 								</li>
 							</value>
 						</li>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Goliath.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Goliath.xml
@@ -105,8 +105,6 @@
 									<MinArmorPct>0.5</MinArmorPct>
 									<MinArmorValueSharp>12</MinArmorValueSharp>
 									<MinArmorValueBlunt>27</MinArmorValueBlunt>
-									<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-									<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 								</li>
 							</value>
 						</li>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Phalanx.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Phalanx.xml
@@ -102,8 +102,6 @@
 									<MinArmorPct>0.5</MinArmorPct>
 									<MinArmorValueSharp>7</MinArmorValueSharp>
 									<MinArmorValueBlunt>16</MinArmorValueBlunt>
-									<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-									<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 								</li>
 							</value>
 						</li>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Siegebreaker.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Siegebreaker.xml
@@ -105,8 +105,6 @@
 									<MinArmorPct>0.5</MinArmorPct>
 									<MinArmorValueSharp>14</MinArmorValueSharp>
 									<MinArmorValueBlunt>35</MinArmorValueBlunt>
-									<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-									<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 								</li>
 							</value>
 						</li>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Slurrymaster.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Slurrymaster.xml
@@ -98,8 +98,6 @@
 									<MinArmorPct>0.5</MinArmorPct>
 									<MinArmorValueSharp>6</MinArmorValueSharp>
 									<MinArmorValueBlunt>12</MinArmorValueBlunt>
-									<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-									<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 								</li>
 							</value>
 						</li>

--- a/Patches/Alpha Mechs/Mods/VRE_Sanguophage/Sanguinarius.xml
+++ b/Patches/Alpha Mechs/Mods/VRE_Sanguophage/Sanguinarius.xml
@@ -111,10 +111,6 @@
 								<CanOverHeal>true</CanOverHeal>
 								<MaxOverHeal>100</MaxOverHeal>
 								<MinArmorPct>0.75</MinArmorPct>
-								<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-								<MinArmorValueBlunt>22</MinArmorValueBlunt>
-								<MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Aura.xml
+++ b/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Aura.xml
@@ -100,10 +100,6 @@
 							<CanOverHeal>true</CanOverHeal>
 							<MaxOverHeal>100</MaxOverHeal>
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>12</MinArmorValueSharp>
-							<MinArmorValueBlunt>27</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Daggersnout.xml
+++ b/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Daggersnout.xml
@@ -113,10 +113,6 @@
 							<CanOverHeal>true</CanOverHeal>
 							<MaxOverHeal>90</MaxOverHeal>
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>8</MinArmorValueSharp>
-							<MinArmorValueBlunt>16</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Demolisher.xml
+++ b/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Demolisher.xml
@@ -97,8 +97,6 @@
 							<MinArmorPct>0.5</MinArmorPct>
 							<MinArmorValueSharp>8</MinArmorValueSharp>
 							<MinArmorValueBlunt>16</MinArmorValueBlunt>
-							<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Fireworm.xml
+++ b/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Fireworm.xml
@@ -93,8 +93,6 @@
 							<MinArmorPct>0.5</MinArmorPct>
 							<MinArmorValueSharp>8</MinArmorValueSharp>
 							<MinArmorValueBlunt>16</MinArmorValueBlunt>
-							<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Goliath.xml
+++ b/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Goliath.xml
@@ -95,8 +95,6 @@
 							<MinArmorPct>0.5</MinArmorPct>
 							<MinArmorValueSharp>12</MinArmorValueSharp>
 							<MinArmorValueBlunt>27</MinArmorValueBlunt>
-							<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Phalanx.xml
+++ b/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Phalanx.xml
@@ -92,8 +92,6 @@
 							<MinArmorPct>0.5</MinArmorPct>
 							<MinArmorValueSharp>7</MinArmorValueSharp>
 							<MinArmorValueBlunt>16</MinArmorValueBlunt>
-							<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Siegebreaker.xml
+++ b/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Siegebreaker.xml
@@ -94,8 +94,6 @@
 							<MinArmorPct>0.5</MinArmorPct>
 							<MinArmorValueSharp>14</MinArmorValueSharp>
 							<MinArmorValueBlunt>35</MinArmorValueBlunt>
-							<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Alpha Mythology/AM_CE_Patch_Races.xml
+++ b/Patches/Alpha Mythology/AM_CE_Patch_Races.xml
@@ -1245,6 +1245,29 @@
 					</value>
 				</li>
 
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[defName="MM_LesserWyvern"]/comps</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="MM_LesserWyvern"]</xpath>
+						<value>
+							<comps />
+						</value>
+					</nomatch>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="MM_LesserWyvern"]/comps</xpath>
+					<value>
+						<li Class="CombatExtended.CompProperties_ArmorDurability">
+							<Durability>4500</Durability>
+							<Regenerates>true</Regenerates>
+							<RegenInterval>600</RegenInterval>
+							<RegenValue>5</RegenValue>
+							<MinArmorPct>0.75</MinArmorPct>
+						</li>
+					</value>
+				</li>
+
 				<!-- ========== Manticore ========== -->
 
 				<li Class="PatchOperationAdd">
@@ -2223,4 +2246,5 @@
 			</operations>
 		</match>
 	</Operation>
+
 </Patch>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Arid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Arid.xml
@@ -91,9 +91,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/ThingDef[[defName="Muffalo"]/comps</xpath>
+		<xpath>Defs/ThingDef[defName="Muffalo"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[[defName="Muffalo"]</xpath>
+			<xpath>Defs/ThingDef[defName="Muffalo"]</xpath>
 			<value>
 				<comps />
 			</value>
@@ -101,7 +101,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[[defName="Muffalo"]/comps</xpath>
+		<xpath>Defs/ThingDef[defName="Muffalo"]/comps</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
 				<Durability>800</Durability>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Arid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Arid.xml
@@ -90,6 +90,29 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[[defName="Muffalo"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[[defName="Muffalo"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[[defName="Muffalo"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>800</Durability>
+				<Regenerates>true</Regenerates>
+				<RegenInterval>600</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<MinArmorPct>0.75</MinArmorPct>
+			</li>
+		</value>
+	</Operation>
+
 	<!-- ========== Gazelle ========== -->
 
 	<Operation Class="PatchOperationReplace">

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Arid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Arid.xml
@@ -7,9 +7,9 @@
 		<xpath>Defs/ThingDef[defName="Muffalo"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>5</MoveSpeed>
-			<MeleeDodgeChance>0.14</MeleeDodgeChance>
-			<MeleeCritChance>0.32</MeleeCritChance>
-			<MeleeParryChance>0.24</MeleeParryChance>
+			<MeleeDodgeChance>0.36</MeleeDodgeChance>
+			<MeleeCritChance>0.12</MeleeCritChance>
+			<MeleeParryChance>0.15</MeleeParryChance>
 		</value>
 	</Operation>
 
@@ -104,7 +104,7 @@
 		<xpath>Defs/ThingDef[defName="Muffalo"]/comps</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
-				<Durability>800</Durability>
+				<Durability>1037</Durability>
 				<Regenerates>true</Regenerates>
 				<RegenInterval>600</RegenInterval>
 				<RegenValue>5</RegenValue>
@@ -119,9 +119,9 @@
 		<xpath>Defs/ThingDef[defName="Gazelle"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>6.2</MoveSpeed>
-			<MeleeDodgeChance>0.24</MeleeDodgeChance>
+			<MeleeDodgeChance>0.23</MeleeDodgeChance>
 			<MeleeCritChance>0.10</MeleeCritChance>
-			<MeleeParryChance>0.06</MeleeParryChance>
+			<MeleeParryChance>0.05</MeleeParryChance>
 		</value>
 	</Operation>
 
@@ -209,7 +209,7 @@
 		<value>
 			<MeleeDodgeChance>0.14</MeleeDodgeChance>
 			<MeleeCritChance>0.02</MeleeCritChance>
-			<MeleeParryChance>0.06</MeleeParryChance>
+			<MeleeParryChance>0.02</MeleeParryChance>
 		</value>
 	</Operation>
 
@@ -373,9 +373,9 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Dromedary"]/statBases</xpath>
 		<value>
-			<MeleeDodgeChance>0.11</MeleeDodgeChance>
-			<MeleeCritChance>0.52</MeleeCritChance>
-			<MeleeParryChance>0.33</MeleeParryChance>
+			<MeleeDodgeChance>0.12</MeleeDodgeChance>
+			<MeleeCritChance>0.18</MeleeCritChance>
+			<MeleeParryChance>0.19</MeleeParryChance>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Arid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Arid.xml
@@ -322,14 +322,50 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="Rhinoceros"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Rhinoceros"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Rhinoceros"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>1625</Durability>
+				<Regenerates>true</Regenerates>
+				<RegenInterval>600</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<!-- <Repairable>true</Repairable>
+				<RepairIngredients>
+					<Steel>5</Steel>
+					<Plasteel>5</Plasteel>
+				</RepairIngredients>
+				<RepairTime>300</RepairTime>
+				<RepairValue>200</RepairValue>
+				<CanOverHeal>true</CanOverHeal>
+				<MaxOverHeal>162</MaxOverHeal> -->
+				<MinArmorPct>0.75</MinArmorPct>
+				<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
+				<MinArmorValueBlunt>22</MinArmorValueBlunt>
+				<MinArmorValueHeat>0.2</MinArmorValueHeat>
+				<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
+			</li>
+		</value>
+	</Operation>
+
 	<!-- ========== Dromedary ========== -->
 
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Dromedary"]/statBases</xpath>
 		<value>
-			<MeleeDodgeChance>0.12</MeleeDodgeChance>
-			<MeleeCritChance>0.18</MeleeCritChance>
-			<MeleeParryChance>0.19</MeleeParryChance>
+			<MeleeDodgeChance>0.11</MeleeDodgeChance>
+			<MeleeCritChance>0.52</MeleeCritChance>
+			<MeleeParryChance>0.33</MeleeParryChance>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Arid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Arid.xml
@@ -340,20 +340,7 @@
 				<Regenerates>true</Regenerates>
 				<RegenInterval>600</RegenInterval>
 				<RegenValue>5</RegenValue>
-				<!-- <Repairable>true</Repairable>
-				<RepairIngredients>
-					<Steel>5</Steel>
-					<Plasteel>5</Plasteel>
-				</RepairIngredients>
-				<RepairTime>300</RepairTime>
-				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>162</MaxOverHeal> -->
 				<MinArmorPct>0.75</MinArmorPct>
-				<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-				<MinArmorValueBlunt>22</MinArmorValueBlunt>
-				<MinArmorValueHeat>0.2</MinArmorValueHeat>
-				<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 			</li>
 		</value>
 	</Operation>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Base.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Base.xml
@@ -35,40 +35,4 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/ThingDef[@Name="AnimalThingBase"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[@Name="AnimalThingBase"]</xpath>
-			<value>
-				<comps/>
-			</value>
-		</nomatch>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[@Name="AnimalThingBase"]/comps</xpath>
-		<value>
-			<li Class="CombatExtended.CompProperties_ArmorDurability">
-				<Durability>500</Durability>
-				<Regenerates>true</Regenerates>
-				<RegenInterval>600</RegenInterval>
-				<RegenValue>5</RegenValue>
-				<!-- <Repairable>true</Repairable>
-				<RepairIngredients>
-					<Steel>5</Steel>
-					<Plasteel>5</Plasteel>
-				</RepairIngredients>
-				<RepairTime>300</RepairTime>
-				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>50</MaxOverHeal> -->
-				<MinArmorPct>0.75</MinArmorPct>
-				<!-- <MinArmorValueSharp>14</MinArmorValueSharp>
-				<MinArmorValueBlunt>30</MinArmorValueBlunt>
-				<MinArmorValueHeat>0.2</MinArmorValueHeat>
-				<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
-			</li>
-		</value>
-	</Operation>
-
 </Patch>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Bears.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Bears.xml
@@ -19,6 +19,26 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[@Name="BaseBear"]/statBases</xpath>
+		<value>
+			<MeleeDodgeChance>0.16</MeleeDodgeChance>
+			<MeleeCritChance>0.23</MeleeCritChance>
+			<MeleeParryChance>0.18</MeleeParryChance>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[@Name="BaseBear"]/tools</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[@Name="BaseBear"]/race/wildness</xpath>
+		<value>
+			<wildness>0.6</wildness>
+		</value>
+	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[@Name="BaseBear"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -33,32 +53,12 @@
 		<xpath>Defs/ThingDef[@Name="BaseBear"]/comps</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
-				<Durability>1100</Durability>
+				<Durability>1162</Durability>
 				<Regenerates>true</Regenerates>
 				<RegenInterval>600</RegenInterval>
 				<RegenValue>5</RegenValue>
 				<MinArmorPct>0.75</MinArmorPct>
 			</li>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[@Name="BaseBear"]/statBases</xpath>
-		<value>
-			<MeleeDodgeChance>0.17</MeleeDodgeChance>
-			<MeleeCritChance>0.21</MeleeCritChance>
-			<MeleeParryChance>0.17</MeleeParryChance>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[@Name="BaseBear"]/tools</xpath>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[@Name="BaseBear"]/race/wildness</xpath>
-		<value>
-			<wildness>0.6</wildness>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Bears.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Bears.xml
@@ -19,6 +19,29 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[@Name="BaseBear"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[@Name="BaseBear"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[@Name="BaseBear"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>1100</Durability>
+				<Regenerates>true</Regenerates>
+				<RegenInterval>600</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<MinArmorPct>0.75</MinArmorPct>
+			</li>
+		</value>
+	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[@Name="BaseBear"]/statBases</xpath>
 		<value>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_BigCat.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_BigCat.xml
@@ -12,34 +12,11 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/ThingDef[@Name="BigCatThingBase"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[@Name="BigCatThingBase"]</xpath>
-			<value>
-				<comps />
-			</value>
-		</nomatch>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[@Name="BigCatThingBase"]/comps</xpath>
-		<value>
-			<li Class="CombatExtended.CompProperties_ArmorDurability">
-				<Durability>800</Durability>
-				<Regenerates>true</Regenerates>
-				<RegenInterval>600</RegenInterval>
-				<RegenValue>5</RegenValue>
-				<MinArmorPct>0.75</MinArmorPct>
-			</li>
-		</value>
-	</Operation>
-
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[@Name="BigCatThingBase"]/statBases</xpath>
 		<value>
-			<MeleeDodgeChance>0.18</MeleeDodgeChance>
-			<MeleeCritChance>0.09</MeleeCritChance>
+			<MeleeDodgeChance>0.19</MeleeDodgeChance>
+			<MeleeCritChance>0.08</MeleeCritChance>
 			<MeleeParryChance>0.07</MeleeParryChance>
 		</value>
 	</Operation>
@@ -117,6 +94,29 @@
 					<armorPenetrationBlunt>0.423</armorPenetrationBlunt>
 				</li>
 			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[@Name="BigCatThingBase"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[@Name="BigCatThingBase"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[@Name="BigCatThingBase"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>575</Durability>
+				<Regenerates>true</Regenerates>
+				<RegenInterval>600</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<MinArmorPct>0.75</MinArmorPct>
+			</li>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Races/Races_Animal_BigCat.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_BigCat.xml
@@ -12,6 +12,29 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[@Name="BigCatThingBase"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[@Name="BigCatThingBase"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[@Name="BigCatThingBase"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>800</Durability>
+				<Regenerates>true</Regenerates>
+				<RegenInterval>600</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<MinArmorPct>0.75</MinArmorPct>
+			</li>
+		</value>
+	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[@Name="BigCatThingBase"]/statBases</xpath>
 		<value>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Farm.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Farm.xml
@@ -66,10 +66,9 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Pig"]/statBases/MoveSpeed</xpath>
 		<value>
-			<MoveSpeed>2.6</MoveSpeed>
-			<MeleeDodgeChance>0.07</MeleeDodgeChance>
-			<MeleeCritChance>0.06</MeleeCritChance>
-			<MeleeParryChance>0.08</MeleeParryChance>
+			<MeleeDodgeChance>0.12</MeleeDodgeChance>
+			<MeleeCritChance>0.11</MeleeCritChance>
+			<MeleeParryChance>0.14</MeleeParryChance>
 		</value>
 	</Operation>
 
@@ -208,7 +207,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Alpaca"]/statBases</xpath>
 		<value>
-			<MeleeDodgeChance>0.14</MeleeDodgeChance>
+			<MeleeDodgeChance>0.15</MeleeDodgeChance>
 			<MeleeCritChance>0.06</MeleeCritChance>
 			<MeleeParryChance>0.07</MeleeParryChance>
 		</value>
@@ -297,8 +296,9 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Duck"]/statBases</xpath>
 		<value>
-			<MeleeDodgeChance>0.14</MeleeDodgeChance>
+			<MeleeDodgeChance>0.15</MeleeDodgeChance>
 			<MeleeCritChance>0.0</MeleeCritChance>
+			<MeleeParryChance>0.01</MeleeParryChance>
 		</value>
 	</Operation>
 
@@ -694,7 +694,7 @@
 		<value>
 			<MoveSpeed>6</MoveSpeed>
 			<MeleeDodgeChance>0.15</MeleeDodgeChance>
-			<MeleeCritChance>0.39</MeleeCritChance>
+			<MeleeCritChance>0.37</MeleeCritChance>
 			<MeleeParryChance>0.24</MeleeParryChance>
 		</value>
 	</Operation>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Giant.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Giant.xml
@@ -91,20 +91,7 @@
 				<Regenerates>true</Regenerates>
 				<RegenInterval>600</RegenInterval>
 				<RegenValue>5</RegenValue>
-				<!-- <Repairable>true</Repairable>
-				<RepairIngredients>
-					<Steel>5</Steel>
-					<Plasteel>5</Plasteel>
-				</RepairIngredients>
-				<RepairTime>300</RepairTime>
-				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>190</MaxOverHeal> -->
 				<MinArmorPct>0.75</MinArmorPct>
-				<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-				<MinArmorValueBlunt>22</MinArmorValueBlunt>
-				<MinArmorValueHeat>0.2</MinArmorValueHeat>
-				<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 			</li>
 		</value>
 	</Operation>
@@ -199,20 +186,7 @@
 				<Regenerates>true</Regenerates>
 				<RegenInterval>600</RegenInterval>
 				<RegenValue>5</RegenValue>
-				<!-- <Repairable>true</Repairable>
-				<RepairIngredients>
-					<Steel>5</Steel>
-					<Plasteel>5</Plasteel>
-				</RepairIngredients>
-				<RepairTime>300</RepairTime>
-				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>190</MaxOverHeal> -->
 				<MinArmorPct>0.75</MinArmorPct>
-				<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-				<MinArmorValueBlunt>22</MinArmorValueBlunt>
-				<MinArmorValueHeat>0.2</MinArmorValueHeat>
-				<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 			</li>
 		</value>
 	</Operation>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Giant.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Giant.xml
@@ -73,6 +73,42 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="Elephant"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Elephant"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Elephant"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>1900</Durability>
+				<Regenerates>true</Regenerates>
+				<RegenInterval>600</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<!-- <Repairable>true</Repairable>
+				<RepairIngredients>
+					<Steel>5</Steel>
+					<Plasteel>5</Plasteel>
+				</RepairIngredients>
+				<RepairTime>300</RepairTime>
+				<RepairValue>200</RepairValue>
+				<CanOverHeal>true</CanOverHeal>
+				<MaxOverHeal>190</MaxOverHeal> -->
+				<MinArmorPct>0.75</MinArmorPct>
+				<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
+				<MinArmorValueBlunt>22</MinArmorValueBlunt>
+				<MinArmorValueHeat>0.2</MinArmorValueHeat>
+				<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
+			</li>
+		</value>
+	</Operation>
+
 	<!-- ========== Megasloth ========== -->
 
 	<Operation Class="PatchOperationAdd">
@@ -141,6 +177,42 @@
 		<value>
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Quadruped</bodyShape>
+			</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="Megasloth"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Megasloth"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Megasloth"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>1900</Durability>
+				<Regenerates>true</Regenerates>
+				<RegenInterval>600</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<!-- <Repairable>true</Repairable>
+				<RepairIngredients>
+					<Steel>5</Steel>
+					<Plasteel>5</Plasteel>
+				</RepairIngredients>
+				<RepairTime>300</RepairTime>
+				<RepairValue>200</RepairValue>
+				<CanOverHeal>true</CanOverHeal>
+				<MaxOverHeal>190</MaxOverHeal> -->
+				<MinArmorPct>0.75</MinArmorPct>
+				<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
+				<MinArmorValueBlunt>22</MinArmorValueBlunt>
+				<MinArmorValueHeat>0.2</MinArmorValueHeat>
+				<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 			</li>
 		</value>
 	</Operation>
@@ -265,7 +337,7 @@
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="Thrumbo"]</xpath>
 			<value>
-				<comps/>
+				<comps />
 			</value>
 		</nomatch>
 	</Operation>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Giant.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Giant.xml
@@ -324,20 +324,7 @@
 				<Regenerates>true</Regenerates>
 				<RegenInterval>600</RegenInterval>
 				<RegenValue>5</RegenValue>
-				<!-- <Repairable>true</Repairable>
-				<RepairIngredients>
-					<Steel>5</Steel>
-					<Plasteel>5</Plasteel>
-				</RepairIngredients>
-				<RepairTime>300</RepairTime>
-				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>300</MaxOverHeal> -->
 				<MinArmorPct>0.75</MinArmorPct>
-				<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-				<MinArmorValueBlunt>22</MinArmorValueBlunt>
-				<MinArmorValueHeat>0.2</MinArmorValueHeat>
-				<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 			</li>
 		</value>
 	</Operation>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Hares.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Hares.xml
@@ -9,6 +9,7 @@
 			<MoveSpeed>4.8</MoveSpeed>
 			<MeleeDodgeChance>0.24</MeleeDodgeChance>
 			<MeleeCritChance>0.02</MeleeCritChance>
+			<MeleeParryChance>0</MeleeParryChance>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Insect.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Insect.xml
@@ -317,20 +317,7 @@
 				<Regenerates>true</Regenerates>
 				<RegenInterval>600</RegenInterval>
 				<RegenValue>5</RegenValue>
-				<!-- <Repairable>true</Repairable>
-				<RepairIngredients>
-					<Steel>5</Steel>
-					<Plasteel>5</Plasteel>
-				</RepairIngredients>
-				<RepairTime>300</RepairTime>
-				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>75</MaxOverHeal> -->
 				<MinArmorPct>0.5</MinArmorPct>
-				<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-				<MinArmorValueBlunt>22</MinArmorValueBlunt>
-				<MinArmorValueHeat>0.2</MinArmorValueHeat>
-				<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 			</li>
 		</value>
 	</Operation>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Insect.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Insect.xml
@@ -110,7 +110,7 @@
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="Megascarab"]</xpath>
 			<value>
-				<comps/>
+				<comps />
 			</value>
 		</nomatch>
 	</Operation>
@@ -123,20 +123,7 @@
 				<Regenerates>true</Regenerates>
 				<RegenInterval>600</RegenInterval>
 				<RegenValue>5</RegenValue>
-				<!-- <Repairable>true</Repairable>
-				<RepairIngredients>
-					<Steel>5</Steel>
-					<Plasteel>5</Plasteel>
-				</RepairIngredients>
-				<RepairTime>300</RepairTime>
-				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>15</MaxOverHeal> -->
 				<MinArmorPct>0.5</MinArmorPct>
-				<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-				<MinArmorValueBlunt>22</MinArmorValueBlunt>
-				<MinArmorValueHeat>0.2</MinArmorValueHeat>
-				<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 			</li>
 		</value>
 	</Operation>
@@ -220,7 +207,7 @@
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="Spelopede"]</xpath>
 			<value>
-				<comps/>
+				<comps />
 			</value>
 		</nomatch>
 	</Operation>
@@ -233,20 +220,7 @@
 				<Regenerates>true</Regenerates>
 				<RegenInterval>600</RegenInterval>
 				<RegenValue>5</RegenValue>
-				<!-- <Repairable>true</Repairable>
-				<RepairIngredients>
-					<Steel>5</Steel>
-					<Plasteel>5</Plasteel>
-				</RepairIngredients>
-				<RepairTime>300</RepairTime>
-				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>50</MaxOverHeal> -->
 				<MinArmorPct>0.5</MinArmorPct>
-				<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-				<MinArmorValueBlunt>22</MinArmorValueBlunt>
-				<MinArmorValueHeat>0.2</MinArmorValueHeat>
-				<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 			</li>
 		</value>
 	</Operation>
@@ -330,7 +304,7 @@
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="Megaspider"]</xpath>
 			<value>
-				<comps/>
+				<comps />
 			</value>
 		</nomatch>
 	</Operation>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Pet.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Pet.xml
@@ -6,8 +6,9 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="YorkshireTerrier"]/statBases</xpath>
 		<value>
-			<MeleeDodgeChance>0.17</MeleeDodgeChance>
+			<MeleeDodgeChance>0.18</MeleeDodgeChance>
 			<MeleeCritChance>0.01</MeleeCritChance>
+			<MeleeParryChance>0.01</MeleeParryChance>
 		</value>
 	</Operation>
 
@@ -149,7 +150,7 @@
 		<xpath>Defs/ThingDef[defName="Husky"]/comps</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
-				<Durability>600</Durability>
+				<Durability>477</Durability>
 				<Regenerates>true</Regenerates>
 				<RegenInterval>600</RegenInterval>
 				<RegenValue>5</RegenValue>
@@ -244,7 +245,7 @@
 		<xpath>Defs/ThingDef[defName="LabradorRetriever"]/comps</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
-				<Durability>600</Durability>
+				<Durability>437</Durability>
 				<Regenerates>true</Regenerates>
 				<RegenInterval>600</RegenInterval>
 				<RegenValue>5</RegenValue>
@@ -269,6 +270,7 @@
 		<value>
 			<MeleeDodgeChance>0.23</MeleeDodgeChance>
 			<MeleeCritChance>0.02</MeleeCritChance>
+			<MeleeParryChance>0.01</MeleeParryChance>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Pet.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Pet.xml
@@ -135,6 +135,29 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="Husky"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Husky"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Husky"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>600</Durability>
+				<Regenerates>true</Regenerates>
+				<RegenInterval>600</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<MinArmorPct>0.75</MinArmorPct>
+			</li>
+		</value>
+	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="Husky"]</xpath>
 		<value>
@@ -204,6 +227,29 @@
 					<armorPenetrationBlunt>0.2</armorPenetrationBlunt>
 				</li>
 			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="LabradorRetriever"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="LabradorRetriever"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="LabradorRetriever"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>600</Durability>
+				<Regenerates>true</Regenerates>
+				<RegenInterval>600</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<MinArmorPct>0.75</MinArmorPct>
+			</li>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Rodentlike.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Rodentlike.xml
@@ -16,7 +16,7 @@
 		<xpath>Defs/ThingDef[defName="Squirrel"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>2.4</MoveSpeed>
-			<MeleeDodgeChance>0.18</MeleeDodgeChance>
+			<MeleeDodgeChance>0.19</MeleeDodgeChance>
 			<MeleeCritChance>0.0</MeleeCritChance>
 		</value>
 	</Operation>
@@ -88,10 +88,9 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Alphabeaver"]/statBases/MoveSpeed</xpath>
 		<value>
-			<MoveSpeed>5</MoveSpeed>
-			<MeleeDodgeChance>0.12</MeleeDodgeChance>
+			<MeleeDodgeChance>0.11</MeleeDodgeChance>
 			<MeleeCritChance>0.05</MeleeCritChance>
-			<MeleeParryChance>0.05</MeleeParryChance>
+			<MeleeParryChance>0.03</MeleeParryChance>
 		</value>
 	</Operation>
 
@@ -162,8 +161,8 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Capybara"]/statBases</xpath>
 		<value>
-			<MeleeDodgeChance>0.15</MeleeDodgeChance>
-			<MeleeCritChance>0.15</MeleeCritChance>
+			<MeleeDodgeChance>0.14</MeleeDodgeChance>
+			<MeleeCritChance>0.05</MeleeCritChance>
 			<MeleeParryChance>0.06</MeleeParryChance>
 		</value>
 	</Operation>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Temperate.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Temperate.xml
@@ -324,9 +324,9 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Caribou"]/statBases/MoveSpeed</xpath>
 		<value>
-			<MoveSpeed>7.8</MoveSpeed>
-			<MeleeDodgeChance>0.25</MeleeDodgeChance>
-			<MeleeCritChance>0.22</MeleeCritChance>
+			<MoveSpeed>7.2</MoveSpeed>
+			<MeleeDodgeChance>0.23</MeleeDodgeChance>
+			<MeleeCritChance>0.19</MeleeCritChance>
 			<MeleeParryChance>0.08</MeleeParryChance>
 		</value>
 	</Operation>
@@ -427,7 +427,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="WildBoar"]/statBases</xpath>
 		<value>
-			<MeleeDodgeChance>0.16</MeleeDodgeChance>
+			<MeleeDodgeChance>0.14</MeleeDodgeChance>
 			<MeleeCritChance>0.09</MeleeCritChance>
 			<MeleeParryChance>0.07</MeleeParryChance>
 		</value>
@@ -508,7 +508,7 @@
 						</parts>
 					</li>
 				</stats>
-			</li> 
+			</li>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Tropical.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Tropical.xml
@@ -15,8 +15,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Cobra"]/statBases/MoveSpeed</xpath>
 		<value>
-			<MoveSpeed>3.84</MoveSpeed>
-			<MeleeDodgeChance>0.17</MeleeDodgeChance>
+			<MeleeDodgeChance>0.16</MeleeDodgeChance>
 			<MeleeCritChance>0.02</MeleeCritChance>
 		</value>
 	</Operation>
@@ -73,9 +72,8 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Monkey"]/statBases/MoveSpeed</xpath>
 		<value>
-			<MoveSpeed>5</MoveSpeed>
-			<MeleeDodgeChance>0.24</MeleeDodgeChance>
-			<MeleeCritChance>0.03</MeleeCritChance>
+			<MeleeDodgeChance>0.20</MeleeDodgeChance>
+			<MeleeCritChance>0.02</MeleeCritChance>
 			<MeleeParryChance>0.01</MeleeParryChance>
 		</value>
 	</Operation>
@@ -151,9 +149,9 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Boomalope"]/statBases</xpath>
 		<value>
-			<MeleeDodgeChance>0.05</MeleeDodgeChance>
-			<MeleeCritChance>0.07</MeleeCritChance>
-			<MeleeParryChance>0.16</MeleeParryChance>
+			<MeleeDodgeChance>0.09</MeleeDodgeChance>
+			<MeleeCritChance>0.14</MeleeCritChance>
+			<MeleeParryChance>0.19</MeleeParryChance>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Races/Races_Animal_WildCanines.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_WildCanines.xml
@@ -12,6 +12,29 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="Warg"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Warg"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Warg"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>950</Durability>
+				<Regenerates>true</Regenerates>
+				<RegenInterval>600</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<MinArmorPct>0.75</MinArmorPct>
+			</li>
+		</value>
+	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Warg"]/statBases/MoveSpeed</xpath>
 		<value>
@@ -121,6 +144,29 @@
 		<value>
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Quadruped</bodyShape>
+			</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[@Name="ThingBaseWolf"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[@Name="ThingBaseWolf"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[@Name="ThingBaseWolf"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>800</Durability>
+				<Regenerates>true</Regenerates>
+				<RegenInterval>600</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<MinArmorPct>0.75</MinArmorPct>
 			</li>
 		</value>
 	</Operation>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_WildCanines.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_WildCanines.xml
@@ -12,29 +12,6 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/ThingDef[defName="Warg"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="Warg"]</xpath>
-			<value>
-				<comps />
-			</value>
-		</nomatch>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Warg"]/comps</xpath>
-		<value>
-			<li Class="CombatExtended.CompProperties_ArmorDurability">
-				<Durability>950</Durability>
-				<Regenerates>true</Regenerates>
-				<RegenInterval>600</RegenInterval>
-				<RegenValue>5</RegenValue>
-				<MinArmorPct>0.75</MinArmorPct>
-			</li>
-		</value>
-	</Operation>
-
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Warg"]/statBases/MoveSpeed</xpath>
 		<value>
@@ -47,9 +24,9 @@
 		<value>
 			<ArmorRating_Blunt>0.075</ArmorRating_Blunt>
 			<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
-			<MeleeDodgeChance>0.21</MeleeDodgeChance>
+			<MeleeDodgeChance>0.23</MeleeDodgeChance>
 			<MeleeCritChance>0.20</MeleeCritChance>
-			<MeleeParryChance>0.09</MeleeParryChance>
+			<MeleeParryChance>0.11</MeleeParryChance>
 		</value>
 	</Operation>
 
@@ -137,21 +114,10 @@
 		</value>
 	</Operation>
 
-	<!-- ========== Base Wolf ========== -->
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[@Name="ThingBaseWolf"]</xpath>
-		<value>
-			<li Class="CombatExtended.RacePropertiesExtensionCE">
-				<bodyShape>Quadruped</bodyShape>
-			</li>
-		</value>
-	</Operation>
-
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/ThingDef[@Name="ThingBaseWolf"]/comps</xpath>
+		<xpath>Defs/ThingDef[defName="Warg"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[@Name="ThingBaseWolf"]</xpath>
+			<xpath>Defs/ThingDef[defName="Warg"]</xpath>
 			<value>
 				<comps />
 			</value>
@@ -159,14 +125,25 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[@Name="ThingBaseWolf"]/comps</xpath>
+		<xpath>Defs/ThingDef[defName="Warg"]/comps</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
-				<Durability>800</Durability>
+				<Durability>700</Durability>
 				<Regenerates>true</Regenerates>
 				<RegenInterval>600</RegenInterval>
 				<RegenValue>5</RegenValue>
 				<MinArmorPct>0.75</MinArmorPct>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- ========== Base Wolf ========== -->
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[@Name="ThingBaseWolf"]</xpath>
+		<value>
+			<li Class="CombatExtended.RacePropertiesExtensionCE">
+				<bodyShape>Quadruped</bodyShape>
 			</li>
 		</value>
 	</Operation>
@@ -260,6 +237,29 @@
 		<xpath>Defs/ThingDef[@Name="ThingBaseWolf"]/race/wildness</xpath>
 		<value>
 			<wildness>0.65</wildness>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[@Name="ThingBaseWolf"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[@Name="ThingBaseWolf"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[@Name="ThingBaseWolf"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>460</Durability>
+				<Regenerates>true</Regenerates>
+				<RegenInterval>600</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<MinArmorPct>0.75</MinArmorPct>
+			</li>
 		</value>
 	</Operation>
 

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_BasiliskCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_BasiliskCE.xml
@@ -122,20 +122,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>325</MaxOverHeal> -->
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_BearofleetCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_BearofleetCE.xml
@@ -91,20 +91,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>525</MaxOverHeal> -->
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_CyclopsCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_CyclopsCE.xml
@@ -110,20 +110,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>300</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>725</MaxOverHeal> -->
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_EkimmaraCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_EkimmaraCE.xml
@@ -113,20 +113,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>500</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>275</MaxOverHeal> -->
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_FlederCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_FlederCE.xml
@@ -111,20 +111,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>400</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>280</MaxOverHeal> -->
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_FoglerCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_FoglerCE.xml
@@ -110,20 +110,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>200</MaxOverHeal> -->
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_GolemCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_GolemCE.xml
@@ -100,20 +100,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>450</MaxOverHeal> -->
 							<MinArmorPct>0.25</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_KikimoreCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_KikimoreCE.xml
@@ -107,20 +107,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>37</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -206,20 +193,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -304,20 +278,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>250</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_WerewolfCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_WerewolfCE.xml
@@ -110,20 +110,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>300</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>237</MaxOverHeal> -->
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_WyvernCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_WyvernCE.xml
@@ -123,20 +123,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>450</MaxOverHeal> -->
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Vanilla Animals Expanded - Caves/ThingDefs_Races/Caves_Animals.xml
+++ b/Patches/Vanilla Animals Expanded - Caves/ThingDefs_Races/Caves_Animals.xml
@@ -135,20 +135,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>140</MaxOverHeal> -->
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -251,20 +238,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>112</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -391,20 +365,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>400</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>17</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -497,20 +458,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>400</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>100</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -621,20 +569,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>400</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>600</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -796,20 +731,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>325</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -1038,20 +960,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>210</MaxOverHeal> -->
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Vanilla Animals Expanded - Waste Animals/ThingDefs_Races/WasteAnimals_Megatardi.xml
+++ b/Patches/Vanilla Animals Expanded - Waste Animals/ThingDefs_Races/WasteAnimals_Megatardi.xml
@@ -90,20 +90,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>112</MaxOverHeal> -->
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Vanilla Animals Expanded - Waste Animals/ThingDefs_Races/WasteAnimals_Pestigator.xml
+++ b/Patches/Vanilla Animals Expanded - Waste Animals/ThingDefs_Races/WasteAnimals_Pestigator.xml
@@ -85,20 +85,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>150</MaxOverHeal> -->
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Vanilla Animals Expanded - Waste Animals/ThingDefs_Races/WasteAnimals_Toxscorpion.xml
+++ b/Patches/Vanilla Animals Expanded - Waste Animals/ThingDefs_Races/WasteAnimals_Toxscorpion.xml
@@ -137,20 +137,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>112</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Vanilla Animals Expanded/Desert_Animals.xml
+++ b/Patches/Vanilla Animals Expanded/Desert_Animals.xml
@@ -8,7 +8,33 @@
 
 		<match Class="PatchOperationSequence">
 			<operations>
+
 				<!-- === Desert Tortoise === -->
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/ThingDef[defName="AEXP_DesertTortoise"]</xpath>
+					<value>
+						<li Class="CombatExtended.PartialArmorExt">
+							<stats>
+								<li>
+									<useStatic>false</useStatic>
+									<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
+									<parts>
+										<li>Leg</li>
+									</parts>
+								</li>
+								<li>
+									<useStatic>false</useStatic>
+									<ArmorRating_Blunt>0.5</ArmorRating_Blunt>
+									<parts>
+										<li>Leg</li>
+									</parts>
+								</li>
+							</stats>
+						</li>
+					</value>
+				</li>
+
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="AEXP_DesertTortoise"]/statBases</xpath>
 					<value>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races/Races_Animal_Insect.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races/Races_Animal_Insect.xml
@@ -93,20 +93,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>300</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -202,20 +189,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>107</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -311,20 +285,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>95</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -450,20 +411,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>153</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Boomtick.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Boomtick.xml
@@ -88,20 +88,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>31</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Gigascorpion.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Gigascorpion.xml
@@ -128,20 +128,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>112</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Gigawig.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Gigawig.xml
@@ -81,20 +81,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>100</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Megacricket.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Megacricket.xml
@@ -81,20 +81,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>71</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Milkbeetle.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Milkbeetle.xml
@@ -81,20 +81,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>147</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Monstrosity.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Monstrosity.xml
@@ -99,20 +99,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>220</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Princess.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Princess.xml
@@ -81,20 +81,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>190</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_RoyalMaggot.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_RoyalMaggot.xml
@@ -81,20 +81,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>47</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Spiderweaver.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Spiderweaver.xml
@@ -81,20 +81,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>68</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Titanbeetle.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Titanbeetle.xml
@@ -99,20 +99,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>131</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_VatGigalocust.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_VatGigalocust.xml
@@ -99,20 +99,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>95</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_VatMegapede.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_VatMegapede.xml
@@ -122,20 +122,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>131</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_VatMegascarab.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_VatMegascarab.xml
@@ -92,20 +92,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>45</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_VatMegaspider.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_VatMegaspider.xml
@@ -99,20 +99,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>73</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_VatSpelopede.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_VatSpelopede.xml
@@ -99,20 +99,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>48</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Wargling.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Wargling.xml
@@ -128,20 +128,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>93</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_WorkerAnt.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_WorkerAnt.xml
@@ -88,20 +88,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>70</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
@@ -150,8 +150,6 @@
 							<MinArmorPct>0.5</MinArmorPct>
 							<MinArmorValueSharp>12</MinArmorValueSharp>
 							<MinArmorValueBlunt>27</MinArmorValueBlunt>
-							<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -335,10 +333,6 @@
 							<CanOverHeal>true</CanOverHeal>
 							<MaxOverHeal>116</MaxOverHeal>
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -371,10 +365,6 @@
 							<CanOverHeal>true</CanOverHeal>
 							<MaxOverHeal>86</MaxOverHeal>
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -480,8 +470,6 @@
 							<MinArmorPct>0.75</MinArmorPct>
 							<MinArmorValueSharp>4</MinArmorValueSharp>
 							<MinArmorValueBlunt>8</MinArmorValueBlunt>
-							<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -595,10 +583,6 @@
 							<CanOverHeal>true</CanOverHeal>
 							<MaxOverHeal>86</MaxOverHeal>
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -716,8 +700,6 @@
 							<MinArmorPct>0.5</MinArmorPct>
 							<MinArmorValueSharp>5</MinArmorValueSharp>
 							<MinArmorValueBlunt>7.5</MinArmorValueBlunt>
-							<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -809,8 +791,6 @@
 							<MinArmorPct>0.5</MinArmorPct>
 							<MinArmorValueSharp>12</MinArmorValueSharp>
 							<MinArmorValueBlunt>27</MinArmorValueBlunt>
-							<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -907,8 +887,6 @@
 							<MinArmorPct>0.5</MinArmorPct>
 							<MinArmorValueSharp>10</MinArmorValueSharp>
 							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid_PlayerControlled.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid_PlayerControlled.xml
@@ -110,8 +110,6 @@
 								<MinArmorPct>0.5</MinArmorPct>
 								<MinArmorValueSharp>12</MinArmorValueSharp>
 								<MinArmorValueBlunt>27</MinArmorValueBlunt>
-								<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>
@@ -294,10 +292,6 @@
 								<CanOverHeal>true</CanOverHeal>
 								<MaxOverHeal>116</MaxOverHeal>
 								<MinArmorPct>0.75</MinArmorPct>
-								<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-								<MinArmorValueBlunt>22</MinArmorValueBlunt>
-								<MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>
@@ -330,10 +324,6 @@
 								<CanOverHeal>true</CanOverHeal>
 								<MaxOverHeal>86</MaxOverHeal>
 								<MinArmorPct>0.75</MinArmorPct>
-								<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-								<MinArmorValueBlunt>22</MinArmorValueBlunt>
-								<MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>
@@ -451,8 +441,6 @@
 								<MinArmorPct>0.75</MinArmorPct>
 								<MinArmorValueSharp>4</MinArmorValueSharp>
 								<MinArmorValueBlunt>8</MinArmorValueBlunt>
-								<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>
@@ -568,10 +556,6 @@
 								<CanOverHeal>true</CanOverHeal>
 								<MaxOverHeal>86</MaxOverHeal>
 								<MinArmorPct>0.75</MinArmorPct>
-								<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-								<MinArmorValueBlunt>22</MinArmorValueBlunt>
-								<MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>
@@ -689,8 +673,6 @@
 								<MinArmorPct>0.5</MinArmorPct>
 								<MinArmorValueSharp>5</MinArmorValueSharp>
 								<MinArmorValueBlunt>7.5</MinArmorValueBlunt>
-								<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>
@@ -784,8 +766,6 @@
 								<MinArmorPct>0.5</MinArmorPct>
 								<MinArmorValueSharp>10</MinArmorValueSharp>
 								<MinArmorValueBlunt>22</MinArmorValueBlunt>
-								<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Machines.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Machines.xml
@@ -229,10 +229,6 @@
 							<CanOverHeal>true</CanOverHeal>
 							<MaxOverHeal>100</MaxOverHeal>
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>12</MinArmorValueSharp>
-							<MinArmorValueBlunt>27</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -436,10 +432,6 @@
 							<CanOverHeal>true</CanOverHeal>
 							<MaxOverHeal>250</MaxOverHeal>
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>12</MinArmorValueSharp>
-							<MinArmorValueBlunt>27</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -472,10 +464,6 @@
 							<CanOverHeal>true</CanOverHeal>
 							<MaxOverHeal>275</MaxOverHeal>
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>12</MinArmorValueSharp>
-							<MinArmorValueBlunt>27</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -564,10 +552,6 @@
 							<CanOverHeal>true</CanOverHeal>
 							<MaxOverHeal>350</MaxOverHeal>
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>12</MinArmorValueSharp>
-							<MinArmorValueBlunt>27</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -673,10 +657,6 @@
 							<CanOverHeal>true</CanOverHeal>
 							<MaxOverHeal>250</MaxOverHeal>
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>12</MinArmorValueSharp>
-							<MinArmorValueBlunt>27</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -174,8 +174,6 @@
 							<MinArmorPct>0.5</MinArmorPct>
 							<MinArmorValueSharp>12</MinArmorValueSharp>
 							<MinArmorValueBlunt>27</MinArmorValueBlunt>
-							<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -359,10 +357,6 @@
 							<CanOverHeal>true</CanOverHeal>
 							<MaxOverHeal>116</MaxOverHeal>
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -395,10 +389,6 @@
 							<CanOverHeal>true</CanOverHeal>
 							<MaxOverHeal>86</MaxOverHeal>
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -504,8 +494,6 @@
 							<MinArmorPct>0.75</MinArmorPct>
 							<MinArmorValueSharp>4</MinArmorValueSharp>
 							<MinArmorValueBlunt>8</MinArmorValueBlunt>
-							<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -621,10 +609,6 @@
 							<CanOverHeal>true</CanOverHeal>
 							<MaxOverHeal>86</MaxOverHeal>
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -743,8 +727,6 @@
 							<MinArmorPct>0.5</MinArmorPct>
 							<MinArmorValueSharp>5</MinArmorValueSharp>
 							<MinArmorValueBlunt>7.5</MinArmorValueBlunt>
-							<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -846,8 +828,6 @@
 							<MinArmorPct>0.5</MinArmorPct>
 							<MinArmorValueSharp>12</MinArmorValueSharp>
 							<MinArmorValueBlunt>27</MinArmorValueBlunt>
-							<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -942,8 +922,6 @@
 							<MinArmorPct>0.5</MinArmorPct>
 							<MinArmorValueSharp>10</MinArmorValueSharp>
 							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid_PlayerControlled.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid_PlayerControlled.xml
@@ -101,8 +101,6 @@
 								<MinArmorPct>0.5</MinArmorPct>
 								<MinArmorValueSharp>10</MinArmorValueSharp>
 								<MinArmorValueBlunt>22</MinArmorValueBlunt>
-								<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>
@@ -218,10 +216,6 @@
 								<CanOverHeal>true</CanOverHeal>
 								<MaxOverHeal>86</MaxOverHeal>
 								<MinArmorPct>0.75</MinArmorPct>
-								<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-								<MinArmorValueBlunt>22</MinArmorValueBlunt>
-								<MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>
@@ -340,8 +334,6 @@
 								<MinArmorPct>0.5</MinArmorPct>
 								<MinArmorValueSharp>5</MinArmorValueSharp>
 								<MinArmorValueBlunt>7.5</MinArmorValueBlunt>
-								<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-								<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 							</li>
 						</value>
 					</li>

--- a/Patches/Vanilla Factions Expanded - Vikings/Races_Animal_Domestic.xml
+++ b/Patches/Vanilla Factions Expanded - Vikings/Races_Animal_Domestic.xml
@@ -48,26 +48,12 @@
 					</value>
 				</li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VFEV_WoolyCow"]/race/baseBodySize</xpath>
-					<value>
-						<baseBodySize>1.7</baseBodySize>
-					</value>
-				</li>
-
 				<li Class="PatchOperationAddModExtension">
 					<xpath>Defs/ThingDef[defName="VFEV_WoolyCow"]</xpath>
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Quadruped</bodyShape>
 						</li>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/PawnKindDef[defName="VFEV_WoolyCow"]/combatPower</xpath>
-					<value>
-						<combatPower>40</combatPower>
 					</value>
 				</li>
 
@@ -137,13 +123,6 @@
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Quadruped</bodyShape>
 						</li>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/PawnKindDef[defName="VFEV_Wolfhound"]/combatPower</xpath>
-					<value>
-						<combatPower>60</combatPower>
 					</value>
 				</li>
 

--- a/Patches/Vanilla Factions Expanded - Vikings/Races_Animal_Giant.xml
+++ b/Patches/Vanilla Factions Expanded - Vikings/Races_Animal_Giant.xml
@@ -140,20 +140,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>300</MaxOverHeal> -->
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -286,20 +273,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>300</MaxOverHeal> -->
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -393,20 +367,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>300</MaxOverHeal> -->
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Vanilla Factions Expanded - Vikings/Races_Animal_Giant.xml
+++ b/Patches/Vanilla Factions Expanded - Vikings/Races_Animal_Giant.xml
@@ -122,10 +122,39 @@
 					</value>
 				</li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/PawnKindDef[defName="VFEV_Lothurr"]/combatPower</xpath>
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[defName="VFEV_Lothurr"]/comps</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="VFEV_Lothurr"]</xpath>
+						<value>
+							<comps />
+						</value>
+					</nomatch>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VFEV_Lothurr"]/comps</xpath>
 					<value>
-						<combatPower>500</combatPower>
+						<li Class="CombatExtended.CompProperties_ArmorDurability">
+							<Durability>4000</Durability>
+							<Regenerates>true</Regenerates>
+							<RegenInterval>600</RegenInterval>
+							<RegenValue>5</RegenValue>
+							<!-- <Repairable>true</Repairable>
+							<RepairIngredients>
+								<Steel>5</Steel>
+								<Plasteel>5</Plasteel>
+							</RepairIngredients>
+							<RepairTime>300</RepairTime>
+							<RepairValue>200</RepairValue>
+							<CanOverHeal>true</CanOverHeal>
+							<MaxOverHeal>300</MaxOverHeal> -->
+							<MinArmorPct>0.75</MinArmorPct>
+							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
+							<MinArmorValueBlunt>22</MinArmorValueBlunt>
+							<MinArmorValueHeat>0.2</MinArmorValueHeat>
+							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
+						</li>
 					</value>
 				</li>
 
@@ -239,6 +268,42 @@
 					</value>
 				</li>
 
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[defName="VFEV_Fenrir"]/comps</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="VFEV_Fenrir"]</xpath>
+						<value>
+							<comps />
+						</value>
+					</nomatch>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VFEV_Fenrir"]/comps</xpath>
+					<value>
+						<li Class="CombatExtended.CompProperties_ArmorDurability">
+							<Durability>1962</Durability>
+							<Regenerates>true</Regenerates>
+							<RegenInterval>600</RegenInterval>
+							<RegenValue>5</RegenValue>
+							<!-- <Repairable>true</Repairable>
+							<RepairIngredients>
+								<Steel>5</Steel>
+								<Plasteel>5</Plasteel>
+							</RepairIngredients>
+							<RepairTime>300</RepairTime>
+							<RepairValue>200</RepairValue>
+							<CanOverHeal>true</CanOverHeal>
+							<MaxOverHeal>300</MaxOverHeal> -->
+							<MinArmorPct>0.75</MinArmorPct>
+							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
+							<MinArmorValueBlunt>22</MinArmorValueBlunt>
+							<MinArmorValueHeat>0.2</MinArmorValueHeat>
+							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
+						</li>
+					</value>
+				</li>
+
 				<!-- ========== Njorun ========== -->
 
 				<li Class="PatchOperationAddModExtension">
@@ -310,7 +375,44 @@
 					</value>
 				</li>
 
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[defName="VFEV_Njorun"]/comps</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="VFEV_Njorun"]</xpath>
+						<value>
+							<comps />
+						</value>
+					</nomatch>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VFEV_Njorun"]/comps</xpath>
+					<value>
+						<li Class="CombatExtended.CompProperties_ArmorDurability">
+							<Durability>4250</Durability>
+							<Regenerates>true</Regenerates>
+							<RegenInterval>600</RegenInterval>
+							<RegenValue>5</RegenValue>
+							<!-- <Repairable>true</Repairable>
+							<RepairIngredients>
+								<Steel>5</Steel>
+								<Plasteel>5</Plasteel>
+							</RepairIngredients>
+							<RepairTime>300</RepairTime>
+							<RepairValue>200</RepairValue>
+							<CanOverHeal>true</CanOverHeal>
+							<MaxOverHeal>300</MaxOverHeal> -->
+							<MinArmorPct>0.75</MinArmorPct>
+							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
+							<MinArmorValueBlunt>22</MinArmorValueBlunt>
+							<MinArmorValueHeat>0.2</MinArmorValueHeat>
+							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
+						</li>
+					</value>
+				</li>
+
 			</operations>
 		</match>
 	</Operation>
+
 </Patch>

--- a/Patches/Vanilla Factions Expanded - Vikings/Races_Mechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Vikings/Races_Mechanoid.xml
@@ -238,10 +238,6 @@
 							<CanOverHeal>true</CanOverHeal>
 							<MaxOverHeal>300</MaxOverHeal>
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Vanilla Factions Expanded - Vikings/Races_Mechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Vikings/Races_Mechanoid.xml
@@ -210,6 +210,42 @@
 					</value>
 				</li>
 
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[defName="VFEV_Mech_Odin"]/comps</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="VFEV_Mech_Odin"]</xpath>
+						<value>
+							<comps />
+						</value>
+					</nomatch>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VFEV_Mech_Odin"]/comps</xpath>
+					<value>
+						<li Class="CombatExtended.CompProperties_ArmorDurability">
+							<Durability>3000</Durability>
+							<Regenerates>true</Regenerates>
+							<RegenInterval>1250</RegenInterval>
+							<RegenValue>5</RegenValue>
+							<Repairable>true</Repairable>
+							<RepairIngredients>
+								<Steel>5</Steel>
+								<Plasteel>5</Plasteel>
+							</RepairIngredients>
+							<RepairTime>300</RepairTime>
+							<RepairValue>200</RepairValue>
+							<CanOverHeal>true</CanOverHeal>
+							<MaxOverHeal>300</MaxOverHeal>
+							<MinArmorPct>0.75</MinArmorPct>
+							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
+							<MinArmorValueBlunt>22</MinArmorValueBlunt>
+							<MinArmorValueHeat>0.2</MinArmorValueHeat>
+							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
+						</li>
+					</value>
+				</li>
+
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/PawnKindDef[defName="VFEV_Mech_Odin"]/combatPower</xpath>
 					<value>

--- a/Patches/Zombieland/Zombieland_Patches.xml
+++ b/Patches/Zombieland/Zombieland_Patches.xml
@@ -146,20 +146,7 @@
 							<Regenerates>true</Regenerates>
 							<RegenInterval>600</RegenInterval>
 							<RegenValue>5</RegenValue>
-							<!-- <Repairable>true</Repairable>
-							<RepairIngredients>
-								<Steel>5</Steel>
-								<Plasteel>5</Plasteel>
-							</RepairIngredients>
-							<RepairTime>300</RepairTime>
-							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>75</MaxOverHeal> -->
 							<MinArmorPct>0.5</MinArmorPct>
-							<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>


### PR DESCRIPTION
## Changes

- What it says on the tin, comps are a list and specifically patched animals are getting two natural armor comps which is not easy and clean enough to get rid of.
- Added the comp to various other pawns.
- Decluttered the comp patches.
- Ran a consistency check for various animal stats.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
