### PR TITLE
Fixed desync with multiplayer 0-tick impact projectiles

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -170,7 +170,12 @@ namespace CombatExtended
                         {
                             destinationInt = origin;
                             startingTicksToImpactInt = 0f;
-                            ImpactSomething();
+                            // During drawing in Multiplayer - impact causes issues. Will get handled inside of the `Tick` call.
+                            // In the future, replace this with `!InInterface` call, as it's more fitting here.
+                            if (!Multiplayer.InMultiplayer)
+                            {
+                                ImpactSomething();
+                            }
                             return 0f;
                         }
                         // Multiplied by ticksPerSecond since the calculated time is actually in seconds.


### PR DESCRIPTION
## Changes

- `ProjectileCE:StartingTicksToImpact` won't call `ImpactSomething` when MP is active.

## Reasoning

- `StartingTicksToImpact` getter can get called outside of ticking (during drawing), causing the `ImpactSomething` method to get called. In MP, `ImpactSomething` will cause issues when called during drawing as the call won't be called at the same time across all players, causing issues.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (around an hour of combat tests)
