### PR TITLE
Dragon Descent Degradable Natural Armor

### DIFF
--- a/Patches/Dragons Descent/ThingDefs_Races/Races_Animal_Dragon_Base.xml
+++ b/Patches/Dragons Descent/ThingDefs_Races/Races_Animal_Dragon_Base.xml
@@ -5,8 +5,10 @@
 		<mods>
 			<li>Dragons Descent</li>
 		</mods>
+
 		<match Class="PatchOperationSequence">
 			<operations>
+
 				<!-- ======== BaseDragon (Dragon Base) ======== -->
 				<!-- ====== ModExtension ====== -->
 				<li Class="PatchOperationAddModExtension">
@@ -17,6 +19,7 @@
 						</li>
 					</value>
 				</li>
+
 				<!-- ======== DragonRaceBase (Common Dragon Base) ======== -->
 				<!-- ====== statBases ====== -->
 				<li Class="PatchOperationAdd">
@@ -28,24 +31,41 @@
 						<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[@Name="DragonRaceBase"]/statBases/MeleeDodgeChance</xpath>
 					<value>
 						<MeleeDodgeChance>0.13</MeleeDodgeChance>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[@Name="DragonRaceBase"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>40</ArmorRating_Blunt>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[@Name="DragonRaceBase"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>16</ArmorRating_Sharp>
 					</value>
 				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[@Name="DragonRaceBase"]/comps</xpath>
+					<value>
+						<li Class="CombatExtended.CompProperties_ArmorDurability">
+							<Durability>4250</Durability>
+							<Regenerates>true</Regenerates>
+							<RegenInterval>600</RegenInterval>
+							<RegenValue>5</RegenValue>
+							<MinArmorPct>0.5</MinArmorPct>
+						</li>
+					</value>
+				</li>
+
 				<!-- ======== RDragonRaceBase (Rare Dragon Base) ======== -->
 				<!-- ====== statBases ====== -->
 				<li Class="PatchOperationAdd">
@@ -76,7 +96,21 @@
 					</value>
 				</li>
 
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[@Name="RDragonRaceBase"]/comps</xpath>
+					<value>
+						<li Class="CombatExtended.CompProperties_ArmorDurability">
+							<Durability>5075</Durability>
+							<Regenerates>true</Regenerates>
+							<RegenInterval>600</RegenInterval>
+							<RegenValue>5</RegenValue>
+							<MinArmorPct>0.5</MinArmorPct>
+						</li>
+					</value>
+				</li>
+
 			</operations>
 		</match>
 	</Operation>
+
 </Patch>

--- a/Patches/RWY Dragon's Descent Void Dwellers/ThingDefs_Races/Races_Animal_SpaceDragon_Base.xml
+++ b/Patches/RWY Dragon's Descent Void Dwellers/ThingDefs_Races/Races_Animal_SpaceDragon_Base.xml
@@ -72,6 +72,46 @@
 					</value>
 				</li>
 
+				<!-- Natural Armor Comp -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[@Name="VoidDragonRaceBase" or @Name="VoidDragonWWRaceBase"]/comps</xpath>
+					<value>
+						<li Class="CombatExtended.CompProperties_ArmorDurability">
+							<Durability>16500</Durability>
+							<Regenerates>true</Regenerates>
+							<RegenInterval>600</RegenInterval>
+							<RegenValue>5</RegenValue>
+							<MinArmorPct>0.5</MinArmorPct>
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[@Name="NebulaDragonRaceBase"]/comps</xpath>
+					<value>
+						<li Class="CombatExtended.CompProperties_ArmorDurability">
+							<Durability>15250</Durability>
+							<Regenerates>true</Regenerates>
+							<RegenInterval>600</RegenInterval>
+							<RegenValue>5</RegenValue>
+							<MinArmorPct>0.5</MinArmorPct>
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[@Name="StarDragonRaceBase"]/comps</xpath>
+					<value>
+						<li Class="CombatExtended.CompProperties_ArmorDurability">
+							<Durability>14000</Durability>
+							<Regenerates>true</Regenerates>
+							<RegenInterval>600</RegenInterval>
+							<RegenValue>5</RegenValue>
+							<MinArmorPct>0.5</MinArmorPct>
+						</li>
+					</value>
+				</li>
+
 				<!-- ====== race (Race Properties) ====== -->
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[@Name="VoidDragonRaceBase"]/race/manhunterOnTameFailChance</xpath>


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Adds degradable natural armor to Dragon's Descent and Void Dwellers

## Reasoning

Why did you choose to implement things this way, e.g.
- To align mods with the degradable natural armor across CE

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
