### PR TITLE
Inferno cannon tweaks

### DIFF
--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -1268,11 +1268,11 @@
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>Gun_ThumpCannon</defName>
 		<statBases>
-			<Mass>200.00</Mass>
-			<RangedWeapon_Cooldown>2.13</RangedWeapon_Cooldown>
+			<Mass>75.00</Mass>
+			<RangedWeapon_Cooldown>2.2</RangedWeapon_Cooldown>
 			<SightsEfficiency>1</SightsEfficiency>
 			<ShotSpread>0.01</ShotSpread>
-			<SwayFactor>0.82</SwayFactor>
+			<SwayFactor>0.21</SwayFactor>
 			<Bulk>20.00</Bulk>
 		</statBases>
 		<Properties>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -1208,15 +1208,15 @@
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>Gun_InfernoCannon</defName>
 		<statBases>
-			<Mass>200.00</Mass>
-			<RangedWeapon_Cooldown>2.5</RangedWeapon_Cooldown>
+			<Mass>50.00</Mass>
+			<RangedWeapon_Cooldown>2.54</RangedWeapon_Cooldown>
 			<SightsEfficiency>1</SightsEfficiency>
 			<ShotSpread>0.01</ShotSpread>
-			<SwayFactor>0.82</SwayFactor>
+			<SwayFactor>0.14</SwayFactor>
 			<Bulk>20.00</Bulk>
 		</statBases>
 		<Properties>
-			<recoilAmount>1.01</recoilAmount>
+			<recoilAmount>2.01</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>

--- a/Patches/Reinforced Mechanoid 2/ThingDefs_Misc/RM_MechWeaponry.xml
+++ b/Patches/Reinforced Mechanoid 2/ThingDefs_Misc/RM_MechWeaponry.xml
@@ -73,11 +73,11 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>RM_Gun_InfernoRifle</defName>
 					<statBases>
-						<Mass>200.00</Mass>
-						<RangedWeapon_Cooldown>2.53</RangedWeapon_Cooldown>
+						<Mass>50.00</Mass>
+						<RangedWeapon_Cooldown>2.68</RangedWeapon_Cooldown>
 						<SightsEfficiency>1</SightsEfficiency>
 						<ShotSpread>0.35</ShotSpread>
-						<SwayFactor>1.02</SwayFactor>
+						<SwayFactor>0.19</SwayFactor>
 						<Bulk>18.00</Bulk>
 					</statBases>
 					<Properties>
@@ -111,11 +111,11 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>RM_Gun_InfernoLauncher</defName>
 					<statBases>
-						<Mass>300.00</Mass>
+						<Mass>75.00</Mass>
 						<RangedWeapon_Cooldown>2.53</RangedWeapon_Cooldown>
 						<SightsEfficiency>1</SightsEfficiency>
 						<ShotSpread>0.35</ShotSpread>
-						<SwayFactor>1.02</SwayFactor>
+						<SwayFactor>0.21</SwayFactor>
 						<Bulk>20.00</Bulk>
 					</statBases>
 					<Properties>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Security_Turrets.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Security_Turrets.xml
@@ -215,14 +215,14 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VFE_Turret_AutoInfernoCannon"]/statBases/ShootingAccuracyTurret</xpath>
 					<value>
-						<ShootingAccuracyTurret>1.0</ShootingAccuracyTurret>
+						<ShootingAccuracyTurret>1.25</ShootingAccuracyTurret>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="VFE_Turret_AutoInfernoCannon"]/statBases</xpath>
 					<value>
-						<AimingAccuracy>0.5</AimingAccuracy>
+						<AimingAccuracy>0.75</AimingAccuracy>
 						<NightVisionEfficiency>0.4</NightVisionEfficiency>
 					</value>
 				</li>
@@ -237,7 +237,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VFE_Turret_AutoInfernoCannon"]/statBases/Mass</xpath>
 					<value>
-						<Mass>325</Mass>
+						<Mass>100</Mass>
 						<Bulk>100</Bulk>
 					</value>
 				</li>
@@ -262,7 +262,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VFE_Turret_AutoInfernoCannon"]/costList/Plasteel</xpath>
 					<value>
-						<Plasteel>120</Plasteel>
+						<Plasteel>90</Plasteel>
 						<Steel>140</Steel>
 					</value>
 				</li>
@@ -277,15 +277,15 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>VFE_Gun_AutoInfernoCannon</defName>
 					<statBases>
-						<Mass>200.00</Mass>
-						<RangedWeapon_Cooldown>2.5</RangedWeapon_Cooldown>
+						<Mass>50.00</Mass>
+						<RangedWeapon_Cooldown>2.54</RangedWeapon_Cooldown>
 						<SightsEfficiency>1</SightsEfficiency>
 						<ShotSpread>0.01</ShotSpread>
-						<SwayFactor>0.82</SwayFactor>
+						<SwayFactor>0.14</SwayFactor>
 						<Bulk>20.00</Bulk>
 					</statBases>
 					<Properties>
-						<recoilAmount>1.01</recoilAmount>
+						<recoilAmount>2.01</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
@@ -661,15 +661,15 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>VFE_Gun_AdvancedInfernoCannon</defName>
 					<statBases>
-						<Mass>250.00</Mass>
-						<RangedWeapon_Cooldown>2.5</RangedWeapon_Cooldown>
+						<Mass>75.00</Mass>
+						<RangedWeapon_Cooldown>2.52</RangedWeapon_Cooldown>
 						<SightsEfficiency>1</SightsEfficiency>
 						<ShotSpread>0.01</ShotSpread>
-						<SwayFactor>0.82</SwayFactor>
+						<SwayFactor>0.21</SwayFactor>
 						<Bulk>20.00</Bulk>
 					</statBases>
 					<Properties>
-						<recoilAmount>0.90</recoilAmount>
+						<recoilAmount>1.90</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
@@ -702,11 +702,11 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>VFE_Gun_AdvancedThumpCannon</defName>
 					<statBases>
-						<Mass>300.00</Mass>
-						<RangedWeapon_Cooldown>2.13</RangedWeapon_Cooldown>
+						<Mass>100.00</Mass>
+						<RangedWeapon_Cooldown>2.22</RangedWeapon_Cooldown>
 						<SightsEfficiency>1</SightsEfficiency>
 						<ShotSpread>0.01</ShotSpread>
-						<SwayFactor>0.82</SwayFactor>
+						<SwayFactor>0.26</SwayFactor>
 						<Bulk>20.00</Bulk>
 					</statBases>
 					<Properties>


### PR DESCRIPTION
## Changes

- Decreased the mass value of the inferno cannon down to 50kg and adjusted similar weapons accordingly.

## References

- https://docs.google.com/spreadsheets/d/1lbT0zzagCRPDJG4GctkeeoTsFCt3lYfM4SRnWt8ql-k/edit#gid=1573763037

## Reasoning

- The high mass is serving no purpose for a mounted weapon and it's only takin inventory space which said inventory space will be adjusted in a later PR.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
