### PR TITLE
Mech heat armor

### DIFF
--- a/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Heavy.xml
+++ b/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Heavy.xml
@@ -45,6 +45,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Mech_Tunneler"]/statBases</xpath>
 		<value>
+			<ArmorRating_Heat>0.25</ArmorRating_Heat>
 			<MeleeDodgeChance>0.02</MeleeDodgeChance>
 			<MeleeCritChance>0.23</MeleeCritChance>
 			<MeleeParryChance>0.53</MeleeParryChance>
@@ -95,7 +96,7 @@
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="Mech_Tunneler"]</xpath>
 			<value>
-				<comps/>
+				<comps />
 			</value>
 		</nomatch>
 	</Operation>

--- a/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Medium.xml
+++ b/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Medium.xml
@@ -95,6 +95,13 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Mech_Tesseron"]/statBases</xpath>
+		<value>
+			<ArmorRating_Heat>0.25</ArmorRating_Heat>
+		</value>
+	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mech_Legionary"]/statBases/EnergyShieldRechargeRate</xpath>
 		<value>
@@ -121,7 +128,7 @@
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="Mech_Legionary" or defName="Mech_Tesseron"]</xpath>
 			<value>
-				<comps/>
+				<comps />
 			</value>
 		</nomatch>
 	</Operation>
@@ -166,6 +173,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Mech_Scorcher"]/statBases</xpath>
 		<value>
+			<ArmorRating_Heat>0.5</ArmorRating_Heat>
 			<CarryBulk>30</CarryBulk>
 			<MeleeDodgeChance>0.13</MeleeDodgeChance>
 			<MeleeCritChance>0.12</MeleeCritChance>
@@ -219,7 +227,7 @@
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="Mech_Scorcher"]</xpath>
 			<value>
-				<comps/>
+				<comps />
 			</value>
 		</nomatch>
 	</Operation>
@@ -264,6 +272,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Mech_Apocriton"]/statBases</xpath>
 		<value>
+			<ArmorRating_Heat>0.5</ArmorRating_Heat>
 			<CarryWeight>60</CarryWeight>
 			<CarryBulk>30</CarryBulk>
 			<MeleeDodgeChance>0.07</MeleeDodgeChance>
@@ -325,7 +334,7 @@
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="Mech_Apocriton"]</xpath>
 			<value>
-				<comps/>
+				<comps />
 			</value>
 		</nomatch>
 	</Operation>

--- a/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_SuperHeavy.xml
+++ b/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_SuperHeavy.xml
@@ -66,6 +66,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Mech_Centurion"]/statBases</xpath>
 		<value>
+			<ArmorRating_Heat>0.25</ArmorRating_Heat>
 			<CarryWeight>100</CarryWeight>
 			<CarryBulk>50</CarryBulk>
 			<AimingAccuracy>1.0</AimingAccuracy>
@@ -167,6 +168,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Mech_Warqueen"]/statBases</xpath>
 		<value>
+			<ArmorRating_Heat>0.5</ArmorRating_Heat>
 			<CarryWeight>100</CarryWeight>
 			<CarryBulk>50</CarryBulk>
 			<AimingAccuracy>1.0</AimingAccuracy>
@@ -248,6 +250,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Mech_Diabolus"]/statBases</xpath>
 		<value>
+			<ArmorRating_Heat>0.5</ArmorRating_Heat>
 			<CarryWeight>300</CarryWeight>
 			<CarryBulk>60</CarryBulk>
 			<AimingAccuracy>1.0</AimingAccuracy>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Apoptosis.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Apoptosis.xml
@@ -26,6 +26,7 @@
 					<li Class="PatchOperationAdd">
 						<xpath>Defs/ThingDef[defName="AM_Apoptosis"]/statBases</xpath>
 						<value>
+							<ArmorRating_Heat>0.75</ArmorRating_Heat>
 							<CarryWeight>60</CarryWeight>
 							<CarryBulk>30</CarryBulk>
 							<MeleeDodgeChance>0.1</MeleeDodgeChance>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Infernus.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Infernus.xml
@@ -26,6 +26,7 @@
 					<li Class="PatchOperationAdd">
 						<xpath>Defs/ThingDef[defName="AM_Infernus"]/statBases</xpath>
 						<value>
+							<ArmorRating_Heat>0.75</ArmorRating_Heat>
 							<CarryWeight>300</CarryWeight>
 							<CarryBulk>60</CarryBulk>
 							<AimingAccuracy>1.0</AimingAccuracy>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Legate.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Legate.xml
