### PR TITLE
Global targeting for rocketswarm-like systems fix

### DIFF
--- a/Source/CombatExtended/CombatExtended/Things/Building_TurretGunCE.cs
+++ b/Source/CombatExtended/CombatExtended/Things/Building_TurretGunCE.cs
@@ -314,7 +314,7 @@ namespace CombatExtended
             //This code runs TryOrderReload for manning pawns or for non-humanlike intelligence such as mechs
             /*if (this.IsHashIntervalTick(TicksBetweenAmmoChecks) && !isReloading && (MannableComp?.MannedNow ?? false))
                   TryOrderReload(CompAmmo?.CurMagCount == 0);*/
-            if (!CanSetForcedTarget && !isReloading && forcedTarget.IsValid && burstCooldownTicksLeft <= 0)
+            if (!CanSetForcedTarget && !isReloading && forcedTarget.IsValid && !globalTargetInfo.IsValid && burstCooldownTicksLeft <= 0)
             {
                 ResetForcedTarget();
             }


### PR DESCRIPTION

## Changes

- Rocketswarms now able to shell world targets... Again.


## Reasoning

- Can't remeber if there was if-statement that I changed.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (tried to shell world object by a rocketswarm)
