### PR TITLE
Fragments' damage adjusted

### DIFF
--- a/Defs/Ammo/Projectiles_Fragments.xml
+++ b/Defs/Ammo/Projectiles_Fragments.xml
@@ -10,7 +10,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Fragment</damageDef>
-			<damageAmountBase>21</damageAmountBase>
+			<damageAmountBase>27</damageAmountBase>
 			<speed>60</speed>
 			<armorPenetrationSharp>4.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>62.5</armorPenetrationBlunt>
@@ -27,7 +27,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Fragment</damageDef>
-			<damageAmountBase>14</damageAmountBase>
+			<damageAmountBase>18</damageAmountBase>
 			<speed>50</speed>
 			<armorPenetrationSharp>3</armorPenetrationSharp>
 			<armorPenetrationBlunt>30.4</armorPenetrationBlunt>
@@ -44,7 +44,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Fragment</damageDef>
-			<damageAmountBase>7</damageAmountBase>
+			<damageAmountBase>9</damageAmountBase>
 			<speed>40</speed>
 			<armorPenetrationSharp>2</armorPenetrationSharp>
 			<armorPenetrationBlunt>6.4</armorPenetrationBlunt>


### PR DESCRIPTION
## Changes

- Changed fragments from being a FMJ round to a HP round in the spreadsheet resulting in more raw damage.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070

## Reasoning

- Frags are anemic damage-wise which is doubled by the fact that the minDamageToFragment node makes the damage value be fragmented into smaller numbers resulting is less than ideal results. Frags are also jagged resulting in nasty wounds like a HP bullet.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
