### PR TITLE
Patch for Appliances Expanded - Chemfuel smithy

### DIFF
--- a/Patches/Appliances Expanded/CA_ChemfuelSmithy.xml
+++ b/Patches/Appliances Expanded/CA_ChemfuelSmithy.xml
@@ -1,14 +1,18 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <Patch>
-    <Operation Class="PatchOperationFindMod">
-        <mods>
-            <li>Appliances Expanded</li>
-        </mods>
-        <match Class="PatchOperationAdd">
-            <xpath>Defs/ThingDef[contains(tradeTags, "CE_AutoEnableCrafting_FueledSmithy")]/tradeTags</xpath>
-                <value>
-                    <li>CE_AutoEnableCrafting_CA_ChemfuelSmithy</li>
-                </value>
-        </match>
-    </Operation>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Appliances Expanded</li>
+		</mods>
+
+		<match Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[contains(tradeTags, "CE_AutoEnableCrafting_FueledSmithy")]/tradeTags</xpath>
+			<value>
+				<li>CE_AutoEnableCrafting_CA_ChemfuelSmithy</li>
+			</value>
+		</match>
+
+	</Operation>
+
 </Patch>

--- a/Patches/Appliances Expanded/CA_ChemfuelSmithy.xml
+++ b/Patches/Appliances Expanded/CA_ChemfuelSmithy.xml
@@ -6,13 +6,34 @@
 			<li>Appliances Expanded</li>
 		</mods>
 
-		<match Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[contains(tradeTags, "CE_AutoEnableCrafting_FueledSmithy")]/tradeTags</xpath>
-			<value>
-				<li>CE_AutoEnableCrafting_CA_ChemfuelSmithy</li>
-			</value>
-		</match>
+    <match Class="PatchOperationFindMod">
+      <mods>
+        <li>Vanilla Furniture Expanded - Production</li>
+      </mods>
+      
+      <!-- Patches for the large smithy if VFE: Production is loaded too -->
+		  <match Class="PatchOperationAdd">
+			  <xpath>Defs/ThingDef[contains(tradeTags, "CE_AutoEnableCrafting_FueledSmithy")]/tradeTags</xpath>
+			    <value>
+				    <li>CE_AutoEnableCrafting_CA_ChemfuelSmithy</li>
+            <li>CE_AutoEnableCrafting_CE_FueledSmithyLarge</li>
+			    </value>
+	  	</match>
 
+      <!-- Patches base Chemfuel smithy standalone -->
+      <nomatch Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[contains(tradeTags, "CE_AutoEnableCrafting_FueledSmithy")]/tradeTags</xpath>
+          <value>
+            <li>CE_AutoEnableCrafting_CA_ChemfuelSmithy</li>
+          </value>
+      </nomatch>
+
+    </match>
+    
 	</Operation>
 
+</Patch>
+            
+        </match>
+    </Operation>
 </Patch>

--- a/Patches/Appliances Expanded/CA_ChemfuelSmithy.xml
+++ b/Patches/Appliances Expanded/CA_ChemfuelSmithy.xml
@@ -2,34 +2,33 @@
 <Patch>
 
 	<Operation Class="PatchOperationFindMod">
-	  <mods>
-	    <li>Appliances Expanded</li>
-	  </mods>
+		<mods>
+			<li>Appliances Expanded</li>
+		</mods>
 
-      <match Class="PatchOperationFindMod">
-        <mods>
-          <li>Vanilla Furniture Expanded - Production</li>
-        </mods>
-      
-        <!-- Patches for the large smithy if VFE: Production is loaded too -->
-		<match Class="PatchOperationAdd">
-		  <xpath>Defs/ThingDef[contains(tradeTags, "CE_AutoEnableCrafting_FueledSmithy")]/tradeTags</xpath>
-		    <value>
-		      <li>CE_AutoEnableCrafting_CA_ChemfuelSmithy</li>
-              <li>CE_AutoEnableCrafting_CE_FueledSmithyLarge</li>
-		  	</value>
-	  	</match>
+		<match Class="PatchOperationFindMod">
+			<mods>
+				<li>Vanilla Furniture Expanded - Production</li>
+			</mods>
 
-        <!-- Patches base Chemfuel smithy standalone -->
-        <nomatch Class="PatchOperationAdd">
-          <xpath>Defs/ThingDef[contains(tradeTags, "CE_AutoEnableCrafting_FueledSmithy")]/tradeTags</xpath>
-            <value>
-              <li>CE_AutoEnableCrafting_CA_ChemfuelSmithy</li>
-            </value>
-        </nomatch>
+			<!-- Patches for the large smithy if VFE: Production is loaded too -->
+			<match Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[contains(tradeTags, "CE_AutoEnableCrafting_FueledSmithy")]/tradeTags</xpath>
+				<value>
+					<li>CE_AutoEnableCrafting_CA_ChemfuelSmithy</li>
+					<li>CE_AutoEnableCrafting_CE_FueledSmithyLarge</li>
+				</value>
+			</match>
 
