### PR TITLE
phynilla Expanded Mech Scyther patch

### DIFF
--- a/Patches/pphhyy Expanded Scythers/MechBodies_CE.xml
+++ b/Patches/pphhyy Expanded Scythers/MechBodies_CE.xml
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>phynilla Expanded Mechs Scyther</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+	
+
+	<!-- ====================Phynilla Scythers ==================== -->
+
+	<!-- ========== Add groups entry if it doesn't exist already ========== -->
+
+	<li Class="PatchOperationConditional">
+		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/groups</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart</xpath>
+			<value>
+				<groups />
+			</value>
+		</nomatch>
+	</li>
+
+	<li Class="PatchOperationConditional">
+		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalNeck"]</xpath>
+			<value>
+				<groups />
+			</value>
+		</nomatch>
+	</li>
+
+	<li Class="PatchOperationConditional">
+		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]</xpath>
+			<value>
+				<groups />
+			</value>
+		</nomatch>
+	</li>
+
+	<li Class="PatchOperationConditional">
+		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]/groups</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]</xpath>
+			<value>
+				<groups />
+			</value>
+		</nomatch>
+	</li>
+
+	<li Class="PatchOperationConditional">
+		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/groups</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]</xpath>
+			<value>
+				<groups />
+			</value>
+		</nomatch>
+	</li>
+
+	<li Class="PatchOperationConditional">
+		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="MechanicalHand"]/groups</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="MechanicalHand"]</xpath>
+			<value>
+				<groups />
+			</value>
+		</nomatch>
+	</li>
+
+	<li Class="PatchOperationConditional">
+		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalLeg"]</xpath>
+			<value>
+				<groups />
+			</value>
+		</nomatch>
+	</li>
+
+	<li Class="PatchOperationConditional">
+		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]</xpath>
+			<value>
+				<groups />
+			</value>
+		</nomatch>
+	</li>
+
+	<!-- ========== Add armor coverage ========== -->
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/groups</xpath>
+		<value>
+			<li>CoveredByNaturalArmor</li>
+		</value>
+	</li>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
+		<value>
+			<li>CoveredByNaturalArmor</li>
+		</value>
+	</li>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
+		<value>
+			<li>CoveredByNaturalArmor</li>
+		</value>
+	</li>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]/groups</xpath>
+		<value>
+			<li>CoveredByNaturalArmor</li>
+		</value>
+	</li>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/groups</xpath>
+		<value>
+			<li>CoveredByNaturalArmor</li>
+		</value>
+	</li>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="MechanicalHand"]/groups</xpath>
+		<value>
+			<li>CoveredByNaturalArmor</li>
+		</value>
+	</li>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="Blade"]/groups</xpath>
+		<value>
+			<li>CoveredByNaturalArmor</li>
+		</value>
+	</li>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="MechanicalHand"]/parts/li[def="MechanicalFinger"]/groups</xpath>
+		<value>
+			<li>CoveredByNaturalArmor</li>
+		</value>
+	</li>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
+		<value>
+			<li>CoveredByNaturalArmor</li>
+		</value>
+	</li>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
+		<value>
+			<li>CoveredByNaturalArmor</li>
+		</value>
+	</li>
+
+	<!-- ========== Modify coverage ========== -->
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]/coverage</xpath>
+		<value>
+			<coverage>0.15</coverage>
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="Blade"]/coverage</xpath>
+		<value>
+			<coverage>0.2</coverage>
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="FluidReprocessor"]/coverage</xpath>
+		<value>
+			<coverage>0.05</coverage>
+		</value>
+	</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/pphhyy Expanded Scythers/MechBodies_CE.xml
+++ b/Patches/pphhyy Expanded Scythers/MechBodies_CE.xml
@@ -7,186 +7,185 @@
 		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>
-	
 
-	<!-- ====================Phynilla Scythers ==================== -->
+			<!-- ==================== Phynilla Scythers ==================== -->
 
-	<!-- ========== Add groups entry if it doesn't exist already ========== -->
+			<!-- ========== Add groups entry if it doesn't exist already ========== -->
 
-	<li Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/groups</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart</xpath>
-			<value>
-				<groups />
-			</value>
-		</nomatch>
-	</li>
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/groups</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart</xpath>
+					<value>
+						<groups />
+					</value>
+				</nomatch>
+			</li>
 
-	<li Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalNeck"]</xpath>
-			<value>
-				<groups />
-			</value>
-		</nomatch>
-	</li>
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalNeck"]</xpath>
+					<value>
+						<groups />
+					</value>
+				</nomatch>
+			</li>
 
-	<li Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]</xpath>
-			<value>
-				<groups />
-			</value>
-		</nomatch>
-	</li>
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]</xpath>
+					<value>
+						<groups />
+					</value>
+				</nomatch>
+			</li>
 
-	<li Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]/groups</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]</xpath>
-			<value>
-				<groups />
-			</value>
-		</nomatch>
-	</li>
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]/groups</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]</xpath>
+					<value>
+						<groups />
+					</value>
+				</nomatch>
+			</li>
 
-	<li Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/groups</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]</xpath>
-			<value>
-				<groups />
-			</value>
-		</nomatch>
-	</li>
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/groups</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]</xpath>
+					<value>
+						<groups />
+					</value>
+				</nomatch>
+			</li>
 
-	<li Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="MechanicalHand"]/groups</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="MechanicalHand"]</xpath>
-			<value>
-				<groups />
-			</value>
-		</nomatch>
-	</li>
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="MechanicalHand"]/groups</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="MechanicalHand"]</xpath>
+					<value>
+						<groups />
+					</value>
+				</nomatch>
+			</li>
 
-	<li Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalLeg"]</xpath>
-			<value>
-				<groups />
-			</value>
-		</nomatch>
-	</li>
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalLeg"]</xpath>
+					<value>
+						<groups />
+					</value>
+				</nomatch>
+			</li>
 
-	<li Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]</xpath>
-			<value>
-				<groups />
-			</value>
-		</nomatch>
-	</li>
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]</xpath>
+					<value>
+						<groups />
+					</value>
+				</nomatch>
+			</li>
 
-	<!-- ========== Add armor coverage ========== -->
+			<!-- ========== Add armor coverage ========== -->
 
-	<li Class="PatchOperationAdd">
-		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/groups</xpath>
-		<value>
-			<li>CoveredByNaturalArmor</li>
-		</value>
-	</li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/groups</xpath>
+				<value>
+					<li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
 
-	<li Class="PatchOperationAdd">
-		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
-		<value>
-			<li>CoveredByNaturalArmor</li>
-		</value>
-	</li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
+				<value>
+					<li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
 
-	<li Class="PatchOperationAdd">
-		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
-		<value>
-			<li>CoveredByNaturalArmor</li>
-		</value>
-	</li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
+				<value>
+					<li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
 
-	<li Class="PatchOperationAdd">
-		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]/groups</xpath>
-		<value>
-			<li>CoveredByNaturalArmor</li>
-		</value>
-	</li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]/groups</xpath>
+				<value>
+					<li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
 
-	<li Class="PatchOperationAdd">
-		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/groups</xpath>
-		<value>
-			<li>CoveredByNaturalArmor</li>
-		</value>
-	</li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/groups</xpath>
+				<value>
+					<li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
 
-	<li Class="PatchOperationAdd">
-		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="MechanicalHand"]/groups</xpath>
-		<value>
-			<li>CoveredByNaturalArmor</li>
-		</value>
-	</li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="MechanicalHand"]/groups</xpath>
+				<value>
+					<li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
 
-	<li Class="PatchOperationAdd">
-		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="Blade"]/groups</xpath>
-		<value>
-			<li>CoveredByNaturalArmor</li>
-		</value>
-	</li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="Blade"]/groups</xpath>
+				<value>
+					<li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
 
-	<li Class="PatchOperationAdd">
-		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="MechanicalHand"]/parts/li[def="MechanicalFinger"]/groups</xpath>
-		<value>
-			<li>CoveredByNaturalArmor</li>
-		</value>
-	</li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="MechanicalHand"]/parts/li[def="MechanicalFinger"]/groups</xpath>
+				<value>
+					<li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
 
-	<li Class="PatchOperationAdd">
-		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
-		<value>
-			<li>CoveredByNaturalArmor</li>
-		</value>
-	</li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
+				<value>
+					<li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
 
-	<li Class="PatchOperationAdd">
-		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
-		<value>
-			<li>CoveredByNaturalArmor</li>
-		</value>
-	</li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
+				<value>
+					<li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
 
-	<!-- ========== Modify coverage ========== -->
+			<!-- ========== Modify coverage ========== -->
 
-	<li Class="PatchOperationReplace">
-		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]/coverage</xpath>
-		<value>
-			<coverage>0.15</coverage>
-		</value>
-	</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]/coverage</xpath>
+				<value>
+					<coverage>0.15</coverage>
+				</value>
+			</li>
 
-	<li Class="PatchOperationReplace">
-		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="Blade"]/coverage</xpath>
-		<value>
-			<coverage>0.2</coverage>
-		</value>
-	</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="Blade"]/coverage</xpath>
+				<value>
+					<coverage>0.2</coverage>
+				</value>
+			</li>
 
-	<li Class="PatchOperationReplace">
-		<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="FluidReprocessor"]/coverage</xpath>
-		<value>
-			<coverage>0.05</coverage>
-		</value>
-	</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/BodyDef[defName="ScytherExpanded"]/corePart/parts/li[def="FluidReprocessor"]/coverage</xpath>
+				<value>
+					<coverage>0.05</coverage>
+				</value>
+			</li>
 
 			</operations>
 		</match>

--- a/Patches/pphhyy Expanded Scythers/MechBodies_CE.xml
+++ b/Patches/pphhyy Expanded Scythers/MechBodies_CE.xml
@@ -190,5 +190,4 @@
 			</operations>
 		</match>
 	</Operation>
-
 </Patch>

--- a/Patches/pphhyy Expanded Scythers/MechKind_CE.xml
+++ b/Patches/pphhyy Expanded Scythers/MechKind_CE.xml
@@ -51,12 +51,10 @@
 		<value>
 			<CarryWeight>50</CarryWeight>
 			<CarryBulk>20</CarryBulk>
-			<AimingAccuracy>1.0</AimingAccuracy>
-			<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
-			<MeleeDodgeChance>0.13</MeleeDodgeChance>
-			<MeleeCritChance>0.12</MeleeCritChance>
-			<MeleeParryChance>0.09</MeleeParryChance>
-			<MaxHitPoints>220</MaxHitPoints>
+			<MeleeDodgeChance>0.18</MeleeDodgeChance>
+			<MeleeCritChance>0.19</MeleeCritChance>
+			<MeleeParryChance>0.23</MeleeParryChance>
+			<MaxHitPoints>250</MaxHitPoints>
 			<ArmorRating_Electric>0.2</ArmorRating_Electric>		
 		</value>
 	</li>
@@ -148,7 +146,7 @@
 		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]/comps</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
-				<Durability>1280</Durability>
+				<Durability>1630</Durability>
 				<Regenerates>true</Regenerates>
 				<RegenInterval>1250</RegenInterval>
 				<RegenValue>5</RegenValue>
@@ -162,10 +160,6 @@
 				<CanOverHeal>true</CanOverHeal>
 				<MaxOverHeal>116</MaxOverHeal>
 				<MinArmorPct>0.75</MinArmorPct>
-				<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-				<MinArmorValueBlunt>22</MinArmorValueBlunt>
-				<MinArmorValueHeat>0.2</MinArmorValueHeat>
-				<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 			</li>
 		</value>
 	</li>
@@ -178,12 +172,10 @@
 		<value>
 			<CarryWeight>50</CarryWeight>
 			<CarryBulk>20</CarryBulk>
-			<AimingAccuracy>0.8</AimingAccuracy>
-			<ShootingAccuracyPawn>0.9</ShootingAccuracyPawn>
 			<MeleeDodgeChance>0.07</MeleeDodgeChance>
 			<MeleeCritChance>0.04</MeleeCritChance>
 			<MeleeParryChance>0.65</MeleeParryChance>
-			<MaxHitPoints>300</MaxHitPoints>
+			<MaxHitPoints>400</MaxHitPoints>
 			<ArmorRating_Heat>0.15</ArmorRating_Heat>
 		</value>
 	</li>
@@ -215,7 +207,7 @@
 					<extraMeleeDamages>
 						<li>
 						  <def>Stun</def>
-						  <amount>3</amount>
+						  <amount>4</amount>
 						</li>
 					</extraMeleeDamages>
 					<cooldownTime>1.33</cooldownTime>
@@ -229,12 +221,6 @@
 						<li>Blunt</li>
 					</capacities>
 					<power>6</power>
-					<extraMeleeDamages>
-						<li>
-						  <def>EMP</def>
-						  <amount>2</amount>
-						</li>
-					</extraMeleeDamages>
 					<cooldownTime>5.9</cooldownTime>
 					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 					<chanceFactor>0.2</chanceFactor>
@@ -258,7 +244,7 @@
 		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]/comps</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
-				<Durability>1550</Durability>
+				<Durability>2080</Durability>
 				<Regenerates>true</Regenerates>
 				<RegenInterval>1250</RegenInterval>
 				<RegenValue>5</RegenValue>
@@ -271,11 +257,7 @@
 				<RepairValue>200</RepairValue>
 				<CanOverHeal>true</CanOverHeal>
 				<MaxOverHeal>140</MaxOverHeal>
-				<MinArmorPct>0.75</MinArmorPct>
-				<MinArmorValueSharp>5</MinArmorValueSharp>
-				<MinArmorValueBlunt>8</MinArmorValueBlunt>
-				<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
-				<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
+				<MinArmorPct>0.65</MinArmorPct>
 			</li>
 		</value>
 	</li>
@@ -342,12 +324,10 @@
 		<value>
 			<CarryWeight>50</CarryWeight>
 			<CarryBulk>20</CarryBulk>
-			<AimingAccuracy>1.0</AimingAccuracy>
-			<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
-			<MeleeDodgeChance>0.18</MeleeDodgeChance>
-			<MeleeCritChance>0.18</MeleeCritChance>
-			<MeleeParryChance>0.14 </MeleeParryChance>
-			<MaxHitPoints>240</MaxHitPoints>
+			<MeleeDodgeChance>0.43</MeleeDodgeChance>
+			<MeleeCritChance>0.41</MeleeCritChance>
+			<MeleeParryChance>0.36</MeleeParryChance>
+			<MaxHitPoints>300</MaxHitPoints>
 		</value>
 	</li>
 
