### PR TITLE
Bursting projectiles shadow

### DIFF
--- a/Defs/Ammo/Flamethrower.xml
+++ b/Defs/Ammo/Flamethrower.xml
@@ -94,6 +94,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<speed>20</speed>
 			<flyOverhead>false</flyOverhead>
+			<castShadow>false</castShadow>
 		</projectile>
 	</ThingDef>
 

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_Bursting.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_Bursting.cs
@@ -29,6 +29,7 @@ namespace CombatExtended
             if (def.projectile is ProjectilePropertiesCE props)
             {
                 armingDelay = props.armingDelay;
+                this.castShadow = props.castShadow;
             }
             if (distance > 0)
             {


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Adds the check introduced in #2640 to Bursting projectile class, which got left out because it overrides the `Launch` method.

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Removes shadows from flame stream of flamethrowers, which uses that Bursting class. Doesn't make sense for a ball of flame to cast a shadow.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] Playtested a colony (specify how long)
