### PR TITLE
Hediff pain tweaks

### DIFF
--- a/Patches/Core/HediffDefs/Hediffs_Local_Injuries.xml
+++ b/Patches/Core/HediffDefs/Hediffs_Local_Injuries.xml
@@ -78,7 +78,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="Crush"]/injuryProps/painPerSeverity</xpath>
 		<value>
-			<painPerSeverity>0.0125</painPerSeverity>
+			<painPerSeverity>0.0175</painPerSeverity>
 		</value>
 	</Operation>
 
@@ -244,6 +244,15 @@
 		<xpath>Defs/HediffDef[defName="Shredded"]/comps/li[@Class="HediffCompProperties_GetsPermanent"]/permanentLabel</xpath>
 		<value>
 			<permanentLabel>shrapnel scar</permanentLabel>
+		</value>
+	</Operation>
+
+	<!-- Bruise -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/HediffDef[defName="Bruise"]/injuryProps/painPerSeverity</xpath>
+		<value>
+			<painPerSeverity>0.0175</painPerSeverity>
 		</value>
 	</Operation>
 

--- a/Patches/Core/HediffDefs/Hediffs_Local_Misc.xml
+++ b/Patches/Core/HediffDefs/Hediffs_Local_Misc.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/HediffDef[defName="Scaria"]</xpath>
+		<value>
+			<stages>
+				<li>
+					<painFactor>0.5</painFactor>
+				</li>
+			</stages>
+		</value>
+	</Operation>
+
+</Patch>


### PR DESCRIPTION
## Changes

- Made Scaria-ridden animals feel 50% less pain.
- Made bruises inflict more pain per severity, from 0.0125 to 0.0175 similar to other patched values in CE.
- Updated the pain patch for the Crush damages as it was simply replacing the vanilla value with the same one, it's 0.0175 similar to other damage types.

## Reasoning

- Rabid animals don't care as much about pain.
- Bruises are trivial in CE and can lead to a body part, mainly the torso, getting destroyed due to chip damage before the pawn goes into pain shock, this will help mitigate that problem to some extent and would be consistent with the changes CE makes to other damage types.

## Alternatives

- Increase pain threshold on rabid animals instead of the pain factor, or increase the pain factor if x0.5 is too low.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] Playtested a colony (specify how long)
