### PR TITLE
Hyperweave rebalanced

### DIFF
--- a/Patches/Core/ThingDefs_Items/Items_Resource_Stuff.xml
+++ b/Patches/Core/ThingDefs_Items/Items_Resource_Stuff.xml
@@ -541,7 +541,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Hyperweave"]/statBases/StuffPower_Armor_Heat</xpath>
 		<value>
-			<StuffPower_Armor_Heat>1.92</StuffPower_Armor_Heat>
+			<StuffPower_Armor_Heat>0.10</StuffPower_Armor_Heat>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Items/Items_Resource_Stuff.xml
+++ b/Patches/Core/ThingDefs_Items/Items_Resource_Stuff.xml
@@ -541,7 +541,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Hyperweave"]/statBases/StuffPower_Armor_Heat</xpath>
 		<value>
-			<StuffPower_Armor_Heat>0.10</StuffPower_Armor_Heat>
+			<StuffPower_Armor_Heat>0.25</StuffPower_Armor_Heat>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Items/Items_Resource_Stuff.xml
+++ b/Patches/Core/ThingDefs_Items/Items_Resource_Stuff.xml
@@ -518,37 +518,21 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Hyperweave"]/statBases/StuffPower_Armor_Heat</xpath>
 		<value>
-			<StuffPower_Armor_Heat>0</StuffPower_Armor_Heat>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Hyperweave"]/stuffProps</xpath>
-		<value>
-			<statOffsets>
-				<Mass>0.75</Mass>
-			</statOffsets>
+			<StuffPower_Armor_Heat>0.2</StuffPower_Armor_Heat>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Hyperweave"]/stuffProps/statFactors</xpath>
 		<value>
-			<Mass>1.8</Mass>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Hyperweave"]/statBases/StuffPower_Armor_Heat</xpath>
-		<value>
-			<StuffPower_Armor_Heat>0.25</StuffPower_Armor_Heat>
+			<Mass>1.25</Mass>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Hyperweave"]/stuffProps/statFactors/Flammability</xpath>
 		<value>
-			<Flammability>0.1</Flammability>
+			<Flammability>0</Flammability>
 		</value>
 	</Operation>
 


### PR DESCRIPTION
## Changes

- Readjusted Hyperweave to be more in line with other armor fabrics like Devilstrand which as a result makes it more viable for use as an endgame fabric.
The heat armor is reduced to 0.2 which used to be absurdly high, the flat mass offset is removed and the mass factor value is reduced as them coupled with the high base mass value of Hyperweave resulted in the material being very unviable for use compared to something like Thrumbofur which does not have these penalties. The new numbers make it more reasonable and accurate to its item description and design compared to something like again Devilstrand.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
