### PR TITLE
Grimforge 40k - Imperium Materials

### DIFF
--- a/Patches/Grimforge 40k - Imperium Materials/ThingDefs_Misc/Items_Resource_Stuff.xml
+++ b/Patches/Grimforge 40k - Imperium Materials/ThingDefs_Misc/Items_Resource_Stuff.xml
@@ -1,0 +1,175 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>GrimForge 40k - Imperium Materials</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<!-- Adamantium -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="GF40K_Adamantium"]/stuffProps/categories</xpath>
+					<value>
+						<li>Metallic_Weapon</li>
+						<li>Steeled</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>
+						Defs/ThingDef[defName="GF40K_Adamantium"]/statBases/StuffPower_Armor_Sharp</xpath>
+					<value>
+						<StuffPower_Armor_Sharp>2.6</StuffPower_Armor_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>
+						Defs/ThingDef[defName="GF40K_Adamantium"]/statBases/StuffPower_Armor_Blunt</xpath>
+					<value>
+						<StuffPower_Armor_Blunt>4</StuffPower_Armor_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="GF40K_Adamantium"]/statBases/StuffPower_Armor_Heat</xpath>
+					<value>
+						<StuffPower_Armor_Heat>0</StuffPower_Armor_Heat>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="GF40K_Adamantium"]/statBases</xpath>
+					<value>
+						<Bulk>0.05</Bulk>
+					</value>
+				</li>
+
+				<!-- Auramite -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="GF40K_Auramite"]/stuffProps/categories</xpath>
+					<value>
+						<li>Metallic_Weapon</li>
+						<li>Steeled</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>
+						Defs/ThingDef[defName="GF40K_Auramite"]/statBases/StuffPower_Armor_Sharp</xpath>
+					<value>
+						<StuffPower_Armor_Sharp>2.4</StuffPower_Armor_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>
+						Defs/ThingDef[defName="GF40K_Auramite"]/statBases/StuffPower_Armor_Blunt</xpath>
+					<value>
+						<StuffPower_Armor_Blunt>3.6</StuffPower_Armor_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="GF40K_Auramite"]/statBases/StuffPower_Armor_Heat</xpath>
+					<value>
+						<StuffPower_Armor_Heat>0</StuffPower_Armor_Heat>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="GF40K_Auramite"]/statBases</xpath>
+					<value>
+						<Bulk>0.04</Bulk>
+					</value>
+				</li>
+
+				<!-- Ceramite -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="GF40K_Ceramite"]/stuffProps/categories</xpath>
+					<value>
+						<li>Metallic_Weapon</li>
+						<li>Steeled</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>
+						Defs/ThingDef[defName="GF40K_Ceramite"]/statBases/StuffPower_Armor_Sharp</xpath>
+					<value>
+						<StuffPower_Armor_Sharp>1.4</StuffPower_Armor_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>
+						Defs/ThingDef[defName="GF40K_Ceramite"]/statBases/StuffPower_Armor_Blunt</xpath>
+					<value>
+						<StuffPower_Armor_Blunt>2.1</StuffPower_Armor_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="GF40K_Ceramite"]/statBases/StuffPower_Armor_Heat</xpath>
+					<value>
+						<StuffPower_Armor_Heat>0</StuffPower_Armor_Heat>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="GF40K_Ceramite"]/statBases</xpath>
+					<value>
+						<Bulk>0.03</Bulk>
+					</value>
+				</li>
+
+				<!-- Diamantine -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="GF40K_Diamantine"]/stuffProps/categories</xpath>
+					<value>
+						<li>Metallic_Weapon</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>
+						Defs/ThingDef[defName="GF40K_Diamantine"]/statBases/StuffPower_Armor_Sharp</xpath>
+					<value>
+						<StuffPower_Armor_Sharp>2.1</StuffPower_Armor_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>
+						Defs/ThingDef[defName="GF40K_Diamantine"]/statBases/StuffPower_Armor_Blunt</xpath>
+					<value>
+						<StuffPower_Armor_Blunt>3.2</StuffPower_Armor_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="GF40K_Diamantine"]/statBases/StuffPower_Armor_Heat</xpath>
+					<value>
+						<StuffPower_Armor_Heat>0</StuffPower_Armor_Heat>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="GF40K_Diamantine"]/statBases</xpath>
+					<value>
+						<Bulk>0.03</Bulk>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Patched the new materials to have the Blunt and Sharp ratings in line with CE
- Added necessary categories for enemies to spawn with armors stuffed by these

## Changes

Describe adjustments to existing features made in this merge, e.g.
- 


## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- From what I saw on the mod page Auramite is meant to be 20% better than plasteel, from there I estimated the values for the rest using the CE patch for vanilla steel and plasteel.

## Alternatives

Describe alternative implementations you have considered, e.g.
- Making the materials even stronger
- If possible could use a check for balancing

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long) - Crafted Armor vests with the new materials to check it was applying the new values correctly. Did this during a dev quicktest
