### PR TITLE
Miho patches

### DIFF
--- a/Patches/Miho Race/Ammo/Ammo_Miho_Advanced.xml
+++ b/Patches/Miho Race/Ammo/Ammo_Miho_Advanced.xml
@@ -170,60 +170,76 @@
 
 				<CombatExtended.AmmoSetDef>
 					<defName>AmmoSet_10mmMihogrenade</defName>
-					<label>Explosive Incendiary Minigrenade</label>
+					<label>Mechanite Grenade (Blast)</label>
 					<ammoTypes>
 						<Ammo_10mmMihogrenade>Bullet_10mmMihogrenade</Ammo_10mmMihogrenade>
 					</ammoTypes>
 				</CombatExtended.AmmoSetDef>
+				
+				<CombatExtended.AmmoSetDef>
+					<defName>AmmoSet_10mmMihogrenadeFlechette</defName>
+					<label>Mechanite Grenade (Flechette)</label>
+					<ammoTypes>
+						<Ammo_10mmMihogrenade>Bullet_10mmMihogrenadeFlechette</Ammo_10mmMihogrenade>
+					</ammoTypes>
+				</CombatExtended.AmmoSetDef>
+				
+				<CombatExtended.AmmoSetDef>
+					<defName>AmmoSet_10mmMihogrenadeBarrier</defName>
+					<label>Mechanite Grenade (Barrier)</label>
+					<ammoTypes>
+						<Ammo_10mmMihogrenade>Bullet_10mmMihogrenadeBarrier</Ammo_10mmMihogrenade>
+					</ammoTypes>
+				</CombatExtended.AmmoSetDef>
 
 				<ThingDef Class="CombatExtended.AmmoDef" ParentName="SpacerSmallAmmoBase">
-					<description>A large and powerful cartridge designed for automatic pistols.</description>
+					<description>Special purpose launcher grenades with variable properties.</description>
 					<thingCategories>
 						<li>Ammo10mmMihogrenade</li>
 					</thingCategories>
 					<defName>Ammo_10mmMihogrenade</defName>
-					<label>10mm HEI minigrenade</label>
+					<label>Mechanite Grenade</label>
 					<graphicData>
-						<texPath>Things/Ammo/Charged/SmallMech</texPath>
+						<texPath>Things/Ammo/Charged/ShotgunMech</texPath>
 						<graphicClass>Graphic_StackCount</graphicClass>
 					</graphicData>
 					<statBases>
-						<MarketValue>1.71</MarketValue>
-						<Mass>0.017</Mass>
-						<Bulk>0.01</Bulk>
+						<MarketValue>17.1</MarketValue>
+						<Mass>0.17</Mass>
+						<Bulk>0.20</Bulk>
 					</statBases>
 					<tradeTags>
 						<li>CE_AutoEnableTrade</li>
 					</tradeTags>
-					<ammoClass>IncendiaryMiho</ammoClass>
+					<ammoClass>MechaniteMiho</ammoClass>
 				</ThingDef>
 
-				<ThingDef ParentName="Base10x18mmChargedBullet">
+				<ThingDef ParentName="Base40x46mmGrenadeBullet">
 					<defName>Bullet_10mmMihogrenade</defName>
-					<label>10mm homing grenade</label>
+					<label>mechanite smart grenade (Explosive)</label>
 					<graphicData>
-						<texPath>Things/Projectile/Bullet_Small</texPath>
+						<texPath>Things/Projectile/Bullet_Big</texPath>
 						<graphicClass>Graphic_Single</graphicClass>
 					</graphicData>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
-						<damageAmountBase>11</damageAmountBase>
-						<damageDef>MihoGunshot</damageDef>
-						<secondaryDamage>
-							<li>
-								<def>Flame_Secondary</def>
-								<amount>3</amount>
-							</li>
-						</secondaryDamage>
-						<armorPenetrationSharp>26</armorPenetrationSharp>
-						<armorPenetrationBlunt>22.56</armorPenetrationBlunt>
+						<damageAmountBase>18</damageAmountBase>
+						<damageDef>Miho_MagicBomb</damageDef>
+						<explosionRadius>1</explosionRadius>
 					</projectile>