@@ -40,6 +40,7 @@
 					<li Class="PatchOperationAdd">
 						<xpath>Defs/ThingDef[defName="AM_Mech_Legate"]/statBases</xpath>
 						<value>
+							<ArmorRating_Heat>0.5</ArmorRating_Heat>
 							<CarryWeight>150</CarryWeight>
 							<CarryBulk>50</CarryBulk>
 							<AimingAccuracy>1.0</AimingAccuracy>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Polychoron.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Polychoron.xml
@@ -34,6 +34,7 @@
 						<xpath>Defs/ThingDef[defName="AM_Mech_Polychoron"]/statBases/ArmorRating_Sharp</xpath>
 						<value>
 							<ArmorRating_Sharp>5</ArmorRating_Sharp>
+							<ArmorRating_Heat>0.5</ArmorRating_Heat>
 						</value>
 					</li>
 

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Sagittarius.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Sagittarius.xml
@@ -23,6 +23,13 @@
 						</value>
 					</li>
 
+					<li Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="AM_Mech_Sagittarius"]/statBases</xpath>
+						<value>
+							<ArmorRating_Electric>0.25</ArmorRating_Electric>
+						</value>
+					</li>
+
 					<li Class="PatchOperationReplace">
 						<xpath>Defs/ThingDef[defName="AM_Mech_Sagittarius"]/tools</xpath>
 						<value>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Siegemelter.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Siegemelter.xml
@@ -39,6 +39,7 @@
 					<li Class="PatchOperationAdd">
 						<xpath>Defs/ThingDef[defName="AM_Siegemelter"]/statBases</xpath>
 						<value>
+							<ArmorRating_Heat>0.5</ArmorRating_Heat>
 							<CarryWeight>200</CarryWeight>
 							<CarryBulk>300</CarryBulk>
 							<AimingAccuracy>1.0</AimingAccuracy>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Starfire.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Starfire.xml
@@ -39,6 +39,7 @@
 					<li Class="PatchOperationAdd">
 						<xpath>Defs/ThingDef[defName="AM_Starfire"]/statBases</xpath>
 						<value>
+							<ArmorRating_Heat>0.5</ArmorRating_Heat>
 							<CarryWeight>200</CarryWeight>
 							<CarryBulk>300</CarryBulk>
 							<AimingAccuracy>1.0</AimingAccuracy>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_WarEmpress.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_WarEmpress.xml
@@ -40,6 +40,7 @@
 					<li Class="PatchOperationAdd">
 						<xpath>Defs/ThingDef[defName="AM_WarEmpress"]/statBases</xpath>
 						<value>
+							<ArmorRating_Heat>0.75</ArmorRating_Heat>
 							<CarryWeight>100</CarryWeight>
 							<CarryBulk>50</CarryBulk>
 							<AimingAccuracy>1.0</AimingAccuracy>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvFireworm.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvFireworm.xml
@@ -40,6 +40,7 @@
 					<li Class="PatchOperationAdd">
 						<xpath>Defs/ThingDef[defName="VFE_Mech_Advanced_Fireworm"]/statBases</xpath>
 						<value>
+							<ArmorRating_Heat>1.0</ArmorRating_Heat>
 							<AimingAccuracy>1.0</AimingAccuracy>
 							<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
 							<MeleeDodgeChance>0.01</MeleeDodgeChance>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvGoliath.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvGoliath.xml
@@ -40,6 +40,7 @@
 					<li Class="PatchOperationAdd">
 						<xpath>Defs/ThingDef[defName="VFE_Mech_Advanced_Goliath"]/statBases</xpath>
 						<value>
+							<ArmorRating_Heat>0.75</ArmorRating_Heat>
 							<CarryWeight>400</CarryWeight>
 							<CarryBulk>200</CarryBulk>
 							<AimingAccuracy>1.0</AimingAccuracy>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvPhalanx.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvPhalanx.xml
@@ -40,6 +40,7 @@
 					<li Class="PatchOperationAdd">
 						<xpath>Defs/ThingDef[defName="VFE_Mech_Advanced_Phalanx"]/statBases</xpath>
 						<value>
+							<ArmorRating_Heat>1.0</ArmorRating_Heat>
 							<AimingAccuracy>1.0</AimingAccuracy>
 							<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
 							<MeleeDodgeChance>0.01</MeleeDodgeChance>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvSiegebreaker.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvSiegebreaker.xml
