### PR TITLE
Shelling Fixes

### DIFF
--- a/Patches/Dubs Rimatomics/Turrets_Rimatomics.xml
+++ b/Patches/Dubs Rimatomics/Turrets_Rimatomics.xml
@@ -1,171 +1,137 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
-	<Operation Class="PatchOperationSequence">
-		<operations>
-			<li Class="PatchOperationFindMod">
 
-				<mods>
-					<li>Dubs Rimatomics</li>
-				</mods>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Dubs Rimatomics</li>
+		</mods>
 
-				<match Class="PatchOperationSequence">
-					<operations>
+		<match Class="PatchOperationSequence">
+			<operations>
 
-						<!--Sabots : Damage Stuff-->
+				<!--Sabots : Damage Stuff-->
 
-						<li Class="PatchOperationReplace">
-							<xpath>Defs/DamageDef[defName="Bomb_Sabot"]/defaultDamage</xpath>
-							<value>
-								<defaultDamage>200</defaultDamage>
-							</value>
-						</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/DamageDef[defName="Bomb_Sabot"]/defaultDamage</xpath>
+					<value>
+						<defaultDamage>200</defaultDamage>
+					</value>
+				</li>
 
-						<li Class="PatchOperationReplace">
-							<xpath>Defs/DamageDef[defName="Bomb_Sabot"]/defaultArmorPenetration</xpath>
-							<value>
-								<defaultArmorPenetration>120000</defaultArmorPenetration>
-							</value>
-						</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/DamageDef[defName="Bomb_Sabot"]/defaultArmorPenetration</xpath>
+					<value>
+						<defaultArmorPenetration>120000</defaultArmorPenetration>
+					</value>
+				</li>
 
-						<li Class="PatchOperationReplace">
-							<xpath>Defs/DamageDef[defName="Bomb_DUSabot"]/defaultDamage</xpath>
-							<value>
-								<defaultDamage>800</defaultDamage>
-							</value>
-						</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/DamageDef[defName="Bomb_DUSabot"]/defaultDamage</xpath>
+					<value>
+						<defaultDamage>800</defaultDamage>
+					</value>
+				</li>
 
-						<li Class="PatchOperationReplace">
-							<xpath>Defs/DamageDef[defName="Bomb_DUSabot"]/defaultArmorPenetration</xpath>
-							<value>
-								<defaultArmorPenetration>240000</defaultArmorPenetration>
-							</value>
-						</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/DamageDef[defName="Bomb_DUSabot"]/defaultArmorPenetration</xpath>
+					<value>
+						<defaultArmorPenetration>240000</defaultArmorPenetration>
+					</value>
+				</li>
 
-						<!--Sabots : Projectile Tweaks-->
+				<!--Sabots : Projectile Tweaks-->
 
-						<li Class="PatchOperationReplace">
-							<xpath>Defs/ThingDef[defName="Bullet_Sabot"]/projectile/speed</xpath>
-							<value>
-								<speed>500</speed>
-							</value>
-						</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Bullet_Sabot"]/projectile/speed</xpath>
+					<value>
+						<speed>500</speed>
+					</value>
+				</li>
 
-						<li Class="PatchOperationReplace">
-							<xpath>Defs/ThingDef[defName="Bullet_Sabot_DU"]/projectile/speed</xpath>
-							<value>
-								<speed>500</speed>
-							</value>
-						</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Bullet_Sabot_DU"]/projectile/speed</xpath>
+					<value>
+						<speed>500</speed>
+					</value>
+				</li>
 
-						<!--Sabots : Fire Mission Tweaks-->
+				<!--Sabots : Fire Mission Tweaks-->
 
-						<li Class="PatchOperationReplace">
-							<xpath>Defs/ThingDef[defName="SabotRoundIncoming"]/skyfaller/explosionDamage</xpath>
-							<value>
-								<explosionDamage>Bomb_Sabot</explosionDamage>
-							</value>
-						</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="SabotRoundIncoming"]/skyfaller/explosionDamage</xpath>
+					<value>
+						<explosionDamage>Bomb_Sabot</explosionDamage>
+					</value>
+				</li>
 
