### PR TITLE
fixed duplicated left claw on reapers' brute

### DIFF
--- a/Patches/Rim-Effect Asari and Reapers/Races_Reapers.xml
+++ b/Patches/Rim-Effect Asari and Reapers/Races_Reapers.xml
@@ -434,7 +434,7 @@
 								<armorPenetrationSharp>60</armorPenetrationSharp>
 							</li>
 							<li Class="CombatExtended.ToolCE">
-								<label>left claw</label>
+								<label>right claw</label>
 								<capacities>
 									<li>Cut</li>
 									<li>Scratch</li>
@@ -447,7 +447,7 @@
 									</li>
 								</extraMeleeDamages>
 								<cooldownTime>3.3</cooldownTime>
-								<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+								<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
 								<armorPenetrationBlunt>500</armorPenetrationBlunt>
 								<armorPenetrationSharp>60</armorPenetrationSharp>
 							</li>


### PR DESCRIPTION
## Changes
Rim-effect asari and reapers brute has 2 left claws. changed one to right claw.

## Reasoning
it has 2 sides, one claw on each.



Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [X] (For compatibility patches) ...with and without patched mod loaded
- [X] Playtested a colony (10 minutes)