+					<comps>
+						<li Class="CombatExtended.CompProperties_Fragments">
+							<fragments>
+								<Fragment_Mihomech>20</Fragment_Mihomech>
+							</fragments>
+						</li>
+					</comps>
 				</ThingDef>
 
 				<RecipeDef ParentName="ChargeAmmoRecipeBase">
 					<defName>MakeAmmo_10mmMihogrenade</defName>
-					<label>make 10mm HEI Minigrenade x500</label>
-					<description>Craft 500 10mm HEI Minigrenades.</description>
-					<jobString>Making 10mm HEI Minigrenades.</jobString>
+					<label>make Mechanite Grenade x50</label>
+					<description>Craft 50 Mechanite Grenades.</description>
+					<jobString>Making Mechanite Grenades.</jobString>
 					<ingredients>
 						<li>
 							<filter>
@@ -258,7 +274,7 @@
 						</thingDefs>
 					</fixedIngredientFilter>
 					<products>
-						<Ammo_10mmMihogrenade>500</Ammo_10mmMihogrenade>
+						<Ammo_10mmMihogrenade>50</Ammo_10mmMihogrenade>
 					</products>
 					<workAmount>20800</workAmount>
 					<researchPrerequisite>Miho_MechHack</researchPrerequisite>
@@ -376,6 +392,64 @@
 						<soundAmbient>MortarRound_Ambient</soundAmbient>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 						<ai_IsIncendiary>true</ai_IsIncendiary>
+					</projectile>
+				</ThingDef>
+				
+				<ThingDef ParentName="BaseFragment">
+					<defName>Fragment_Mihomech</defName>
+					<label>fragments</label>
+					<graphicData>
+						<texPath>Things/Projectile/MihoThunderSpear</texPath>
+						<graphicClass>Graphic_Single</graphicClass>
+						<drawSize>0.88</drawSize>
+					</graphicData>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<damageDef>Miho_MagicBomb</damageDef>
+						<damageAmountBase>4</damageAmountBase>
+						<speed>35</speed>
+						<gravityFactor>5</gravityFactor>
+					</projectile>
+				</ThingDef>
+				
+				<ThingDef ParentName="Base12GaugeChargedBullet">
+					<defName>Bullet_10mmMihogrenadeFlechette</defName>
+					<label>flechette</label>
+					<graphicData>
+						<texPath>Things/Projectile/MihoThunderSpear</texPath>
+						<graphicClass>Graphic_Single</graphicClass>
+						<drawSize>1.35</drawSize>
+					</graphicData>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<speed>65</speed>
+						<damageAmountBase>10</damageAmountBase>
+						<damageDef>Miho_MagicBombEMP</damageDef>
+						<secondaryDamage>
+							<li>
+								<def>EMP</def>
+								<amount>8</amount>
+								<chance>1</chance>
+							</li>
+						</secondaryDamage>
+						<armorPenetrationSharp>0</armorPenetrationSharp>
+						<armorPenetrationBlunt>0</armorPenetrationBlunt>
+						<pelletCount>6</pelletCount>
+						<spreadMult>8.9</spreadMult>
+					</projectile>
+				</ThingDef>
+				
+				<ThingDef ParentName="Base40x46mmGrenadeBullet">
+					<defName>Bullet_10mmMihogrenadeBarrier</defName>
+					<label>mechanite smart grenade (barrier)</label>
+					<graphicData>
+						<texPath>Things/Projectile/Bullet_Big</texPath>
+						<graphicClass>Graphic_Single</graphicClass>
+					</graphicData>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<damageAmountBase>0</damageAmountBase>
+						<damageDef>Smoke</damageDef>
+						<explosionRadius>0.5</explosionRadius>
+						<preExplosionSpawnThingDef>Miho_BulletShieldPsychicSmall</preExplosionSpawnThingDef>
+						<preExplosionSpawnChance>1</preExplosionSpawnChance>
 					</projectile>
 				</ThingDef>
 

