### PR TITLE
Repairing armor from CompArmorDurability forces the target to wait in place

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompArmorDurability.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompArmorDurability.cs
@@ -374,7 +374,7 @@ namespace CombatExtended
 
             yield return toil;
 
-            var toilWait = Toils_General.Wait(natArmor.durabilityProps.RepairTime, TargetIndex.A).WithProgressBarToilDelay(TargetIndex.A);
+            var toilWait = Toils_General.WaitWith(TargetIndex.A, natArmor.durabilityProps.RepairTime, true, true, true, face: TargetIndex.A);
 
             toilWait.AddFinishAction(
                 delegate


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- When repairing armor from `CompArmorDurability`, the target will wait along with the pawn repairing the armor
- `WithProgressBarToilDelay` was removed as `WaitWith` has an argument `useProgressBar`, which does exactly the same thing

## Reasoning

Why did you choose to implement things this way, e.g.
- Pawns walking away while having their armor repaired and then still getting the effect of repairing from a distance is rather unrealistic

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] Playtested a colony (a few minutes of testing)
