### PR TITLE
Launcher grenade updates and tweaks

### DIFF
--- a/Defs/Ammo/Grenade/25x40mmGrenade.xml
+++ b/Defs/Ammo/Grenade/25x40mmGrenade.xml
@@ -49,7 +49,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>1.68</MarketValue>
+			<MarketValue>1.76</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHE</ammoClass>
 		<detonateProjectile>Bullet_25x40mmGrenade_HE</detonateProjectile>
@@ -63,7 +63,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>2.66</MarketValue>
+			<MarketValue>2.73</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHETF</ammoClass>
 		<detonateProjectile>Bullet_25x40mmGrenade_HE</detonateProjectile>
@@ -119,7 +119,7 @@
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bomb</damageDef>
-			<damageAmountBase>17</damageAmountBase>
+			<damageAmountBase>18</damageAmountBase>
 			<explosionRadius>1</explosionRadius>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 		</projectile>
@@ -138,7 +138,7 @@
 		<thingClass>CombatExtended.ProjectileCE_Bursting</thingClass>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bomb</damageDef>
-			<damageAmountBase>17</damageAmountBase>
+			<damageAmountBase>18</damageAmountBase>
 			<explosionRadius>1</explosionRadius>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 			<aimHeightOffset>0.5</aimHeightOffset>
@@ -199,7 +199,7 @@
 						<li>FSX</li>
 					</thingDefs>
 				</filter>
-				<count>5</count>
+				<count>6</count>
 			</li>
 			<li>
 				<filter>
@@ -220,7 +220,7 @@
 		<products>
 			<Ammo_25x40mmGrenade_HE>100</Ammo_25x40mmGrenade_HE>
 		</products>
-		<workAmount>6400</workAmount>
+		<workAmount>6800</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="LauncherAmmoRecipeBase">
@@ -235,7 +235,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>30</count>
+				<count>32</count>
 			</li>
 			<li>
 				<filter>
@@ -243,7 +243,7 @@
 						<li>FSX</li>
 					</thingDefs>
 				</filter>
-				<count>5</count>
+				<count>6</count>
 			</li>
 			<li>
 				<filter>
@@ -264,7 +264,7 @@
 		<products>
 			<Ammo_25x40mmGrenade_HE_TFuzed>100</Ammo_25x40mmGrenade_HE_TFuzed>
 		</products>
-		<workAmount>8200</workAmount>
+		<workAmount>8600</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="LauncherAmmoRecipeBase">

--- a/Defs/Ammo/Grenade/25x59mmGrenade.xml
+++ b/Defs/Ammo/Grenade/25x59mmGrenade.xml
@@ -312,7 +312,7 @@
 	<RecipeDef ParentName="LauncherAmmoRecipeBase">
 		<defName>MakeAmmo_25x59mmGrenade_HEDP</defName>
 		<label>make 25x59mm HEDP grenades x100</label>
-		<description>Craft 50 25x59mm HEDP grenades.</description>
+		<description>Craft 100 25x59mm HEDP grenades.</description>
 		<jobString>Making 25x59mm HEDP grenades.</jobString>
 		<ingredients>
 			<li>

--- a/Defs/Ammo/Grenade/25x59mmGrenade.xml
+++ b/Defs/Ammo/Grenade/25x59mmGrenade.xml
@@ -14,9 +14,9 @@
 		<defName>AmmoSet_25x59mmGrenade</defName>
 		<label>25x59mm Grenades</label>
 		<ammoTypes>
-			<Ammo_25x59mmGrenade_HEDP>Bullet_25x59mmGrenade_HEDP</Ammo_25x59mmGrenade_HEDP>
 			<Ammo_25x59mmGrenade_HE>Bullet_25x59mmGrenade_HE</Ammo_25x59mmGrenade_HE>
 			<Ammo_25x59mmGrenade_HE_TFuzed>Bullet_25x59mmGrenade_HE_TFuzed</Ammo_25x59mmGrenade_HE_TFuzed>
+			<Ammo_25x59mmGrenade_HEDP>Bullet_25x59mmGrenade_HEDP</Ammo_25x59mmGrenade_HEDP>
 			<Ammo_25x59mmGrenade_EMP>Bullet_25x59mmGrenade_EMP</Ammo_25x59mmGrenade_EMP>
 			<Ammo_25x59mmGrenade_Smoke>Bullet_25x59mmGrenade_Smoke</Ammo_25x59mmGrenade_Smoke>
 		</ammoTypes>