@@ -377,7 +357,7 @@
 					<power>45</power>
 					<cooldownTime>1.84</cooldownTime>
 					<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
-					<armorPenetrationSharp>18</armorPenetrationSharp>
+					<armorPenetrationSharp>16</armorPenetrationSharp>
 					<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 				</li>
@@ -401,7 +381,7 @@
 					<power>45</power>
 					<cooldownTime>1.84</cooldownTime>
 					<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
-					<armorPenetrationSharp>18</armorPenetrationSharp>
+					<armorPenetrationSharp>16</armorPenetrationSharp>
 					<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 				</li>
@@ -446,7 +426,7 @@
 		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]/comps</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
-				<Durability>1390</Durability>
+				<Durability>1850</Durability>
 				<Regenerates>true</Regenerates>
 				<RegenInterval>1250</RegenInterval>
 				<RegenValue>5</RegenValue>
@@ -460,10 +440,6 @@
 				<CanOverHeal>true</CanOverHeal>
 				<MaxOverHeal>116</MaxOverHeal>
 				<MinArmorPct>0.75</MinArmorPct>
-				<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-				<MinArmorValueBlunt>22</MinArmorValueBlunt>
-				<MinArmorValueHeat>0.2</MinArmorValueHeat>
-				<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
 			</li>
 		</value>
 	</li>
@@ -476,12 +452,10 @@
 		<value>
 			<CarryWeight>50</CarryWeight>
 			<CarryBulk>20</CarryBulk>
-			<AimingAccuracy>1.0</AimingAccuracy>
-			<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
-			<MeleeDodgeChance>0.13</MeleeDodgeChance>
-			<MeleeCritChance>0.12</MeleeCritChance>
-			<MeleeParryChance>0.09 </MeleeParryChance>
-			<MaxHitPoints>220</MaxHitPoints>
+			<MeleeDodgeChance>0.18</MeleeDodgeChance>
+			<MeleeCritChance>0.23</MeleeCritChance>
+			<MeleeParryChance>0.19</MeleeParryChance>
+			<MaxHitPoints>250</MaxHitPoints>
 			<ArmorRating_Heat>0.4</ArmorRating_Heat>
 		</value>
 	</li>
@@ -517,7 +491,7 @@
 						  <chance>0.3</chance>
 						</li>
 					</extraMeleeDamages>
-					<cooldownTime>1.84</cooldownTime>
+					<cooldownTime>2.07</cooldownTime>
 					<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
 					<armorPenetrationSharp>2.16</armorPenetrationSharp>
 					<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
@@ -536,7 +510,7 @@
 						  <chance>0.3</chance>
 						</li>
 					</extraMeleeDamages>
-					<cooldownTime>1.03</cooldownTime>
+					<cooldownTime>1.33</cooldownTime>
 					<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
 					<armorPenetrationSharp>40</armorPenetrationSharp>
 					<armorPenetrationBlunt>20</armorPenetrationBlunt>
@@ -555,7 +529,7 @@
 						  <chance>0.3</chance>
 						</li>
 					</extraMeleeDamages>
-					<cooldownTime>1.84</cooldownTime>
+					<cooldownTime>2.07</cooldownTime>
 					<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
 					<armorPenetrationSharp>2.16</armorPenetrationSharp>
 					<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
@@ -574,7 +548,7 @@
 						  <chance>0.3</chance>
 						</li>
 					</extraMeleeDamages>
-					<cooldownTime>1.03</cooldownTime>
+					<cooldownTime>1.33</cooldownTime>
 					<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
 					<armorPenetrationSharp>40</armorPenetrationSharp>
 					<armorPenetrationBlunt>20</armorPenetrationBlunt>
@@ -609,7 +583,7 @@
 		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]/comps</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
-				<Durability>1280</Durability>
+				<Durability>1630</Durability>
 				<Regenerates>true</Regenerates>
 				<RegenInterval>1250</RegenInterval>
 				<RegenValue>5</RegenValue>
@@ -623,10 +597,6 @@
 				<CanOverHeal>true</CanOverHeal>
 				<MaxOverHeal>116</MaxOverHeal>
 				<MinArmorPct>0.75</MinArmorPct>
-				<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
-				<MinArmorValueBlunt>22</MinArmorValueBlunt> 
-			    <MinArmorValueElectric>0.1</MinArmorValueElectric>-->
-				<MinArmorValueHeat>0.2</MinArmorValueHeat>
 			</li>
 		</value>
 	</li>
@@ -639,12 +609,10 @@
 		<value>
 			<CarryWeight>50</CarryWeight>
 			<CarryBulk>20</CarryBulk>
-			<AimingAccuracy>1.0</AimingAccuracy>
-			<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
-			<MeleeDodgeChance>0.21</MeleeDodgeChance>
-			<MeleeCritChance>0.25</MeleeCritChance>
-			<MeleeParryChance>0.2</MeleeParryChance>
-			<MaxHitPoints>265</MaxHitPoints>
+			<MeleeDodgeChance>0.58</MeleeDodgeChance>
+			<MeleeCritChance>0.54</MeleeCritChance>
+			<MeleeParryChance>0.45</MeleeParryChance>
+			<MaxHitPoints>380</MaxHitPoints>
 			<ArmorRating_Electric>0.2</ArmorRating_Electric>
 			<ArmorRating_Heat>0.15</ArmorRating_Heat>			
 		</value>
@@ -745,7 +713,7 @@
 		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]/comps</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
-				<Durability>1450</Durability>
+				<Durability>2450</Durability>
 				<Regenerates>true</Regenerates>
 				<RegenInterval>1250</RegenInterval>
 				<RegenValue>5</RegenValue>
@@ -757,12 +725,8 @@
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
 				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>125</MaxOverHeal>
+				<MaxOverHeal>150</MaxOverHeal>
 				<MinArmorPct>0.75</MinArmorPct>
-				<MinArmorValueSharp>8</MinArmorValueSharp>
-				<MinArmorValueBlunt>10</MinArmorValueBlunt>
-				<MinArmorValueHeat>0.05</MinArmorValueHeat>
-				<MinArmorValueElectric>0.05</MinArmorValueElectric>
 			</li>
 		</value>
 	</li>

--- a/Patches/pphhyy Expanded Scythers/MechKind_CE.xml
+++ b/Patches/pphhyy Expanded Scythers/MechKind_CE.xml
@@ -6,737 +6,736 @@
 			<li>phynilla Expanded Mechs Scyther</li>
 		</mods>
 		<match Class="PatchOperationSequence">
-			<operations>
+		<operations>
 
-	<li Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch" or
-			                 defName="pphhyy_ScytherExpandedMono" or
-			                 defName="pphhyy_ScytherExpandedSearing" or
-			                 defName="pphhyy_ScytherExpandedPrestige"]</xpath>
-		<value>
-			<li Class="CombatExtended.RacePropertiesExtensionCE">
-				<bodyShape>Humanoid</bodyShape>
-			</li>
-		</value>
-	</li>
-
-	<li Class="PatchOperationReplace">
-		<xpath>Defs/PawnKindDef[defName="pphhyy_ScytherExpandedTank" or 
-			                 defName="pphhyy_ScytherExpandedArch" or
-							 defName="pphhyy_ScytherExpandedSearing"]/combatPower</xpath>
-		<value>
-			<combatPower>190</combatPower>
-		</value>
-	</li>
-
-	<li Class="PatchOperationReplace">
-		<xpath>Defs/PawnKindDef[defName="pphhyy_ScytherExpandedMono"]/combatPower</xpath>
-		<value>
-			<combatPower>240</combatPower>
-		</value>
-	</li>
-
-	<li Class="PatchOperationReplace">
-		<xpath>Defs/PawnKindDef[defName="pphhyy_ScytherExpandedPrestige"]/combatPower</xpath>
-		<value>
-			<combatPower>320</combatPower>
-		</value>
-	</li>
-
-
-	<!--Arch Scyther (EMP one)-->
-
-	<li Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]/statBases</xpath>
-		<value>
-			<CarryWeight>50</CarryWeight>
-			<CarryBulk>20</CarryBulk>
-			<MeleeDodgeChance>0.18</MeleeDodgeChance>
-			<MeleeCritChance>0.19</MeleeCritChance>
-			<MeleeParryChance>0.23</MeleeParryChance>
-			<MaxHitPoints>250</MaxHitPoints>
-			<ArmorRating_Electric>0.2</ArmorRating_Electric>		
-		</value>
-	</li>
-
-	<li Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]/statBases/ArmorRating_Blunt</xpath>
-		<value>
-			<ArmorRating_Blunt>8</ArmorRating_Blunt>
-		</value>
-	</li>
-
-	<li Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]/statBases/ArmorRating_Sharp</xpath>
-		<value>
-			<ArmorRating_Sharp>6</ArmorRating_Sharp>
-		</value>
-	</li>
-
-	<li Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]/tools</xpath>
-		<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-					<label>left Mace</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>24</power>
-					<extraMeleeDamages>
-						<li>
-						  <def>EMP</def>
-						  <amount>4</amount>
-						</li>
-					</extraMeleeDamages>
-					<cooldownTime>1.33</cooldownTime>
-					<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
-					<armorPenetrationBlunt>35</armorPenetrationBlunt>
-					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>right Mace</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>24</power>
-					<extraMeleeDamages>
-						<li>
-						  <def>EMP</def>
-						  <amount>4</amount>
-						</li>
-					</extraMeleeDamages>
-					<cooldownTime>1.33</cooldownTime>
-					<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
-					<armorPenetrationBlunt>35</armorPenetrationBlunt>
-					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>head</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>6</power>
-					<extraMeleeDamages>
-						<li>
-						  <def>EMP</def>
-						  <amount>2</amount>
-						</li>
-					</extraMeleeDamages>
-					<cooldownTime>5.9</cooldownTime>
-					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-					<chanceFactor>0.2</chanceFactor>
-					<armorPenetrationBlunt>1.875</armorPenetrationBlunt>
-				</li>
-			</tools>
-		</value>
-	</li>
-
-	<li Class="PatchOperationConditional">
-		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]</xpath>
+		<li Class="PatchOperationAddModExtension">
+			<xpath>Defs/ThingDef[
+			defName="pphhyy_ScytherExpandedArch" or
+			defName="pphhyy_ScytherExpandedMono" or
+			defName="pphhyy_ScytherExpandedSearing" or
+			defName="pphhyy_ScytherExpandedPrestige"
+			]</xpath>
 			<value>
-				<comps />
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Humanoid</bodyShape>
+				</li>
 			</value>
-		</nomatch>
-	</li>
+		</li>
 
-	<li Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]/comps</xpath>
-		<value>
-			<li Class="CombatExtended.CompProperties_ArmorDurability">
-				<Durability>1225</Durability>
-				<Regenerates>true</Regenerates>
-				<RegenInterval>1250</RegenInterval>
-				<RegenValue>5</RegenValue>
-				<Repairable>true</Repairable>
-				<RepairIngredients>
-					<Steel>5</Steel>
-					<Plasteel>5</Plasteel>
-				</RepairIngredients>
-				<RepairTime>300</RepairTime>
-				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>116</MaxOverHeal>
-				<MinArmorPct>0.75</MinArmorPct>
-			</li>
-		</value>
-	</li>
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/PawnKindDef[
+			defName="pphhyy_ScytherExpandedTank" or 
+			defName="pphhyy_ScytherExpandedArch" or
+			defName="pphhyy_ScytherExpandedSearing"
+			]/combatPower</xpath>
+			<value>
+				<combatPower>190</combatPower>
+			</value>
+		</li>
 
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/PawnKindDef[defName="pphhyy_ScytherExpandedMono"]/combatPower</xpath>
+			<value>
+				<combatPower>240</combatPower>
+			</value>
+		</li>
 
-	<!--Scyther Guard (Tank one)-->
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/PawnKindDef[defName="pphhyy_ScytherExpandedPrestige"]/combatPower</xpath>
+			<value>
+				<combatPower>320</combatPower>
+			</value>
+		</li>
 
-	<li Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]/statBases</xpath>
-		<value>
-			<CarryWeight>50</CarryWeight>
-			<CarryBulk>20</CarryBulk>
-			<MeleeDodgeChance>0.07</MeleeDodgeChance>
-			<MeleeCritChance>0.04</MeleeCritChance>
-			<MeleeParryChance>0.65</MeleeParryChance>
-			<MaxHitPoints>400</MaxHitPoints>
-			<ArmorRating_Heat>0.15</ArmorRating_Heat>
-		</value>
-	</li>
+		<!--Arch Scyther (EMP one)-->
 
-	<li Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]/statBases/ArmorRating_Blunt</xpath>
-		<value>
-			<ArmorRating_Blunt>24</ArmorRating_Blunt>
-		</value>
-	</li>
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]/statBases</xpath>
+			<value>
+				<CarryWeight>50</CarryWeight>
+				<CarryBulk>20</CarryBulk>
+				<MeleeDodgeChance>0.18</MeleeDodgeChance>
+				<MeleeCritChance>0.19</MeleeCritChance>
+				<MeleeParryChance>0.23</MeleeParryChance>
+				<MaxHitPoints>250</MaxHitPoints>
+				<ArmorRating_Electric>0.2</ArmorRating_Electric>		
+			</value>
+		</li>
 
-	<li Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]/statBases/ArmorRating_Sharp</xpath>
-		<value>
-			<ArmorRating_Sharp>16</ArmorRating_Sharp>
-		</value>
-	</li>
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>8</ArmorRating_Blunt>
+			</value>
+		</li>
 