@@ -40,6 +40,7 @@
 					<li Class="PatchOperationAdd">
 						<xpath>Defs/ThingDef[defName="VFE_Mech_Advanced_Siegebreaker"]/statBases</xpath>
 						<value>
+							<ArmorRating_Heat>0.75</ArmorRating_Heat>
 							<CarryWeight>200</CarryWeight>
 							<CarryBulk>300</CarryBulk>
 							<AimingAccuracy>1.0</AimingAccuracy>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEFireworm.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEFireworm.xml
@@ -39,6 +39,7 @@
 					<li Class="PatchOperationAdd">
 						<xpath>Defs/ThingDef[defName="VFE_Mech_Fireworm"]/statBases</xpath>
 						<value>
+							<ArmorRating_Heat>0.5</ArmorRating_Heat>
 							<AimingAccuracy>1.0</AimingAccuracy>
 							<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
 							<MeleeDodgeChance>0.01</MeleeDodgeChance>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEGoliath.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEGoliath.xml
@@ -39,6 +39,7 @@
 					<li Class="PatchOperationAdd">
 						<xpath>Defs/ThingDef[defName="VFE_Mech_Goliath"]/statBases</xpath>
 						<value>
+							<ArmorRating_Heat>0.25</ArmorRating_Heat>
 							<CarryWeight>400</CarryWeight>
 							<CarryBulk>200</CarryBulk>
 							<AimingAccuracy>1.0</AimingAccuracy>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEPhalanx.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEPhalanx.xml
@@ -38,6 +38,7 @@
 					<li Class="PatchOperationAdd">
 						<xpath>Defs/ThingDef[defName="VFE_Mech_Phalanx"]/statBases</xpath>
 						<value>
+							<ArmorRating_Heat>0.5</ArmorRating_Heat>
 							<AimingAccuracy>1.0</AimingAccuracy>
 							<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
 							<MeleeDodgeChance>0.01</MeleeDodgeChance>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFESiegebreaker.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFESiegebreaker.xml
@@ -39,6 +39,7 @@
 					<li Class="PatchOperationAdd">
 						<xpath>Defs/ThingDef[defName="VFE_Mech_Siegebreaker"]/statBases</xpath>
 						<value>
+							<ArmorRating_Heat>0.25</ArmorRating_Heat>
 							<CarryWeight>200</CarryWeight>
 							<CarryBulk>300</CarryBulk>
 							<AimingAccuracy>1.0</AimingAccuracy>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Aura.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Aura.xml
@@ -33,6 +33,7 @@
 							<value>
 								<ArmorRating_Blunt>7.5</ArmorRating_Blunt>
 								<ArmorRating_Sharp>5</ArmorRating_Sharp>
+								<ArmorRating_Heat>0.5</ArmorRating_Heat>
 								<MeleeDodgeChance>0.66</MeleeDodgeChance>
 								<MeleeCritChance>0.3</MeleeCritChance>
 								<MeleeParryChance>0.33</MeleeParryChance>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Daggersnout.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Daggersnout.xml
@@ -31,6 +31,7 @@
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/ThingDef[defName="VFE_Mech_Advanced_Daggersnout_PlayerControlled"]/statBases</xpath>
 							<value>
+								<ArmorRating_Heat>0.5</ArmorRating_Heat>
 								<MeleeDodgeChance>0.08</MeleeDodgeChance>
 								<MeleeCritChance>0.27</MeleeCritChance>
 								<MeleeParryChance>0.18</MeleeParryChance>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Fireworm.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Fireworm.xml
@@ -45,6 +45,7 @@
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/ThingDef[defName="VFE_Mech_Advanced_Fireworm_PlayerControlled"]/statBases</xpath>
 							<value>
+								<ArmorRating_Heat>1.0</ArmorRating_Heat>
 								<AimingAccuracy>1.0</AimingAccuracy>
 								<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
 								<MeleeDodgeChance>0.01</MeleeDodgeChance>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Goliath.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Goliath.xml
@@ -45,6 +45,7 @@
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/ThingDef[defName="VFE_Mech_Advanced_Goliath_PlayerControlled"]/statBases</xpath>
 							<value>
+								<ArmorRating_Heat>0.75</ArmorRating_Heat>
 								<CarryWeight>400</CarryWeight>
 								<CarryBulk>200</CarryBulk>
 								<AimingAccuracy>1.0</AimingAccuracy>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Phalanx.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Phalanx.xml