@@ -43,6 +43,34 @@
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="25x59mmGrenadeBase">
+		<defName>Ammo_25x59mmGrenade_HE</defName>
+		<label>25x59mm grenade (HE)</label>
+		<graphicData>
+			<texPath>Things/Ammo/GrenadeLauncher/HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>2.35</MarketValue>
+		</statBases>
+		<ammoClass>GrenadeHE</ammoClass>
+		<detonateProjectile>Bullet_25x59mmGrenade_HE</detonateProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="25x59mmGrenadeBase">
+		<defName>Ammo_25x59mmGrenade_HE_TFuzed</defName>
+		<label>25x59mm grenade (HE Time-Fuzed)</label>
+		<graphicData>
+			<texPath>Things/Ammo/GrenadeLauncher/AIR</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>3.33</MarketValue>
+		</statBases>
+		<ammoClass>GrenadeHETF</ammoClass>
+		<detonateProjectile>Bullet_25x59mmGrenade_HE</detonateProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="25x59mmGrenadeBase">
 		<defName>Ammo_25x59mmGrenade_HEDP</defName>
 		<label>25x59mm grenade (HEDP)</label>
 		<graphicData>
@@ -57,34 +85,6 @@
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="25x59mmGrenadeBase">
-		<defName>Ammo_25x59mmGrenade_HE</defName>
-		<label>25x59mm grenade (HE)</label>
-		<graphicData>
-			<texPath>Things/Ammo/GrenadeLauncher/HE</texPath>
-			<graphicClass>Graphic_StackCount</graphicClass>
-		</graphicData>
-		<statBases>
-			<MarketValue>2.2</MarketValue>
-		</statBases>
-		<ammoClass>GrenadeHE</ammoClass>
-		<detonateProjectile>Bullet_25x59mmGrenade_HE</detonateProjectile>
-	</ThingDef>
-
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="25x59mmGrenadeBase">
-		<defName>Ammo_25x59mmGrenade_HE_TFuzed</defName>
-		<label>25x59mm grenade (HE Time-Fuzed)</label>
-		<graphicData>
-			<texPath>Things/Ammo/GrenadeLauncher/AIR</texPath>
-			<graphicClass>Graphic_StackCount</graphicClass>
-		</graphicData>
-		<statBases>
-			<MarketValue>3.17</MarketValue>
-		</statBases>
-		<ammoClass>GrenadeHETF</ammoClass>
-		<detonateProjectile>Bullet_25x59mmGrenade_HE</detonateProjectile>
-	</ThingDef>
-
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="25x59mmGrenadeBase">
 		<defName>Ammo_25x59mmGrenade_EMP</defName>
 		<label>25x59mm grenade (EMP)</label>
 		<graphicData>
@@ -92,7 +92,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>3.43</MarketValue>
+			<MarketValue>4.08</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeEMP</ammoClass>
 		<generateAllowChance>0.5</generateAllowChance>
@@ -129,12 +129,53 @@
 	</ThingDef>
 
 	<ThingDef ParentName="Base25x59mmGrenadeBullet">
+		<defName>Bullet_25x59mmGrenade_HE</defName>
+		<label>25x59mm grenade</label>
+		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bomb</damageDef>
+			<damageAmountBase>19</damageAmountBase>
+			<explosionRadius>1</explosionRadius>
+			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+		</projectile>
+		<comps>
+			<li Class="CombatExtended.CompProperties_Fragments">
+				<fragments>
+					<Fragment_Small>24</Fragment_Small>
+				</fragments>
+			</li>
+		</comps>
+	</ThingDef>
+
+	<ThingDef ParentName="Base25x59mmGrenadeBullet">
+		<defName>Bullet_25x59mmGrenade_HE_TFuzed</defName>
+		<thingClass>CombatExtended.ProjectileCE_Bursting</thingClass>
+		<label>25x59mm grenade (HE Time-Fuzed)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bomb</damageDef>
+			<damageAmountBase>19</damageAmountBase>
+			<explosionRadius>1</explosionRadius>
+			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			<aimHeightOffset>1.4</aimHeightOffset>
+			<armingDelay>2</armingDelay>
+		</projectile>
+		<comps>
+			<li Class="CombatExtended.CompProperties_Fragments">
+				<fragments>
+					<Fragment_Small>24</Fragment_Small>
+				</fragments>
+				<fragAngleRange>-89~-5</fragAngleRange>
+			</li>
+		</comps>
+	</ThingDef>
+
+	<ThingDef ParentName="Base25x59mmGrenadeBullet">
 		<defName>Bullet_25x59mmGrenade_HEDP</defName>
 		<label>25x59mm grenade</label>
 		<thingClass>CombatExtended.BulletCE</thingClass>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<damageAmountBase>28</damageAmountBase>