-	<li Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]/tools</xpath>
-		<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-					<label>right Mace</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>24</power>
-					<extraMeleeDamages>
-						<li>
-						  <def>Stun</def>
-						  <amount>4</amount>
-						</li>
-					</extraMeleeDamages>
-					<cooldownTime>1.33</cooldownTime>
-					<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
-					<armorPenetrationBlunt>16</armorPenetrationBlunt>
-					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>6</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>left Mace</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>24</power>
+						<extraMeleeDamages>
+							<li>
+							<def>EMP</def>
+							<amount>4</amount>
+							</li>
+						</extraMeleeDamages>
+						<cooldownTime>1.33</cooldownTime>
+						<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>35</armorPenetrationBlunt>
+						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>right Mace</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>24</power>
+						<extraMeleeDamages>
+							<li>
+							<def>EMP</def>
+							<amount>4</amount>
+							</li>
+						</extraMeleeDamages>
+						<cooldownTime>1.33</cooldownTime>
+						<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>35</armorPenetrationBlunt>
+						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>6</power>
+						<extraMeleeDamages>
+							<li>
+							<def>EMP</def>
+							<amount>2</amount>
+							</li>
+						</extraMeleeDamages>
+						<cooldownTime>5.9</cooldownTime>
+						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+						<chanceFactor>0.2</chanceFactor>
+						<armorPenetrationBlunt>1.875</armorPenetrationBlunt>
+					</li>
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]/comps</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]</xpath>
+				<value>
+					<comps />
+				</value>
+			</nomatch>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]/comps</xpath>
+			<value>
+				<li Class="CombatExtended.CompProperties_ArmorDurability">
+					<Durability>1225</Durability>
+					<Regenerates>true</Regenerates>
+					<RegenInterval>1250</RegenInterval>
+					<RegenValue>5</RegenValue>
+					<Repairable>true</Repairable>
+					<RepairIngredients>
+						<Steel>5</Steel>
+						<Plasteel>5</Plasteel>
+					</RepairIngredients>
+					<RepairTime>300</RepairTime>
+					<RepairValue>200</RepairValue>
+					<CanOverHeal>true</CanOverHeal>
+					<MaxOverHeal>116</MaxOverHeal>
+					<MinArmorPct>0.75</MinArmorPct>
 				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>head</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>6</power>
-					<cooldownTime>5.9</cooldownTime>
-					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-					<chanceFactor>0.2</chanceFactor>
-					<armorPenetrationBlunt>1.875</armorPenetrationBlunt>
-				</li>
-			</tools>
-		</value>
-	</li>
+			</value>
+		</li>
 
-	<li Class="PatchOperationConditional">
-		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
+		<!--Scyther Guard (Tank one)-->
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]/statBases</xpath>
+			<value>
+				<CarryWeight>50</CarryWeight>
+				<CarryBulk>20</CarryBulk>
+				<MeleeDodgeChance>0.07</MeleeDodgeChance>
+				<MeleeCritChance>0.04</MeleeCritChance>
+				<MeleeParryChance>0.65</MeleeParryChance>
+				<MaxHitPoints>400</MaxHitPoints>
+				<ArmorRating_Heat>0.15</ArmorRating_Heat>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>24</ArmorRating_Blunt>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>16</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>right Mace</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>24</power>
+						<extraMeleeDamages>
+							<li>
+							<def>Stun</def>
+							<amount>4</amount>
+							</li>
+						</extraMeleeDamages>
+						<cooldownTime>1.33</cooldownTime>
+						<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>16</armorPenetrationBlunt>
+						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>6</power>
+						<cooldownTime>5.9</cooldownTime>
+						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+						<chanceFactor>0.2</chanceFactor>
+						<armorPenetrationBlunt>1.875</armorPenetrationBlunt>
+					</li>
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]/comps</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]</xpath>
+				<value>
+					<comps />
+				</value>
+			</nomatch>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]/comps</xpath>
+			<value>
+				<li Class="CombatExtended.CompProperties_ArmorDurability">
+					<Durability>1875</Durability>
+					<Regenerates>true</Regenerates>
+					<RegenInterval>1250</RegenInterval>
+					<RegenValue>5</RegenValue>
+					<Repairable>true</Repairable>
+					<RepairIngredients>
+						<Steel>5</Steel>
+						<Plasteel>5</Plasteel>
+					</RepairIngredients>
+					<RepairTime>300</RepairTime>
+					<RepairValue>200</RepairValue>
+					<CanOverHeal>true</CanOverHeal>
+					<MaxOverHeal>140</MaxOverHeal>
+					<MinArmorPct>0.65</MinArmorPct>
+				</li>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]</xpath>
 			<value>
-				<comps />
+				<modExtensions Inherit="False">
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Humanoid</bodyShape>
+				</li>
+				<li Class="CombatExtended.PartialArmorExt">
+					<stats>
+						<li>
+							<useStatic>false</useStatic>
+							<ArmorRating_Sharp>0.1</ArmorRating_Sharp>
+							<parts>
+								<li>SightSensor</li>
+							</parts>
+						</li>
+						<li>
+							<useStatic>false</useStatic>
+							<ArmorRating_Blunt>0.1</ArmorRating_Blunt>
+							<parts>
+								<li>SightSensor</li>
+							</parts>
+						</li>
+						<li>
+							<useStatic>false</useStatic>
+							<ArmorRating_Sharp>0.625</ArmorRating_Sharp>
+							<parts>
+								<li>MechanicalHead</li>
+							</parts>
+						</li>
+						<li>
+							<useStatic>false</useStatic>
+							<ArmorRating_Blunt>0.625</ArmorRating_Blunt>
+							<parts>
+								<li>MechanicalHead</li>
+							</parts>
+						</li>
+						<li>
+							<useStatic>false</useStatic>
+							<ArmorRating_Sharp>0.625</ArmorRating_Sharp>
+							<parts>
+								<li>MechanicalLeg</li>
+							</parts>
+						</li>
+						<li>
+							<useStatic>false</useStatic>
+							<ArmorRating_Blunt>0.625</ArmorRating_Blunt>
+							<parts>
+								<li>MechanicalLeg</li>
+							</parts>
+						</li>
+					</stats>
+				</li>
+				</modExtensions>
 			</value>
-		</nomatch>
-	</li>
+		</li>
 
-	<li Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]/comps</xpath>
-		<value>
-			<li Class="CombatExtended.CompProperties_ArmorDurability">
-				<Durability>1875</Durability>
-				<Regenerates>true</Regenerates>
-				<RegenInterval>1250</RegenInterval>
-				<RegenValue>5</RegenValue>
-				<Repairable>true</Repairable>
-				<RepairIngredients>
-					<Steel>5</Steel>
-					<Plasteel>5</Plasteel>
-				</RepairIngredients>
-				<RepairTime>300</RepairTime>
-				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>140</MaxOverHeal>
-				<MinArmorPct>0.65</MinArmorPct>
-			</li>
-		</value>
-	</li>
+		<!--Mono Scyther -->
 
-	<li Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]</xpath>
-		<value>
-			<modExtensions Inherit="False">
-			<li Class="CombatExtended.RacePropertiesExtensionCE">
-				<bodyShape>Humanoid</bodyShape>
-			</li>
-			<li Class="CombatExtended.PartialArmorExt">
-				<stats>
-					<li>
-						<useStatic>false</useStatic>
-						<ArmorRating_Sharp>0.1</ArmorRating_Sharp>
-						<parts>
-							<li>SightSensor</li>
-						</parts>
-					</li>
-					<li>
-						<useStatic>false</useStatic>
-						<ArmorRating_Blunt>0.1</ArmorRating_Blunt>
-						<parts>
-							<li>SightSensor</li>
-						</parts>
-					</li>
-					<li>
-						<useStatic>false</useStatic>
-						<ArmorRating_Sharp>0.625</ArmorRating_Sharp>
-						<parts>
-							<li>MechanicalHead</li>
-						</parts>
-					</li>
-					<li>
-						<useStatic>false</useStatic>
-						<ArmorRating_Blunt>0.625</ArmorRating_Blunt>
-						<parts>
-							<li>MechanicalHead</li>
-						</parts>
-					</li>
-					<li>
-						<useStatic>false</useStatic>
-						<ArmorRating_Sharp>0.625</ArmorRating_Sharp>
-						<parts>
-							<li>MechanicalLeg</li>
-						</parts>
-					</li>
-					<li>
-						<useStatic>false</useStatic>
-						<ArmorRating_Blunt>0.625</ArmorRating_Blunt>
-						<parts>
-							<li>MechanicalLeg</li>
-						</parts>
-					</li>
-				</stats>
-			</li>
-			</modExtensions>
-		</value>
-	</li>
-
-
-
-	<!--Mono Scyther -->
-
-	<li Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]/statBases</xpath>
-		<value>
-			<CarryWeight>50</CarryWeight>
-			<CarryBulk>20</CarryBulk>
-			<MeleeDodgeChance>0.43</MeleeDodgeChance>
-			<MeleeCritChance>0.41</MeleeCritChance>
-			<MeleeParryChance>0.36</MeleeParryChance>
-			<MaxHitPoints>300</MaxHitPoints>
-		</value>
-	</li>
-
-	<li Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]/statBases/ArmorRating_Blunt</xpath>
-		<value>
-			<ArmorRating_Blunt>14</ArmorRating_Blunt>
-		</value>
-	</li>
-
-	<li Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]/statBases/ArmorRating_Sharp</xpath>
-		<value>
-			<ArmorRating_Sharp>10</ArmorRating_Sharp>
-		</value>
-	</li>
-
-	<li Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]/tools</xpath>
-		<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-					<label>left blade</label>
-					<capacities>
-						<li>Cut</li>
-					</capacities>
-					<power>45</power>
-					<cooldownTime>1.84</cooldownTime>
-					<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
-					<armorPenetrationSharp>16</armorPenetrationSharp>
-					<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
-					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>left blade</label>
-					<capacities>
-						<li>Stab</li>
-					</capacities>
-					<power>27</power>
-					<cooldownTime>1.03</cooldownTime>
-					<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
-					<armorPenetrationSharp>45</armorPenetrationSharp>
-					<armorPenetrationBlunt>20</armorPenetrationBlunt>
-					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>right blade</label>
-					<capacities>
-						<li>Cut</li>
-					</capacities>
-					<power>45</power>
-					<cooldownTime>1.84</cooldownTime>
-					<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
-					<armorPenetrationSharp>16</armorPenetrationSharp>
-					<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
-					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>right blade</label>
-					<capacities>
-						<li>Stab</li>
-					</capacities>
-					<power>27</power>
-					<cooldownTime>1.03</cooldownTime>
-					<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
-					<armorPenetrationSharp>45</armorPenetrationSharp>
-					<armorPenetrationBlunt>20</armorPenetrationBlunt>
-					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>head</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>6</power>
-					<cooldownTime>5.9</cooldownTime>
-					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-					<chanceFactor>0.2</chanceFactor>
-					<armorPenetrationBlunt>1.875</armorPenetrationBlunt>
-				</li>
-			</tools>
-		</value>
-	</li>
-
-	<li Class="PatchOperationConditional">
-		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]</xpath>
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]/statBases</xpath>
 			<value>
-				<comps />
+				<CarryWeight>50</CarryWeight>
+				<CarryBulk>20</CarryBulk>
+				<MeleeDodgeChance>0.43</MeleeDodgeChance>
+				<MeleeCritChance>0.41</MeleeCritChance>
+				<MeleeParryChance>0.36</MeleeParryChance>
+				<MaxHitPoints>300</MaxHitPoints>
 			</value>
-		</nomatch>
-	</li>
+		</li>
 
-	<li Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]/comps</xpath>
-		<value>
-			<li Class="CombatExtended.CompProperties_ArmorDurability">
-				<Durability>1300</Durability>
-				<Regenerates>true</Regenerates>
-				<RegenInterval>1250</RegenInterval>
-				<RegenValue>5</RegenValue>
-				<Repairable>true</Repairable>
-				<RepairIngredients>
-					<Steel>5</Steel>
-					<Plasteel>5</Plasteel>
-				</RepairIngredients>
-				<RepairTime>300</RepairTime>
-				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>116</MaxOverHeal>
-				<MinArmorPct>0.75</MinArmorPct>
-			</li>
-		</value>
-	</li>
-
-
-	<!--Searing Scyther -->
-
-	<li Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]/statBases</xpath>
-		<value>
-			<CarryWeight>50</CarryWeight>
-			<CarryBulk>20</CarryBulk>
-			<MeleeDodgeChance>0.18</MeleeDodgeChance>
-			<MeleeCritChance>0.23</MeleeCritChance>
-			<MeleeParryChance>0.19</MeleeParryChance>
-			<MaxHitPoints>250</MaxHitPoints>
-			<ArmorRating_Heat>0.4</ArmorRating_Heat>
-		</value>
-	</li>
-
-	<li Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]/statBases/ArmorRating_Blunt</xpath>
-		<value>
-			<ArmorRating_Blunt>8</ArmorRating_Blunt>
-		</value>
-	</li>
-
-	<li Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]/statBases/ArmorRating_Sharp</xpath>
-		<value>
-			<ArmorRating_Sharp>6</ArmorRating_Sharp>
-		</value>
-	</li>
-
-	<li Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]/tools</xpath>
-		<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-					<label>left blade</label>
-					<capacities>
-						<li>Cut</li>
-					</capacities>
-					<power>43</power>
-					<extraMeleeDamages>
-						<li>
-						  <def>Flame</def>
-						  <amount>5</amount>
-						  <chance>0.3</chance>
-						</li>
-					</extraMeleeDamages>
-					<cooldownTime>2.07</cooldownTime>
-					<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
-					<armorPenetrationSharp>2.16</armorPenetrationSharp>
-					<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
-					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>left blade</label>
-					<capacities>
-						<li>Stab</li>
-					</capacities>
-					<power>24</power>
-					<extraMeleeDamages>
-						<li>
-						  <def>Flame</def>
-						  <amount>5</amount>
-						  <chance>0.3</chance>
-						</li>
-					</extraMeleeDamages>
-					<cooldownTime>1.33</cooldownTime>
-					<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
-					<armorPenetrationSharp>40</armorPenetrationSharp>
-					<armorPenetrationBlunt>20</armorPenetrationBlunt>
-					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>right blade</label>
-					<capacities>
-						<li>Cut</li>
-					</capacities>
-					<power>43</power>
-					<extraMeleeDamages>
-						<li>
-						  <def>Flame</def>
-						  <amount>5</amount>
-						  <chance>0.3</chance>
-						</li>
-					</extraMeleeDamages>
-					<cooldownTime>2.07</cooldownTime>
-					<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
-					<armorPenetrationSharp>2.16</armorPenetrationSharp>
-					<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
-					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>right blade</label>
-					<capacities>
-						<li>Stab</li>
-					</capacities>
-					<power>24</power>
-					<extraMeleeDamages>
-						<li>
-						  <def>Flame</def>
-						  <amount>5</amount>
-						  <chance>0.3</chance>
-						</li>
-					</extraMeleeDamages>
-					<cooldownTime>1.33</cooldownTime>
-					<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
-					<armorPenetrationSharp>40</armorPenetrationSharp>
-					<armorPenetrationBlunt>20</armorPenetrationBlunt>
-					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>head</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>6</power>
-					<cooldownTime>5.9</cooldownTime>
-					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-					<chanceFactor>0.2</chanceFactor>
-					<armorPenetrationBlunt>1.875</armorPenetrationBlunt>
-				</li>
-			</tools>
-		</value>
-	</li>
-
-	<li Class="PatchOperationConditional">
-		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]</xpath>
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]/statBases/ArmorRating_Blunt</xpath>
 			<value>
