### PR TITLE
Mechanoid tweaks

### DIFF
--- a/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Medium.xml
+++ b/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Medium.xml
@@ -87,7 +87,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Mech_Legionary"]/statBases</xpath>
 		<value>
-			<CarryWeight>60</CarryWeight>
+			<CarryWeight>75</CarryWeight>
 			<CarryBulk>40</CarryBulk>
 			<MeleeDodgeChance>0.12</MeleeDodgeChance>
 			<MeleeCritChance>0.11</MeleeCritChance>
@@ -265,7 +265,7 @@
 		<xpath>Defs/ThingDef[defName="Mech_Apocriton"]/statBases</xpath>
 		<value>
 			<ArmorRating_Heat>0.5</ArmorRating_Heat>
-			<CarryWeight>60</CarryWeight>
+			<CarryWeight>75</CarryWeight>
 			<CarryBulk>30</CarryBulk>
 			<MeleeDodgeChance>0.07</MeleeDodgeChance>
 			<MeleeCritChance>0.13</MeleeCritChance>

--- a/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_SuperHeavy.xml
+++ b/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_SuperHeavy.xml
@@ -52,14 +52,14 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mech_Centurion"]/statBases/EnergyShieldRechargeRate</xpath>
 		<value>
-			<EnergyShieldRechargeRate>0.75</EnergyShieldRechargeRate>
+			<EnergyShieldRechargeRate>1.0</EnergyShieldRechargeRate>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mech_Centurion"]/statBases/EnergyShieldEnergyMax</xpath>
 		<value>
-			<EnergyShieldEnergyMax>4.5</EnergyShieldEnergyMax>
+			<EnergyShieldEnergyMax>6.0</EnergyShieldEnergyMax>
 		</value>
 	</Operation>
 
@@ -67,7 +67,7 @@
 		<xpath>Defs/ThingDef[defName="Mech_Centurion"]/statBases</xpath>
 		<value>
 			<ArmorRating_Heat>0.25</ArmorRating_Heat>
-			<CarryWeight>100</CarryWeight>
+			<CarryWeight>50</CarryWeight>
 			<CarryBulk>50</CarryBulk>
 			<AimingAccuracy>1.0</AimingAccuracy>
 			<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
@@ -81,7 +81,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mech_Centurion"]/comps/li[@Class="CompProperties_ProjectileInterceptor"]/hitPoints</xpath>
 		<value>
-			<hitPoints>450</hitPoints>
+			<hitPoints>600</hitPoints>
 		</value>
 	</Operation>
 
@@ -167,7 +167,7 @@
 		<xpath>Defs/ThingDef[defName="Mech_Warqueen"]/statBases</xpath>
 		<value>
 			<ArmorRating_Heat>0.5</ArmorRating_Heat>
-			<CarryWeight>100</CarryWeight>
+			<CarryWeight>75</CarryWeight>
 			<CarryBulk>50</CarryBulk>
 			<AimingAccuracy>1.0</AimingAccuracy>
 			<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
@@ -247,7 +247,7 @@
 		<xpath>Defs/ThingDef[defName="Mech_Diabolus"]/statBases</xpath>
 		<value>
 			<ArmorRating_Heat>0.5</ArmorRating_Heat>
-			<CarryWeight>300</CarryWeight>
+			<CarryWeight>75</CarryWeight>
 			<CarryBulk>60</CarryBulk>
 			<AimingAccuracy>1.0</AimingAccuracy>
 			<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>

--- a/Patches/Advanced Mechanoid Warfare/Patches/Patch_Races.xml
+++ b/Patches/Advanced Mechanoid Warfare/Patches/Patch_Races.xml
@@ -156,7 +156,7 @@
 						defName="Mech_Wraith"
 						]/statBases </xpath>
 					<value>
-						<CarryWeight>400</CarryWeight>
+						<CarryWeight>200</CarryWeight>
 						<CarryBulk>80</CarryBulk>
 						<AimingAccuracy>1.0</AimingAccuracy>
 						<ShootingAccuracyPawn>1</ShootingAccuracyPawn>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Apoptosis.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Apoptosis.xml
@@ -27,7 +27,7 @@
 						<xpath>Defs/ThingDef[defName="AM_Apoptosis"]/statBases</xpath>
 						<value>
 							<ArmorRating_Heat>0.75</ArmorRating_Heat>
