### PR TITLE
Fix Multiplayer issue with Fire at Will gizmo

### DIFF
--- a/Source/CombatExtended/Compatibility/Multiplayer.cs
+++ b/Source/CombatExtended/Compatibility/Multiplayer.cs
@@ -40,6 +40,19 @@ namespace CombatExtended.Compatibility
             }
         }
 
+        public static bool IsExecutingCommands
+        {
+            get
+            {
+                if (isMultiplayerActive)
+                {
+                    return _isExecutingCommands();
+                }
+
+                return false;
+            }
+        }
+
         public static bool IsExecutingCommandsIssuedBySelf
         {
             get
@@ -52,13 +65,16 @@ namespace CombatExtended.Compatibility
             }
         }
 
-        public static void registerCallbacks(Func<bool> inMP, Func<bool> iecibs)
+        public static void registerCallbacks(Func<bool> inMP, Func<bool> iec, Func<bool> iecibs)
         {
             _inMultiplayer = inMP;
+            _isExecutingCommands = iec;
             _isExecutingCommandsIssuedBySelf = iecibs;
         }
 
         private static Func<bool> _inMultiplayer = null;
+
+        private static Func<bool> _isExecutingCommands = null;
 
         private static Func<bool> _isExecutingCommandsIssuedBySelf = null;
 

--- a/Source/CombatExtended/Harmony/Harmony_Pawn_DraftController.cs
+++ b/Source/CombatExtended/Harmony/Harmony_Pawn_DraftController.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using CombatExtended.Compatibility;
 using Verse.AI;
 
 namespace CombatExtended.HarmonyCE
@@ -16,6 +17,16 @@ namespace CombatExtended.HarmonyCE
         {
             if (!___fireAtWillInt)
             {
+                // In Multiplayer, the FireAtWill setter is marked as a sync method.
+                // Due to how those work - the method will be stopped from running, the call synchronized to all players and then will run
+                // fully. However, because of how Harmony works all prefixes, postfixes, finalizers will still run - which will cause issues
+                // as this postfix will run before it ends up being synchronized in Multiplayer.
+                // Once Multiplayer API exposes `InInterface` method, it should replace this check (as it'll better handle a few edge cases).
+                if (Multiplayer.InMultiplayer && !Multiplayer.IsExecutingCommands)
+                {
+                    return;
+                }
+
                 var jobTracker = __instance.pawn.jobs;
                 foreach (var queuedJob in jobTracker.jobQueue.ToList())
                 {

--- a/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
+++ b/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
@@ -65,7 +65,7 @@ namespace CombatExtended.Compatibility.MultiplayerAPI
 
             MP.RegisterAll();
 
-            global::CombatExtended.Compatibility.Multiplayer.registerCallbacks((() => MP.IsInMultiplayer), (() => MP.IsExecutingSyncCommandIssuedBySelf));
+            global::CombatExtended.Compatibility.Multiplayer.registerCallbacks((() => MP.IsInMultiplayer), (() => MP.IsExecutingSyncCommand), (() => MP.IsExecutingSyncCommandIssuedBySelf));
         }
 
 


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Added callback for `MP.IsExecutingSyncCommand`
- Cancel execution of postfix to `Pawn_DraftController.FireAtWill` in Multiplayer outside of synced commands (delay the call)

## Reasoning

Why did you choose to implement things this way, e.g.
- The callback is required for the second part of the PR
- `FireAtWill` is a synced method in Multiplayer, which causes the execution to be delayed until synchronized. However, this does not affect prefixes, postfixes, and finalizer thus the postfix would run and cause a desync in Multiplayer. The postfix will still run after the method is synchronized, just won't run when the original method was cancelled by Multiplayer.

## Alternatives

Describe alternative implementations you have considered, e.g.
- Instead of using `MP.IsExecutingSyncCommand`, we could directly access Multiplayer code (through reflection, harmony, etc.) and get access to `InInterface` getter. It would be slightly more reliable in a few edge cases, but personally I think it's better to wait until it's exposed through the API.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (around 5 minutes with and without Multiplayer active)