@@ -44,6 +44,7 @@
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/ThingDef[defName="VFE_Mech_Advanced_Phalanx_PlayerControlled"]/statBases</xpath>
 							<value>
+								<ArmorRating_Heat>1.0</ArmorRating_Heat>
 								<AimingAccuracy>1.0</AimingAccuracy>
 								<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
 								<MeleeDodgeChance>0.01</MeleeDodgeChance>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Siegebreaker.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Siegebreaker.xml
@@ -45,6 +45,7 @@
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/ThingDef[defName="VFE_Mech_Advanced_Siegebreaker_PlayerControlled"]/statBases</xpath>
 							<value>
+								<ArmorRating_Heat>0.75</ArmorRating_Heat>
 								<CarryWeight>200</CarryWeight>
 								<CarryBulk>300</CarryBulk>
 								<AimingAccuracy>1.0</AimingAccuracy>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Slurrymaster.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Slurrymaster.xml
@@ -31,6 +31,7 @@
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/ThingDef[defName="AM_Mech_Advanced_PristineSlurrypede_PlayerControlled"]/statBases</xpath>
 							<value>
+								<ArmorRating_Heat>0.5</ArmorRating_Heat>
 								<MeleeDodgeChance>0.12</MeleeDodgeChance>
 								<MeleeCritChance>0.1</MeleeCritChance>
 								<MeleeParryChance>0.17</MeleeParryChance>

--- a/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Demolisher.xml
+++ b/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Demolisher.xml
@@ -35,6 +35,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="AM_Demolisher"]/statBases</xpath>
 					<value>
+						<ArmorRating_Heat>0.25</ArmorRating_Heat>
 						<CarryWeight>50</CarryWeight>
 						<CarryBulk>100</CarryBulk>
 						<AimingAccuracy>1.0</AimingAccuracy>

--- a/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Fireworm.xml
+++ b/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Fireworm.xml
@@ -35,6 +35,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="AM_Fireworm"]/statBases</xpath>
 					<value>
+						<ArmorRating_Heat>0.5</ArmorRating_Heat>
 						<AimingAccuracy>1.0</AimingAccuracy>
 						<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
 						<MeleeDodgeChance>0.01</MeleeDodgeChance>

--- a/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Goliath.xml
+++ b/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Goliath.xml
@@ -35,6 +35,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="AM_Goliath"]/statBases</xpath>
 					<value>
+						<ArmorRating_Heat>0.25</ArmorRating_Heat>
 						<CarryWeight>400</CarryWeight>
 						<CarryBulk>200</CarryBulk>
 						<AimingAccuracy>1.0</AimingAccuracy>

--- a/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Phalanx.xml
+++ b/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Phalanx.xml
@@ -34,6 +34,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="AM_Phalanx"]/statBases</xpath>
 					<value>
+						<ArmorRating_Heat>0.5</ArmorRating_Heat>
 						<AimingAccuracy>1.0</AimingAccuracy>
 						<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
 						<MeleeDodgeChance>0.01</MeleeDodgeChance>

--- a/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Siegebreaker.xml
+++ b/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Siegebreaker.xml
@@ -34,6 +34,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="AM_Siegebreaker"]/statBases</xpath>
 					<value>
+						<ArmorRating_Heat>0.25</ArmorRating_Heat>
 						<CarryWeight>200</CarryWeight>
 						<CarryBulk>300</CarryBulk>
 						<AimingAccuracy>1.0</AimingAccuracy>

--- a/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
@@ -145,6 +145,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[@Name="MechCentipede"]/statBases</xpath>
 		<value>
+			<ArmorRating_Heat>0.25</ArmorRating_Heat>
 			<CarryWeight>250</CarryWeight>
 			<CarryBulk>60</CarryBulk>
 			<AimingAccuracy>1.0</AimingAccuracy>
@@ -595,6 +596,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Mech_Termite"]/statBases</xpath>
 		<value>
+			<ArmorRating_Heat>0.25</ArmorRating_Heat>
 			<CarryWeight>300</CarryWeight>
 			<CarryBulk>60</CarryBulk>
 			<AimingAccuracy>1.0</AimingAccuracy>