--- a/Patches/Miho Race/ThingDefs_Misc/Weapons_Ranged.xml
+++ b/Patches/Miho Race/ThingDefs_Misc/Weapons_Ranged.xml
@@ -37,7 +37,8 @@
 						<li Class="PatchOperationRemove">
 							<xpath>Defs/ThingDef[
 								defName="Miho_Weapon_Shotgun" or
-								defName="Miho_Weapon_ShotgunPsychic"
+								defName="Miho_Weapon_ShotgunPsychic" or
+								defName="Miho_Weapon_HeavyPistolFlechette"
 								]/verbs/li[@Class="TorgueMiho.Verb_Properties_ShotGun"] </xpath>
 						</li>
 
@@ -294,41 +295,92 @@
 							<statBases>
 								<SightsEfficiency>0.80</SightsEfficiency>
 								<ShotSpread>0.15</ShotSpread>
-								<SwayFactor>0.75</SwayFactor>
+								<SwayFactor>1.75</SwayFactor>
 								<Bulk>4.7</Bulk>
 								<Mass>3</Mass>
-								<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+								<RangedWeapon_Cooldown>2.1</RangedWeapon_Cooldown>
 							</statBases>
 							<Properties>
 								<recoilAmount>2.71</recoilAmount>
 								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 								<hasStandardCommand>true</hasStandardCommand>
 								<defaultProjectile>Bullet_10mmMihogrenade</defaultProjectile>
-								<warmupTime>0.5</warmupTime>
-								<burstShotCount>6</burstShotCount>
-								<ticksBetweenBurstShots>7</ticksBetweenBurstShots>
-								<range>21</range>
+								<warmupTime>1.1</warmupTime>
+								<range>35</range>
 								<soundCast>Miho_Pistol</soundCast>
 								<soundCastTail>GunTail_Medium</soundCastTail>
 								<muzzleFlashScale>9</muzzleFlashScale>
 							</Properties>
 							<AmmoUser>
-								<magazineSize>18</magazineSize>
-								<reloadTime>4.5</reloadTime>
 								<ammoSet>AmmoSet_10mmMihogrenade</ammoSet>
+								<AmmoGenPerMagOverride>3</AmmoGenPerMagOverride>
 							</AmmoUser>
 							<FireModes>
-								<aimedBurstShotCount>3</aimedBurstShotCount>
 								<aiUseBurstMode>FALSE</aiUseBurstMode>
 								<aiAimMode>Snapshot</aiAimMode>
 							</FireModes>
 						</li>
-
-						<li Class="PatchOperationAdd">
-							<xpath>Defs/ThingDef[defName="Miho_Weapon_HeavyPistol"]/weaponTags</xpath>
-							<value>
-								<li>CE_OneHandedWeapon</li>
-							</value>
+						
+						<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+							<defName>Miho_Weapon_HeavyPistolFlechette</defName>
+							<statBases>
+								<SightsEfficiency>0.80</SightsEfficiency>
+								<ShotSpread>0.15</ShotSpread>
+								<SwayFactor>1.75</SwayFactor>
+								<Bulk>4.7</Bulk>
+								<Mass>3</Mass>
+								<RangedWeapon_Cooldown>2.1</RangedWeapon_Cooldown>
+							</statBases>
+							<Properties>
+								<recoilAmount>2.71</recoilAmount>
+								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+								<hasStandardCommand>true</hasStandardCommand>
+								<defaultProjectile>Bullet_10mmMihogrenade</defaultProjectile>
+								<warmupTime>1.1</warmupTime>
+								<range>35</range>
+								<soundCast>Miho_Pistol</soundCast>
+								<soundCastTail>GunTail_Medium</soundCastTail>
+								<muzzleFlashScale>9</muzzleFlashScale>
+							</Properties>
+							<AmmoUser>
+								<ammoSet>AmmoSet_10mmMihogrenadeFlechette</ammoSet>
+								<AmmoGenPerMagOverride>3</AmmoGenPerMagOverride>
+							</AmmoUser>
+							<FireModes>
+								<aiUseBurstMode>FALSE</aiUseBurstMode>
+								<aiAimMode>Snapshot</aiAimMode>
+							</FireModes>
+						</li>
+						
+						<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+							<defName>Miho_Weapon_HeavyPistolHardkill</defName>
+							<statBases>
+								<SightsEfficiency>0.80</SightsEfficiency>
+								<ShotSpread>0.15</ShotSpread>
+								<SwayFactor>1.75</SwayFactor>
+								<Bulk>4.7</Bulk>
+								<Mass>3</Mass>
+								<RangedWeapon_Cooldown>2.1</RangedWeapon_Cooldown>
+							</statBases>
+							<Properties>
+								<recoilAmount>2.71</recoilAmount>
+								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+								<hasStandardCommand>true</hasStandardCommand>
+								<defaultProjectile>Bullet_10mmMihogrenade</defaultProjectile>
+								<warmupTime>1.1</warmupTime>
+								<range>35</range>
+								<soundCast>Miho_Pistol</soundCast>
+								<soundCastTail>GunTail_Medium</soundCastTail>
+								<muzzleFlashScale>9</muzzleFlashScale>
+							</Properties>
+							<AmmoUser>
+								<ammoSet>AmmoSet_10mmMihogrenadeBarrier</ammoSet>
+								<AmmoGenPerMagOverride>3</AmmoGenPerMagOverride>
+							</AmmoUser>
+							<FireModes>
+								<aiUseBurstMode>FALSE</aiUseBurstMode>
+								<aiAimMode>Snapshot</aiAimMode>
+							</FireModes>
 						</li>
 
 						<!-- ========== Plamsa Rifle =========== -->