-						<li Class="PatchOperationReplace">
-							<xpath>Defs/ThingDef[defName="DUSabotRoundIncoming"]/skyfaller/explosionDamage</xpath>
-							<value>
-								<explosionDamage>Bomb_DUSabot</explosionDamage>
-							</value>
-						</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="DUSabotRoundIncoming"]/skyfaller/explosionDamage</xpath>
+					<value>
+						<explosionDamage>Bomb_DUSabot</explosionDamage>
+					</value>
+				</li>
 
-						<!--Marauder : Damage Stuff-->
+				<!--Marauder : Damage Stuff-->
 
-						<li Class="PatchOperationReplace">
-							<xpath>Defs/DamageDef[defName="Bomb_PlasmaToroid"]/defaultDamage</xpath>
-							<value>
-								<defaultDamage>70</defaultDamage>
-							</value>
-						</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/DamageDef[defName="Bomb_PlasmaToroid"]/defaultDamage</xpath>
+					<value>
+						<defaultDamage>70</defaultDamage>
+					</value>
+				</li>
 
-						<li Class="PatchOperationReplace">
-							<xpath>Defs/DamageDef[defName="Bomb_PlasmaToroid"]/defaultArmorPenetration</xpath>
-							<value>
-								<defaultArmorPenetration>80</defaultArmorPenetration>
-							</value>
-						</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/DamageDef[defName="Bomb_PlasmaToroid"]/defaultArmorPenetration</xpath>
+					<value>
+						<defaultArmorPenetration>80</defaultArmorPenetration>
+					</value>
+				</li>
 
-						<li Class="PatchOperationReplace">
-							<xpath>Defs/ThingDef[defName="Bullet_PlasmaToroid"]/projectile/speed</xpath>
-							<value>
-								<speed>300</speed>
-							</value>
-						</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Bullet_PlasmaToroid"]/projectile/speed</xpath>
+					<value>
+						<speed>300</speed>
+					</value>
+				</li>
 
-						<li Class="PatchOperationRemove">
-							<xpath>Defs/ThingDef[defName="Bullet_PlasmaToroid"]/projectile/damageAmountBase</xpath>
-						</li>
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/ThingDef[defName="Bullet_PlasmaToroid"]/projectile/damageAmountBase</xpath>
+				</li>
 
-						<!--Marauder : Range-->
+				<!--Marauder : Range-->
 
-						<li Class="PatchOperationReplace">
-							<xpath>Defs/ThingDef[defName="Marauder_Railgun"]/verbs/li/range</xpath>
-							<value>
-								<range>86</range>
-							</value>
-						</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Marauder_Railgun"]/verbs/li/range</xpath>
+					<value>
+						<range>86</range>
+					</value>
+				</li>
 
-						<li Class="PatchOperationReplace">
-							<xpath>Defs/ThingDef[defName="Marauder_Railgun"]/EnergyWep/range</xpath>
-							<value>
-								<range>86</range>
-							</value>
-						</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Marauder_Railgun"]/EnergyWep/range</xpath>
+					<value>
+						<range>86</range>
+					</value>
+				</li>
 
-						<!--Turrets : Stats-->
+				<!--Turrets : Stats-->
 
-						<li Class="PatchOperationAdd">
-							<xpath>Defs/ThingDef[defName="PPCMarauder" or defName="PPCRailgun"]/statBases</xpath>
-							<value>
-								<ShootingAccuracyTurret>5</ShootingAccuracyTurret>
-							</value>
-						</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="PPCMarauder" or defName="PPCRailgun"]/statBases</xpath>
+					<value>
+						<ShootingAccuracyTurret>5</ShootingAccuracyTurret>
+					</value>
+				</li>
 