+			<damageAmountBase>26</damageAmountBase>
 			<armorPenetrationSharp>50</armorPenetrationSharp>
 			<armorPenetrationBlunt>4.818</armorPenetrationBlunt>
 		</projectile>
@@ -154,53 +195,12 @@
 	</ThingDef>
 
 	<ThingDef ParentName="Base25x59mmGrenadeBullet">
-		<defName>Bullet_25x59mmGrenade_HE</defName>
-		<label>25x59mm grenade</label>
-		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>Bomb</damageDef>
-			<damageAmountBase>16</damageAmountBase>
-			<explosionRadius>1</explosionRadius>
-			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-		</projectile>
-		<comps>
-			<li Class="CombatExtended.CompProperties_Fragments">
-				<fragments>
-					<Fragment_Small>24</Fragment_Small>
-				</fragments>
-			</li>
-		</comps>
-	</ThingDef>
-
-	<ThingDef ParentName="Base25x59mmGrenadeBullet">
-		<defName>Bullet_25x59mmGrenade_HE_TFuzed</defName>
-		<thingClass>CombatExtended.ProjectileCE_Bursting</thingClass>
-		<label>25x59mm grenade (HE Time-Fuzed)</label>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<explosionRadius>1.0</explosionRadius>
-			<damageDef>Bomb</damageDef>
-			<damageAmountBase>16</damageAmountBase>
-			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-			<aimHeightOffset>1.4</aimHeightOffset>
-			<armingDelay>2</armingDelay>
-		</projectile>
-		<comps>
-			<li Class="CombatExtended.CompProperties_Fragments">
-				<fragments>
-					<Fragment_Small>24</Fragment_Small>
-				</fragments>
-				<fragAngleRange>-89~-5</fragAngleRange>
-			</li>
-		</comps>
-	</ThingDef>
-
-	<ThingDef ParentName="Base25x59mmGrenadeBullet">
 		<defName>Bullet_25x59mmGrenade_EMP</defName>
 		<label>25x59mm grenade</label>
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>EMP</damageDef>
-			<damageAmountBase>16</damageAmountBase>
+			<damageAmountBase>19</damageAmountBase>
 			<explosionRadius>1.5</explosionRadius>
 		</projectile>
 	</ThingDef>
@@ -219,6 +219,95 @@
 	</ThingDef>
 
 	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="LauncherAmmoRecipeBase">
+		<defName>MakeAmmo_25x59mmGrenade_HE</defName>
+		<label>make 25x59mm HE grenades x100</label>
+		<description>Craft 100 25x59mm HE grenades.</description>
+		<jobString>Making 25x59mm HE grenades.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>58</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>FSX</li>
+					</thingDefs>
+				</filter>
+				<count>7</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>2</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>FSX</li>
+				<li>ComponentIndustrial</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_25x59mmGrenade_HE>100</Ammo_25x59mmGrenade_HE>
+		</products>
+		<workAmount>9800</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="LauncherAmmoRecipeBase">
+		<defName>MakeAmmo_25x59mmGrenade_HE_TFuzed</defName>
+		<label>make 25x59mm HE Time-Fuzed grenades x100</label>
+		<description>Craft 100 25x59mm HE Time-Fuzed grenades.</description>
+		<jobString>Making 25x59mm HE Time-Fuzed grenades.</jobString>
+		<researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>58</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>FSX</li>
+					</thingDefs>
+				</filter>
+				<count>7</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>5</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>FSX</li>
+				<li>ComponentIndustrial</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_25x59mmGrenade_HE_TFuzed>100</Ammo_25x59mmGrenade_HE_TFuzed>
+		</products>
+		<workAmount>11600</workAmount>
+	</RecipeDef>
 
 	<RecipeDef ParentName="LauncherAmmoRecipeBase">
 		<defName>MakeAmmo_25x59mmGrenade_HEDP</defName>
@@ -265,95 +354,6 @@
 	</RecipeDef>
 
 	<RecipeDef ParentName="LauncherAmmoRecipeBase">