-				<comps />
+				<ArmorRating_Blunt>14</ArmorRating_Blunt>
 			</value>
-		</nomatch>
-	</li>
+		</li>
 
-	<li Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]/comps</xpath>
-		<value>
-			<li Class="CombatExtended.CompProperties_ArmorDurability">
-				<Durability>1225</Durability>
-				<Regenerates>true</Regenerates>
-				<RegenInterval>1250</RegenInterval>
-				<RegenValue>5</RegenValue>
-				<Repairable>true</Repairable>
-				<RepairIngredients>
-					<Steel>5</Steel>
-					<Plasteel>5</Plasteel>
-				</RepairIngredients>
-				<RepairTime>300</RepairTime>
-				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>116</MaxOverHeal>
-				<MinArmorPct>0.75</MinArmorPct>
-			</li>
-		</value>
-	</li>
-
-
-	<!--Prestige Scyther -->
-
-	<li Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]/statBases</xpath>
-		<value>
-			<CarryWeight>50</CarryWeight>
-			<CarryBulk>20</CarryBulk>
-			<MeleeDodgeChance>0.58</MeleeDodgeChance>
-			<MeleeCritChance>0.54</MeleeCritChance>
-			<MeleeParryChance>0.45</MeleeParryChance>
-			<MaxHitPoints>380</MaxHitPoints>
-			<ArmorRating_Electric>0.2</ArmorRating_Electric>
-			<ArmorRating_Heat>0.15</ArmorRating_Heat>			
-		</value>
-	</li>
-
-	<li Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]/statBases/ArmorRating_Blunt</xpath>
-		<value>
-			<ArmorRating_Blunt>24</ArmorRating_Blunt>
-		</value>
-	</li>
-
-	<li Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]/statBases/ArmorRating_Sharp</xpath>
-		<value>
-			<ArmorRating_Sharp>16</ArmorRating_Sharp>
-		</value>
-	</li>
-
-	<li Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]/tools</xpath>
-		<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-					<label>left blade</label>
-					<capacities>
-						<li>Cut</li>
-					</capacities>
-					<power>46</power>
-					<cooldownTime>1.84</cooldownTime>
-					<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
-					<armorPenetrationSharp>20</armorPenetrationSharp>
-					<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
-					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>left blade</label>
-					<capacities>
-						<li>Stab</li>
-					</capacities>
-					<power>28</power>
-					<cooldownTime>1.03</cooldownTime>
-					<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
-					<armorPenetrationSharp>45</armorPenetrationSharp>
-					<armorPenetrationBlunt>20</armorPenetrationBlunt>
-					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>right blade</label>
-					<capacities>
-						<li>Cut</li>
-					</capacities>
-					<power>46</power>
-					<cooldownTime>1.84</cooldownTime>
-					<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
-					<armorPenetrationSharp>20</armorPenetrationSharp>
-					<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
-					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>right blade</label>
-					<capacities>
-						<li>Stab</li>
-					</capacities>
-					<power>28</power>
-					<cooldownTime>1.03</cooldownTime>
-					<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
-					<armorPenetrationSharp>45</armorPenetrationSharp>
-					<armorPenetrationBlunt>20</armorPenetrationBlunt>
-					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>head</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>6</power>
-					<cooldownTime>5.9</cooldownTime>
-					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-					<chanceFactor>0.2</chanceFactor>
-					<armorPenetrationBlunt>1.875</armorPenetrationBlunt>
-				</li>
-			</tools>
-		</value>
-	</li>
-
-	<li Class="PatchOperationConditional">
-		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]</xpath>
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]/statBases/ArmorRating_Sharp</xpath>
 			<value>
-				<comps />
+				<ArmorRating_Sharp>10</ArmorRating_Sharp>
 			</value>
-		</nomatch>
-	</li>
+		</li>
 
-	<li Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]/comps</xpath>
-		<value>
-			<li Class="CombatExtended.CompProperties_ArmorDurability">
-				<Durability>1500</Durability>
-				<Regenerates>true</Regenerates>
-				<RegenInterval>1250</RegenInterval>
-				<RegenValue>5</RegenValue>
-				<Repairable>true</Repairable>
-				<RepairIngredients>
-					<Steel>5</Steel>
-					<Plasteel>5</Plasteel>
-				</RepairIngredients>
-				<RepairTime>300</RepairTime>
-				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>150</MaxOverHeal>
-				<MinArmorPct>0.75</MinArmorPct>
-			</li>
-		</value>
-	</li>
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>left blade</label>
+						<capacities>
+							<li>Cut</li>
+						</capacities>
+						<power>45</power>
+						<cooldownTime>1.84</cooldownTime>
+						<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
+						<armorPenetrationSharp>16</armorPenetrationSharp>
+						<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
+						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>left blade</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<power>27</power>
+						<cooldownTime>1.03</cooldownTime>
+						<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
+						<armorPenetrationSharp>45</armorPenetrationSharp>
+						<armorPenetrationBlunt>20</armorPenetrationBlunt>
+						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>right blade</label>
+						<capacities>
+							<li>Cut</li>
+						</capacities>
+						<power>45</power>
+						<cooldownTime>1.84</cooldownTime>
+						<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
+						<armorPenetrationSharp>16</armorPenetrationSharp>
+						<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
+						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>right blade</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<power>27</power>
+						<cooldownTime>1.03</cooldownTime>
+						<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
+						<armorPenetrationSharp>45</armorPenetrationSharp>
+						<armorPenetrationBlunt>20</armorPenetrationBlunt>
+						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>6</power>
+						<cooldownTime>5.9</cooldownTime>
+						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+						<chanceFactor>0.2</chanceFactor>
+						<armorPenetrationBlunt>1.875</armorPenetrationBlunt>
+					</li>
+				</tools>
+			</value>
+		</li>
 
-</operations>
-</match>
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]/comps</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]</xpath>
+				<value>
+					<comps />
+				</value>
+			</nomatch>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]/comps</xpath>
+			<value>
+				<li Class="CombatExtended.CompProperties_ArmorDurability">
+					<Durability>1300</Durability>
+					<Regenerates>true</Regenerates>
+					<RegenInterval>1250</RegenInterval>
+					<RegenValue>5</RegenValue>
+					<Repairable>true</Repairable>
+					<RepairIngredients>
+						<Steel>5</Steel>
+						<Plasteel>5</Plasteel>
+					</RepairIngredients>
+					<RepairTime>300</RepairTime>
+					<RepairValue>200</RepairValue>
+					<CanOverHeal>true</CanOverHeal>
+					<MaxOverHeal>116</MaxOverHeal>
+					<MinArmorPct>0.75</MinArmorPct>
+				</li>
+			</value>
+		</li>
+
+
+		<!--Searing Scyther -->
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]/statBases</xpath>
+			<value>
+				<CarryWeight>50</CarryWeight>
+				<CarryBulk>20</CarryBulk>
+				<MeleeDodgeChance>0.18</MeleeDodgeChance>
+				<MeleeCritChance>0.23</MeleeCritChance>
+				<MeleeParryChance>0.19</MeleeParryChance>
+				<MaxHitPoints>250</MaxHitPoints>
+				<ArmorRating_Heat>0.4</ArmorRating_Heat>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>8</ArmorRating_Blunt>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>6</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>left blade</label>
+						<capacities>
+							<li>Cut</li>
+						</capacities>
+						<power>43</power>
+						<extraMeleeDamages>
+							<li>
+							<def>Flame</def>
+							<amount>5</amount>
+							<chance>0.3</chance>
+							</li>
+						</extraMeleeDamages>
+						<cooldownTime>2.07</cooldownTime>
+						<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
+						<armorPenetrationSharp>2.16</armorPenetrationSharp>
+						<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
+						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>left blade</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<power>24</power>
+						<extraMeleeDamages>
+							<li>
+							<def>Flame</def>
+							<amount>5</amount>
+							<chance>0.3</chance>
+							</li>
+						</extraMeleeDamages>
+						<cooldownTime>1.33</cooldownTime>
+						<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
+						<armorPenetrationSharp>40</armorPenetrationSharp>
+						<armorPenetrationBlunt>20</armorPenetrationBlunt>
+						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>right blade</label>
+						<capacities>
+							<li>Cut</li>
+						</capacities>
+						<power>43</power>
+						<extraMeleeDamages>
+							<li>
+							<def>Flame</def>
+							<amount>5</amount>
+							<chance>0.3</chance>
+							</li>
+						</extraMeleeDamages>
+						<cooldownTime>2.07</cooldownTime>
+						<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
+						<armorPenetrationSharp>2.16</armorPenetrationSharp>
+						<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
+						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>right blade</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<power>24</power>
+						<extraMeleeDamages>
+							<li>
+							<def>Flame</def>
+							<amount>5</amount>
+							<chance>0.3</chance>
+							</li>
+						</extraMeleeDamages>
+						<cooldownTime>1.33</cooldownTime>
+						<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
+						<armorPenetrationSharp>40</armorPenetrationSharp>
+						<armorPenetrationBlunt>20</armorPenetrationBlunt>
+						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>6</power>
+						<cooldownTime>5.9</cooldownTime>
+						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+						<chanceFactor>0.2</chanceFactor>
+						<armorPenetrationBlunt>1.875</armorPenetrationBlunt>
+					</li>
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]/comps</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]</xpath>
+				<value>
+					<comps />
+				</value>
+			</nomatch>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]/comps</xpath>
+			<value>
+				<li Class="CombatExtended.CompProperties_ArmorDurability">
+					<Durability>1225</Durability>
+					<Regenerates>true</Regenerates>
+					<RegenInterval>1250</RegenInterval>
+					<RegenValue>5</RegenValue>
+					<Repairable>true</Repairable>
+					<RepairIngredients>
+						<Steel>5</Steel>
+						<Plasteel>5</Plasteel>
+					</RepairIngredients>
+					<RepairTime>300</RepairTime>
+					<RepairValue>200</RepairValue>
+					<CanOverHeal>true</CanOverHeal>
+					<MaxOverHeal>116</MaxOverHeal>
+					<MinArmorPct>0.75</MinArmorPct>
+				</li>
+			</value>
+		</li>
+
+		<!--Prestige Scyther -->
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]/statBases</xpath>
+			<value>
+				<CarryWeight>50</CarryWeight>
+				<CarryBulk>20</CarryBulk>
+				<MeleeDodgeChance>0.58</MeleeDodgeChance>
+				<MeleeCritChance>0.54</MeleeCritChance>
+				<MeleeParryChance>0.45</MeleeParryChance>
+				<MaxHitPoints>380</MaxHitPoints>
+				<ArmorRating_Electric>0.2</ArmorRating_Electric>
+				<ArmorRating_Heat>0.15</ArmorRating_Heat>			
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>24</ArmorRating_Blunt>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>16</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>left blade</label>
+						<capacities>
+							<li>Cut</li>
+						</capacities>
+						<power>46</power>
+						<cooldownTime>1.84</cooldownTime>
+						<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
+						<armorPenetrationSharp>20</armorPenetrationSharp>
+						<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
+						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>left blade</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<power>28</power>
+						<cooldownTime>1.03</cooldownTime>
+						<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
+						<armorPenetrationSharp>45</armorPenetrationSharp>
+						<armorPenetrationBlunt>20</armorPenetrationBlunt>
+						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>right blade</label>
+						<capacities>
+							<li>Cut</li>
+						</capacities>
+						<power>46</power>
+						<cooldownTime>1.84</cooldownTime>
+						<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
+						<armorPenetrationSharp>20</armorPenetrationSharp>
+						<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
+						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>right blade</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<power>28</power>
+						<cooldownTime>1.03</cooldownTime>
+						<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
+						<armorPenetrationSharp>45</armorPenetrationSharp>
+						<armorPenetrationBlunt>20</armorPenetrationBlunt>
+						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>6</power>
+						<cooldownTime>5.9</cooldownTime>
+						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+						<chanceFactor>0.2</chanceFactor>
+						<armorPenetrationBlunt>1.875</armorPenetrationBlunt>
+					</li>
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]/comps</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]</xpath>
+				<value>
+					<comps />
+				</value>
+			</nomatch>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]/comps</xpath>
+			<value>
+				<li Class="CombatExtended.CompProperties_ArmorDurability">
+					<Durability>1500</Durability>
+					<Regenerates>true</Regenerates>
+					<RegenInterval>1250</RegenInterval>
+					<RegenValue>5</RegenValue>
+					<Repairable>true</Repairable>
+					<RepairIngredients>
+						<Steel>5</Steel>
+						<Plasteel>5</Plasteel>
+					</RepairIngredients>
+					<RepairTime>300</RepairTime>
+					<RepairValue>200</RepairValue>
+					<CanOverHeal>true</CanOverHeal>
+					<MaxOverHeal>150</MaxOverHeal>
+					<MinArmorPct>0.75</MinArmorPct>
+				</li>
+			</value>
+		</li>
+
+		</operations>
+	</match>
 </Operation>
 
 

--- a/Patches/pphhyy Expanded Scythers/MechKind_CE.xml
+++ b/Patches/pphhyy Expanded Scythers/MechKind_CE.xml
@@ -6,737 +6,735 @@
 			<li>phynilla Expanded Mechs Scyther</li>
 		</mods>
 		<match Class="PatchOperationSequence">
-		<operations>
+			<operations>
 