-						<li Class="PatchOperationReplace">
-							<xpath>Defs/ThingDef[defName="PPCMarauder"]/specialDisplayRadius</xpath>
-							<value>
-								<specialDisplayRadius>86</specialDisplayRadius>
-							</value>
-						</li>
-						
-						<li Class="PatchOperationReplace">
-							<xpath>Defs/ThingDef[defName="HEL_Laser"]/EnergyWep/turretSpeed</xpath>
-							<value>
-								<turretSpeed>480</turretSpeed>
-							</value>
-						</li>
-						
-						<li Class="PatchOperationReplace">
-							<xpath>Defs/ThingDef[defName="HEL_Laser"]/EnergyWep/turretSpeed</xpath>
-							<value>
-								<cooldownForShot>8</cooldownForShot>
-							</value>
-						</li>
-						
-						<li Class="PatchOperationReplace">
-							<xpath>Defs/ThingDef[defName="HEL_Laser"]/verbs/li/ticksBetweenBurstShots</xpath>
-							<value>
-								<ticksBetweenBurstShots>9</ticksBetweenBurstShots>
-							</value>
-						</li>
-						
-						<li Class="PatchOperationReplace">
-							<xpath>Defs/ThingDef[defName="HEL_Laser"]/verbs/li/warmupTime</xpath>
-							<value>
-								<warmupTime>0.05</warmupTime>
-							</value>
-						</li>
-						
-						
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="PPCMarauder"]/specialDisplayRadius</xpath>
+					<value>
+						<specialDisplayRadius>86</specialDisplayRadius>
+					</value>
+				</li>
 
-					</operations>
-				</match>
-			</li>
-		</operations>
+			</operations>
+		</match>
 	</Operation>
 
 </Patch>

--- a/Patches/Dubs Rimatomics/Turrets_Rimatomics.xml
+++ b/Patches/Dubs Rimatomics/Turrets_Rimatomics.xml
@@ -130,6 +130,27 @@
 					</value>
 				</li>
 
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="HEL_Laser"]/EnergyWep/range</xpath>
+					<value>
+						<range>62</range>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="HEL_Laser"]/EnergyWep/turretSpeed</xpath>
+					<value>
+						<cooldownForShot>8</cooldownForShot>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="HEL_Laser"]/verbs/li/ticksBetweenBurstShots</xpath>
+					<value>
+						<ticksBetweenBurstShots>9</ticksBetweenBurstShots>
+					</value>
+				</li>
+
 			</operations>
 		</match>
 	</Operation>

--- a/Patches/Dubs Rimatomics/Turrets_Rimatomics.xml
+++ b/Patches/Dubs Rimatomics/Turrets_Rimatomics.xml
@@ -131,6 +131,36 @@
 								<specialDisplayRadius>86</specialDisplayRadius>
 							</value>
 						</li>
+						
+						<li Class="PatchOperationReplace">
+							<xpath>Defs/ThingDef[defName="HEL_Laser"]/EnergyWep/turretSpeed</xpath>
+							<value>
+								<turretSpeed>480</turretSpeed>
+							</value>
+						</li>
+						
+						<li Class="PatchOperationReplace">
+							<xpath>Defs/ThingDef[defName="HEL_Laser"]/EnergyWep/turretSpeed</xpath>
+							<value>
+								<cooldownForShot>8</cooldownForShot>
+							</value>
+						</li>
+						
+						<li Class="PatchOperationReplace">
+							<xpath>Defs/ThingDef[defName="HEL_Laser"]/verbs/li/ticksBetweenBurstShots</xpath>
+							<value>
+								<ticksBetweenBurstShots>9</ticksBetweenBurstShots>
+							</value>
+						</li>
+						
+						<li Class="PatchOperationReplace">
+							<xpath>Defs/ThingDef[defName="HEL_Laser"]/verbs/li/warmupTime</xpath>
+							<value>
+								<warmupTime>0.05</warmupTime>
+							</value>
+						</li>
+						
+						
 
 					</operations>
 				</match>