--- a/Patches/MoreMechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/MoreMechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -79,6 +79,42 @@
 					</value>
 				</li>
 
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[defName="Mech_Crawler"]/comps</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="Mech_Crawler"]</xpath>
+						<value>
+							<comps />
+						</value>
+					</nomatch>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Mech_Crawler"]/comps</xpath>
+					<value>
+						<li Class="CombatExtended.CompProperties_ArmorDurability">
+							<Durability>275</Durability>
+							<Regenerates>true</Regenerates>
+							<RegenInterval>1250</RegenInterval>
+							<RegenValue>5</RegenValue>
+							<Repairable>true</Repairable>
+							<RepairIngredients>
+								<Steel>5</Steel>
+								<Plasteel>5</Plasteel>
+							</RepairIngredients>
+							<RepairTime>300</RepairTime>
+							<RepairValue>200</RepairValue>
+							<CanOverHeal>true</CanOverHeal>
+							<MaxOverHeal>27</MaxOverHeal>
+							<MinArmorPct>0.75</MinArmorPct>
+							<!-- <MinArmorValueSharp>6</MinArmorValueSharp>
+							<MinArmorValueBlunt>12</MinArmorValueBlunt>
+							<MinArmorValueHeat>0.2</MinArmorValueHeat>
+							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
+						</li>
+					</value>
+				</li>
+
 				<!-- ========== Skullywag ========== -->
 
 				<li Class="PatchOperationAddModExtension">
@@ -146,6 +182,42 @@
 					</value>
 				</li>
 
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[defName="Mech_Skullywag"]/comps</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="Mech_Skullywag"]</xpath>
+						<value>
+							<comps />
+						</value>
+					</nomatch>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Mech_Skullywag"]/comps</xpath>
+					<value>
+						<li Class="CombatExtended.CompProperties_ArmorDurability">
+							<Durability>850</Durability>
+							<Regenerates>true</Regenerates>
+							<RegenInterval>1250</RegenInterval>
+							<RegenValue>5</RegenValue>
+							<Repairable>true</Repairable>
+							<RepairIngredients>
+								<Steel>5</Steel>
+								<Plasteel>5</Plasteel>
+							</RepairIngredients>
+							<RepairTime>300</RepairTime>
+							<RepairValue>200</RepairValue>
+							<CanOverHeal>true</CanOverHeal>
+							<MaxOverHeal>85</MaxOverHeal>
+							<MinArmorPct>0.75</MinArmorPct>
+							<!-- <MinArmorValueSharp>6</MinArmorValueSharp>
+							<MinArmorValueBlunt>12</MinArmorValueBlunt>
+							<MinArmorValueHeat>0.2</MinArmorValueHeat>
+							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
+						</li>
+					</value>
+				</li>
+
 				<!-- ========== Flamebot ========== -->
 
 				<li Class="PatchOperationAddModExtension">
@@ -173,6 +245,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="Mech_Flamebot"]/statBases</xpath>
 					<value>
+						<ArmorRating_Heat>0.5</ArmorRating_Heat>
 						<CarryWeight>50</CarryWeight>
 						<CarryBulk>100</CarryBulk>
 						<AimingAccuracy>1.0</AimingAccuracy>
@@ -203,6 +276,42 @@
 					</value>
 				</li>
 
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[defName="Mech_Flamebot"]/comps</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="Mech_Flamebot"]</xpath>
+						<value>
+							<comps />
+						</value>
+					</nomatch>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Mech_Flamebot"]/comps</xpath>
+					<value>
+						<li Class="CombatExtended.CompProperties_ArmorDurability">
+							<Durability>400</Durability>
+							<Regenerates>true</Regenerates>
+							<RegenInterval>1250</RegenInterval>
+							<RegenValue>5</RegenValue>
+							<Repairable>true</Repairable>
+							<RepairIngredients>
+								<Steel>5</Steel>
+								<Plasteel>5</Plasteel>
+							</RepairIngredients>
+							<RepairTime>300</RepairTime>
+							<RepairValue>200</RepairValue>
+							<CanOverHeal>true</CanOverHeal>
+							<MaxOverHeal>40</MaxOverHeal>
+							<MinArmorPct>0.75</MinArmorPct>
+							<!-- <MinArmorValueSharp>6</MinArmorValueSharp>
+							<MinArmorValueBlunt>12</MinArmorValueBlunt>
+							<MinArmorValueHeat>0.2</MinArmorValueHeat>
+							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
+						</li>
+					</value>
+				</li>
+
 				<!-- ========== Mammoth ========== -->
 
 				<li Class="PatchOperationAddModExtension">