-							<CarryWeight>60</CarryWeight>
+							<CarryWeight>75</CarryWeight>
 							<CarryBulk>30</CarryBulk>
 							<MeleeDodgeChance>0.1</MeleeDodgeChance>
 							<MeleeCritChance>0.13</MeleeCritChance>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Infernus.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Infernus.xml
@@ -27,7 +27,7 @@
 						<xpath>Defs/ThingDef[defName="AM_Infernus"]/statBases</xpath>
 						<value>
 							<ArmorRating_Heat>0.75</ArmorRating_Heat>
-							<CarryWeight>300</CarryWeight>
+							<CarryWeight>75</CarryWeight>
 							<CarryBulk>60</CarryBulk>
 							<AimingAccuracy>1.0</AimingAccuracy>
 							<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Legate.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Legate.xml
@@ -26,14 +26,14 @@
 					<li Class="PatchOperationReplace">
 						<xpath>Defs/ThingDef[defName="AM_Mech_Legate"]/statBases/EnergyShieldRechargeRate</xpath>
 						<value>
-							<EnergyShieldRechargeRate>1.125</EnergyShieldRechargeRate>
+							<EnergyShieldRechargeRate>1.5</EnergyShieldRechargeRate>
 						</value>
 					</li>
 
 					<li Class="PatchOperationReplace">
 						<xpath>Defs/ThingDef[defName="AM_Mech_Legate"]/statBases/EnergyShieldEnergyMax</xpath>
 						<value>
-							<EnergyShieldEnergyMax>7.5</EnergyShieldEnergyMax>
+							<EnergyShieldEnergyMax>10.0</EnergyShieldEnergyMax>
 						</value>
 					</li>
 
@@ -41,8 +41,8 @@
 						<xpath>Defs/ThingDef[defName="AM_Mech_Legate"]/statBases</xpath>
 						<value>
 							<ArmorRating_Heat>0.5</ArmorRating_Heat>
-							<CarryWeight>150</CarryWeight>
-							<CarryBulk>50</CarryBulk>
+							<CarryWeight>100</CarryWeight>
+							<CarryBulk>75</CarryBulk>
 							<AimingAccuracy>1.0</AimingAccuracy>
 							<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
 							<MeleeDodgeChance>0.02</MeleeDodgeChance>
@@ -55,7 +55,7 @@
 					<li Class="PatchOperationReplace">
 						<xpath>Defs/ThingDef[defName="AM_Mech_Legate"]/comps/li[@Class="CompProperties_ProjectileInterceptor"]/hitPoints</xpath>
 						<value>
-							<hitPoints>675</hitPoints>
+							<hitPoints>1000</hitPoints>
 						</value>
 					</li>
 

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Siegemelter.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Siegemelter.xml
@@ -41,7 +41,7 @@
 						<value>
 							<ArmorRating_Heat>0.5</ArmorRating_Heat>
 							<CarryWeight>200</CarryWeight>
-							<CarryBulk>300</CarryBulk>
+							<CarryBulk>150</CarryBulk>
 							<AimingAccuracy>1.0</AimingAccuracy>
 							<ShootingAccuracyPawn>1.0</ShootingAccuracyPawn>
 							<MeleeDodgeChance>0.01</MeleeDodgeChance>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Starfire.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Starfire.xml
@@ -41,7 +41,7 @@
 						<value>
 							<ArmorRating_Heat>0.5</ArmorRating_Heat>
 							<CarryWeight>200</CarryWeight>
-							<CarryBulk>300</CarryBulk>
+							<CarryBulk>150</CarryBulk>
 							<AimingAccuracy>1.0</AimingAccuracy>
 							<ShootingAccuracyPawn>1.0</ShootingAccuracyPawn>
 							<MeleeDodgeChance>0.01</MeleeDodgeChance>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_WarEmpress.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_WarEmpress.xml
@@ -41,7 +41,7 @@
 						<xpath>Defs/ThingDef[defName="AM_WarEmpress"]/statBases</xpath>
 						<value>
 							<ArmorRating_Heat>0.75</ArmorRating_Heat>
-							<CarryWeight>100</CarryWeight>
+							<CarryWeight>75</CarryWeight>
 							<CarryBulk>50</CarryBulk>
 							<AimingAccuracy>1.0</AimingAccuracy>
 							<ShootingAccuracyPawn>1</ShootingAccuracyPawn>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvGoliath.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvGoliath.xml
@@ -41,8 +41,8 @@
 						<xpath>Defs/ThingDef[defName="VFE_Mech_Advanced_Goliath"]/statBases</xpath>
 						<value>
 							<ArmorRating_Heat>0.75</ArmorRating_Heat>