@@ -536,6 +588,8 @@
 						<li Class="PatchOperationReplace">
 							<xpath>Defs/ThingDef[
 								defName="Miho_Weapon_HeavyPistol" or
+								defName="Miho_Weapon_HeavyPistolFlechette" or
+								defName="Miho_Weapon_HeavyPistolHardkill" or
 								defName="Miho_Weapon_RifleCQB" or
 								defName="Miho_Weapon_Pistol"
 								]/tools </xpath>

--- a/Patches/Miho Race/ThingDefs_Races/AlienRace_Miho.xml
+++ b/Patches/Miho Race/ThingDefs_Races/AlienRace_Miho.xml
@@ -18,6 +18,13 @@
 								<compClass>CombatExtended.CompPawnGizmo</compClass>
 							</li>
 							<li Class="CombatExtended.CompProperties_Suppressable" />
+							<li Class="CombatExtended.CompProperties_ArmorDurability">
+								<Durability>500</Durability>
+								<Regenerates>true</Regenerates>
+								<RegenInterval>600</RegenInterval>
+								<RegenValue>5</RegenValue>
+								<MinArmorPct>0.75</MinArmorPct>
+							</li>
 						</value>
 					</match>
 					<nomatch Class="PatchOperationAdd">
@@ -28,6 +35,13 @@
 									<compClass>CombatExtended.CompPawnGizmo</compClass>
 								</li>
 								<li Class="CombatExtended.CompProperties_Suppressable" />
+								<li Class="CombatExtended.CompProperties_ArmorDurability">
+									<Durability>500</Durability>
+									<Regenerates>true</Regenerates>
+									<RegenInterval>600</RegenInterval>
+									<RegenValue>5</RegenValue>
+									<MinArmorPct>0.75</MinArmorPct>
+								</li>
 							</comps>
 						</value>
 					</nomatch>

--- a/Patches/Miho Race/ThingDefs_Races/Race_MihoMech.xml
+++ b/Patches/Miho Race/ThingDefs_Races/Race_MihoMech.xml
@@ -10,7 +10,31 @@
 
 				<match Class="PatchOperationSequence">
 					<operations>
-
+					
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/ThingDef[defName="Miho_Mech_Sapsal"]</xpath>
+							<value>
+								<comps>
+									<li Class="CombatExtended.CompProperties_ArmorDurability">
+										<Durability>1000</Durability>
+										<Regenerates>true</Regenerates>
+										<RegenInterval>1250</RegenInterval>
+										<RegenValue>5</RegenValue>
+										<Repairable>true</Repairable>
+										<RepairIngredients>
+											<Steel>5</Steel>
+											<Miho_MilitaryGradeBalisticCeramics>5</Miho_MilitaryGradeBalisticCeramics>
+										</RepairIngredients>
+										<RepairTime>300</RepairTime>
+										<RepairValue>200</RepairValue>
+										<CanOverHeal>true</CanOverHeal>
+										<MaxOverHeal>100</MaxOverHeal>
+										<MinArmorPct>0.50</MinArmorPct>
+									</li>
+								</comps>
+							</value>
+						</li>
+						
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/ThingDef[defName="Miho_Mech_Sapsal"]/statBases</xpath>
 							<value>