@@ -217,6 +326,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="Mech_Mammoth"]/statBases</xpath>
 					<value>
+						<ArmorRating_Heat>0.5</ArmorRating_Heat>
 						<MeleeDodgeChance>0.04</MeleeDodgeChance>
 						<MeleeCritChance>0.64</MeleeCritChance>
 						<MeleeParryChance>0.58</MeleeParryChance>
@@ -298,6 +408,42 @@
 					</value>
 				</li>
 
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[defName="Mech_Mammoth"]/comps</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="Mech_Mammoth"]</xpath>
+						<value>
+							<comps />
+						</value>
+					</nomatch>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Mech_Mammoth"]/comps</xpath>
+					<value>
+						<li Class="CombatExtended.CompProperties_ArmorDurability">
+							<Durability>5500</Durability>
+							<Regenerates>true</Regenerates>
+							<RegenInterval>1250</RegenInterval>
+							<RegenValue>5</RegenValue>
+							<Repairable>true</Repairable>
+							<RepairIngredients>
+								<Steel>5</Steel>
+								<Plasteel>5</Plasteel>
+							</RepairIngredients>
+							<RepairTime>300</RepairTime>
+							<RepairValue>200</RepairValue>
+							<CanOverHeal>true</CanOverHeal>
+							<MaxOverHeal>550</MaxOverHeal>
+							<MinArmorPct>0.5</MinArmorPct>
+							<MinArmorValueSharp>12</MinArmorValueSharp>
+							<MinArmorValueBlunt>27</MinArmorValueBlunt>
+							<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
+							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
+						</li>
+					</value>
+				</li>
+
 				<!-- ========== Assaulter ========== -->
 
 				<li Class="PatchOperationAddModExtension">
@@ -325,6 +471,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="Mech_Assaulter"]/statBases</xpath>
 					<value>
+						<ArmorRating_Heat>0.25</ArmorRating_Heat>
 						<CarryWeight>50</CarryWeight>
 						<CarryBulk>40</CarryBulk>
 						<AimingAccuracy>1.0</AimingAccuracy>
@@ -375,7 +522,44 @@
 					</value>
 				</li>
 
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[defName="Mech_Assaulter"]/comps</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="Mech_Assaulter"]</xpath>
+						<value>
+							<comps />
+						</value>
+					</nomatch>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Mech_Assaulter"]/comps</xpath>
+					<value>
+						<li Class="CombatExtended.CompProperties_ArmorDurability">
+							<Durability>1525</Durability>
+							<Regenerates>true</Regenerates>
+							<RegenInterval>1250</RegenInterval>
+							<RegenValue>5</RegenValue>
+							<Repairable>true</Repairable>
+							<RepairIngredients>
+								<Steel>5</Steel>
+								<Plasteel>5</Plasteel>
+							</RepairIngredients>
+							<RepairTime>300</RepairTime>
+							<RepairValue>200</RepairValue>
+							<CanOverHeal>true</CanOverHeal>
+							<MaxOverHeal>152</MaxOverHeal>
+							<MinArmorPct>0.5</MinArmorPct>
+							<MinArmorValueSharp>10</MinArmorValueSharp>
+							<MinArmorValueBlunt>22</MinArmorValueBlunt>
+							<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
+							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
+						</li>
+					</value>
+				</li>
+
 			</operations>
 		</match>
 	</Operation>
+
 </Patch>

--- a/Patches/MoreMechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/MoreMechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -107,10 +107,6 @@
 							<CanOverHeal>true</CanOverHeal>
 							<MaxOverHeal>27</MaxOverHeal>
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>6</MinArmorValueSharp>
-							<MinArmorValueBlunt>12</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -210,10 +206,6 @@
 							<CanOverHeal>true</CanOverHeal>
 							<MaxOverHeal>85</MaxOverHeal>
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>6</MinArmorValueSharp>
-							<MinArmorValueBlunt>12</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -304,10 +296,6 @@
 							<CanOverHeal>true</CanOverHeal>
 							<MaxOverHeal>40</MaxOverHeal>
 							<MinArmorPct>0.75</MinArmorPct>
-							<!-- <MinArmorValueSharp>6</MinArmorValueSharp>
-							<MinArmorValueBlunt>12</MinArmorValueBlunt>
-							<MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -438,8 +426,6 @@
 							<MinArmorPct>0.5</MinArmorPct>
 							<MinArmorValueSharp>12</MinArmorValueSharp>
 							<MinArmorValueBlunt>27</MinArmorValueBlunt>