-							<CarryWeight>400</CarryWeight>
-							<CarryBulk>200</CarryBulk>
+							<CarryWeight>200</CarryWeight>
+							<CarryBulk>100</CarryBulk>
 							<AimingAccuracy>1.0</AimingAccuracy>
 							<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
 							<MeleeDodgeChance>0.05</MeleeDodgeChance>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvSiegebreaker.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvSiegebreaker.xml
@@ -42,7 +42,7 @@
 						<value>
 							<ArmorRating_Heat>0.75</ArmorRating_Heat>
 							<CarryWeight>200</CarryWeight>
-							<CarryBulk>300</CarryBulk>
+							<CarryBulk>200</CarryBulk>
 							<AimingAccuracy>1.0</AimingAccuracy>
 							<ShootingAccuracyPawn>1.0</ShootingAccuracyPawn>
 							<MeleeDodgeChance>0.01</MeleeDodgeChance>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEGoliath.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEGoliath.xml
@@ -40,8 +40,8 @@
 						<xpath>Defs/ThingDef[defName="VFE_Mech_Goliath"]/statBases</xpath>
 						<value>
 							<ArmorRating_Heat>0.25</ArmorRating_Heat>
-							<CarryWeight>400</CarryWeight>
-							<CarryBulk>200</CarryBulk>
+							<CarryWeight>200</CarryWeight>
+							<CarryBulk>100</CarryBulk>
 							<AimingAccuracy>1.0</AimingAccuracy>
 							<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
 							<MeleeDodgeChance>0.05</MeleeDodgeChance>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFESiegebreaker.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFESiegebreaker.xml
@@ -41,7 +41,7 @@
 						<value>
 							<ArmorRating_Heat>0.25</ArmorRating_Heat>
 							<CarryWeight>200</CarryWeight>
-							<CarryBulk>300</CarryBulk>
+							<CarryBulk>150</CarryBulk>
 							<AimingAccuracy>1.0</AimingAccuracy>
 							<ShootingAccuracyPawn>1.0</ShootingAccuracyPawn>
 							<MeleeDodgeChance>0.01</MeleeDodgeChance>

--- a/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Goliath.xml
+++ b/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Goliath.xml
@@ -36,8 +36,8 @@
 					<xpath>Defs/ThingDef[defName="AM_Goliath"]/statBases</xpath>
 					<value>
 						<ArmorRating_Heat>0.25</ArmorRating_Heat>
-						<CarryWeight>400</CarryWeight>
-						<CarryBulk>200</CarryBulk>
+						<CarryWeight>200</CarryWeight>
+						<CarryBulk>100</CarryBulk>
 						<AimingAccuracy>1.0</AimingAccuracy>
 						<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
 						<MeleeDodgeChance>0.05</MeleeDodgeChance>

--- a/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Siegebreaker.xml
+++ b/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Siegebreaker.xml
@@ -36,7 +36,7 @@
 					<value>
 						<ArmorRating_Heat>0.25</ArmorRating_Heat>
 						<CarryWeight>200</CarryWeight>
-						<CarryBulk>300</CarryBulk>
+						<CarryBulk>150</CarryBulk>
 						<AimingAccuracy>1.0</AimingAccuracy>
 						<ShootingAccuracyPawn>1.0</ShootingAccuracyPawn>
 						<MeleeDodgeChance>0.01</MeleeDodgeChance>

--- a/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
@@ -146,7 +146,7 @@
 		<xpath>Defs/ThingDef[@Name="MechCentipede"]/statBases</xpath>
 		<value>
 			<ArmorRating_Heat>0.25</ArmorRating_Heat>
-			<CarryWeight>250</CarryWeight>
+			<CarryWeight>150</CarryWeight>
 			<CarryBulk>60</CarryBulk>
 			<AimingAccuracy>1.0</AimingAccuracy>
 			<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
@@ -597,7 +597,7 @@
 		<xpath>Defs/ThingDef[defName="Mech_Termite"]/statBases</xpath>
 		<value>
 			<ArmorRating_Heat>0.25</ArmorRating_Heat>
-			<CarryWeight>300</CarryWeight>
+			<CarryWeight>150</CarryWeight>
 			<CarryBulk>60</CarryBulk>
 			<AimingAccuracy>1.0</AimingAccuracy>
 			<ShootingAccuracyPawn>1</ShootingAccuracyPawn>