-		<defName>MakeAmmo_25x59mmGrenade_HE</defName>
-		<label>make 25x59mm HE grenades x100</label>
-		<description>Craft 100 25x59mm HE grenades.</description>
-		<jobString>Making 25x59mm HE grenades.</jobString>
-		<ingredients>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>Steel</li>
-					</thingDefs>
-				</filter>
-				<count>58</count>
-			</li>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>FSX</li>
-					</thingDefs>
-				</filter>
-				<count>5</count>
-			</li>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>ComponentIndustrial</li>
-					</thingDefs>
-				</filter>
-				<count>2</count>
-			</li>
-		</ingredients>
-		<fixedIngredientFilter>
-			<thingDefs>
-				<li>Steel</li>
-				<li>FSX</li>
-				<li>ComponentIndustrial</li>
-			</thingDefs>
-		</fixedIngredientFilter>
-		<products>
-			<Ammo_25x59mmGrenade_HE>100</Ammo_25x59mmGrenade_HE>
-		</products>
-		<workAmount>9000</workAmount>
-	</RecipeDef>
-
-	<RecipeDef ParentName="LauncherAmmoRecipeBase">
-		<defName>MakeAmmo_25x59mmGrenade_HE_TFuzed</defName>
-		<label>make 25x59mm HE Time-Fuzed grenades x100</label>
-		<description>Craft 100 25x59mm HE Time-Fuzed grenades.</description>
-		<jobString>Making 25x59mm HE Time-Fuzed grenades.</jobString>
-		<researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
-		<ingredients>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>Steel</li>
-					</thingDefs>
-				</filter>
-				<count>58</count>
-			</li>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>FSX</li>
-					</thingDefs>
-				</filter>
-				<count>5</count>
-			</li>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>ComponentIndustrial</li>
-					</thingDefs>
-				</filter>
-				<count>5</count>
-			</li>
-		</ingredients>
-		<fixedIngredientFilter>
-			<thingDefs>
-				<li>Steel</li>
-				<li>FSX</li>
-				<li>ComponentIndustrial</li>
-			</thingDefs>
-		</fixedIngredientFilter>
-		<products>
-			<Ammo_25x59mmGrenade_HE_TFuzed>100</Ammo_25x59mmGrenade_HE_TFuzed>
-		</products>
-		<workAmount>10800</workAmount>
-	</RecipeDef>
-
-	<RecipeDef ParentName="LauncherAmmoRecipeBase">
 		<defName>MakeAmmo_25x59mmGrenade_EMP</defName>
 		<label>make 25x59mm EMP grenades x100</label>
 		<description>Craft 100 25x59mm EMP grenades.</description>
@@ -377,7 +377,7 @@
 						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
-				<count>7</count>
+				<count>9</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -389,7 +389,7 @@
 		<products>
 			<Ammo_25x59mmGrenade_EMP>100</Ammo_25x59mmGrenade_EMP>
 		</products>
-		<workAmount>10000</workAmount>
+		<workAmount>11200</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="LauncherAmmoRecipeBase">

--- a/Defs/Ammo/Grenade/25x59mmGrenade.xml
+++ b/Defs/Ammo/Grenade/25x59mmGrenade.xml
@@ -175,7 +175,7 @@
 		<thingClass>CombatExtended.BulletCE</thingClass>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<damageAmountBase>26</damageAmountBase>
+			<damageAmountBase>30</damageAmountBase>
 			<armorPenetrationSharp>50</armorPenetrationSharp>
 			<armorPenetrationBlunt>4.818</armorPenetrationBlunt>
 		</projectile>

--- a/Defs/Ammo/Grenade/30x29mmGrenade.xml
+++ b/Defs/Ammo/Grenade/30x29mmGrenade.xml
@@ -49,7 +49,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>2.67</MarketValue>
+			<MarketValue>2.75</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHE</ammoClass>
 		<detonateProjectile>Bullet_30x29mmGrenade_HE</detonateProjectile>
@@ -63,7 +63,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>3.65</MarketValue>
+			<MarketValue>3.72</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHETF</ammoClass>
 		<detonateProjectile>Bullet_30x29mmGrenade_HE</detonateProjectile>
@@ -109,7 +109,7 @@
 			<drawSize>(0.4,0.4)</drawSize>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>52</speed>
+			<speed>51</speed>
 			<flyOverhead>false</flyOverhead>
 		</projectile>
 	</ThingDef>
@@ -120,7 +120,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<explosionRadius>1</explosionRadius>
 			<damageDef>Bomb</damageDef>