-							<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>
@@ -552,8 +538,6 @@
 							<MinArmorPct>0.5</MinArmorPct>
 							<MinArmorValueSharp>10</MinArmorValueSharp>
 							<MinArmorValueBlunt>22</MinArmorValueBlunt>
-							<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-							<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 						</li>
 					</value>
 				</li>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
@@ -67,6 +67,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedCentipede"]/statBases</xpath>
 					<value>
+						<ArmorRating_Heat>0.75</ArmorRating_Heat>
 						<CarryWeight>260</CarryWeight>
 						<CarryBulk>70</CarryBulk>
 						<AimingAccuracy>1.05</AimingAccuracy>
@@ -617,6 +618,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedInquisitor"]/statBases</xpath>
 					<value>
+						<ArmorRating_Heat>1.0</ArmorRating_Heat>
 						<CarryWeight>50</CarryWeight>
 						<CarryBulk>50</CarryBulk>
 						<AimingAccuracy>1.0</AimingAccuracy>
@@ -736,6 +738,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedCarpenter"]/statBases</xpath>
 					<value>
+						<ArmorRating_Heat>0.75</ArmorRating_Heat>
 						<CarryWeight>400</CarryWeight>
 						<CarryBulk>80</CarryBulk>
 						<MeleeDodgeChance>0.04</MeleeDodgeChance>
@@ -830,6 +833,7 @@
 					<xpath>Defs/ThingDef[defName="VFE_Mech_AdvTermite"]/statBases</xpath>
 					<value>
 						<statBases>
+							<ArmorRating_Heat>0.75</ArmorRating_Heat>
 							<CarryWeight>300</CarryWeight>
 							<CarryBulk>60</CarryBulk>
 							<AimingAccuracy>1.0</AimingAccuracy>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid_PlayerControlled.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid_PlayerControlled.xml
@@ -27,6 +27,7 @@
 					<li Class="PatchOperationAdd">
 						<xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedCentipede_PlayerControlled"]/statBases</xpath>
 						<value>
+							<ArmorRating_Heat>0.75</ArmorRating_Heat>
 							<CarryWeight>260</CarryWeight>
 							<CarryBulk>70</CarryBulk>
 							<AimingAccuracy>1.05</AimingAccuracy>
@@ -590,6 +591,7 @@
 					<li Class="PatchOperationAdd">
 						<xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedInquisitor_PlayerControlled"]/statBases</xpath>
 						<value>
+							<ArmorRating_Heat>1.0</ArmorRating_Heat>
 							<CarryWeight>50</CarryWeight>
 							<CarryBulk>50</CarryBulk>
 							<AimingAccuracy>1.0</AimingAccuracy>
@@ -709,6 +711,7 @@
 					<li Class="PatchOperationAdd">
 						<xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedTermite_PlayerControlled"]/statBases</xpath>
 						<value>
+							<ArmorRating_Heat>0.75</ArmorRating_Heat>
 							<CarryWeight>300</CarryWeight>
 							<CarryBulk>60</CarryBulk>
 							<AimingAccuracy>1.0</AimingAccuracy>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -644,7 +644,6 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="VFE_Mech_Inquisitor"]/statBases</xpath>
 					<value>
-						<ArmorRating_Heat>0.5</ArmorRating_Heat>
 						<CarryWeight>50</CarryWeight>
 						<CarryBulk>50</CarryBulk>
 						<AimingAccuracy>1.0</AimingAccuracy>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -644,6 +644,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="VFE_Mech_Inquisitor"]/statBases</xpath>
 					<value>
+						<ArmorRating_Heat>0.5</ArmorRating_Heat>
 						<CarryWeight>50</CarryWeight>
 						<CarryBulk>50</CarryBulk>
 						<AimingAccuracy>1.0</AimingAccuracy>
@@ -659,7 +660,6 @@
 					<xpath>Defs/ThingDef[defName="VFE_Mech_Inquisitor"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>12</ArmorRating_Blunt>
-						<ArmorRating_Heat>1</ArmorRating_Heat>
 					</value>
 				</li>
 

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -91,6 +91,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="VFE_Mech_Centipede"]/statBases</xpath>
 					<value>
+						<ArmorRating_Heat>0.25</ArmorRating_Heat>
 						<CarryWeight>250</CarryWeight>
 						<CarryBulk>60</CarryBulk>
 						<AimingAccuracy>1.0</AimingAccuracy>