-		<li Class="PatchOperationAddModExtension">
-			<xpath>Defs/ThingDef[
-			defName="pphhyy_ScytherExpandedArch" or
-			defName="pphhyy_ScytherExpandedMono" or
-			defName="pphhyy_ScytherExpandedSearing" or
-			defName="pphhyy_ScytherExpandedPrestige"
-			]</xpath>
-			<value>
-				<li Class="CombatExtended.RacePropertiesExtensionCE">
-					<bodyShape>Humanoid</bodyShape>
-				</li>
-			</value>
-		</li>
-
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/PawnKindDef[
-			defName="pphhyy_ScytherExpandedTank" or 
-			defName="pphhyy_ScytherExpandedArch" or
-			defName="pphhyy_ScytherExpandedSearing"
-			]/combatPower</xpath>
-			<value>
-				<combatPower>190</combatPower>
-			</value>
-		</li>
-
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/PawnKindDef[defName="pphhyy_ScytherExpandedMono"]/combatPower</xpath>
-			<value>
-				<combatPower>240</combatPower>
-			</value>
-		</li>
-
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/PawnKindDef[defName="pphhyy_ScytherExpandedPrestige"]/combatPower</xpath>
-			<value>
-				<combatPower>320</combatPower>
-			</value>
-		</li>
-
-		<!--Arch Scyther (EMP one)-->
-
-		<li Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]/statBases</xpath>
-			<value>
-				<CarryWeight>50</CarryWeight>
-				<CarryBulk>20</CarryBulk>
-				<MeleeDodgeChance>0.18</MeleeDodgeChance>
-				<MeleeCritChance>0.19</MeleeCritChance>
-				<MeleeParryChance>0.23</MeleeParryChance>
-				<MaxHitPoints>250</MaxHitPoints>
-				<ArmorRating_Electric>0.2</ArmorRating_Electric>		
-			</value>
-		</li>
-
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]/statBases/ArmorRating_Blunt</xpath>
-			<value>
-				<ArmorRating_Blunt>8</ArmorRating_Blunt>
-			</value>
-		</li>
-
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]/statBases/ArmorRating_Sharp</xpath>
-			<value>
-				<ArmorRating_Sharp>6</ArmorRating_Sharp>
-			</value>
-		</li>
-
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]/tools</xpath>
-			<value>
-				<tools>
-					<li Class="CombatExtended.ToolCE">
-						<label>left Mace</label>
-						<capacities>
-							<li>Blunt</li>
-						</capacities>
-						<power>24</power>
-						<extraMeleeDamages>
-							<li>
-							<def>EMP</def>
-							<amount>4</amount>
-							</li>
-						</extraMeleeDamages>
-						<cooldownTime>1.33</cooldownTime>
-						<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
-						<armorPenetrationBlunt>35</armorPenetrationBlunt>
-						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-					</li>
-					<li Class="CombatExtended.ToolCE">
-						<label>right Mace</label>
-						<capacities>
-							<li>Blunt</li>
-						</capacities>
-						<power>24</power>
-						<extraMeleeDamages>
-							<li>
-							<def>EMP</def>
-							<amount>4</amount>
-							</li>
-						</extraMeleeDamages>
-						<cooldownTime>1.33</cooldownTime>
-						<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
-						<armorPenetrationBlunt>35</armorPenetrationBlunt>
-						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-					</li>
-					<li Class="CombatExtended.ToolCE">
-						<label>head</label>
-						<capacities>
-							<li>Blunt</li>
-						</capacities>
-						<power>6</power>
-						<extraMeleeDamages>
-							<li>
-							<def>EMP</def>
-							<amount>2</amount>
-							</li>
-						</extraMeleeDamages>
-						<cooldownTime>5.9</cooldownTime>
-						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-						<chanceFactor>0.2</chanceFactor>
-						<armorPenetrationBlunt>1.875</armorPenetrationBlunt>
-					</li>
-				</tools>
-			</value>
-		</li>
-
-		<li Class="PatchOperationConditional">
-			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]/comps</xpath>
-			<nomatch Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]</xpath>
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[
+				defName="pphhyy_ScytherExpandedArch" or
+				defName="pphhyy_ScytherExpandedMono" or
+				defName="pphhyy_ScytherExpandedSearing" or
+				defName="pphhyy_ScytherExpandedPrestige"
+				]</xpath>
 				<value>
-					<comps />
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Humanoid</bodyShape>
+					</li>
 				</value>
-			</nomatch>
-		</li>
+			</li>
 
-		<li Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]/comps</xpath>
-			<value>
-				<li Class="CombatExtended.CompProperties_ArmorDurability">
-					<Durability>1225</Durability>
-					<Regenerates>true</Regenerates>
-					<RegenInterval>1250</RegenInterval>
-					<RegenValue>5</RegenValue>
-					<Repairable>true</Repairable>
-					<RepairIngredients>
-						<Steel>5</Steel>
-						<Plasteel>5</Plasteel>
-					</RepairIngredients>
-					<RepairTime>300</RepairTime>
-					<RepairValue>200</RepairValue>
-					<CanOverHeal>true</CanOverHeal>
-					<MaxOverHeal>116</MaxOverHeal>
-					<MinArmorPct>0.75</MinArmorPct>
-				</li>
-			</value>
-		</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/PawnKindDef[
+				defName="pphhyy_ScytherExpandedTank" or 
+				defName="pphhyy_ScytherExpandedArch" or
+				defName="pphhyy_ScytherExpandedSearing"
+				]/combatPower</xpath>
+				<value>
+					<combatPower>190</combatPower>
+				</value>
+			</li>
 
-		<!--Scyther Guard (Tank one)-->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/PawnKindDef[defName="pphhyy_ScytherExpandedMono"]/combatPower</xpath>
+				<value>
+					<combatPower>240</combatPower>
+				</value>
+			</li>
 
-		<li Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]/statBases</xpath>
-			<value>
-				<CarryWeight>50</CarryWeight>
-				<CarryBulk>20</CarryBulk>
-				<MeleeDodgeChance>0.07</MeleeDodgeChance>
-				<MeleeCritChance>0.04</MeleeCritChance>
-				<MeleeParryChance>0.65</MeleeParryChance>
-				<MaxHitPoints>400</MaxHitPoints>
-				<ArmorRating_Heat>0.15</ArmorRating_Heat>
-			</value>
-		</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/PawnKindDef[defName="pphhyy_ScytherExpandedPrestige"]/combatPower</xpath>
+				<value>
+					<combatPower>320</combatPower>
+				</value>
+			</li>
 
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]/statBases/ArmorRating_Blunt</xpath>
-			<value>
-				<ArmorRating_Blunt>24</ArmorRating_Blunt>
-			</value>
-		</li>
+			<!--Arch Scyther (EMP one)-->
 
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]/statBases/ArmorRating_Sharp</xpath>
-			<value>
-				<ArmorRating_Sharp>16</ArmorRating_Sharp>
-			</value>
-		</li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]/statBases</xpath>
+				<value>
+					<CarryWeight>50</CarryWeight>
+					<CarryBulk>20</CarryBulk>
+					<MeleeDodgeChance>0.18</MeleeDodgeChance>
+					<MeleeCritChance>0.19</MeleeCritChance>
+					<MeleeParryChance>0.23</MeleeParryChance>
+					<MaxHitPoints>250</MaxHitPoints>
+					<ArmorRating_Electric>0.2</ArmorRating_Electric>		
+				</value>
+			</li>
 
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]/tools</xpath>
-			<value>
-				<tools>
-					<li Class="CombatExtended.ToolCE">
-						<label>right Mace</label>
-						<capacities>
-							<li>Blunt</li>
-						</capacities>
-						<power>24</power>
-						<extraMeleeDamages>
-							<li>
-							<def>Stun</def>
-							<amount>4</amount>
-							</li>
-						</extraMeleeDamages>
-						<cooldownTime>1.33</cooldownTime>
-						<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
-						<armorPenetrationBlunt>16</armorPenetrationBlunt>
-						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>8</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>6</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left Mace</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>24</power>
+							<extraMeleeDamages>
+								<li>
+								<def>EMP</def>
+								<amount>4</amount>
+								</li>
+							</extraMeleeDamages>
+							<cooldownTime>1.33</cooldownTime>
+							<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>35</armorPenetrationBlunt>
+							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right Mace</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>24</power>
+							<extraMeleeDamages>
+								<li>
+								<def>EMP</def>
+								<amount>4</amount>
+								</li>
+							</extraMeleeDamages>
+							<cooldownTime>1.33</cooldownTime>
+							<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>35</armorPenetrationBlunt>
+							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>6</power>
+							<extraMeleeDamages>
+								<li>
+								<def>EMP</def>
+								<amount>2</amount>
+								</li>
+							</extraMeleeDamages>
+							<cooldownTime>5.9</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<chanceFactor>0.2</chanceFactor>
+							<armorPenetrationBlunt>1.875</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]/comps</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]</xpath>
+					<value>
+						<comps />
+					</value>
+				</nomatch>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]/comps</xpath>
+				<value>
+					<li Class="CombatExtended.CompProperties_ArmorDurability">
+						<Durability>1225</Durability>
+						<Regenerates>true</Regenerates>
+						<RegenInterval>1250</RegenInterval>
+						<RegenValue>5</RegenValue>
+						<Repairable>true</Repairable>
+						<RepairIngredients>
+							<Steel>5</Steel>
+							<Plasteel>5</Plasteel>
+						</RepairIngredients>
+						<RepairTime>300</RepairTime>
+						<RepairValue>200</RepairValue>
+						<CanOverHeal>true</CanOverHeal>
+						<MaxOverHeal>116</MaxOverHeal>
+						<MinArmorPct>0.75</MinArmorPct>
 					</li>
-					<li Class="CombatExtended.ToolCE">
-						<label>head</label>
-						<capacities>
-							<li>Blunt</li>
-						</capacities>
-						<power>6</power>
-						<cooldownTime>5.9</cooldownTime>
-						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-						<chanceFactor>0.2</chanceFactor>
-						<armorPenetrationBlunt>1.875</armorPenetrationBlunt>
-					</li>
-				</tools>
-			</value>
-		</li>
+				</value>
+			</li>
 
-		<li Class="PatchOperationConditional">
-			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]/comps</xpath>
-			<nomatch Class="PatchOperationAdd">
+			<!--Scyther Guard (Tank one)-->
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]/statBases</xpath>
+				<value>
+					<CarryWeight>50</CarryWeight>
+					<CarryBulk>20</CarryBulk>
+					<MeleeDodgeChance>0.07</MeleeDodgeChance>
+					<MeleeCritChance>0.04</MeleeCritChance>
+					<MeleeParryChance>0.65</MeleeParryChance>
+					<MaxHitPoints>400</MaxHitPoints>
+					<ArmorRating_Heat>0.15</ArmorRating_Heat>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>24</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>16</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>right Mace</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>24</power>
+							<extraMeleeDamages>
+								<li>
+								<def>Stun</def>
+								<amount>4</amount>
+								</li>
+							</extraMeleeDamages>
+							<cooldownTime>1.33</cooldownTime>
+							<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>16</armorPenetrationBlunt>
+							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>6</power>
+							<cooldownTime>5.9</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<chanceFactor>0.2</chanceFactor>
+							<armorPenetrationBlunt>1.875</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]/comps</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]</xpath>
+					<value>
+						<comps />
+					</value>
+				</nomatch>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]/comps</xpath>
+				<value>
+					<li Class="CombatExtended.CompProperties_ArmorDurability">
+						<Durability>1875</Durability>
+						<Regenerates>true</Regenerates>
+						<RegenInterval>1250</RegenInterval>
+						<RegenValue>5</RegenValue>
+						<Repairable>true</Repairable>
+						<RepairIngredients>
+							<Steel>5</Steel>
+							<Plasteel>5</Plasteel>
+						</RepairIngredients>
+						<RepairTime>300</RepairTime>
+						<RepairValue>200</RepairValue>
+						<CanOverHeal>true</CanOverHeal>
+						<MaxOverHeal>140</MaxOverHeal>
+						<MinArmorPct>0.65</MinArmorPct>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]</xpath>
 				<value>
-					<comps />
+					<modExtensions Inherit="False">
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Humanoid</bodyShape>
+					</li>
+					<li Class="CombatExtended.PartialArmorExt">
+						<stats>
+							<li>
+								<useStatic>false</useStatic>
+								<ArmorRating_Sharp>0.1</ArmorRating_Sharp>
+								<parts>
+									<li>SightSensor</li>
+								</parts>
+							</li>
+							<li>
+								<useStatic>false</useStatic>
+								<ArmorRating_Blunt>0.1</ArmorRating_Blunt>
+								<parts>
+									<li>SightSensor</li>
+								</parts>
+							</li>
+							<li>
+								<useStatic>false</useStatic>
+								<ArmorRating_Sharp>0.625</ArmorRating_Sharp>
+								<parts>
+									<li>MechanicalHead</li>
+								</parts>
+							</li>
+							<li>
+								<useStatic>false</useStatic>
+								<ArmorRating_Blunt>0.625</ArmorRating_Blunt>
+								<parts>
+									<li>MechanicalHead</li>
+								</parts>
+							</li>
+							<li>
+								<useStatic>false</useStatic>
+								<ArmorRating_Sharp>0.625</ArmorRating_Sharp>
+								<parts>
+									<li>MechanicalLeg</li>
+								</parts>
+							</li>
+							<li>
+								<useStatic>false</useStatic>
+								<ArmorRating_Blunt>0.625</ArmorRating_Blunt>
+								<parts>
+									<li>MechanicalLeg</li>
+								</parts>
+							</li>
+						</stats>
+					</li>
+					</modExtensions>
 				</value>
-			</nomatch>
-		</li>
+			</li>
 
-		<li Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]/comps</xpath>
-			<value>
-				<li Class="CombatExtended.CompProperties_ArmorDurability">
-					<Durability>1875</Durability>
-					<Regenerates>true</Regenerates>
-					<RegenInterval>1250</RegenInterval>
-					<RegenValue>5</RegenValue>
-					<Repairable>true</Repairable>
-					<RepairIngredients>
-						<Steel>5</Steel>
-						<Plasteel>5</Plasteel>
-					</RepairIngredients>
-					<RepairTime>300</RepairTime>
-					<RepairValue>200</RepairValue>
-					<CanOverHeal>true</CanOverHeal>
-					<MaxOverHeal>140</MaxOverHeal>
-					<MinArmorPct>0.65</MinArmorPct>
-				</li>
-			</value>
-		</li>
+			<!--Mono Scyther -->
 
