### PR TITLE
Make BlockerRegistry public

### DIFF
--- a/Source/CombatExtended/Compatibility/BlockerRegistry.cs
+++ b/Source/CombatExtended/Compatibility/BlockerRegistry.cs
@@ -9,7 +9,7 @@ using Verse.Sound;
 
 namespace CombatExtended.Compatibility
 {
-    static class BlockerRegistry
+    public static class BlockerRegistry
     {
         private static bool enabled = false;
         private static List<Func<ProjectileCE, IntVec3, Thing, bool>> checkCellForCollisionCallbacks;


### PR DESCRIPTION

## Changes

CombatExtended.Compatibility.BlockerRegistry is now `public static` instead of just `static`


## Reasoning

It's an API we want downstream mods to use, so it needs to be public.

## Alternatives

Create a separate public API (would end up just proxying calls to this one).
Make them use a publicized CE (defeats the purpose of marking anything not public)
Make them use reflection (ick)

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