--- a/Source/CombatExtended/CombatExtended/WorldObjects/HostilitySheller.cs
+++ b/Source/CombatExtended/CombatExtended/WorldObjects/HostilitySheller.cs
@@ -199,7 +199,6 @@ namespace CombatExtended.WorldObjects
             Find.World.worldObjects.Add(shell);
             if (shooter == null && comp.parent.Faction.def.humanlikeFaction)
             {
-                Log.Warning("CE: Shooter of HostilitySheller from " + comp.parent.ID + ", " + comp.parent.Faction.name + " is null, regenerating");
                 shooter = comp.parent.Faction.GetRandomWorldPawn();
             }
             shell.launcher = shooter;

--- a/Source/CombatExtended/CombatExtended/WorldObjects/HostilitySheller.cs
+++ b/Source/CombatExtended/CombatExtended/WorldObjects/HostilitySheller.cs
@@ -138,6 +138,10 @@ namespace CombatExtended.WorldObjects
             if (comp.parent.Faction.def.humanlikeFaction)
             {
                 shooter = comp.parent.Faction.GetRandomWorldPawn();
+                if (shooter == null)
+                {
+                    Log.Error($"CE: shooter for HostilitySheller from {comp.parent} is null");
+                }
             }
             target = targetInfo;
             ticksToNextShot = GetTicksToCooldown();
@@ -193,6 +197,11 @@ namespace CombatExtended.WorldObjects
             shell.tileInt = comp.parent.Tile;
             shell.SpawnSetup();
             Find.World.worldObjects.Add(shell);
+            if (shooter == null && comp.parent.Faction.def.humanlikeFaction)
+            {
+                Log.Warning("CE: Shooter of HostilitySheller from " + comp.parent.ID + ", " + comp.parent.Faction.name + " is null, regenerating");
+                shooter = comp.parent.Faction.GetRandomWorldPawn();
+            }
             shell.launcher = shooter;
             shell.equipmentDef = null;
             shell.globalSource = new GlobalTargetInfo(comp.parent);

--- a/Source/CombatExtended/CombatExtended/WorldObjects/HostilitySheller.cs
+++ b/Source/CombatExtended/CombatExtended/WorldObjects/HostilitySheller.cs
@@ -199,6 +199,10 @@ namespace CombatExtended.WorldObjects
             shell.globalSource.worldObjectInt = comp.parent;
             shell.shellDef = projectileDef;
             shell.globalTarget = target;
+            if (shell.launcher == null)
+            {
+                Log.Warning($"CE: Launcher of shell {projectileDef} is null, this may cause targeting issues");
+            }
             if (!shell.TryTravel(comp.parent.Tile, target.Tile))
             {
                 Stop();

--- a/Source/CombatExtended/CombatExtended/WorldObjects/TravelingShell.cs
+++ b/Source/CombatExtended/CombatExtended/WorldObjects/TravelingShell.cs
@@ -130,7 +130,7 @@ namespace CombatExtended
                     sourceCell,
                     targetCell,
                     map: map,
-                    shotSpeed: 120f);
+                    shotSpeed: 55f);
             }
             WorldObjects.HostilityComp hostility = worldObject.GetComponent<WorldObjects.HostilityComp>();
             WorldObjects.HealthComp healthComp = worldObject.GetComponent<WorldObjects.HealthComp>();
@@ -149,7 +149,7 @@ namespace CombatExtended
             return shelled;
         }
 
-        private void LaunchProjectile(IntVec3 sourceCell, LocalTargetInfo target, Map map, float shotSpeed = 20, float shotHeight = 100)
+        private void LaunchProjectile(IntVec3 sourceCell, LocalTargetInfo target, Map map, float shotSpeed = 20, float shotHeight = 200)
         {
             IntVec3 targetCell = target.Cell;
             Vector2 source = new Vector2(sourceCell.x, sourceCell.z);


### PR DESCRIPTION
## Changes

- Fix Rimatomics HEL not targeting incoming world shells.

## Reasoning

- Shells launched by a HostilitySheller have a null launcher pawn, when they should not

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