--- a/Patches/MechanoidsExtraordinaire/ThingDefs_Races/Races_Mechanoid_MechanoidsExtraordinaire.xml
+++ b/Patches/MechanoidsExtraordinaire/ThingDefs_Races/Races_Mechanoid_MechanoidsExtraordinaire.xml
@@ -80,7 +80,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="Mechanoid_Hound"]/statBases</xpath>
 					<value>
-						<CarryWeight>350</CarryWeight>
+						<CarryWeight>200</CarryWeight>
 						<CarryBulk>100</CarryBulk>
 						<AimingAccuracy>0.8</AimingAccuracy>
 						<ShootingAccuracyPawn>0.8</ShootingAccuracyPawn>
@@ -141,7 +141,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="Mechanoid_Chimera"]/statBases</xpath>
 					<value>
-						<CarryWeight>380</CarryWeight>
+						<CarryWeight>200</CarryWeight>
 						<CarryBulk>120</CarryBulk>
 						<AimingAccuracy>1.0</AimingAccuracy>
 						<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
@@ -202,7 +202,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="Mechanoid_Goliath"]/statBases</xpath>
 					<value>
-						<CarryWeight>200</CarryWeight>
+						<CarryWeight>150</CarryWeight>
 						<CarryBulk>40</CarryBulk>
 						<AimingAccuracy>0.8</AimingAccuracy>
 						<ShootingAccuracyPawn>0.8</ShootingAccuracyPawn>
@@ -263,8 +263,8 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="Mechanoid_Kraken"]/statBases</xpath>
 					<value>
-						<CarryWeight>400</CarryWeight>
-						<CarryBulk>200</CarryBulk>
+						<CarryWeight>200</CarryWeight>
+						<CarryBulk>150</CarryBulk>
 						<AimingAccuracy>1.0</AimingAccuracy>
 						<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
 						<MeleeDodgeChance>0.15</MeleeDodgeChance>

--- a/Patches/Reinforced Mechanoid 2/ThingDefs_Races/RM_Races_Mechanoids.xml
+++ b/Patches/Reinforced Mechanoid 2/ThingDefs_Races/RM_Races_Mechanoids.xml
@@ -101,7 +101,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="RM_Mech_Caretaker"]/statBases</xpath>
 					<value>
-						<CarryWeight>400</CarryWeight>
+						<CarryWeight>200</CarryWeight>
 						<CarryBulk>80</CarryBulk>
 						<AimingAccuracy>1.0</AimingAccuracy>
 						<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
@@ -770,7 +770,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="RM_Mech_Behemoth"]/statBases</xpath>
 					<value>
-						<CarryWeight>300</CarryWeight>
+						<CarryWeight>200</CarryWeight>
 						<CarryBulk>80</CarryBulk>
 						<AimingAccuracy>1.0</AimingAccuracy>
 						<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
@@ -851,7 +851,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="RM_Mech_Wraith"]/statBases</xpath>
 					<value>
-						<CarryWeight>400</CarryWeight>
+						<CarryWeight>200</CarryWeight>
 						<CarryBulk>80</CarryBulk>
 						<AimingAccuracy>1.0</AimingAccuracy>
 						<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
@@ -908,7 +908,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="RM_Mech_Locust"]/statBases</xpath>
 					<value>
-						<CarryWeight>400</CarryWeight>
+						<CarryWeight>200</CarryWeight>
 						<CarryBulk>80</CarryBulk>
 						<AimingAccuracy>1.0</AimingAccuracy>
 						<ShootingAccuracyPawn>1</ShootingAccuracyPawn>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
@@ -68,7 +68,7 @@
 					<xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedCentipede"]/statBases</xpath>
 					<value>
 						<ArmorRating_Heat>0.75</ArmorRating_Heat>
-						<CarryWeight>260</CarryWeight>
+						<CarryWeight>160</CarryWeight>
 						<CarryBulk>70</CarryBulk>
 						<AimingAccuracy>1.05</AimingAccuracy>
 						<ShootingAccuracyPawn>1.05</ShootingAccuracyPawn>
@@ -721,7 +721,7 @@
 					<xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedCarpenter"]/statBases</xpath>
 					<value>
 						<ArmorRating_Heat>0.75</ArmorRating_Heat>
-						<CarryWeight>400</CarryWeight>
+						<CarryWeight>150</CarryWeight>
 						<CarryBulk>80</CarryBulk>
 						<MeleeDodgeChance>0.04</MeleeDodgeChance>
 						<MeleeCritChance>0.47</MeleeCritChance>