-			<damageAmountBase>20</damageAmountBase>
+			<damageAmountBase>21</damageAmountBase>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 		</projectile>
 		<comps>
@@ -139,7 +139,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<explosionRadius>1</explosionRadius>
 			<damageDef>Bomb</damageDef>
-			<damageAmountBase>20</damageAmountBase>
+			<damageAmountBase>21</damageAmountBase>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 			<aimHeightOffset>1.4</aimHeightOffset>
 			<armingDelay>2</armingDelay>
@@ -160,7 +160,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<explosionRadius>1.5</explosionRadius>
 			<damageDef>EMP</damageDef>
-			<damageAmountBase>20</damageAmountBase>
+			<damageAmountBase>21</damageAmountBase>
 		</projectile>
 	</ThingDef>
 
@@ -199,7 +199,7 @@
 						<li>FSX</li>
 					</thingDefs>
 				</filter>
-				<count>7</count>
+				<count>8</count>
 			</li>
 			<li>
 				<filter>
@@ -220,7 +220,7 @@
 		<products>
 			<Ammo_30x29mmGrenade_HE>100</Ammo_30x29mmGrenade_HE>
 		</products>
-		<workAmount>11400</workAmount>
+		<workAmount>11800</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="LauncherAmmoRecipeBase">
@@ -243,7 +243,7 @@
 						<li>FSX</li>
 					</thingDefs>
 				</filter>
-				<count>7</count>
+				<count>8</count>
 			</li>
 			<li>
 				<filter>
@@ -264,7 +264,7 @@
 		<products>
 			<Ammo_30x29mmGrenade_HE_TFuzed>100</Ammo_30x29mmGrenade_HE_TFuzed>
 		</products>
-		<workAmount>13200</workAmount>
+		<workAmount>13600</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="LauncherAmmoRecipeBase">

--- a/Defs/Ammo/Grenade/30x29mmGrenade.xml
+++ b/Defs/Ammo/Grenade/30x29mmGrenade.xml
@@ -77,7 +77,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>4.72</MarketValue>
+			<MarketValue>5.05</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeEMP</ammoClass>
 		<generateAllowChance>0.5</generateAllowChance>
@@ -120,7 +120,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<explosionRadius>1</explosionRadius>
 			<damageDef>Bomb</damageDef>
-			<damageAmountBase>21</damageAmountBase>
+			<damageAmountBase>22</damageAmountBase>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 		</projectile>
 		<comps>
@@ -139,7 +139,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<explosionRadius>1</explosionRadius>
 			<damageDef>Bomb</damageDef>
-			<damageAmountBase>21</damageAmountBase>
+			<damageAmountBase>22</damageAmountBase>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 			<aimHeightOffset>1.4</aimHeightOffset>
 			<armingDelay>2</armingDelay>
