### PR TITLE
Fix for 762x385mmRCannon and 762x539mmR

### DIFF
--- a/Defs/Ammo/Shell/762x385mmRCannon.xml
+++ b/Defs/Ammo/Shell/762x385mmRCannon.xml
@@ -46,7 +46,7 @@
 		<label>76.2x385mmR Cannon shell (HEAT)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Cannon/Tank/HEAT</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>58.1</MarketValue>
@@ -60,7 +60,7 @@
 		<label>76.2x385mmR Cannon shell (HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Cannon/Tank/HE</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>56.54</MarketValue>
@@ -74,7 +74,7 @@
 		<label>76.2x385mmR Cannon shell (EMP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Cannon/Tank/EMP</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>87.70</MarketValue>

--- a/Defs/Ammo/Shell/762x539mmR.xml
+++ b/Defs/Ammo/Shell/762x539mmR.xml
@@ -44,7 +44,7 @@
 		<defName>Ammo_762x539mmR_AP</defName>
 		<label>76.2x539mmR Cannon shell (AP)</label>
 		<graphicData>
-			<texPath>Things/Ammo/Cannon/Flak/APHE</texPath>
+			<texPath>Things/Ammo/Cannon/Tank/APHE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
@@ -58,7 +58,7 @@
 		<defName>Ammo_762x539mmR_HE</defName>
 		<label>76.2x539mmR Cannon shell (HE)</label>
 		<graphicData>
-			<texPath>Things/Ammo/Cannon/Flak/HE</texPath>
+			<texPath>Things/Ammo/Cannon/Tank/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- 762x539mmR texPath updated. Was referencing deleted textures
- 762x385mmRCannon GraphicClass updated to Graphic_StackCount as was giving errors when GraphicClass set to Graphic_Single. 

## Reasoning
Red errors on launch from missing textures and incorrect GraphicClass

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [x] Game runs without errors (Red errors on launch are gone)
