### PR TITLE
Charge weapon crafting recipe tweaks

### DIFF
--- a/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
@@ -109,7 +109,7 @@
 		</graphicData>
 		<uiIconPath>UI/Icons/Turrets/ChargeBlaster_uiIcon</uiIconPath>
 		<statBases>
-			<WorkToBuild>48000</WorkToBuild>
+			<WorkToBuild>46000</WorkToBuild>
 			<MaxHitPoints>150</MaxHitPoints>
 			<Mass>20</Mass>
 			<Bulk>25</Bulk>
@@ -128,7 +128,8 @@
 		<costList>
 			<Steel>125</Steel>
 			<Plasteel>40</Plasteel>
-			<ComponentIndustrial>12</ComponentIndustrial>
+			<ComponentIndustrial>6</ComponentIndustrial>
+			<ComponentSpacer>1</ComponentSpacer>
 		</costList>
 		<building>
 			<turretGunDef>Gun_BlasterTurret</turretGunDef>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -761,12 +761,13 @@
 			<ShotSpread>0.08</ShotSpread>
 			<SwayFactor>1.20</SwayFactor>
 			<Bulk>7.00</Bulk>
-			<WorkToMake>50500</WorkToMake>
+			<WorkToMake>49000</WorkToMake>
 		</statBases>
 		<costList>
 			<Steel>45</Steel>
 			<Plasteel>25</Plasteel>
-			<ComponentIndustrial>10</ComponentIndustrial>
+			<ComponentIndustrial>4</ComponentIndustrial>
+			<ComponentSpacer>1</ComponentSpacer>
 			<Chemfuel>10</Chemfuel>
 		</costList>
 		<Properties>

--- a/Patches/Vanilla Weapons Expanded/Spacer_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded/Spacer_Ranged.xml
@@ -109,7 +109,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>VWE_Gun_ChargePistol</defName>
 					<statBases>
-						<WorkToMake>17500</WorkToMake>
+						<WorkToMake>16000</WorkToMake>
 						<Mass>1.50</Mass>
 						<Bulk>2.60</Bulk>
 						<SwayFactor>1.07</SwayFactor>
@@ -122,6 +122,7 @@
 						<Plasteel>30</Plasteel>
 						<Chemfuel>5</Chemfuel>
 						<ComponentIndustrial>2</ComponentIndustrial>
+						<ComponentSpacer>1</ComponentSpacer>
 					</costList>
 					<Properties>
 						<recoilAmount>3.0</recoilAmount>
@@ -157,7 +158,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>VWE_Gun_ChargeSMG</defName>
 					<statBases>
-						<WorkToMake>36000</WorkToMake>
+						<WorkToMake>40000</WorkToMake>
 						<Mass>2.80</Mass>
 						<Bulk>5.00</Bulk>
 						<SwayFactor>0.75</SwayFactor>
@@ -169,7 +170,8 @@
 						<Steel>55</Steel>
 						<Plasteel>25</Plasteel>
 						<Chemfuel>15</Chemfuel>
-						<ComponentIndustrial>10</ComponentIndustrial>
+						<ComponentIndustrial>4</ComponentIndustrial>
+						<ComponentSpacer>1</ComponentSpacer>
 					</costList>
 					<Properties>
 						<recoilAmount>1.20</recoilAmount>
@@ -203,7 +205,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>VWE_Gun_ChargeShotgun</defName>
 					<statBases>
-						<WorkToMake>47500</WorkToMake>
+						<WorkToMake>46000</WorkToMake>
 						<Mass>4.35</Mass>
 						<Bulk>6.0</Bulk>
 						<SwayFactor>1.25</SwayFactor>
@@ -215,7 +217,8 @@
 						<Steel>50</Steel>
 						<Plasteel>25</Plasteel>
 						<Chemfuel>15</Chemfuel>
-						<ComponentIndustrial>10</ComponentIndustrial>
+						<ComponentIndustrial>4</ComponentIndustrial>
+						<ComponentSpacer>1</ComponentSpacer>
 					</costList>
 					<Properties>
 						<recoilAmount>3.0</recoilAmount>
@@ -246,7 +249,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>VWE_Gun_ChargeSniperRifle</defName>
 					<statBases>
-						<WorkToMake>50500</WorkToMake>
+						<WorkToMake>49000</WorkToMake>
 						<Mass>8</Mass>
 						<Bulk>14.5</Bulk>
 						<SwayFactor>2.25</SwayFactor>
@@ -259,7 +262,8 @@
 						<Steel>75</Steel>
 						<Plasteel>40</Plasteel>
 						<Chemfuel>15</Chemfuel>
-						<ComponentIndustrial>12</ComponentIndustrial>
+						<ComponentIndustrial>6</ComponentIndustrial>
+						<ComponentSpacer>1</ComponentSpacer>
 					</costList>
 					<Properties>
 						<recoilAmount>1.5</recoilAmount>
@@ -293,7 +297,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>VWE_Gun_ChargeLMG</defName>
 					<statBases>
-						<WorkToMake>57000</WorkToMake>
+						<WorkToMake>55000</WorkToMake>
 						<Mass>9.0</Mass>
 						<Bulk>16.46</Bulk>
 						<SwayFactor>1.26</SwayFactor>
@@ -305,7 +309,8 @@
 						<Steel>65</Steel>
 						<Plasteel>30</Plasteel>
 						<Chemfuel>15</Chemfuel>
-						<ComponentIndustrial>10</ComponentIndustrial>
+						<ComponentIndustrial>4</ComponentIndustrial>
+						<ComponentSpacer>1</ComponentSpacer>
 					</costList>
 					<Properties>
 						<recoilAmount>1.16</recoilAmount>
@@ -346,7 +351,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>VWE_Gun_ChargeMinigun</defName>
 					<statBases>
-						<WorkToMake>75500</WorkToMake>
+						<WorkToMake>60000</WorkToMake>
 						<Mass>20.0</Mass>
 						<Bulk>12.0</Bulk>
 						<SwayFactor>1.35</SwayFactor>
@@ -358,7 +363,8 @@
 						<Steel>120</Steel>
 						<Plasteel>40</Plasteel>
 						<Chemfuel>15</Chemfuel>
-						<ComponentIndustrial>15</ComponentIndustrial>
+						<ComponentIndustrial>6</ComponentIndustrial>
+						<ComponentSpacer>1</ComponentSpacer>
 					</costList>
 					<Properties>
 						<recoilAmount>1.0</recoilAmount>
@@ -392,7 +398,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>VWE_Gun_ChargeRocketLauncher</defName>
 					<statBases>
-						<WorkToMake>90000</WorkToMake>
+						<WorkToMake>88000</WorkToMake>
 						<Mass>24.0</Mass>
 						<Bulk>15.65</Bulk>
 						<SwayFactor>3.24</SwayFactor>
@@ -404,7 +410,8 @@
 						<Steel>125</Steel>
 						<Plasteel>45</Plasteel>
 						<FSX>10</FSX>
-						<ComponentIndustrial>10</ComponentIndustrial>
+						<ComponentIndustrial>4</ComponentIndustrial>
+						<ComponentSpacer>1</ComponentSpacer>
 					</costList>
 					<Properties>
 						<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>


### PR DESCRIPTION
## Changes

- Replaced x6 industrial components in the charge guns' crafting recipe with x1 advanced component and adjusted the workToMake accordingly.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