@@ -18,7 +42,7 @@
 								<MeleeCritChance>0.15</MeleeCritChance>
 								<MeleeParryChance>0.30</MeleeParryChance>
 								<NightVisionEfficiency>0.60</NightVisionEfficiency>
-								<ShootingAccuracyPawn>4.5</ShootingAccuracyPawn>
+								<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 							</value>
 						</li>
 
@@ -78,6 +102,30 @@
 								</tools>
 							</value>
 						</li>
+						
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/ThingDef[defName="Miho_Mech_DesertSphex"]</xpath>
+							<value>
+								<comps>
+									<li Class="CombatExtended.CompProperties_ArmorDurability">
+										<Durability>500</Durability>
+										<Regenerates>true</Regenerates>
+										<RegenInterval>1250</RegenInterval>
+										<RegenValue>5</RegenValue>
+										<Repairable>true</Repairable>
+										<RepairIngredients>
+											<Steel>5</Steel>
+											<Miho_MilitaryGradeBalisticCeramics>5</Miho_MilitaryGradeBalisticCeramics>
+										</RepairIngredients>
+										<RepairTime>300</RepairTime>
+										<RepairValue>200</RepairValue>
+										<CanOverHeal>true</CanOverHeal>
+										<MaxOverHeal>100</MaxOverHeal>
+										<MinArmorPct>0.50</MinArmorPct>
+									</li>
+								</comps>
+							</value>
+						</li>
 
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/ThingDef[defName="Miho_Mech_DesertSphex"]/statBases</xpath>
@@ -86,7 +134,7 @@
 								<MeleeCritChance>0.05</MeleeCritChance>
 								<MeleeParryChance>0.30</MeleeParryChance>
 								<NightVisionEfficiency>0.60</NightVisionEfficiency>
-								<ShootingAccuracyPawn>4.5</ShootingAccuracyPawn>
+								<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 							</value>
 						</li>
 
@@ -123,6 +171,52 @@
 								<ArmorRating_Blunt>6</ArmorRating_Blunt>
 							</value>
 						</li>
+						
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/ThingDef[defName="Miho_Mech_Bulgasal" or  defName="Miho_Mech_BulgasalGrenade"]/comps</xpath>
+							<value>
+								<li Class="CombatExtended.CompProperties_ArmorDurability">
+									<Durability>3500</Durability>
+									<Regenerates>true</Regenerates>
+									<RegenInterval>1250</RegenInterval>
+									<RegenValue>5</RegenValue>
+									<Repairable>true</Repairable>
+									<RepairIngredients>
+										<Steel>5</Steel>
+										<Miho_MilitaryGradeBalisticCeramics>5</Miho_MilitaryGradeBalisticCeramics>
+									</RepairIngredients>
+									<RepairTime>300</RepairTime>
+									<RepairValue>200</RepairValue>
+									<CanOverHeal>true</CanOverHeal>
+									<MaxOverHeal>100</MaxOverHeal>
+									<MinArmorPct>0.50</MinArmorPct>
+								</li>
+							</value>
+						</li>
+						
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/ThingDef[defName="Miho_Mech_BulgasalSiege"]</xpath>
+							<value>
+								<comps>
+									<li Class="CombatExtended.CompProperties_ArmorDurability">
+										<Durability>3500</Durability>
+										<Regenerates>true</Regenerates>
+										<RegenInterval>1250</RegenInterval>
+										<RegenValue>5</RegenValue>
+										<Repairable>true</Repairable>
+										<RepairIngredients>
+											<Steel>5</Steel>
+											<Miho_MilitaryGradeBalisticCeramics>5</Miho_MilitaryGradeBalisticCeramics>
+										</RepairIngredients>
+										<RepairTime>300</RepairTime>
+										<RepairValue>200</RepairValue>
+										<CanOverHeal>true</CanOverHeal>
+										<MaxOverHeal>100</MaxOverHeal>
+										<MinArmorPct>0.50</MinArmorPct>
+									</li>
+								</comps>
+							</value>
+						</li>
 
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/ThingDef[defName="Miho_Mech_Bulgasal" or defName="Miho_Mech_BulgasalSiege" or defName="Miho_Mech_BulgasalGrenade"]/statBases</xpath>
@@ -131,8 +225,9 @@
 								<MeleeCritChance>0.15</MeleeCritChance>
 								<MeleeParryChance>0.30</MeleeParryChance>
 								<NightVisionEfficiency>0.60</NightVisionEfficiency>