-		<li Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]</xpath>
-			<value>
-				<modExtensions Inherit="False">
-				<li Class="CombatExtended.RacePropertiesExtensionCE">
-					<bodyShape>Humanoid</bodyShape>
-				</li>
-				<li Class="CombatExtended.PartialArmorExt">
-					<stats>
-						<li>
-							<useStatic>false</useStatic>
-							<ArmorRating_Sharp>0.1</ArmorRating_Sharp>
-							<parts>
-								<li>SightSensor</li>
-							</parts>
-						</li>
-						<li>
-							<useStatic>false</useStatic>
-							<ArmorRating_Blunt>0.1</ArmorRating_Blunt>
-							<parts>
-								<li>SightSensor</li>
-							</parts>
-						</li>
-						<li>
-							<useStatic>false</useStatic>
-							<ArmorRating_Sharp>0.625</ArmorRating_Sharp>
-							<parts>
-								<li>MechanicalHead</li>
-							</parts>
-						</li>
-						<li>
-							<useStatic>false</useStatic>
-							<ArmorRating_Blunt>0.625</ArmorRating_Blunt>
-							<parts>
-								<li>MechanicalHead</li>
-							</parts>
-						</li>
-						<li>
-							<useStatic>false</useStatic>
-							<ArmorRating_Sharp>0.625</ArmorRating_Sharp>
-							<parts>
-								<li>MechanicalLeg</li>
-							</parts>
-						</li>
-						<li>
-							<useStatic>false</useStatic>
-							<ArmorRating_Blunt>0.625</ArmorRating_Blunt>
-							<parts>
-								<li>MechanicalLeg</li>
-							</parts>
-						</li>
-					</stats>
-				</li>
-				</modExtensions>
-			</value>
-		</li>
-
-		<!--Mono Scyther -->
-
-		<li Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]/statBases</xpath>
-			<value>
-				<CarryWeight>50</CarryWeight>
-				<CarryBulk>20</CarryBulk>
-				<MeleeDodgeChance>0.43</MeleeDodgeChance>
-				<MeleeCritChance>0.41</MeleeCritChance>
-				<MeleeParryChance>0.36</MeleeParryChance>
-				<MaxHitPoints>300</MaxHitPoints>
-			</value>
-		</li>
-
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]/statBases/ArmorRating_Blunt</xpath>
-			<value>
-				<ArmorRating_Blunt>14</ArmorRating_Blunt>
-			</value>
-		</li>
-
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]/statBases/ArmorRating_Sharp</xpath>
-			<value>
-				<ArmorRating_Sharp>10</ArmorRating_Sharp>
-			</value>
-		</li>
-
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]/tools</xpath>
-			<value>
-				<tools>
-					<li Class="CombatExtended.ToolCE">
-						<label>left blade</label>
-						<capacities>
-							<li>Cut</li>
-						</capacities>
-						<power>45</power>
-						<cooldownTime>1.84</cooldownTime>
-						<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
-						<armorPenetrationSharp>16</armorPenetrationSharp>
-						<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
-						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-					</li>
-					<li Class="CombatExtended.ToolCE">
-						<label>left blade</label>
-						<capacities>
-							<li>Stab</li>
-						</capacities>
-						<power>27</power>
-						<cooldownTime>1.03</cooldownTime>
-						<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
-						<armorPenetrationSharp>45</armorPenetrationSharp>
-						<armorPenetrationBlunt>20</armorPenetrationBlunt>
-						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-					</li>
-					<li Class="CombatExtended.ToolCE">
-						<label>right blade</label>
-						<capacities>
-							<li>Cut</li>
-						</capacities>
-						<power>45</power>
-						<cooldownTime>1.84</cooldownTime>
-						<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
-						<armorPenetrationSharp>16</armorPenetrationSharp>
-						<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
-						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-					</li>
-					<li Class="CombatExtended.ToolCE">
-						<label>right blade</label>
-						<capacities>
-							<li>Stab</li>
-						</capacities>
-						<power>27</power>
-						<cooldownTime>1.03</cooldownTime>
-						<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
-						<armorPenetrationSharp>45</armorPenetrationSharp>
-						<armorPenetrationBlunt>20</armorPenetrationBlunt>
-						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-					</li>
-					<li Class="CombatExtended.ToolCE">
-						<label>head</label>
-						<capacities>
-							<li>Blunt</li>
-						</capacities>
-						<power>6</power>
-						<cooldownTime>5.9</cooldownTime>
-						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-						<chanceFactor>0.2</chanceFactor>
-						<armorPenetrationBlunt>1.875</armorPenetrationBlunt>
-					</li>
-				</tools>
-			</value>
-		</li>
-
-		<li Class="PatchOperationConditional">
-			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]/comps</xpath>
-			<nomatch Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]</xpath>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]/statBases</xpath>
 				<value>
-					<comps />
+					<CarryWeight>50</CarryWeight>
+					<CarryBulk>20</CarryBulk>
+					<MeleeDodgeChance>0.43</MeleeDodgeChance>
+					<MeleeCritChance>0.41</MeleeCritChance>
+					<MeleeParryChance>0.36</MeleeParryChance>
+					<MaxHitPoints>300</MaxHitPoints>
 				</value>
-			</nomatch>
-		</li>
+			</li>
 
-		<li Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]/comps</xpath>
-			<value>
-				<li Class="CombatExtended.CompProperties_ArmorDurability">
-					<Durability>1300</Durability>
-					<Regenerates>true</Regenerates>
-					<RegenInterval>1250</RegenInterval>
-					<RegenValue>5</RegenValue>
-					<Repairable>true</Repairable>
-					<RepairIngredients>
-						<Steel>5</Steel>
-						<Plasteel>5</Plasteel>
-					</RepairIngredients>
-					<RepairTime>300</RepairTime>
-					<RepairValue>200</RepairValue>
-					<CanOverHeal>true</CanOverHeal>
-					<MaxOverHeal>116</MaxOverHeal>
-					<MinArmorPct>0.75</MinArmorPct>
-				</li>
-			</value>
-		</li>
-
-
-		<!--Searing Scyther -->
-
-		<li Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]/statBases</xpath>
-			<value>
-				<CarryWeight>50</CarryWeight>
-				<CarryBulk>20</CarryBulk>
-				<MeleeDodgeChance>0.18</MeleeDodgeChance>
-				<MeleeCritChance>0.23</MeleeCritChance>
-				<MeleeParryChance>0.19</MeleeParryChance>
-				<MaxHitPoints>250</MaxHitPoints>
-				<ArmorRating_Heat>0.4</ArmorRating_Heat>
-			</value>
-		</li>
-
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]/statBases/ArmorRating_Blunt</xpath>
-			<value>
-				<ArmorRating_Blunt>8</ArmorRating_Blunt>
-			</value>
-		</li>
-
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]/statBases/ArmorRating_Sharp</xpath>
-			<value>
-				<ArmorRating_Sharp>6</ArmorRating_Sharp>
-			</value>
-		</li>
-
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]/tools</xpath>
-			<value>
-				<tools>
-					<li Class="CombatExtended.ToolCE">
-						<label>left blade</label>
-						<capacities>
-							<li>Cut</li>
-						</capacities>
-						<power>43</power>
-						<extraMeleeDamages>
-							<li>
-							<def>Flame</def>
-							<amount>5</amount>
-							<chance>0.3</chance>
-							</li>
-						</extraMeleeDamages>
-						<cooldownTime>2.07</cooldownTime>
-						<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
-						<armorPenetrationSharp>2.16</armorPenetrationSharp>
-						<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
-						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-					</li>
-					<li Class="CombatExtended.ToolCE">
-						<label>left blade</label>
-						<capacities>
-							<li>Stab</li>
-						</capacities>
-						<power>24</power>
-						<extraMeleeDamages>
-							<li>
-							<def>Flame</def>
-							<amount>5</amount>
-							<chance>0.3</chance>
-							</li>
-						</extraMeleeDamages>
-						<cooldownTime>1.33</cooldownTime>
-						<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
-						<armorPenetrationSharp>40</armorPenetrationSharp>
-						<armorPenetrationBlunt>20</armorPenetrationBlunt>
-						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-					</li>
-					<li Class="CombatExtended.ToolCE">
-						<label>right blade</label>
-						<capacities>
-							<li>Cut</li>
-						</capacities>
-						<power>43</power>
-						<extraMeleeDamages>
-							<li>
-							<def>Flame</def>
-							<amount>5</amount>
-							<chance>0.3</chance>
-							</li>
-						</extraMeleeDamages>
-						<cooldownTime>2.07</cooldownTime>
-						<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
-						<armorPenetrationSharp>2.16</armorPenetrationSharp>
-						<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
-						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-					</li>
-					<li Class="CombatExtended.ToolCE">
-						<label>right blade</label>
-						<capacities>
-							<li>Stab</li>
-						</capacities>
-						<power>24</power>
-						<extraMeleeDamages>
-							<li>
-							<def>Flame</def>
-							<amount>5</amount>
-							<chance>0.3</chance>
-							</li>
-						</extraMeleeDamages>
-						<cooldownTime>1.33</cooldownTime>
-						<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
-						<armorPenetrationSharp>40</armorPenetrationSharp>
-						<armorPenetrationBlunt>20</armorPenetrationBlunt>
-						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-					</li>
-					<li Class="CombatExtended.ToolCE">
-						<label>head</label>
-						<capacities>
-							<li>Blunt</li>
-						</capacities>
-						<power>6</power>
-						<cooldownTime>5.9</cooldownTime>
-						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-						<chanceFactor>0.2</chanceFactor>
-						<armorPenetrationBlunt>1.875</armorPenetrationBlunt>
-					</li>
-				</tools>
-			</value>
-		</li>
-
-		<li Class="PatchOperationConditional">
-			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]/comps</xpath>
-			<nomatch Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<comps />
+					<ArmorRating_Blunt>14</ArmorRating_Blunt>
 				</value>
-			</nomatch>
-		</li>
+			</li>
 
-		<li Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]/comps</xpath>
-			<value>
-				<li Class="CombatExtended.CompProperties_ArmorDurability">
-					<Durability>1225</Durability>
-					<Regenerates>true</Regenerates>
-					<RegenInterval>1250</RegenInterval>
-					<RegenValue>5</RegenValue>
-					<Repairable>true</Repairable>
-					<RepairIngredients>
-						<Steel>5</Steel>
-						<Plasteel>5</Plasteel>
-					</RepairIngredients>
-					<RepairTime>300</RepairTime>
-					<RepairValue>200</RepairValue>
-					<CanOverHeal>true</CanOverHeal>
-					<MaxOverHeal>116</MaxOverHeal>
-					<MinArmorPct>0.75</MinArmorPct>
-				</li>
-			</value>
-		</li>
-
-		<!--Prestige Scyther -->
-
-		<li Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]/statBases</xpath>
-			<value>
-				<CarryWeight>50</CarryWeight>
-				<CarryBulk>20</CarryBulk>
-				<MeleeDodgeChance>0.58</MeleeDodgeChance>
-				<MeleeCritChance>0.54</MeleeCritChance>
-				<MeleeParryChance>0.45</MeleeParryChance>
-				<MaxHitPoints>380</MaxHitPoints>
-				<ArmorRating_Electric>0.2</ArmorRating_Electric>
-				<ArmorRating_Heat>0.15</ArmorRating_Heat>			
-			</value>
-		</li>
-
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]/statBases/ArmorRating_Blunt</xpath>
-			<value>
-				<ArmorRating_Blunt>24</ArmorRating_Blunt>
-			</value>
-		</li>
-
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]/statBases/ArmorRating_Sharp</xpath>
-			<value>
-				<ArmorRating_Sharp>16</ArmorRating_Sharp>
-			</value>
-		</li>
-
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]/tools</xpath>
-			<value>
-				<tools>
-					<li Class="CombatExtended.ToolCE">
-						<label>left blade</label>
-						<capacities>
-							<li>Cut</li>
-						</capacities>
-						<power>46</power>
-						<cooldownTime>1.84</cooldownTime>
-						<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
-						<armorPenetrationSharp>20</armorPenetrationSharp>
-						<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
-						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-					</li>
-					<li Class="CombatExtended.ToolCE">
-						<label>left blade</label>
-						<capacities>
-							<li>Stab</li>
-						</capacities>
-						<power>28</power>
-						<cooldownTime>1.03</cooldownTime>
-						<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
-						<armorPenetrationSharp>45</armorPenetrationSharp>
-						<armorPenetrationBlunt>20</armorPenetrationBlunt>
-						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-					</li>
-					<li Class="CombatExtended.ToolCE">
-						<label>right blade</label>
-						<capacities>
-							<li>Cut</li>
-						</capacities>
-						<power>46</power>
-						<cooldownTime>1.84</cooldownTime>
-						<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
-						<armorPenetrationSharp>20</armorPenetrationSharp>
-						<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
-						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-					</li>
-					<li Class="CombatExtended.ToolCE">
-						<label>right blade</label>
-						<capacities>
-							<li>Stab</li>
-						</capacities>
-						<power>28</power>
-						<cooldownTime>1.03</cooldownTime>
-						<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
-						<armorPenetrationSharp>45</armorPenetrationSharp>
-						<armorPenetrationBlunt>20</armorPenetrationBlunt>
-						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-					</li>
-					<li Class="CombatExtended.ToolCE">
-						<label>head</label>
-						<capacities>
-							<li>Blunt</li>
-						</capacities>
-						<power>6</power>
-						<cooldownTime>5.9</cooldownTime>
-						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-						<chanceFactor>0.2</chanceFactor>
-						<armorPenetrationBlunt>1.875</armorPenetrationBlunt>
-					</li>
-				</tools>
-			</value>
-		</li>
-
-		<li Class="PatchOperationConditional">
-			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]/comps</xpath>
-			<nomatch Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<comps />
+					<ArmorRating_Sharp>10</ArmorRating_Sharp>
 				</value>
-			</nomatch>
-		</li>
+			</li>
 
