### PR TITLE
Shelling distance and long range radio stats

### DIFF
--- a/Defs/Stats/Stats_Basics_Inventory.xml
+++ b/Defs/Stats/Stats_Basics_Inventory.xml
@@ -25,4 +25,14 @@
 		<displayPriorityInCategory>898</displayPriorityInCategory>
 	</StatDef>
 
+  <StatDef>
+    <defName>LongRange</defName>
+    <workerClass>CombatExtended.StatWorker_LongRange</workerClass>
+    <label>distance</label>
+    <description>How many world tiles projectile can fly</description>
+    <category>BasicsNonPawn</category>
+    <showIfUndefined>true</showIfUndefined>
+    <displayPriorityInCategory>899</displayPriorityInCategory>
+  </StatDef>
+
 </Defs>

--- a/Defs/Stats/Stats_Basics_Inventory.xml
+++ b/Defs/Stats/Stats_Basics_Inventory.xml
@@ -25,14 +25,14 @@
 		<displayPriorityInCategory>898</displayPriorityInCategory>
 	</StatDef>
 
-  <StatDef>
-    <defName>LongRange</defName>
-    <workerClass>CombatExtended.StatWorker_LongRange</workerClass>
-    <label>distance</label>
-    <description>How many world tiles projectile can fly</description>
-    <category>BasicsNonPawn</category>
-    <showIfUndefined>true</showIfUndefined>
-    <displayPriorityInCategory>899</displayPriorityInCategory>
-  </StatDef>
+	<StatDef>
+		<defName>LongRange</defName>
+		<workerClass>CombatExtended.StatWorker_LongRange</workerClass>
+		<label>range</label>
+		<description>The projectile's range on the world map.</description>
+		<category>BasicsNonPawn</category>
+		<showIfUndefined>true</showIfUndefined>
+		<displayPriorityInCategory>899</displayPriorityInCategory>
+	</StatDef>
 
 </Defs>

--- a/Languages/English/Keyed/Descriptions.xml
+++ b/Languages/English/Keyed/Descriptions.xml
@@ -26,6 +26,6 @@
 	<CE_FactionRecord_Explanation_SiteDestroyed>Site belonging to {0} was destroyed</CE_FactionRecord_Explanation_SiteDestroyed>
 	<CE_FactionRecord_Explanation_EnemyWeakened>Strengthened after an enemy of {0} was weakened</CE_FactionRecord_Explanation_EnemyWeakened>
 
-  <CE_Long_Range_Radio_Desc>Ability to send coordinates across the planet.</CE_Long_Range_Radio_Desc>
+  <CE_Long_Range_Radio_Desc>Whether or not this item can be used to spot for artillery fire between maps.</CE_Long_Range_Radio_Desc>
 
 </LanguageData>

--- a/Languages/English/Keyed/Descriptions.xml
+++ b/Languages/English/Keyed/Descriptions.xml
@@ -26,4 +26,6 @@
 	<CE_FactionRecord_Explanation_SiteDestroyed>Site belonging to {0} was destroyed</CE_FactionRecord_Explanation_SiteDestroyed>
 	<CE_FactionRecord_Explanation_EnemyWeakened>Strengthened after an enemy of {0} was weakened</CE_FactionRecord_Explanation_EnemyWeakened>
 
+  <CE_Long_Range_Radio_Desc>Ability to send coordinates across the planet.</CE_Long_Range_Radio_Desc>
+
 </LanguageData>

--- a/Languages/English/Keyed/Stats.xml
+++ b/Languages/English/Keyed/Stats.xml
@@ -8,5 +8,6 @@
 	<CE_MassEffect>Carried weight:</CE_MassEffect>
 	<CE_StatsReport_WeaponToughness_StuffEffect>Additional material toughness multiplier:</CE_StatsReport_WeaponToughness_StuffEffect>
 	<CE_StatsReport_WeaponToughness_HolderEffect>Wielder skill effect:</CE_StatsReport_WeaponToughness_HolderEffect>
+  <CE_Long_Range_Radio>Long range radio</CE_Long_Range_Radio>
 
 </LanguageData>

--- a/Languages/Russian/DefInjected/StatDef/Stats_Basics_Inventory.xml
+++ b/Languages/Russian/DefInjected/StatDef/Stats_Basics_Inventory.xml
@@ -7,4 +7,7 @@
 	<AmmoCaliber.label>калибр</AmmoCaliber.label>
 	<AmmoCaliber.description>Оружие, использующее данный тип боеприпасов</AmmoCaliber.description>
 
+  <LongRange.label>дистанция</LongRange.label>
+  <LongRange.description>Дистанция, измеряемая в клетках мира, которую может пролететь снаряд</LongRange.description>
+
 </LanguageData>

--- a/Languages/Russian/Keyed/Descriptions.xml
+++ b/Languages/Russian/Keyed/Descriptions.xml
@@ -11,6 +11,7 @@
 	<CE_DescPelletCount>Кол-во дробинок</CE_DescPelletCount>
 	<CE_DescSpreadMult>Фактор разброса</CE_DescSpreadMult>
 	<CE_DescFragments>Осколки</CE_DescFragments>
+  <CE_Long_Range_Radio_Desc>Наличие возможности отправлять координаты для удара на большие растояния</CE_Long_Range_Radio_Desc>
 
 	<!--<CE_DescFragRange>Радиус осколков</CE_DescFragRange>-->
 

--- a/Languages/Russian/Keyed/Stats.xml
+++ b/Languages/Russian/Keyed/Stats.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LanguageData>
+
+  <CE_Long_Range_Radio>Радио дальнего действия</CE_Long_Range_Radio>
+
+</LanguageData>

--- a/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_LongRange.cs
+++ b/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_LongRange.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Verse;
+using RimWorld;
+using UnityEngine;
+
+namespace CombatExtended
+{
+    public class StatWorker_LongRange : StatWorker
+    {
+        public override float GetValueUnfinalized(StatRequest req, bool applyPostProcess = true)
+        {
+            float result = ((req.Def as ThingDef)?.GetProjectile()?.projectile as ProjectilePropertiesCE)?.shellingProps?.range ?? 0f;
+            return result;
+        }
+        public override bool ShouldShowFor(StatRequest req)
+        {
+            return this.GetValueUnfinalized(req) > 0f && base.ShouldShowFor(req);
+        }
+    }
+}

--- a/Source/CombatExtended/Harmony/Harmony_ThingDef.cs
+++ b/Source/CombatExtended/Harmony/Harmony_ThingDef.cs
@@ -95,6 +95,10 @@ namespace CombatExtended.HarmonyCE
     {
         public static void Postfix(ThingDef __instance, ref IEnumerable<StatDrawEntry> __result, StatRequest req)
         {
+            if (__instance.GetModExtension<ApparelDefExtension>()?.isRadioPack ?? false)
+            {
+                __result = __result.Concat(new StatDrawEntry(StatCategoryDefOf.BasicsNonPawn, "CE_Long_Range_Radio".Translate(), "CE_Yes".Translate(), "CE_Long_Range_Radio_Desc".Translate(), 899));
+            }
             var turretGunDef = __instance.building?.turretGunDef ?? null;
 
             if (turretGunDef != null)


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Distance stat for shells/rockets
- Long range radio stat (Appears only with ApparelDefExtension.isRadioPack == true)

## Need to check

- Description of stat
- Stat naming (Might be "LongRange" is a bit incorrect)

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (a few minutes. Just checked 81mm and 105mm shells stat page)
