### PR TITLE
Fix warnings thrown on structure destruction in melee

### DIFF
--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
@@ -171,6 +171,9 @@ namespace CombatExtended
                 casterPawn.skills.Learn(SkillDefOf.Melee, HitXP * verbProps.AdjustedFullCycleTime(this, casterPawn), false);
             }
 
+            //init target info for sfx here, where we're sure the target still exists.
+            TargetInfo targInfo = new TargetInfo(targetThing.PositionHeld, targetThing.MapHeld);
+
             // Hit calculations
             bool result;
             string moteText = "";
@@ -268,10 +271,9 @@ namespace CombatExtended
                 MoteMakerCE.ThrowText(targetThing.PositionHeld.ToVector3Shifted(), targetThing.MapHeld, moteText);
             }
 
-            // targetThing may be destroyed at this point
-            if (targetThing != null && targetThing.Spawned)
+            if (targInfo.Map != null)
             {
-                soundDef.PlayOneShot(new TargetInfo(targetThing.PositionHeld, targetThing.MapHeld));
+                soundDef.PlayOneShot(targInfo);
             }
 
             // The caster could be dead at this point due to a successful riposte from the defender,

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
@@ -267,7 +267,12 @@ namespace CombatExtended
             {
                 MoteMakerCE.ThrowText(targetThing.PositionHeld.ToVector3Shifted(), targetThing.MapHeld, moteText);
             }
-            soundDef.PlayOneShot(new TargetInfo(targetThing.PositionHeld, targetThing.MapHeld));
+
+            // targetThing may be destroyed at this point
+            if (targetThing != null && targetThing.Spawned)
+            {
+                soundDef.PlayOneShot(new TargetInfo(targetThing.PositionHeld, targetThing.MapHeld));
+            }
 
             // The caster could be dead at this point due to a successful riposte from the defender,
             // so check for that as appropriate.


### PR DESCRIPTION
## Changes

- Fix null map warning that somehow cleared queued attack orders 

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (10 minutes)