-		<li Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]/comps</xpath>
-			<value>
-				<li Class="CombatExtended.CompProperties_ArmorDurability">
-					<Durability>1500</Durability>
-					<Regenerates>true</Regenerates>
-					<RegenInterval>1250</RegenInterval>
-					<RegenValue>5</RegenValue>
-					<Repairable>true</Repairable>
-					<RepairIngredients>
-						<Steel>5</Steel>
-						<Plasteel>5</Plasteel>
-					</RepairIngredients>
-					<RepairTime>300</RepairTime>
-					<RepairValue>200</RepairValue>
-					<CanOverHeal>true</CanOverHeal>
-					<MaxOverHeal>150</MaxOverHeal>
-					<MinArmorPct>0.75</MinArmorPct>
-				</li>
-			</value>
-		</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left blade</label>
+							<capacities>
+								<li>Cut</li>
+							</capacities>
+							<power>45</power>
+							<cooldownTime>1.84</cooldownTime>
+							<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
+							<armorPenetrationSharp>16</armorPenetrationSharp>
+							<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
+							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>left blade</label>
+							<capacities>
+								<li>Stab</li>
+							</capacities>
+							<power>27</power>
+							<cooldownTime>1.03</cooldownTime>
+							<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
+							<armorPenetrationSharp>45</armorPenetrationSharp>
+							<armorPenetrationBlunt>20</armorPenetrationBlunt>
+							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right blade</label>
+							<capacities>
+								<li>Cut</li>
+							</capacities>
+							<power>45</power>
+							<cooldownTime>1.84</cooldownTime>
+							<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
+							<armorPenetrationSharp>16</armorPenetrationSharp>
+							<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
+							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right blade</label>
+							<capacities>
+								<li>Stab</li>
+							</capacities>
+							<power>27</power>
+							<cooldownTime>1.03</cooldownTime>
+							<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
+							<armorPenetrationSharp>45</armorPenetrationSharp>
+							<armorPenetrationBlunt>20</armorPenetrationBlunt>
+							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>6</power>
+							<cooldownTime>5.9</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<chanceFactor>0.2</chanceFactor>
+							<armorPenetrationBlunt>1.875</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
 
-		</operations>
-	</match>
-</Operation>
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]/comps</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]</xpath>
+					<value>
+						<comps />
+					</value>
+				</nomatch>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]/comps</xpath>
+				<value>
+					<li Class="CombatExtended.CompProperties_ArmorDurability">
+						<Durability>1300</Durability>
+						<Regenerates>true</Regenerates>
+						<RegenInterval>1250</RegenInterval>
+						<RegenValue>5</RegenValue>
+						<Repairable>true</Repairable>
+						<RepairIngredients>
+							<Steel>5</Steel>
+							<Plasteel>5</Plasteel>
+						</RepairIngredients>
+						<RepairTime>300</RepairTime>
+						<RepairValue>200</RepairValue>
+						<CanOverHeal>true</CanOverHeal>
+						<MaxOverHeal>116</MaxOverHeal>
+						<MinArmorPct>0.75</MinArmorPct>
+					</li>
+				</value>
+			</li>
 
 
+			<!--Searing Scyther -->
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]/statBases</xpath>
+				<value>
+					<CarryWeight>50</CarryWeight>
+					<CarryBulk>20</CarryBulk>
+					<MeleeDodgeChance>0.18</MeleeDodgeChance>
+					<MeleeCritChance>0.23</MeleeCritChance>
+					<MeleeParryChance>0.19</MeleeParryChance>
+					<MaxHitPoints>250</MaxHitPoints>
+					<ArmorRating_Heat>0.4</ArmorRating_Heat>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>8</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>6</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left blade</label>
+							<capacities>
+								<li>Cut</li>
+							</capacities>
+							<power>43</power>
+							<extraMeleeDamages>
+								<li>
+								<def>Flame</def>
+								<amount>5</amount>
+								<chance>0.3</chance>
+								</li>
+							</extraMeleeDamages>
+							<cooldownTime>2.07</cooldownTime>
+							<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
+							<armorPenetrationSharp>2.16</armorPenetrationSharp>
+							<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
+							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>left blade</label>
+							<capacities>
+								<li>Stab</li>
+							</capacities>
+							<power>24</power>
+							<extraMeleeDamages>
+								<li>
+								<def>Flame</def>
+								<amount>5</amount>
+								<chance>0.3</chance>
+								</li>
+							</extraMeleeDamages>
+							<cooldownTime>1.33</cooldownTime>
+							<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
+							<armorPenetrationSharp>40</armorPenetrationSharp>
+							<armorPenetrationBlunt>20</armorPenetrationBlunt>
+							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right blade</label>
+							<capacities>
+								<li>Cut</li>
+							</capacities>
+							<power>43</power>
+							<extraMeleeDamages>
+								<li>
+								<def>Flame</def>
+								<amount>5</amount>
+								<chance>0.3</chance>
+								</li>
+							</extraMeleeDamages>
+							<cooldownTime>2.07</cooldownTime>
+							<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
+							<armorPenetrationSharp>2.16</armorPenetrationSharp>
+							<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
+							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right blade</label>
+							<capacities>
+								<li>Stab</li>
+							</capacities>
+							<power>24</power>
+							<extraMeleeDamages>
+								<li>
+								<def>Flame</def>
+								<amount>5</amount>
+								<chance>0.3</chance>
+								</li>
+							</extraMeleeDamages>
+							<cooldownTime>1.33</cooldownTime>
+							<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
+							<armorPenetrationSharp>40</armorPenetrationSharp>
+							<armorPenetrationBlunt>20</armorPenetrationBlunt>
+							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>6</power>
+							<cooldownTime>5.9</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<chanceFactor>0.2</chanceFactor>
+							<armorPenetrationBlunt>1.875</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]/comps</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]</xpath>
+					<value>
+						<comps />
+					</value>
+				</nomatch>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]/comps</xpath>
+				<value>
+					<li Class="CombatExtended.CompProperties_ArmorDurability">
+						<Durability>1225</Durability>
+						<Regenerates>true</Regenerates>
+						<RegenInterval>1250</RegenInterval>
+						<RegenValue>5</RegenValue>
+						<Repairable>true</Repairable>
+						<RepairIngredients>
+							<Steel>5</Steel>
+							<Plasteel>5</Plasteel>
+						</RepairIngredients>
+						<RepairTime>300</RepairTime>
+						<RepairValue>200</RepairValue>
+						<CanOverHeal>true</CanOverHeal>
+						<MaxOverHeal>116</MaxOverHeal>
+						<MinArmorPct>0.75</MinArmorPct>
+					</li>
+				</value>
+			</li>
+
+			<!--Prestige Scyther -->
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]/statBases</xpath>
+				<value>
+					<CarryWeight>50</CarryWeight>
+					<CarryBulk>20</CarryBulk>
+					<MeleeDodgeChance>0.58</MeleeDodgeChance>
+					<MeleeCritChance>0.54</MeleeCritChance>
+					<MeleeParryChance>0.45</MeleeParryChance>
+					<MaxHitPoints>380</MaxHitPoints>
+					<ArmorRating_Electric>0.2</ArmorRating_Electric>
+					<ArmorRating_Heat>0.15</ArmorRating_Heat>			
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>24</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>16</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left blade</label>
+							<capacities>
+								<li>Cut</li>
+							</capacities>
+							<power>46</power>
+							<cooldownTime>1.84</cooldownTime>
+							<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
+							<armorPenetrationSharp>20</armorPenetrationSharp>
+							<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
+							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>left blade</label>
+							<capacities>
+								<li>Stab</li>
+							</capacities>
+							<power>28</power>
+							<cooldownTime>1.03</cooldownTime>
+							<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
+							<armorPenetrationSharp>45</armorPenetrationSharp>
+							<armorPenetrationBlunt>20</armorPenetrationBlunt>
+							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right blade</label>
+							<capacities>
+								<li>Cut</li>
+							</capacities>
+							<power>46</power>
+							<cooldownTime>1.84</cooldownTime>
+							<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
+							<armorPenetrationSharp>20</armorPenetrationSharp>
+							<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
+							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right blade</label>
+							<capacities>
+								<li>Stab</li>
+							</capacities>
+							<power>28</power>
+							<cooldownTime>1.03</cooldownTime>
+							<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
+							<armorPenetrationSharp>45</armorPenetrationSharp>
+							<armorPenetrationBlunt>20</armorPenetrationBlunt>
+							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>6</power>
+							<cooldownTime>5.9</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<chanceFactor>0.2</chanceFactor>
+							<armorPenetrationBlunt>1.875</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]/comps</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]</xpath>
+					<value>
+						<comps />
+					</value>
+				</nomatch>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]/comps</xpath>
+				<value>
+					<li Class="CombatExtended.CompProperties_ArmorDurability">
+						<Durability>1500</Durability>
+						<Regenerates>true</Regenerates>
+						<RegenInterval>1250</RegenInterval>
+						<RegenValue>5</RegenValue>
+						<Repairable>true</Repairable>
+						<RepairIngredients>
+							<Steel>5</Steel>
+							<Plasteel>5</Plasteel>
+						</RepairIngredients>
+						<RepairTime>300</RepairTime>
+						<RepairValue>200</RepairValue>
+						<CanOverHeal>true</CanOverHeal>
+						<MaxOverHeal>150</MaxOverHeal>
+						<MinArmorPct>0.75</MinArmorPct>
+					</li>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
 </Patch>

--- a/Patches/pphhyy Expanded Scythers/MechKind_CE.xml
+++ b/Patches/pphhyy Expanded Scythers/MechKind_CE.xml
@@ -91,7 +91,7 @@
 					</extraMeleeDamages>
 					<cooldownTime>1.33</cooldownTime>
 					<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
-					<armorPenetrationBlunt>25</armorPenetrationBlunt>
+					<armorPenetrationBlunt>35</armorPenetrationBlunt>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 				</li>
 				<li Class="CombatExtended.ToolCE">
@@ -108,7 +108,7 @@
 					</extraMeleeDamages>
 					<cooldownTime>1.33</cooldownTime>
 					<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
-					<armorPenetrationBlunt>25</armorPenetrationBlunt>
+					<armorPenetrationBlunt>35</armorPenetrationBlunt>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 				</li>
 				<li Class="CombatExtended.ToolCE">
@@ -146,7 +146,7 @@
 		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]/comps</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
-				<Durability>1630</Durability>
+				<Durability>1225</Durability>
 				<Regenerates>true</Regenerates>
 				<RegenInterval>1250</RegenInterval>
 				<RegenValue>5</RegenValue>
@@ -212,7 +212,7 @@
 					</extraMeleeDamages>
 					<cooldownTime>1.33</cooldownTime>
 					<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
-					<armorPenetrationBlunt>25</armorPenetrationBlunt>
+					<armorPenetrationBlunt>16</armorPenetrationBlunt>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 				</li>
 				<li Class="CombatExtended.ToolCE">
@@ -244,7 +244,7 @@
 		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]/comps</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
-				<Durability>2080</Durability>
+				<Durability>1875</Durability>
 				<Regenerates>true</Regenerates>
 				<RegenInterval>1250</RegenInterval>
 				<RegenValue>5</RegenValue>
@@ -286,24 +286,28 @@
 						</parts>
 					</li>
 					<li>
+						<useStatic>false</useStatic>
 						<ArmorRating_Sharp>0.625</ArmorRating_Sharp>
 						<parts>
 							<li>MechanicalHead</li>
 						</parts>
 					</li>
 					<li>
+						<useStatic>false</useStatic>
 						<ArmorRating_Blunt>0.625</ArmorRating_Blunt>
 						<parts>
 							<li>MechanicalHead</li>
 						</parts>
 					</li>
 					<li>
+						<useStatic>false</useStatic>
 						<ArmorRating_Sharp>0.625</ArmorRating_Sharp>
 						<parts>
 							<li>MechanicalLeg</li>
 						</parts>
 					</li>
 					<li>
+						<useStatic>false</useStatic>
 						<ArmorRating_Blunt>0.625</ArmorRating_Blunt>
 						<parts>
 							<li>MechanicalLeg</li>
@@ -426,7 +430,7 @@
 		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]/comps</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
-				<Durability>1850</Durability>
+				<Durability>1300</Durability>
 				<Regenerates>true</Regenerates>
 				<RegenInterval>1250</RegenInterval>
 				<RegenValue>5</RegenValue>
@@ -583,7 +587,7 @@
 		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]/comps</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
-				<Durability>1630</Durability>
+				<Durability>1225</Durability>
 				<Regenerates>true</Regenerates>
 				<RegenInterval>1250</RegenInterval>
 				<RegenValue>5</RegenValue>
@@ -713,7 +717,7 @@
 		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]/comps</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
-				<Durability>2450</Durability>
+				<Durability>1500</Durability>
 				<Regenerates>true</Regenerates>
 				<RegenInterval>1250</RegenInterval>
 				<RegenValue>5</RegenValue>