-      </match>
-    
+			<!-- Patches base Chemfuel smithy standalone -->
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[contains(tradeTags, "CE_AutoEnableCrafting_FueledSmithy")]/tradeTags</xpath>
+				<value>
+					<li>CE_AutoEnableCrafting_CA_ChemfuelSmithy</li>
+				</value>
+			</nomatch>
+
+		</match>
 	</Operation>
 
 </Patch>

--- a/Patches/Appliances Expanded/CA_ChemfuelSmithy.xml
+++ b/Patches/Appliances Expanded/CA_ChemfuelSmithy.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+            <li>Appliances Expanded</li>
+        </mods>
+        <match Class="PatchOperationAdd">
+            <xpath>Defs/ThingDef[contains(tradeTags, "CE_AutoEnableCrafting_FueledSmithy")]/tradeTags</xpath>
+                <value>
+                    <li>CE_AutoEnableCrafting_CA_ChemfuelSmithy</li>
+                </value>
+        </match>
+    </Operation>
+</Patch>

--- a/Patches/Appliances Expanded/CA_ChemfuelSmithy.xml
+++ b/Patches/Appliances Expanded/CA_ChemfuelSmithy.xml
@@ -2,38 +2,34 @@
 <Patch>
 
 	<Operation Class="PatchOperationFindMod">
-		<mods>
-			<li>Appliances Expanded</li>
-		</mods>
+	  <mods>
+	    <li>Appliances Expanded</li>
+	  </mods>
 
-    <match Class="PatchOperationFindMod">
-      <mods>
-        <li>Vanilla Furniture Expanded - Production</li>
-      </mods>
+      <match Class="PatchOperationFindMod">
+        <mods>
+          <li>Vanilla Furniture Expanded - Production</li>
+        </mods>
       
-      <!-- Patches for the large smithy if VFE: Production is loaded too -->
-		  <match Class="PatchOperationAdd">
-			  <xpath>Defs/ThingDef[contains(tradeTags, "CE_AutoEnableCrafting_FueledSmithy")]/tradeTags</xpath>
-			    <value>
-				    <li>CE_AutoEnableCrafting_CA_ChemfuelSmithy</li>
-            <li>CE_AutoEnableCrafting_CE_FueledSmithyLarge</li>
-			    </value>
+        <!-- Patches for the large smithy if VFE: Production is loaded too -->
+		<match Class="PatchOperationAdd">
+		  <xpath>Defs/ThingDef[contains(tradeTags, "CE_AutoEnableCrafting_FueledSmithy")]/tradeTags</xpath>
+		    <value>
+		      <li>CE_AutoEnableCrafting_CA_ChemfuelSmithy</li>
+              <li>CE_AutoEnableCrafting_CE_FueledSmithyLarge</li>
+		  	</value>
 	  	</match>
 
-      <!-- Patches base Chemfuel smithy standalone -->
-      <nomatch Class="PatchOperationAdd">
-        <xpath>Defs/ThingDef[contains(tradeTags, "CE_AutoEnableCrafting_FueledSmithy")]/tradeTags</xpath>
-          <value>
-            <li>CE_AutoEnableCrafting_CA_ChemfuelSmithy</li>
-          </value>
-      </nomatch>
+        <!-- Patches base Chemfuel smithy standalone -->
+        <nomatch Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[contains(tradeTags, "CE_AutoEnableCrafting_FueledSmithy")]/tradeTags</xpath>
+            <value>
+              <li>CE_AutoEnableCrafting_CA_ChemfuelSmithy</li>
+            </value>
+        </nomatch>
 
-    </match>
+      </match>
     
 	</Operation>
 
-</Patch>
-            
-        </match>
-    </Operation>
 </Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -101,6 +101,7 @@ Anty the War Ant Race |
 AOC The Cleanup Devil |
 Apex: Rimworld Legends (Continued)  |
 Apparello 2	|
+Appliances Expanded	|
 Arachne Race	|
 Archotech Expanded  |
 Archotech Expanded Prosthetics  |


### PR DESCRIPTION
## Additions
Fixes ammo inheritance on Appliances Expanded for the Chemfuel Smithy.

## Changes
Used 'generic' patch by targeting the ElectricSmithy tradeTags on ammunition defs and adding the required AutoEnableCrafting tag to them for the CA_ChemfuelSmithy

## Reasoning
Simple and ensures all ammos, including any added by ANYTHING and other mods, is patched appropriately to the matching workbench type.

## Alternatives
N/A

## Testing
Patch works in local copy.