@@ -643,6 +644,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="VFE_Mech_Inquisitor"]/statBases</xpath>
 					<value>
+						<ArmorRating_Heat>0.5</ArmorRating_Heat>
 						<CarryWeight>50</CarryWeight>
 						<CarryBulk>50</CarryBulk>
 						<AimingAccuracy>1.0</AimingAccuracy>
@@ -763,6 +765,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="VFE_Mech_Carpenter" or defName="VFE_AncientMech_AncientCarpenter"]/statBases</xpath>
 					<value>
+						<ArmorRating_Heat>0.25</ArmorRating_Heat>
 						<CarryWeight>400</CarryWeight>
 						<CarryBulk>80</CarryBulk>
 						<MeleeDodgeChance>0.03</MeleeDodgeChance>
@@ -866,6 +869,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="VFE_Mech_Termite"]/statBases</xpath>
 					<value>
+						<ArmorRating_Heat>0.25</ArmorRating_Heat>
 						<CarryWeight>300</CarryWeight>
 						<CarryBulk>60</CarryBulk>
 						<AimingAccuracy>1.0</AimingAccuracy>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid_PlayerControlled.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid_PlayerControlled.xml
@@ -241,7 +241,6 @@
 					<li Class="PatchOperationAdd">
 						<xpath>Defs/ThingDef[defName="VFE_Mech_Inquisitor_PlayerControlled"]/statBases</xpath>
 						<value>
-							<ArmorRating_Heat>0.5</ArmorRating_Heat>
 							<CarryWeight>50</CarryWeight>
 							<CarryBulk>50</CarryBulk>
 							<AimingAccuracy>1.0</AimingAccuracy>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid_PlayerControlled.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid_PlayerControlled.xml
@@ -241,6 +241,7 @@
 					<li Class="PatchOperationAdd">
 						<xpath>Defs/ThingDef[defName="VFE_Mech_Inquisitor_PlayerControlled"]/statBases</xpath>
 						<value>
+							<ArmorRating_Heat>0.5</ArmorRating_Heat>
 							<CarryWeight>50</CarryWeight>
 							<CarryBulk>50</CarryBulk>
 							<AimingAccuracy>1.0</AimingAccuracy>
@@ -256,7 +257,6 @@
 						<xpath>Defs/ThingDef[defName="VFE_Mech_Inquisitor_PlayerControlled"]/statBases/ArmorRating_Blunt</xpath>
 						<value>
 							<ArmorRating_Blunt>12</ArmorRating_Blunt>
-							<ArmorRating_Heat>1</ArmorRating_Heat>
 						</value>
 					</li>
 

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid_PlayerControlled.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid_PlayerControlled.xml
@@ -26,6 +26,7 @@
 					<li Class="PatchOperationAdd">
 						<xpath>Defs/ThingDef[defName="VFE_Mech_Termite_PlayerControlled"]/statBases</xpath>
 						<value>
+							<ArmorRating_Heat>0.25</ArmorRating_Heat>
 							<CarryWeight>300</CarryWeight>
 							<CarryBulk>60</CarryBulk>
 							<AimingAccuracy>1.0</AimingAccuracy>
@@ -240,6 +241,7 @@
 					<li Class="PatchOperationAdd">
 						<xpath>Defs/ThingDef[defName="VFE_Mech_Inquisitor_PlayerControlled"]/statBases</xpath>
 						<value>
+							<ArmorRating_Heat>0.5</ArmorRating_Heat>
 							<CarryWeight>50</CarryWeight>
 							<CarryBulk>50</CarryBulk>
 							<AimingAccuracy>1.0</AimingAccuracy>


### PR DESCRIPTION
## Changes

- Added appropriate amounts of heat armor to various mechs, boss mechs and similar mechs receive 50% heat armor, heavy mechs like centipedes receive 25% and mechs that have flamethrower type weapons receive 50% heat armor. Advanced mechs from VFE have 50% base heat armor plus the mech's inherent heat armor.

## Reasoning

- With the introduction of degradable natural armor, there has to be a compensation for the nerf that mechs received and also there has to be a slight damper on the effectiveness of AP-I ammo and other means of burn damage on mechs (not just for smallarms that fail to penetrate their armor, but in general) it was decided that reintroducing heat armor to some extent for specific mechs is the way to go.

## Alternatives

- Values are subject to change.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