--- a/Patches/pphhyy Expanded Scythers/MechKind_CE.xml
+++ b/Patches/pphhyy Expanded Scythers/MechKind_CE.xml
@@ -1,0 +1,775 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>phynilla Expanded Mechs Scyther</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+	<li Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch" or
+			                 defName="pphhyy_ScytherExpandedMono" or
+			                 defName="pphhyy_ScytherExpandedSearing" or
+			                 defName="pphhyy_ScytherExpandedPrestige"]</xpath>
+		<value>
+			<li Class="CombatExtended.RacePropertiesExtensionCE">
+				<bodyShape>Humanoid</bodyShape>
+			</li>
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/PawnKindDef[defName="pphhyy_ScytherExpandedTank" or 
+			                 defName="pphhyy_ScytherExpandedArch" or
+							 defName="pphhyy_ScytherExpandedSearing"]/combatPower</xpath>
+		<value>
+			<combatPower>190</combatPower>
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/PawnKindDef[defName="pphhyy_ScytherExpandedMono"]/combatPower</xpath>
+		<value>
+			<combatPower>240</combatPower>
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/PawnKindDef[defName="pphhyy_ScytherExpandedPrestige"]/combatPower</xpath>
+		<value>
+			<combatPower>320</combatPower>
+		</value>
+	</li>
+
+
+	<!--Arch Scyther (EMP one)-->
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]/statBases</xpath>
+		<value>
+			<CarryWeight>50</CarryWeight>
+			<CarryBulk>20</CarryBulk>
+			<AimingAccuracy>1.0</AimingAccuracy>
+			<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
+			<MeleeDodgeChance>0.13</MeleeDodgeChance>
+			<MeleeCritChance>0.12</MeleeCritChance>
+			<MeleeParryChance>0.09</MeleeParryChance>
+			<MaxHitPoints>220</MaxHitPoints>
+			<ArmorRating_Electric>0.2</ArmorRating_Electric>		
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>8</ArmorRating_Blunt>
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>6</ArmorRating_Sharp>
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>left Mace</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>24</power>
+					<extraMeleeDamages>
+						<li>
+						  <def>EMP</def>
+						  <amount>4</amount>
+						</li>
+					</extraMeleeDamages>
+					<cooldownTime>1.33</cooldownTime>
+					<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
+					<armorPenetrationBlunt>25</armorPenetrationBlunt>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>right Mace</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>24</power>
+					<extraMeleeDamages>
+						<li>
+						  <def>EMP</def>
+						  <amount>4</amount>
+						</li>
+					</extraMeleeDamages>
+					<cooldownTime>1.33</cooldownTime>
+					<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
+					<armorPenetrationBlunt>25</armorPenetrationBlunt>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>6</power>
+					<extraMeleeDamages>
+						<li>
+						  <def>EMP</def>
+						  <amount>2</amount>
+						</li>
+					</extraMeleeDamages>
+					<cooldownTime>5.9</cooldownTime>
+					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					<chanceFactor>0.2</chanceFactor>
+					<armorPenetrationBlunt>1.875</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</li>
+
+	<li Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</li>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>1280</Durability>
+				<Regenerates>true</Regenerates>
+				<RegenInterval>1250</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<Repairable>true</Repairable>
+				<RepairIngredients>
+					<Steel>5</Steel>
+					<Plasteel>5</Plasteel>
+				</RepairIngredients>
+				<RepairTime>300</RepairTime>
+				<RepairValue>200</RepairValue>
+				<CanOverHeal>true</CanOverHeal>
+				<MaxOverHeal>116</MaxOverHeal>
+				<MinArmorPct>0.75</MinArmorPct>
+				<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
+				<MinArmorValueBlunt>22</MinArmorValueBlunt>
+				<MinArmorValueHeat>0.2</MinArmorValueHeat>
+				<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
+			</li>
+		</value>
+	</li>
+
+
+	<!--Scyther Guard (Tank one)-->
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]/statBases</xpath>
+		<value>
+			<CarryWeight>50</CarryWeight>
+			<CarryBulk>20</CarryBulk>
+			<AimingAccuracy>0.8</AimingAccuracy>
+			<ShootingAccuracyPawn>0.9</ShootingAccuracyPawn>
+			<MeleeDodgeChance>0.07</MeleeDodgeChance>
+			<MeleeCritChance>0.04</MeleeCritChance>
+			<MeleeParryChance>0.65</MeleeParryChance>
+			<MaxHitPoints>300</MaxHitPoints>
+			<ArmorRating_Heat>0.15</ArmorRating_Heat>
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>24</ArmorRating_Blunt>
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>16</ArmorRating_Sharp>
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>right Mace</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>24</power>
+					<extraMeleeDamages>
+						<li>
+						  <def>Stun</def>
+						  <amount>3</amount>
+						</li>
+					</extraMeleeDamages>
+					<cooldownTime>1.33</cooldownTime>
+					<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
+					<armorPenetrationBlunt>25</armorPenetrationBlunt>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>6</power>
+					<extraMeleeDamages>
+						<li>
+						  <def>EMP</def>
+						  <amount>2</amount>
+						</li>
+					</extraMeleeDamages>
+					<cooldownTime>5.9</cooldownTime>
+					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					<chanceFactor>0.2</chanceFactor>
+					<armorPenetrationBlunt>1.875</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</li>
+
+	<li Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</li>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>1550</Durability>
+				<Regenerates>true</Regenerates>
+				<RegenInterval>1250</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<Repairable>true</Repairable>
+				<RepairIngredients>
+					<Steel>5</Steel>
+					<Plasteel>5</Plasteel>
+				</RepairIngredients>
+				<RepairTime>300</RepairTime>
+				<RepairValue>200</RepairValue>
+				<CanOverHeal>true</CanOverHeal>
+				<MaxOverHeal>140</MaxOverHeal>
+				<MinArmorPct>0.75</MinArmorPct>
+				<MinArmorValueSharp>5</MinArmorValueSharp>
+				<MinArmorValueBlunt>8</MinArmorValueBlunt>
+				<!-- <MinArmorValueHeat>0.2</MinArmorValueHeat>
+				<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
+			</li>
+		</value>
+	</li>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]</xpath>
+		<value>
+			<modExtensions Inherit="False">
+			<li Class="CombatExtended.RacePropertiesExtensionCE">
+				<bodyShape>Humanoid</bodyShape>
+			</li>
+			<li Class="CombatExtended.PartialArmorExt">
+				<stats>
+					<li>
+						<useStatic>false</useStatic>
+						<ArmorRating_Sharp>0.1</ArmorRating_Sharp>
+						<parts>
+							<li>SightSensor</li>
+						</parts>
+					</li>
+					<li>
+						<useStatic>false</useStatic>
+						<ArmorRating_Blunt>0.1</ArmorRating_Blunt>
+						<parts>
+							<li>SightSensor</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.625</ArmorRating_Sharp>
+						<parts>
+							<li>MechanicalHead</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.625</ArmorRating_Blunt>
+						<parts>
+							<li>MechanicalHead</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.625</ArmorRating_Sharp>
+						<parts>
+							<li>MechanicalLeg</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.625</ArmorRating_Blunt>
+						<parts>
+							<li>MechanicalLeg</li>
+						</parts>
+					</li>
+				</stats>
+			</li>
+			</modExtensions>
+		</value>
+	</li>
+
+
+
+	<!--Mono Scyther -->
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]/statBases</xpath>
+		<value>
+			<CarryWeight>50</CarryWeight>
+			<CarryBulk>20</CarryBulk>
+			<AimingAccuracy>1.0</AimingAccuracy>
+			<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
+			<MeleeDodgeChance>0.18</MeleeDodgeChance>
+			<MeleeCritChance>0.18</MeleeCritChance>
+			<MeleeParryChance>0.14 </MeleeParryChance>
+			<MaxHitPoints>240</MaxHitPoints>
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>14</ArmorRating_Blunt>
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>10</ArmorRating_Sharp>
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>left blade</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>45</power>
+					<cooldownTime>1.84</cooldownTime>
+					<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
+					<armorPenetrationSharp>18</armorPenetrationSharp>
+					<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>left blade</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>27</power>
+					<cooldownTime>1.03</cooldownTime>
+					<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
+					<armorPenetrationSharp>45</armorPenetrationSharp>
+					<armorPenetrationBlunt>20</armorPenetrationBlunt>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>right blade</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>45</power>
+					<cooldownTime>1.84</cooldownTime>
+					<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
+					<armorPenetrationSharp>18</armorPenetrationSharp>
+					<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>right blade</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>27</power>
+					<cooldownTime>1.03</cooldownTime>
+					<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
+					<armorPenetrationSharp>45</armorPenetrationSharp>
+					<armorPenetrationBlunt>20</armorPenetrationBlunt>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>6</power>
+					<cooldownTime>5.9</cooldownTime>
+					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					<chanceFactor>0.2</chanceFactor>
+					<armorPenetrationBlunt>1.875</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</li>
+
+	<li Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</li>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>1390</Durability>
+				<Regenerates>true</Regenerates>
+				<RegenInterval>1250</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<Repairable>true</Repairable>
+				<RepairIngredients>
+					<Steel>5</Steel>
+					<Plasteel>5</Plasteel>
+				</RepairIngredients>
+				<RepairTime>300</RepairTime>
+				<RepairValue>200</RepairValue>
+				<CanOverHeal>true</CanOverHeal>
+				<MaxOverHeal>116</MaxOverHeal>
+				<MinArmorPct>0.75</MinArmorPct>
+				<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
+				<MinArmorValueBlunt>22</MinArmorValueBlunt>
+				<MinArmorValueHeat>0.2</MinArmorValueHeat>
+				<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
+			</li>
+		</value>
+	</li>
+
+
+	<!--Searing Scyther -->
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]/statBases</xpath>
+		<value>
+			<CarryWeight>50</CarryWeight>
+			<CarryBulk>20</CarryBulk>
+			<AimingAccuracy>1.0</AimingAccuracy>
+			<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
+			<MeleeDodgeChance>0.13</MeleeDodgeChance>
+			<MeleeCritChance>0.12</MeleeCritChance>
+			<MeleeParryChance>0.09 </MeleeParryChance>
+			<MaxHitPoints>220</MaxHitPoints>
+			<ArmorRating_Heat>0.4</ArmorRating_Heat>
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>8</ArmorRating_Blunt>
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>6</ArmorRating_Sharp>
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>left blade</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>43</power>
+					<extraMeleeDamages>
+						<li>
+						  <def>Flame</def>
+						  <amount>5</amount>
+						  <chance>0.3</chance>
+						</li>
+					</extraMeleeDamages>
+					<cooldownTime>1.84</cooldownTime>
+					<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
+					<armorPenetrationSharp>2.16</armorPenetrationSharp>
+					<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>left blade</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>24</power>
+					<extraMeleeDamages>
+						<li>
+						  <def>Flame</def>
+						  <amount>5</amount>
+						  <chance>0.3</chance>
+						</li>
+					</extraMeleeDamages>
+					<cooldownTime>1.03</cooldownTime>
+					<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
+					<armorPenetrationSharp>40</armorPenetrationSharp>
+					<armorPenetrationBlunt>20</armorPenetrationBlunt>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>right blade</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>43</power>
+					<extraMeleeDamages>
+						<li>
+						  <def>Flame</def>
+						  <amount>5</amount>
+						  <chance>0.3</chance>
+						</li>
+					</extraMeleeDamages>
+					<cooldownTime>1.84</cooldownTime>
+					<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
+					<armorPenetrationSharp>2.16</armorPenetrationSharp>
+					<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>right blade</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>24</power>
+					<extraMeleeDamages>
+						<li>
+						  <def>Flame</def>
+						  <amount>5</amount>
+						  <chance>0.3</chance>
+						</li>
+					</extraMeleeDamages>
+					<cooldownTime>1.03</cooldownTime>
+					<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
+					<armorPenetrationSharp>40</armorPenetrationSharp>
+					<armorPenetrationBlunt>20</armorPenetrationBlunt>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>6</power>
+					<cooldownTime>5.9</cooldownTime>
+					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					<chanceFactor>0.2</chanceFactor>
+					<armorPenetrationBlunt>1.875</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</li>
+
+	<li Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</li>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>1280</Durability>
+				<Regenerates>true</Regenerates>
+				<RegenInterval>1250</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<Repairable>true</Repairable>
+				<RepairIngredients>
+					<Steel>5</Steel>
+					<Plasteel>5</Plasteel>
+				</RepairIngredients>
+				<RepairTime>300</RepairTime>
+				<RepairValue>200</RepairValue>
+				<CanOverHeal>true</CanOverHeal>
+				<MaxOverHeal>116</MaxOverHeal>
+				<MinArmorPct>0.75</MinArmorPct>
+				<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
+				<MinArmorValueBlunt>22</MinArmorValueBlunt> 
+			    <MinArmorValueElectric>0.1</MinArmorValueElectric>-->
+				<MinArmorValueHeat>0.2</MinArmorValueHeat>
+			</li>
+		</value>
+	</li>
+
+
+	<!--Prestige Scyther -->
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]/statBases</xpath>
+		<value>
+			<CarryWeight>50</CarryWeight>
+			<CarryBulk>20</CarryBulk>
+			<AimingAccuracy>1.0</AimingAccuracy>
+			<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
+			<MeleeDodgeChance>0.21</MeleeDodgeChance>
+			<MeleeCritChance>0.25</MeleeCritChance>
+			<MeleeParryChance>0.2</MeleeParryChance>
+			<MaxHitPoints>265</MaxHitPoints>
+			<ArmorRating_Electric>0.2</ArmorRating_Electric>
+			<ArmorRating_Heat>0.15</ArmorRating_Heat>			
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>24</ArmorRating_Blunt>
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>16</ArmorRating_Sharp>
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>left blade</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>46</power>
+					<cooldownTime>1.84</cooldownTime>
+					<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
+					<armorPenetrationSharp>20</armorPenetrationSharp>
+					<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>left blade</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>28</power>
+					<cooldownTime>1.03</cooldownTime>
+					<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
+					<armorPenetrationSharp>45</armorPenetrationSharp>
+					<armorPenetrationBlunt>20</armorPenetrationBlunt>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>right blade</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>46</power>
+					<cooldownTime>1.84</cooldownTime>
+					<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
+					<armorPenetrationSharp>20</armorPenetrationSharp>
+					<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>right blade</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>28</power>
+					<cooldownTime>1.03</cooldownTime>
+					<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
+					<armorPenetrationSharp>45</armorPenetrationSharp>
+					<armorPenetrationBlunt>20</armorPenetrationBlunt>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>6</power>
+					<cooldownTime>5.9</cooldownTime>
+					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					<chanceFactor>0.2</chanceFactor>
+					<armorPenetrationBlunt>1.875</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</li>
+
+	<li Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</li>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>1450</Durability>
+				<Regenerates>true</Regenerates>
+				<RegenInterval>1250</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<Repairable>true</Repairable>
+				<RepairIngredients>
+					<Steel>5</Steel>
+					<Plasteel>5</Plasteel>
+				</RepairIngredients>
+				<RepairTime>300</RepairTime>
+				<RepairValue>200</RepairValue>
+				<CanOverHeal>true</CanOverHeal>
+				<MaxOverHeal>125</MaxOverHeal>
+				<MinArmorPct>0.75</MinArmorPct>
+				<MinArmorValueSharp>8</MinArmorValueSharp>
+				<MinArmorValueBlunt>10</MinArmorValueBlunt>
+				<MinArmorValueHeat>0.05</MinArmorValueHeat>
+				<MinArmorValueElectric>0.05</MinArmorValueElectric>
+			</li>
+		</value>
+	</li>
+
+</operations>
+</match>
+</Operation>
+
+
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -357,6 +357,7 @@ Polarisbloc - Security Force	|
 Poleepkwa Race	|
 Possessed Weapons	|
 pphhyy's Demigryphs   |
+phynilla Expanded Mechs Scyther |
 pphhyy Sanguinary Animals   |
 Prestige Specialist Armours	|
 Project RimFactory - Materials |


### PR DESCRIPTION
## Additions

- Patch for [phynilla Expanded Mech Scythers]
 Patch 5 new kinds of scythers, each with their own charateristics and roles
 Mainly for player side use (might be a bit too powerful), also possible to spawn on enemy side. I've tried to balance it while 
 keeping their intended roles.

   **the mechs use exact same Bodies def as vanilla mechanoid walkers, but the author still make a new one for some reason
## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