@@ -814,7 +814,7 @@
 					<value>
 						<statBases>
 							<ArmorRating_Heat>0.75</ArmorRating_Heat>
-							<CarryWeight>300</CarryWeight>
+							<CarryWeight>150</CarryWeight>
 							<CarryBulk>60</CarryBulk>
 							<AimingAccuracy>1.0</AimingAccuracy>
 							<ShootingAccuracyPawn>1</ShootingAccuracyPawn>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid_PlayerControlled.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid_PlayerControlled.xml
@@ -28,7 +28,7 @@
 						<xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedCentipede_PlayerControlled"]/statBases</xpath>
 						<value>
 							<ArmorRating_Heat>0.75</ArmorRating_Heat>
-							<CarryWeight>260</CarryWeight>
+							<CarryWeight>160</CarryWeight>
 							<CarryBulk>70</CarryBulk>
 							<AimingAccuracy>1.05</AimingAccuracy>
 							<ShootingAccuracyPawn>1.05</ShootingAccuracyPawn>
@@ -694,7 +694,7 @@
 						<xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedTermite_PlayerControlled"]/statBases</xpath>
 						<value>
 							<ArmorRating_Heat>0.75</ArmorRating_Heat>
-							<CarryWeight>300</CarryWeight>
+							<CarryWeight>150</CarryWeight>
 							<CarryBulk>60</CarryBulk>
 							<AimingAccuracy>1.0</AimingAccuracy>
 							<ShootingAccuracyPawn>1</ShootingAccuracyPawn>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -92,7 +92,7 @@
 					<xpath>Defs/ThingDef[defName="VFE_Mech_Centipede"]/statBases</xpath>
 					<value>
 						<ArmorRating_Heat>0.25</ArmorRating_Heat>
-						<CarryWeight>250</CarryWeight>
+						<CarryWeight>150</CarryWeight>
 						<CarryBulk>60</CarryBulk>
 						<AimingAccuracy>1.0</AimingAccuracy>
 						<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
@@ -747,7 +747,7 @@
 					<xpath>Defs/ThingDef[defName="VFE_Mech_Carpenter" or defName="VFE_AncientMech_AncientCarpenter"]/statBases</xpath>
 					<value>
 						<ArmorRating_Heat>0.25</ArmorRating_Heat>
-						<CarryWeight>400</CarryWeight>
+						<CarryWeight>150</CarryWeight>
 						<CarryBulk>80</CarryBulk>
 						<MeleeDodgeChance>0.03</MeleeDodgeChance>
 						<MeleeCritChance>0.40</MeleeCritChance>
@@ -849,7 +849,7 @@
 					<xpath>Defs/ThingDef[defName="VFE_Mech_Termite"]/statBases</xpath>
 					<value>
 						<ArmorRating_Heat>0.25</ArmorRating_Heat>
-						<CarryWeight>300</CarryWeight>
+						<CarryWeight>150</CarryWeight>
 						<CarryBulk>60</CarryBulk>
 						<AimingAccuracy>1.0</AimingAccuracy>
 						<ShootingAccuracyPawn>1</ShootingAccuracyPawn>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid_PlayerControlled.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid_PlayerControlled.xml
@@ -27,7 +27,7 @@
 						<xpath>Defs/ThingDef[defName="VFE_Mech_Termite_PlayerControlled"]/statBases</xpath>
 						<value>
 							<ArmorRating_Heat>0.25</ArmorRating_Heat>
-							<CarryWeight>300</CarryWeight>
+							<CarryWeight>150</CarryWeight>
 							<CarryBulk>60</CarryBulk>
 							<AimingAccuracy>1.0</AimingAccuracy>
 							<ShootingAccuracyPawn>1</ShootingAccuracyPawn>


### PR DESCRIPTION
## Changes

- Reduced the mass carry capacity of large mechs. Centipedes got reduced from 250kg base down to 150 kg (750kg to 450kg). 
- Increased the shield capacity of centurion mechs.

## Reasoning

- With the introduction of Biotech and buildable mechs, the inventory size of large mechs in the hands of the player neared unreasonably high amounts which made certain pawns/entities that handled the duty of carrying things in caravans pretty much obsolete. This coupled with the fact that mech loadouts received a reduction in size, results in a need for reducing the mass capacity of large mechs which used to be just free inventory space ripe for filling up.
- Centurions have very little going for them aside from the shield and the turret on their back, increased their shield capacity to make them more viable and desirable to build considering their high cost to make.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