-								<ShootingAccuracyPawn>4.5</ShootingAccuracyPawn>
-								<CarryBulk>40</CarryBulk>
+								<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
+								<CarryWeight>50</CarryWeight>
+								<CarryBulk>50</CarryBulk>
 							</value>
 						</li>
 
@@ -179,7 +274,53 @@
 								</tools>
 							</value>
 						</li>
-
+						
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/ThingDef[defName="Miho_Mech_CataphractRocket" or defName="Miho_Mech_CataphractCluRocket"]/comps</xpath>
+							<value>
+								<li Class="CombatExtended.CompProperties_ArmorDurability">
+									<Durability>5000</Durability>
+									<Regenerates>true</Regenerates>
+									<RegenInterval>1250</RegenInterval>
+									<RegenValue>5</RegenValue>
+									<Repairable>true</Repairable>
+									<RepairIngredients>
+										<Steel>5</Steel>
+										<Miho_MilitaryGradeBalisticCeramics>5</Miho_MilitaryGradeBalisticCeramics>
+									</RepairIngredients>
+									<RepairTime>300</RepairTime>
+									<RepairValue>200</RepairValue>
+									<CanOverHeal>true</CanOverHeal>
+									<MaxOverHeal>100</MaxOverHeal>
+									<MinArmorPct>0.50</MinArmorPct>
+								</li>
+							</value>
+						</li>
+						
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/ThingDef[defName="Miho_Mech_Cataphract"]</xpath>
+							<value>
+								<comps>
+									<li Class="CombatExtended.CompProperties_ArmorDurability">
+										<Durability>5000</Durability>
+										<Regenerates>true</Regenerates>
+										<RegenInterval>1250</RegenInterval>
+										<RegenValue>5</RegenValue>
+										<Repairable>true</Repairable>
+										<RepairIngredients>
+											<Steel>5</Steel>
+											<Miho_MilitaryGradeBalisticCeramics>5</Miho_MilitaryGradeBalisticCeramics>
+										</RepairIngredients>
+										<RepairTime>300</RepairTime>
+										<RepairValue>200</RepairValue>
+										<CanOverHeal>true</CanOverHeal>
+										<MaxOverHeal>100</MaxOverHeal>
+										<MinArmorPct>0.50</MinArmorPct>
+									</li>
+								</comps>
+							</value>
+						</li>
+						
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/ThingDef[defName="Miho_Mech_Cataphract" or defName="Miho_Mech_CataphractRocket" or defName="Miho_Mech_CataphractCluRocket"]/statBases</xpath>
 							<value>
@@ -187,7 +328,7 @@
 								<MeleeCritChance>0.15</MeleeCritChance>
 								<MeleeParryChance>0.30</MeleeParryChance>
 								<NightVisionEfficiency>0.60</NightVisionEfficiency>
-								<ShootingAccuracyPawn>4.5</ShootingAccuracyPawn>
+								<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 								<CarryWeight>100</CarryWeight>
 								<CarryBulk>150</CarryBulk>
 							</value>


### PR DESCRIPTION
## Additions

Added armor comps

## Changes

Reduced mech shooting accuracy.
Increased carry weight on the heavy gun mechs to allow for better ammo load.
10mm gun was changed in properties, so updated that to match.

## Reasoning

Matching grenade launcher performance to the vanilla equivalent means that there isn't a need to add 3 additional ammodefs for the weapon itself. Increased carry weight for heavy gun mech allows for 1 + 3 reloads of grenades with a bit spare.

## Testing

Check tests you have performed:
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