@@ -158,9 +158,9 @@
 		<defName>Bullet_30x29mmGrenade_EMP</defName>
 		<label>30x29mm grenade (EMP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<explosionRadius>1.5</explosionRadius>
+			<explosionRadius>2</explosionRadius>
 			<damageDef>EMP</damageDef>
-			<damageAmountBase>21</damageAmountBase>
+			<damageAmountBase>22</damageAmountBase>
 		</projectile>
 	</ThingDef>
 
@@ -291,7 +291,7 @@
 						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
-				<count>10</count>
+				<count>11</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>

--- a/Defs/Ammo/Grenade/35x32mmSRGrenade.xml
+++ b/Defs/Ammo/Grenade/35x32mmSRGrenade.xml
@@ -137,7 +137,7 @@
 		<label>35x32mmSR grenade (HEDP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<damageAmountBase>23</damageAmountBase>
+			<damageAmountBase>31</damageAmountBase>
 			<armorPenetrationSharp>55</armorPenetrationSharp>
 			<armorPenetrationBlunt>5.552</armorPenetrationBlunt>
 		</projectile>

--- a/Defs/Ammo/Grenade/35x32mmSRGrenade.xml
+++ b/Defs/Ammo/Grenade/35x32mmSRGrenade.xml
@@ -49,7 +49,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>2.12</MarketValue>
+			<MarketValue>2.19</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHE</ammoClass>
 		<detonateProjectile>Bullet_35x32mmSRGrenade_HE</detonateProjectile>
@@ -63,7 +63,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>2.12</MarketValue>
+			<MarketValue>2.04</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHEDP</ammoClass>
 		<detonateProjectile>Bullet_35x32mmSRGrenade_HE</detonateProjectile>
@@ -92,7 +92,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>1.77</MarketValue>
+			<MarketValue>1.84</MarketValue>
 		</statBases>
 		<ammoClass>Smoke</ammoClass>
 		<generateAllowChance>0</generateAllowChance>
@@ -119,7 +119,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<explosionRadius>1</explosionRadius>
 			<damageDef>Bomb</damageDef>
-			<damageAmountBase>19</damageAmountBase>
+			<damageAmountBase>20</damageAmountBase>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 		</projectile>
 		<comps>
@@ -137,13 +137,13 @@
 		<label>35x32mmSR grenade (HEDP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<damageAmountBase>17</damageAmountBase>
+			<damageAmountBase>23</damageAmountBase>
 			<armorPenetrationSharp>55</armorPenetrationSharp>
 			<armorPenetrationBlunt>5.552</armorPenetrationBlunt>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>19</damageAmountBase>
+				<damageAmountBase>17</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
 				<explosiveRadius>0.5</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
@@ -163,7 +163,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<explosionRadius>1.5</explosionRadius>
 			<damageDef>EMP</damageDef>
-			<damageAmountBase>19</damageAmountBase>
+			<damageAmountBase>20</damageAmountBase>
 		</projectile>
 	</ThingDef>
 
@@ -202,7 +202,7 @@
 						<li>FSX</li>
 					</thingDefs>
 				</filter>
-				<count>6</count>
+				<count>7</count>
 			</li>
 			<li>
 				<filter>
@@ -223,7 +223,7 @@
 		<products>
 			<Ammo_35x32mmSRGrenade_HE>100</Ammo_35x32mmSRGrenade_HE>
 		</products>
-		<workAmount>8600</workAmount>
+		<workAmount>9000</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="LauncherAmmoRecipeBase">
@@ -238,7 +238,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>46</count>
+				<count>50</count>
 			</li>
 			<li>
 				<filter>
@@ -246,7 +246,7 @@
 						<li>FSX</li>
 					</thingDefs>
 				</filter>
-				<count>8</count>
+				<count>5</count>
 			</li>
 			<li>
 				<filter>
@@ -267,7 +267,7 @@
 		<products>
 			<Ammo_35x32mmSRGrenade_HEDP>100</Ammo_35x32mmSRGrenade_HEDP>
 		</products>
-		<workAmount>9000</workAmount>
+		<workAmount>8200</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="LauncherAmmoRecipeBase">
@@ -329,7 +329,7 @@
 						<li>Prometheum</li>
 					</thingDefs>
 				</filter>
-				<count>2</count>
+				<count>3</count>
 			</li>
 			<li>
 				<filter>
@@ -350,7 +350,7 @@
 		<products>
 			<Ammo_35x32mmSRGrenade_Smoke>100</Ammo_35x32mmSRGrenade_Smoke>
 		</products>
-		<workAmount>7000</workAmount>
+		<workAmount>7400</workAmount>
 	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Grenade/40x46mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x46mmGrenade.xml
@@ -192,7 +192,7 @@
 		<label>40x46mm grenade (HEDP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<damageAmountBase>19</damageAmountBase>
+			<damageAmountBase>35</damageAmountBase>
 			<armorPenetrationSharp>63</armorPenetrationSharp>
 			<armorPenetrationBlunt>5.942</armorPenetrationBlunt>
 		</projectile>

--- a/Defs/Ammo/Grenade/40x46mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x46mmGrenade.xml
@@ -50,7 +50,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>2.19</MarketValue>
+			<MarketValue>2.27</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHE</ammoClass>
 		<detonateProjectile>Bullet_40x46mmGrenade_HE</detonateProjectile>
@@ -64,7 +64,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>3.17</MarketValue>
+			<MarketValue>3.25</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHETF</ammoClass>
 		<detonateProjectile>Bullet_40x46mmGrenade_HE</detonateProjectile>
@@ -78,7 +78,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>2.19</MarketValue>
+			<MarketValue>2.12</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHEDP</ammoClass>
 		<detonateProjectile>Bullet_40x46mmGrenade_HE</detonateProjectile>
@@ -92,7 +92,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>4.25</MarketValue>
+			<MarketValue>4.57</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeEMP</ammoClass>
 		<generateAllowChance>0.5</generateAllowChance>
@@ -152,7 +152,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<explosionRadius>1.0</explosionRadius>
 			<damageDef>Bomb</damageDef>
-			<damageAmountBase>20</damageAmountBase>
+			<damageAmountBase>22</damageAmountBase>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 		</projectile>
 		<comps>
@@ -171,7 +171,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<explosionRadius>1.0</explosionRadius>
 			<damageDef>Bomb</damageDef>
-			<damageAmountBase>20</damageAmountBase>
+			<damageAmountBase>22</damageAmountBase>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 			<aimHeightOffset>1.4</aimHeightOffset>
 			<armingDelay>2</armingDelay>
@@ -192,13 +192,13 @@
 		<label>40x46mm grenade (HEDP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<damageAmountBase>9</damageAmountBase>
+			<damageAmountBase>19</damageAmountBase>
 			<armorPenetrationSharp>63</armorPenetrationSharp>
 			<armorPenetrationBlunt>5.942</armorPenetrationBlunt>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>20</damageAmountBase>
+				<damageAmountBase>18</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
 				<explosiveRadius>0.5</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
@@ -217,7 +217,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<explosionRadius>1.5</explosionRadius>
 			<damageDef>EMP</damageDef>
-			<damageAmountBase>20</damageAmountBase>
+			<damageAmountBase>22</damageAmountBase>
 		</projectile>
 	</ThingDef>
 
@@ -238,7 +238,7 @@
 		<defName>Bullet_40x46mmGrenade_Tox</defName>
 		<label>40x46mm grenade (Tox)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<explosionRadius>1.9</explosionRadius>
+			<explosionRadius>2</explosionRadius>
 			<damageDef>ToxGas</damageDef>
 			<postExplosionGasType>ToxGas</postExplosionGasType>
 			<preExplosionSpawnChance>1</preExplosionSpawnChance>
@@ -267,7 +267,7 @@
 						<li>FSX</li>
 					</thingDefs>
 				</filter>
-				<count>7</count>
+				<count>8</count>
 			</li>
 			<li>
 				<filter>
@@ -288,7 +288,7 @@
 		<products>
 			<Ammo_40x46mmGrenade_HE>100</Ammo_40x46mmGrenade_HE>
 		</products>
-		<workAmount>9000</workAmount>
+		<workAmount>9400</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="LauncherAmmoRecipeBase">
@@ -312,7 +312,7 @@
 						<li>FSX</li>
 					</thingDefs>
 				</filter>
-				<count>7</count>
+				<count>8</count>
 			</li>
 			<li>
 				<filter>
@@ -333,7 +333,7 @@
 		<products>
 			<Ammo_40x46mmGrenade_HE_TFuzed>100</Ammo_40x46mmGrenade_HE_TFuzed>
 		</products>
-		<workAmount>10800</workAmount>
+		<workAmount>11200</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="LauncherAmmoRecipeBase">
@@ -356,7 +356,7 @@
 						<li>FSX</li>
 					</thingDefs>
 				</filter>
-				<count>7</count>
+				<count>6</count>
 			</li>
 			<li>
 				<filter>
@@ -377,7 +377,7 @@
 		<products>
 			<Ammo_40x46mmGrenade_HEDP>100</Ammo_40x46mmGrenade_HEDP>
 		</products>
-		<workAmount>9000</workAmount>
+		<workAmount>8600</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="LauncherAmmoRecipeBase">
@@ -404,7 +404,7 @@
 						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
-				<count>10</count>
+				<count>11</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -416,7 +416,7 @@
 		<products>
 			<Ammo_40x46mmGrenade_EMP>100</Ammo_40x46mmGrenade_EMP>
 		</products>
-		<workAmount>11000</workAmount>
+		<workAmount>11600</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="LauncherAmmoRecipeBase">

--- a/Defs/Ammo/Grenade/40x53mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmGrenade.xml
@@ -177,7 +177,7 @@
 		<label>40x53mm grenade (HEDP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<damageAmountBase>26</damageAmountBase>
+			<damageAmountBase>36</damageAmountBase>
 			<armorPenetrationSharp>76</armorPenetrationSharp>
 			<armorPenetrationBlunt>5.942</armorPenetrationBlunt>
 		</projectile>

--- a/Defs/Ammo/Grenade/40x53mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmGrenade.xml
@@ -50,7 +50,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>2.71</MarketValue>
+			<MarketValue>2.87</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHE</ammoClass>
 		<detonateProjectile>Bullet_40x53mmGrenade_HE</detonateProjectile>
@@ -64,7 +64,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>3.59</MarketValue>
+			<MarketValue>3.84</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHETF</ammoClass>
 		<detonateProjectile>Bullet_40x53mmGrenade_HE</detonateProjectile>
@@ -92,7 +92,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>4.76</MarketValue>
+			<MarketValue>5.09</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeEMP</ammoClass>
 		<generateAllowChance>0.5</generateAllowChance>
@@ -137,7 +137,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<explosionRadius>1</explosionRadius>
 			<damageDef>Bomb</damageDef>
-			<damageAmountBase>20</damageAmountBase>
+			<damageAmountBase>23</damageAmountBase>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 		</projectile>
 		<comps>
@@ -156,7 +156,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<explosionRadius>1.0</explosionRadius>
 			<damageDef>Bomb</damageDef>
-			<damageAmountBase>20</damageAmountBase>
+			<damageAmountBase>23</damageAmountBase>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 			<aimHeightOffset>1.4</aimHeightOffset>
 			<armingDelay>2</armingDelay>
@@ -177,13 +177,13 @@
 		<label>40x53mm grenade (HEDP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<damageAmountBase>25</damageAmountBase>
+			<damageAmountBase>26</damageAmountBase>
 			<armorPenetrationSharp>76</armorPenetrationSharp>
 			<armorPenetrationBlunt>5.942</armorPenetrationBlunt>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>20</damageAmountBase>
+				<damageAmountBase>19</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
 				<explosiveRadius>0.5</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
@@ -202,7 +202,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<explosionRadius>1.5</explosionRadius>
 			<damageDef>EMP</damageDef>
-			<damageAmountBase>20</damageAmountBase>
+			<damageAmountBase>23</damageAmountBase>
 		</projectile>
 	</ThingDef>
 
@@ -210,7 +210,7 @@
 		<defName>Bullet_40x53mmGrenade_Smoke</defName>
 		<label>40x53mm grenade (Smoke)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<explosionRadius>2</explosionRadius>
+			<explosionRadius>2.5</explosionRadius>
 			<damageDef>Smoke</damageDef>
 			<suppressionFactor>0.0</suppressionFactor>
 			<dangerFactor>0.0</dangerFactor>
@@ -241,7 +241,7 @@
 						<li>FSX</li>
 					</thingDefs>
 				</filter>
-				<count>7</count>
+				<count>9</count>
 			</li>
 			<li>
 				<filter>
@@ -262,7 +262,7 @@
 		<products>
 			<Ammo_40x53mmGrenade_HE>100</Ammo_40x53mmGrenade_HE>
 		</products>
-		<workAmount>11600</workAmount>
+		<workAmount>12400</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="LauncherAmmoRecipeBase">
@@ -286,7 +286,7 @@
 						<li>FSX</li>
 					</thingDefs>
 				</filter>
-				<count>7</count>
+				<count>9</count>
 			</li>
 			<li>
 				<filter>
@@ -307,7 +307,7 @@
 		<products>
 			<Ammo_40x53mmGrenade_HE_TFuzed>100</Ammo_40x53mmGrenade_HE_TFuzed>
 		</products>
-		<workAmount>13400</workAmount>
+		<workAmount>14200</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="LauncherAmmoRecipeBase">
@@ -330,7 +330,7 @@
 						<li>FSX</li>
 					</thingDefs>
 				</filter>
-				<count>12</count>
+				<count>7</count>
 			</li>
 			<li>
 				<filter>
@@ -351,7 +351,7 @@
 		<products>
 			<Ammo_40x53mmGrenade_HEDP>100</Ammo_40x53mmGrenade_HEDP>
 		</products>
-		<workAmount>13600</workAmount>
+		<workAmount>11600</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="LauncherAmmoRecipeBase">
@@ -378,7 +378,7 @@
 						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
-				<count>10</count>
+				<count>11</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -390,7 +390,7 @@
 		<products>
 			<Ammo_40x53mmGrenade_EMP>100</Ammo_40x53mmGrenade_EMP>
 		</products>
-		<workAmount>13600</workAmount>
+		<workAmount>14200</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="LauncherAmmoRecipeBase">


### PR DESCRIPTION
## Changes

- Updated the stats of launcher grenades, especially the filling amount.
- Introduced a new formula for HEDP damage calculations based on explosive filling and reduced its filling amount by 25% since not all of it is used for the external explosion, some of it is used to deal the bullet damage.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
