### PR TITLE
Ammo label tweaks

### DIFF
--- a/Defs/Ammo/Advanced/10x18mmCharged.xml
+++ b/Defs/Ammo/Advanced/10x18mmCharged.xml
@@ -41,7 +41,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="10x18mmChargedBase">
 		<defName>Ammo_10x18mmCharged</defName>
-		<label>10x18mm Charged cartridge</label>
+		<label>10x18mm Charged</label>
 		<graphicData>
 			<texPath>Things/Ammo/Charged/SmallRegular</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="10x18mmChargedBase">
 		<defName>Ammo_10x18mmCharged_AP</defName>
-		<label>10x18mm Charged cartridge (Conc.)</label>
+		<label>10x18mm Charged (Conc.)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Charged/SmallConc</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -67,7 +67,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="10x18mmChargedBase">
 		<defName>Ammo_10x18mmCharged_Ion</defName>
-		<label>10x18mm Charged cartridge (Ion)</label>
+		<label>10x18mm Charged (Ion)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Charged/SmallIon</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Advanced/12GaugeCharged.xml
+++ b/Defs/Ammo/Advanced/12GaugeCharged.xml
@@ -40,7 +40,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="12GaugeChargedBase">
 		<defName>Ammo_12GaugeCharged</defName>
-		<label>12 gauge charged shell</label>
+		<label>12 gauge charged</label>
 		<graphicData>
 			<texPath>Things/Ammo/Charged/ShotgunRegular</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -53,7 +53,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="12GaugeChargedBase">
 		<defName>Ammo_12GaugeCharged_Slug</defName>
-		<label>12 gauge charged shell (Slug)</label>
+		<label>12 gauge charged (Slug)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Charged/ShotgunConc</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -67,7 +67,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="12GaugeChargedBase">
 		<defName>Ammo_12GaugeCharged_Ion</defName>
-		<label>12 gauge charged shell (Ion Shot)</label>
+		<label>12 gauge charged (Ion Shot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Charged/ShotgunIon</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Advanced/12mmRailgun.xml
+++ b/Defs/Ammo/Advanced/12mmRailgun.xml
@@ -22,7 +22,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="SpacerMediumAmmoBase">
 		<defName>Ammo_12mmRailgun_Sabot</defName>
-		<label>12mm Railgun cartridge (Sabot)</label>
+		<label>12mm Railgun (Sabot)</label>
 		<description>Fin-stabilized tungsten carbide penetrator with discarding sabot, designed for large-caliber railgun weapons.</description>
 		<statBases>
 			<Mass>0.051</Mass>

--- a/Defs/Ammo/Advanced/12x64mmCharged.xml
+++ b/Defs/Ammo/Advanced/12x64mmCharged.xml
@@ -39,7 +39,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="12x64mmChargedBase">
 		<defName>Ammo_12x64mmCharged</defName>
-		<label>12x64mm Charged cartridge</label>
+		<label>12x64mm Charged</label>
 		<graphicData>
 			<texPath>Things/Ammo/Charged/LargeMech</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Advanced/12x72mmCharged.xml
+++ b/Defs/Ammo/Advanced/12x72mmCharged.xml
@@ -41,7 +41,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="12x72mmChargedBase">
 		<defName>Ammo_12x72mmCharged</defName>
-		<label>12x72mm Charged cartridge</label>
+		<label>12x72mm Charged</label>
 		<graphicData>
 			<texPath>Things/Ammo/Charged/LargeRegular</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="12x72mmChargedBase">
 		<defName>Ammo_12x72mmCharged_AP</defName>
-		<label>12x72mm Charged cartridge (Conc.)</label>
+		<label>12x72mm Charged (Conc.)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Charged/LargeConc</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -67,7 +67,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="12x72mmChargedBase">
 		<defName>Ammo_12x72mmCharged_Ion</defName>
-		<label>12x72mm Charged cartridge (Ion)</label>
+		<label>12x72mm Charged (Ion)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Charged/LargeIon</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Advanced/15x65mmDiffusingCharged.xml
+++ b/Defs/Ammo/Advanced/15x65mmDiffusingCharged.xml
@@ -37,7 +37,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="15x65mmDiffusingChargedBase">
 		<defName>Ammo_15x65mmDiffusingCharged</defName>
-		<label>15x65mm Diffusing Charged cartridge</label>
+		<label>15x65mm Diffusing Charged</label>
 		<graphicData>
 			<texPath>Things/Ammo/Charged/ShotgunMech</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Advanced/164x284mmDemoShell.xml
+++ b/Defs/Ammo/Advanced/164x284mmDemoShell.xml
@@ -38,7 +38,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="164x284mmDemoBase">
 		<defName>Ammo_164x284mmDemo</defName>
-		<label>164x284mm Demolition Shell</label>
+		<label>164x284mm demolition shell</label>
 		<graphicData>
 			<texPath>Things/Ammo/FuelCell/Large</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Advanced/20x105mmCharged.xml
+++ b/Defs/Ammo/Advanced/20x105mmCharged.xml
@@ -41,7 +41,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="20x105mmChargedBase">
 		<defName>Ammo_20x105mmCharged</defName>
-		<label>20x105mm Charged cartridge</label>
+		<label>20x105mm Charged</label>
 		<graphicData>
 			<texPath>Things/Ammo/Charged/LargeRegular</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="20x105mmChargedBase">
 		<defName>Ammo_20x105mmCharged_AP</defName>
-		<label>20x105mm Charged cartridge (Conc.)</label>
+		<label>20x105mm Charged (Conc.)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Charged/LargeConc</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -67,7 +67,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="20x105mmChargedBase">
 		<defName>Ammo_20x105mmCharged_Ion</defName>
-		<label>20x105mm Charged cartridge (Ion)</label>
+		<label>20x105mm Charged (Ion)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Charged/LargeIon</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Advanced/5x16mmCharged.xml
+++ b/Defs/Ammo/Advanced/5x16mmCharged.xml
@@ -39,7 +39,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="5x16mmChargedBase">
 		<defName>Ammo_5x16mmCharged</defName>
-		<label>5x16mm Charged cartridge</label>
+		<label>5x16mm Charged</label>
 		<graphicData>
 			<texPath>Things/Ammo/Charged/SmallMech</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Advanced/5x35mmCharged.xml
+++ b/Defs/Ammo/Advanced/5x35mmCharged.xml
@@ -39,7 +39,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="5x35mmChargedBase">
 		<defName>Ammo_5x35mmCharged</defName>
-		<label>5x35mm Charged cartridge</label>
+		<label>5x35mm Charged</label>
 		<graphicData>
 			<texPath>Things/Ammo/Charged/MediumMech</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Advanced/60x225mmGammaShell.xml
+++ b/Defs/Ammo/Advanced/60x225mmGammaShell.xml
@@ -37,7 +37,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="60x225mmGammaBase">
 		<defName>Ammo_60x225mmGamma_Standard</defName>
-		<label>60x225mm Gamma Shell (Standard)</label>
+		<label>60x225mm gamma shell (Standard)</label>
 		<graphicData>
 			<texPath>Things/Ammo/FuelCell/Large</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Advanced/6mmRailgun.xml
+++ b/Defs/Ammo/Advanced/6mmRailgun.xml
@@ -22,7 +22,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="SpacerSmallAmmoBase">
 		<defName>Ammo_6mmRailgun_Sabot</defName>
-		<label>6mm Railgun cartridge (Sabot)</label>
+		<label>6mm Railgun (Sabot)</label>
 		<description>Fin-stabilized tungsten carbide penetrator with discarding sabot, designed for railgun rifles.</description>
 		<statBases>
 			<Mass>0.01</Mass>

--- a/Defs/Ammo/Advanced/6x18mmCharged.xml
+++ b/Defs/Ammo/Advanced/6x18mmCharged.xml
@@ -41,7 +41,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="6x18mmChargedBase">
 		<defName>Ammo_6x18mmCharged</defName>
-		<label>6x18mm Charged cartridge</label>
+		<label>6x18mm Charged</label>
 		<graphicData>
 			<texPath>Things/Ammo/Charged/SmallRegular</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="6x18mmChargedBase">
 		<defName>Ammo_6x18mmCharged_AP</defName>
-		<label>6x18mm Charged cartridge (Conc.)</label>
+		<label>6x18mm Charged (Conc.)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Charged/SmallConc</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -67,7 +67,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="6x18mmChargedBase">
 		<defName>Ammo_6x18mmCharged_Ion</defName>
-		<label>6x18mm Charged cartridge (Ion)</label>
+		<label>6x18mm Charged (Ion)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Charged/SmallIon</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Advanced/6x22mmCharged.xml
+++ b/Defs/Ammo/Advanced/6x22mmCharged.xml
@@ -39,7 +39,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="6x22mmChargedBase">
 		<defName>Ammo_6x22mmCharged</defName>
-		<label>6x22mm Charged cartridge</label>
+		<label>6x22mm Charged</label>
 		<graphicData>
 			<texPath>Things/Ammo/Charged/MediumMech</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Advanced/6x24mmCharged.xml
+++ b/Defs/Ammo/Advanced/6x24mmCharged.xml
@@ -41,7 +41,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="6x24mmChargedBase">
 		<defName>Ammo_6x24mmCharged</defName>
-		<label>6x24mm Charged cartridge</label>
+		<label>6x24mm Charged</label>
 		<graphicData>
 			<texPath>Things/Ammo/Charged/MediumRegular</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="6x24mmChargedBase">
 		<defName>Ammo_6x24mmCharged_AP</defName>
-		<label>6x24mm Charged cartridge (Conc.)</label>
+		<label>6x24mm Charged (Conc.)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Charged/MediumConc</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -67,7 +67,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="6x24mmChargedBase">
 		<defName>Ammo_6x24mmCharged_Ion</defName>
-		<label>6x24mm Charged cartridge (Ion)</label>
+		<label>6x24mm Charged (Ion)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Charged/MediumIon</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Advanced/8mmRailgun.xml
+++ b/Defs/Ammo/Advanced/8mmRailgun.xml
@@ -22,7 +22,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="SpacerAmmoBase">
 		<defName>Ammo_8mmRailgun_Sabot</defName>
-		<label>8mm Railgun cartridge (Sabot)</label>
+		<label>8mm Railgun (Sabot)</label>
 		<description>Fin-stabilized tungsten carbide penetrator with discarding sabot, designed for railgun pistols.</description>
 		<statBases>
 			<Mass>0.009</Mass>

--- a/Defs/Ammo/Advanced/8x35mmCharged.xml
+++ b/Defs/Ammo/Advanced/8x35mmCharged.xml
@@ -41,7 +41,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="8x35mmChargedBase">
 		<defName>Ammo_8x35mmCharged</defName>
-		<label>8x35mm Charged cartridge</label>
+		<label>8x35mm Charged</label>
 		<graphicData>
 			<texPath>Things/Ammo/Charged/MediumRegular</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="8x35mmChargedBase">
 		<defName>Ammo_8x35mmCharged_AP</defName>
-		<label>8x35mm Charged cartridge (Conc.)</label>
+		<label>8x35mm Charged (Conc.)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Charged/MediumConc</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -67,7 +67,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="8x35mmChargedBase">
 		<defName>Ammo_8x35mmCharged_Ion</defName>
-		<label>8x35mm Charged cartridge (Ion)</label>
+		<label>8x35mm Charged (Ion)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Charged/MediumIon</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Advanced/8x40mmCharged.xml
+++ b/Defs/Ammo/Advanced/8x40mmCharged.xml
@@ -39,7 +39,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="8x40mmChargedBase">
 		<defName>Ammo_8x40mmCharged</defName>
-		<label>8x40mm Charged cartridge</label>
+		<label>8x40mm Charged</label>
 		<graphicData>
 			<texPath>Things/Ammo/Charged/MediumMech</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Advanced/8x50mmCharged.xml
+++ b/Defs/Ammo/Advanced/8x50mmCharged.xml
@@ -41,7 +41,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="8x50mmChargedBase">
 		<defName>Ammo_8x50mmCharged</defName>
-		<label>8x50mm Charged cartridge</label>
+		<label>8x50mm Charged</label>
 		<graphicData>
 			<texPath>Things/Ammo/Charged/MediumRegular</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="8x50mmChargedBase">
 		<defName>Ammo_8x50mmCharged_AP</defName>
-		<label>8x50mm Charged cartridge (Conc.)</label>
+		<label>8x50mm Charged (Conc.)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Charged/MediumConc</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -67,7 +67,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="8x50mmChargedBase">
 		<defName>Ammo_8x50mmCharged_Ion</defName>
-		<label>8x50mm Charged cartridge (Ion)</label>
+		<label>8x50mm Charged (Ion)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Charged/MediumIon</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Advanced/PlasmaCellHeavy.xml
+++ b/Defs/Ammo/Advanced/PlasmaCellHeavy.xml
@@ -22,7 +22,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="SpacerMediumAmmoBase">
 		<defName>Ammo_PlasmaCellHeavy</defName>
-		<label>Plasma Heavy Power Cell</label>
+		<label>plasma heavy power cell</label>
 		<description>Plasma containment power cell optimized for heavy weapons</description>
 		<statBases>
 			<Mass>0.134</Mass>

--- a/Defs/Ammo/Advanced/PlasmaCellPistol.xml
+++ b/Defs/Ammo/Advanced/PlasmaCellPistol.xml
@@ -22,7 +22,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="SpacerSmallAmmoBase">
 		<defName>Ammo_PlasmaCellPistol</defName>
-		<label>Plasma Pistol Power Cell</label>
+		<label>plasma pistol power cell</label>
 		<description>Plasma containment power cell optimized for pistols</description>
 		<statBases>
 			<Mass>0.014</Mass>

--- a/Defs/Ammo/Advanced/PlasmaCellRifle.xml
+++ b/Defs/Ammo/Advanced/PlasmaCellRifle.xml
@@ -22,7 +22,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="SpacerSmallAmmoBase">
 		<defName>Ammo_PlasmaCellRifle</defName>
-		<label>Plasma Rifle Power Cell</label>
+		<label>plasma rifle power cell</label>
 		<description>Plasma containment power cell optimized for rifles</description>
 		<statBases>
 			<Mass>0.017</Mass>

--- a/Defs/Ammo/GENERIC/Mech.xml
+++ b/Defs/Ammo/GENERIC/Mech.xml
@@ -87,7 +87,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="MechShellAmmo">
 		<defName>Ammo_MechShell</defName>
-		<label>Mech Shell</label>
+		<label>Mechanoid shell</label>
 		<graphicData>
 			<texPath>Things/Ammo/FuelCell/Large</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/HighCaliber/12.7x108mmSoviet.xml
+++ b/Defs/Ammo/HighCaliber/12.7x108mmSoviet.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo127x108mmBase">
 		<defName>Ammo_127x108mm_FMJ</defName>
-		<label>12.7x108mm cartridge (FMJ)</label>
+		<label>12.7x108mm (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo127x108mmBase">
 		<defName>Ammo_127x108mm_AP</defName>
-		<label>12.7x108mm cartridge (AP)</label>
+		<label>12.7x108mm (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo127x108mmBase">
 		<defName>Ammo_127x108mm_Incendiary</defName>
-		<label>12.7x108mm cartridge (AP-I)</label>
+		<label>12.7x108mm (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo127x108mmBase">
 		<defName>Ammo_127x108mm_HE</defName>
-		<label>12.7x108mm cartridge (AP-HE)</label>
+		<label>12.7x108mm (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo127x108mmBase">
 		<defName>Ammo_127x108mm_Sabot</defName>
-		<label>12.7x108mm cartridge (Sabot)</label>
+		<label>12.7x108mm (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/HighCaliber/13.2x92mmSRTuF.xml
+++ b/Defs/Ammo/HighCaliber/13.2x92mmSRTuF.xml
@@ -42,7 +42,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo132x92mmSRTuFBase">
 		<defName>Ammo_132x92mmSRTuF_FMJ</defName>
-		<label>13.2x92mmSR TuF cartridge (FMJ)</label>
+		<label>13.2x92mmSR TuF (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -56,7 +56,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo132x92mmSRTuFBase">
 		<defName>Ammo_132x92mmSRTuF_AP</defName>
-		<label>13.2x92mmSR TuF cartridge (AP)</label>
+		<label>13.2x92mmSR TuF (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -70,7 +70,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo132x92mmSRTuFBase">
 		<defName>Ammo_132x92mmSRTuF_Incendiary</defName>
-		<label>13.2x92mmSR TuF cartridge (AP-I)</label>
+		<label>13.2x92mmSR TuF (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -84,7 +84,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo132x92mmSRTuFBase">
 		<defName>Ammo_132x92mmSRTuF_HE</defName>
-		<label>13.2x92mmSR TuF cartridge (AP-HE)</label>
+		<label>13.2x92mmSR TuF (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -98,7 +98,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo132x92mmSRTuFBase">
 		<defName>Ammo_132x92mmSRTuF_Sabot</defName>
-		<label>13.2x92mmSR TuF cartridge (Sabot)</label>
+		<label>13.2x92mmSR TuF (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/HighCaliber/14.5x114mmSoviet.xml
+++ b/Defs/Ammo/HighCaliber/14.5x114mmSoviet.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo145x114mmBase">
 		<defName>Ammo_145x114mm_FMJ</defName>
-		<label>14.5x114mm cartridge (FMJ)</label>
+		<label>14.5x114mm (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo145x114mmBase">
 		<defName>Ammo_145x114mm_AP</defName>
-		<label>14.5x114mm cartridge (AP)</label>
+		<label>14.5x114mm (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo145x114mmBase">
 		<defName>Ammo_145x114mm_Incendiary</defName>
-		<label>14.5x114mm cartridge (AP-I)</label>
+		<label>14.5x114mm (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo145x114mmBase">
 		<defName>Ammo_145x114mm_HE</defName>
-		<label>14.5x114mm cartridge (AP-HE)</label>
+		<label>14.5x114mm (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo145x114mmBase">
 		<defName>Ammo_145x114mm_Sabot</defName>
-		<label>14.5x114mm cartridge (Sabot)</label>
+		<label>14.5x114mm (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/HighCaliber/15.2x169mm.xml
+++ b/Defs/Ammo/HighCaliber/15.2x169mm.xml
@@ -39,7 +39,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo152x169mmBase">
 		<defName>Ammo_152x169mm_Sabot</defName>
-		<label>15.2x169mm cartridge (Sabot)</label>
+		<label>15.2x169mm (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/HighCaliber/2-Bore.xml
+++ b/Defs/Ammo/HighCaliber/2-Bore.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo2BoreBase">
 		<defName>Ammo_2Bore_FMJ</defName>
-		<label>2-Bore cartridge (FMJ)</label>
+		<label>2-Bore (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo2BoreBase">
 		<defName>Ammo_2Bore_AP</defName>
-		<label>2-Bore cartridge (AP)</label>
+		<label>2-Bore (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo2BoreBase">
 		<defName>Ammo_2Bore_Incendiary</defName>
-		<label>2-Bore cartridge (AP-I)</label>
+		<label>2-Bore (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo2BoreBase">
 		<defName>Ammo_2Bore_HE</defName>
-		<label>2-Bore cartridge (AP-HE)</label>
+		<label>2-Bore (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo2BoreBase">
 		<defName>Ammo_2Bore_Sabot</defName>
-		<label>2-Bore cartridge (Sabot)</label>
+		<label>2-Bore (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/HighCaliber/20x102mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/20x102mmNATO.xml
@@ -42,7 +42,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x102mmNATOBase">
 		<defName>Ammo_20x102mmNATO_AP</defName>
-		<label>20x102mm NATO cartridge (AP)</label>
+		<label>20x102mm NATO (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -56,7 +56,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x102mmNATOBase">
 		<defName>Ammo_20x102mmNATO_Incendiary</defName>
-		<label>20x102mm NATO cartridge (AP-I)</label>
+		<label>20x102mm NATO (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -70,7 +70,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x102mmNATOBase">
 		<defName>Ammo_20x102mmNATO_HE</defName>
-		<label>20x102mm NATO cartridge (AP-HE)</label>
+		<label>20x102mm NATO (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -84,7 +84,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x102mmNATOBase">
 		<defName>Ammo_20x102mmNATO_Sabot</defName>
-		<label>20x102mm NATO cartridge (Sabot)</label>
+		<label>20x102mm NATO (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/HighCaliber/20x110mmHispano.xml
+++ b/Defs/Ammo/HighCaliber/20x110mmHispano.xml
@@ -42,7 +42,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x110mmHispanoBase">
 		<defName>Ammo_20x110mmHispano_AP</defName>
-		<label>20x110mm Hispano cartridge (AP)</label>
+		<label>20x110mm Hispano (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -56,7 +56,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x110mmHispanoBase">
 		<defName>Ammo_20x110mmHispano_Incendiary</defName>
-		<label>20x110mm Hispano cartridge (AP-I)</label>
+		<label>20x110mm Hispano (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -70,7 +70,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x110mmHispanoBase">
 		<defName>Ammo_20x110mmHispano_HE</defName>
-		<label>20x110mm Hispano cartridge (AP-HE)</label>
+		<label>20x110mm Hispano (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -84,7 +84,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x110mmHispanoBase">
 		<defName>Ammo_20x110mmHispano_Sabot</defName>
-		<label>20x110mm Hispano cartridge (Sabot)</label>
+		<label>20x110mm Hispano (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/HighCaliber/20x128mmOerlikon.xml
+++ b/Defs/Ammo/HighCaliber/20x128mmOerlikon.xml
@@ -42,7 +42,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x128mmOerlikonBase">
 		<defName>Ammo_20x128mmOerlikon_AP</defName>
-		<label>20x128mm Oerlikon cartridge (AP)</label>
+		<label>20x128mm Oerlikon (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -56,7 +56,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x128mmOerlikonBase">
 		<defName>Ammo_20x128mmOerlikon_Incendiary</defName>
-		<label>20x128mm Oerlikon cartridge (AP-I)</label>
+		<label>20x128mm Oerlikon (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -70,7 +70,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x128mmOerlikonBase">
 		<defName>Ammo_20x128mmOerlikon_HE</defName>
-		<label>20x128mm Oerlikon cartridge (AP-HE)</label>
+		<label>20x128mm Oerlikon (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -84,7 +84,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x128mmOerlikonBase">
 		<defName>Ammo_20x128mmOerlikon_Sabot</defName>
-		<label>20x128mm Oerlikon cartridge (Sabot)</label>
+		<label>20x128mm Oerlikon (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/HighCaliber/20x138mmB.xml
+++ b/Defs/Ammo/HighCaliber/20x138mmB.xml
@@ -42,7 +42,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x138mmBBase">
 		<defName>Ammo_20x138mmB_AP</defName>
-		<label>20x138mmB cartridge (AP)</label>
+		<label>20x138mmB (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -56,7 +56,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x138mmBBase">
 		<defName>Ammo_20x138mmB_Incendiary</defName>
-		<label>20x138mmB cartridge (AP-I)</label>
+		<label>20x138mmB (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -70,7 +70,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x138mmBBase">
 		<defName>Ammo_20x138mmB_HE</defName>
-		<label>20x138mmB cartridge (AP-HE)</label>
+		<label>20x138mmB (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -84,7 +84,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x138mmBBase">
 		<defName>Ammo_20x138mmB_Sabot</defName>
-		<label>20x138mmB cartridge (Sabot)</label>
+		<label>20x138mmB (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/HighCaliber/20x139mm.xml
+++ b/Defs/Ammo/HighCaliber/20x139mm.xml
@@ -42,7 +42,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x139mmBase">
 		<defName>Ammo_20x139mm_AP</defName>
-		<label>20x139mm cartridge (AP)</label>
+		<label>20x139mm (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -56,7 +56,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x139mmBase">
 		<defName>Ammo_20x139mm_Incendiary</defName>
-		<label>20x139mm cartridge (AP-I)</label>
+		<label>20x139mm (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -70,7 +70,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x139mmBase">
 		<defName>Ammo_20x139mm_HE</defName>
-		<label>20x139mm cartridge (AP-HE)</label>
+		<label>20x139mm (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -84,7 +84,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x139mmBase">
 		<defName>Ammo_20x139mm_Sabot</defName>
-		<label>20x139mm cartridge (Sabot)</label>
+		<label>20x139mm (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/HighCaliber/20x82mmMauser.xml
+++ b/Defs/Ammo/HighCaliber/20x82mmMauser.xml
@@ -42,7 +42,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x82mmMauserBase">
 		<defName>Ammo_20x82mmMauser_AP</defName>
-		<label>20x82mm Mauser cartridge (AP)</label>
+		<label>20x82mm Mauser (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -56,7 +56,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x82mmMauserBase">
 		<defName>Ammo_20x82mmMauser_Incendiary</defName>
-		<label>20x82mm Mauser cartridge (AP-I)</label>
+		<label>20x82mm Mauser (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -70,7 +70,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x82mmMauserBase">
 		<defName>Ammo_20x82mmMauser_HE</defName>
-		<label>20x82mm Mauser cartridge (AP-HE)</label>
+		<label>20x82mm Mauser (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -84,7 +84,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x82mmMauserBase">
 		<defName>Ammo_20x82mmMauser_Sabot</defName>
-		<label>20x82mm Mauser cartridge (Sabot)</label>
+		<label>20x82mm Mauser (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/HighCaliber/20x99mmShVAK.xml
+++ b/Defs/Ammo/HighCaliber/20x99mmShVAK.xml
@@ -42,7 +42,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x99mmRShVAKBase">
 		<defName>Ammo_20x99mmRShVAK_AP</defName>
-		<label>20x99mmR ShVAK cartridge (AP)</label>
+		<label>20x99mmR ShVAK (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -56,7 +56,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x99mmRShVAKBase">
 		<defName>Ammo_20x99mmRShVAK_Incendiary</defName>
-		<label>20x99mmR ShVAK cartridge (AP-I)</label>
+		<label>20x99mmR ShVAK (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -70,7 +70,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x99mmRShVAKBase">
 		<defName>Ammo_20x99mmRShVAK_HE</defName>
-		<label>20x99mmR ShVAK cartridge (AP-HE)</label>
+		<label>20x99mmR ShVAK (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -84,7 +84,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x99mmRShVAKBase">
 		<defName>Ammo_20x99mmRShVAK_Sabot</defName>
-		<label>20x99mmR ShVAK cartridge (Sabot)</label>
+		<label>20x99mmR ShVAK (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/HighCaliber/23x152mmB.xml
+++ b/Defs/Ammo/HighCaliber/23x152mmB.xml
@@ -42,7 +42,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo23x152mmBBase">
 		<defName>Ammo_23x152mmB_AP</defName>
-		<label>23x152mmB cartridge (AP)</label>
+		<label>23x152mmB (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -56,7 +56,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo23x152mmBBase">
 		<defName>Ammo_23x152mmB_Incendiary</defName>
-		<label>23x152mmB cartridge (AP-I)</label>
+		<label>23x152mmB (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -70,7 +70,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo23x152mmBBase">
 		<defName>Ammo_23x152mmB_APHE</defName>
-		<label>23x152mmB cartridge (AP-HE)</label>
+		<label>23x152mmB (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -84,7 +84,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo23x152mmBBase">
 		<defName>Ammo_23x152mmB_Sabot</defName>
-		<label>23x152mmB cartridge (Sabot)</label>
+		<label>23x152mmB (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/HighCaliber/25x137mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/25x137mmNATO.xml
@@ -42,7 +42,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo25x137mmNATOBase">
 		<defName>Ammo_25x137mmNATO_AP</defName>
-		<label>25x137mm NATO cartridge (AP)</label>
+		<label>25x137mm NATO (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -56,7 +56,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo25x137mmNATOBase">
 		<defName>Ammo_25x137mmNATO_Incendiary</defName>
-		<label>25x137mm NATO cartridge (AP-I)</label>
+		<label>25x137mm NATO (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -70,7 +70,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo25x137mmNATOBase">
 		<defName>Ammo_25x137mmNATO_HE</defName>
-		<label>25x137mm NATO cartridge (AP-HE)</label>
+		<label>25x137mm NATO (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -84,7 +84,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo25x137mmNATOBase">
 		<defName>Ammo_25x137mmNATO_Sabot</defName>
-		<label>25x137mm NATO cartridge (Sabot)</label>
+		<label>25x137mm NATO (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/HighCaliber/300WinchesterMagnum.xml
+++ b/Defs/Ammo/HighCaliber/300WinchesterMagnum.xml
@@ -42,7 +42,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo300WinchesterMagnumBase">
 		<defName>Ammo_300WinchesterMagnum_FMJ</defName>
-		<label>.300 Winchester Magnum cartridge (FMJ)</label>
+		<label>.300 Winchester Magnum (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -56,7 +56,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo300WinchesterMagnumBase">
 		<defName>Ammo_300WinchesterMagnum_AP</defName>
-		<label>.300 Winchester Magnum cartridge (AP)</label>
+		<label>.300 Winchester Magnum (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -70,7 +70,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo300WinchesterMagnumBase">
 		<defName>Ammo_300WinchesterMagnum_Incendiary</defName>
-		<label>.300 Winchester Magnum cartridge (AP-I)</label>
+		<label>.300 Winchester Magnum (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -84,7 +84,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo300WinchesterMagnumBase">
 		<defName>Ammo_300WinchesterMagnum_HE</defName>
-		<label>.300 Winchester Magnum cartridge (AP-HE)</label>
+		<label>.300 Winchester Magnum (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -98,7 +98,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo300WinchesterMagnumBase">
 		<defName>Ammo_300WinchesterMagnum_Sabot</defName>
-		<label>.300 Winchester Magnum cartridge (Sabot)</label>
+		<label>.300 Winchester Magnum (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/HighCaliber/30x113mmB.xml
+++ b/Defs/Ammo/HighCaliber/30x113mmB.xml
@@ -42,7 +42,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo30x113mmBBase">
 		<defName>Ammo_30x113mmB_AP</defName>
-		<label>30x113mmB cartridge (AP)</label>
+		<label>30x113mmB (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -56,7 +56,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo30x113mmBBase">
 		<defName>Ammo_30x113mmB_Incendiary</defName>
-		<label>30x113mmB cartridge (AP-I)</label>
+		<label>30x113mmB (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -70,7 +70,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo30x113mmBBase">
 		<defName>Ammo_30x113mmB_HE</defName>
-		<label>30x113mmB cartridge (AP-HE)</label>
+		<label>30x113mmB (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -84,7 +84,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x102mmNATOBase">
 		<defName>Ammo_30x113mmB_Sabot</defName>
-		<label>30x113mmB cartridge (Sabot)</label>
+		<label>30x113mmB (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/HighCaliber/30x165mm.xml
+++ b/Defs/Ammo/HighCaliber/30x165mm.xml
@@ -42,7 +42,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo30x165mmBase">
 		<defName>Ammo_30x165mm_AP</defName>
-		<label>30x165mm cartridge (AP)</label>
+		<label>30x165mm (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -56,7 +56,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo30x165mmBase">
 		<defName>Ammo_30x165mm_Incendiary</defName>
-		<label>30x165mm cartridge (AP-I)</label>
+		<label>30x165mm (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -70,7 +70,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo30x165mmBase">
 		<defName>Ammo_30x165mm_HE</defName>
-		<label>30x165mm cartridge (AP-HE)</label>
+		<label>30x165mm (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -84,7 +84,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo30x165mmBase">
 		<defName>Ammo_30x165mm_Sabot</defName>
-		<label>30x165mm cartridge (Sabot)</label>
+		<label>30x165mm (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/HighCaliber/30x173mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/30x173mmNATO.xml
@@ -42,7 +42,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo30x173mmNATOBase">
 		<defName>Ammo_30x173mmNATO_AP</defName>
-		<label>30x173mm NATO cartridge (AP)</label>
+		<label>30x173mm NATO (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -56,7 +56,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo30x173mmNATOBase">
 		<defName>Ammo_30x173mmNATO_Incendiary</defName>
-		<label>30x173mm NATO cartridge (AP-I)</label>
+		<label>30x173mm NATO (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -70,7 +70,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo30x173mmNATOBase">
 		<defName>Ammo_30x173mmNATO_HE</defName>
-		<label>30x173mm NATO cartridge (AP-HE)</label>
+		<label>30x173mm NATO (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -84,7 +84,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo30x173mmNATOBase">
 		<defName>Ammo_30x173mmNATO_Sabot</defName>
-		<label>30x173mm NATO cartridge (Sabot)</label>
+		<label>30x173mm NATO (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/HighCaliber/338LapuaMagnum.xml
+++ b/Defs/Ammo/HighCaliber/338LapuaMagnum.xml
@@ -42,7 +42,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo338LapuaBase">
 		<defName>Ammo_338Lapua_FMJ</defName>
-		<label>.338 Lapua Magnum cartridge (FMJ)</label>
+		<label>.338 Lapua Magnum (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -56,7 +56,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo338LapuaBase">
 		<defName>Ammo_338Lapua_AP</defName>
-		<label>.338 Lapua Magnum cartridge (AP)</label>
+		<label>.338 Lapua Magnum (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -70,7 +70,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo338LapuaBase">
 		<defName>Ammo_338Lapua_Incendiary</defName>
-		<label>.338 Lapua Magnum cartridge (AP-I)</label>
+		<label>.338 Lapua Magnum (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -84,7 +84,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo338LapuaBase">
 		<defName>Ammo_338Lapua_HE</defName>
-		<label>.338 Lapua Magnum cartridge (AP-HE)</label>
+		<label>.338 Lapua Magnum (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -98,7 +98,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo338LapuaBase">
 		<defName>Ammo_338Lapua_Sabot</defName>
-		<label>.338 Lapua Magnum cartridge (Sabot)</label>
+		<label>.338 Lapua Magnum (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/HighCaliber/338NormaMagnum.xml
+++ b/Defs/Ammo/HighCaliber/338NormaMagnum.xml
@@ -42,7 +42,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo338NormaBase">
 		<defName>Ammo_338Norma_FMJ</defName>
-		<label>.338 Norma Magnum cartridge (FMJ)</label>
+		<label>.338 Norma Magnum (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -56,7 +56,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo338NormaBase">
 		<defName>Ammo_338Norma_AP</defName>
-		<label>.338 Norma Magnum cartridge (AP)</label>
+		<label>.338 Norma Magnum (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -70,7 +70,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo338NormaBase">
 		<defName>Ammo_338Norma_Incendiary</defName>
-		<label>.338 Norma Magnum cartridge (AP-I)</label>
+		<label>.338 Norma Magnum (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -84,7 +84,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo338NormaBase">
 		<defName>Ammo_338Norma_HE</defName>
-		<label>.338 Norma Magnum cartridge (AP-HE)</label>
+		<label>.338 Norma Magnum (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -98,7 +98,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo338NormaBase">
 		<defName>Ammo_338Norma_Sabot</defName>
-		<label>.338 Norma Magnum cartridge (Sabot)</label>
+		<label>.338 Norma Magnum (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/HighCaliber/408CheyenneTactical.xml
+++ b/Defs/Ammo/HighCaliber/408CheyenneTactical.xml
@@ -42,7 +42,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo408CheyenneTacticalBase">
 		<defName>Ammo_408CheyenneTactical_FMJ</defName>
-		<label>.408 Cheyenne Tactical cartridge (FMJ)</label>
+		<label>.408 Cheyenne Tactical (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -56,7 +56,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo408CheyenneTacticalBase">
 		<defName>Ammo_408CheyenneTactical_AP</defName>
-		<label>.408 Cheyenne Tactical cartridge (AP)</label>
+		<label>.408 Cheyenne Tactical (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -70,7 +70,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo408CheyenneTacticalBase">
 		<defName>Ammo_408CheyenneTactical_Incendiary</defName>
-		<label>.408 Cheyenne Tactical cartridge (AP-I)</label>
+		<label>.408 Cheyenne Tactical (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -84,7 +84,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo408CheyenneTacticalBase">
 		<defName>Ammo_408CheyenneTactical_HE</defName>
-		<label>.408 Cheyenne Tactical cartridge (AP-HE)</label>
+		<label>.408 Cheyenne Tactical (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -98,7 +98,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo408CheyenneTacticalBase">
 		<defName>Ammo_408CheyenneTactical_Sabot</defName>
-		<label>.408 Cheyenne Tactical cartridge (Sabot)</label>
+		<label>.408 Cheyenne Tactical (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/HighCaliber/40x311mmR.xml
+++ b/Defs/Ammo/HighCaliber/40x311mmR.xml
@@ -42,7 +42,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo40x311mmRBase">
 		<defName>Ammo_40x311mmR_AP</defName>
-		<label>40x311mmR cartridge (AP)</label>
+		<label>40x311mmR (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Bofors/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -56,7 +56,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo40x311mmRBase">
 		<defName>Ammo_40x311mmR_Incendiary</defName>
-		<label>40x311mmR cartridge (AP-I)</label>
+		<label>40x311mmR (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Bofors/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -70,7 +70,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo40x311mmRBase">
 		<defName>Ammo_40x311mmR_HE</defName>
-		<label>40x311mmR cartridge (AP-HE)</label>
+		<label>40x311mmR (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Bofors/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -84,7 +84,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo40x311mmRBase">
 		<defName>Ammo_40x311mmR_Sabot</defName>
-		<label>40x311mmR cartridge (Sabot)</label>
+		<label>40x311mmR (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Bofors/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/HighCaliber/470NitroExpress.xml
+++ b/Defs/Ammo/HighCaliber/470NitroExpress.xml
@@ -42,7 +42,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo470NitroExpressBase">
 		<defName>Ammo_470NitroExpress_FMJ</defName>
-		<label>.470 Nitro Express cartridge (FMJ)</label>
+		<label>.470 Nitro Express (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -56,7 +56,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo470NitroExpressBase">
 		<defName>Ammo_470NitroExpress_AP</defName>
-		<label>.470 Nitro Express cartridge (AP)</label>
+		<label>.470 Nitro Express (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -70,7 +70,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo470NitroExpressBase">
 		<defName>Ammo_470NitroExpress_Incendiary</defName>
-		<label>.470 Nitro Express cartridge (AP-I)</label>
+		<label>.470 Nitro Express (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -84,7 +84,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo470NitroExpressBase">
 		<defName>Ammo_470NitroExpress_HE</defName>
-		<label>.470 Nitro Express cartridge (AP-HE)</label>
+		<label>.470 Nitro Express (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -98,7 +98,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo470NitroExpressBase">
 		<defName>Ammo_470NitroExpress_Sabot</defName>
-		<label>.470 Nitro Express cartridge (Sabot)</label>
+		<label>.470 Nitro Express (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/HighCaliber/50BMG.xml
+++ b/Defs/Ammo/HighCaliber/50BMG.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo50BMGBase">
 		<defName>Ammo_50BMG_FMJ</defName>
-		<label>.50 BMG cartridge (FMJ)</label>
+		<label>.50 BMG (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo50BMGBase">
 		<defName>Ammo_50BMG_AP</defName>
-		<label>.50 BMG cartridge (AP)</label>
+		<label>.50 BMG (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo50BMGBase">
 		<defName>Ammo_50BMG_Incendiary</defName>
-		<label>.50 BMG cartridge (AP-I)</label>
+		<label>.50 BMG (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo50BMGBase">
 		<defName>Ammo_50BMG_HE</defName>
-		<label>.50 BMG cartridge (AP-HE)</label>
+		<label>.50 BMG (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo50BMGBase">
 		<defName>Ammo_50BMG_Sabot</defName>
-		<label>.50 BMG cartridge (Sabot)</label>
+		<label>.50 BMG (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/HighCaliber/55Boys.xml
+++ b/Defs/Ammo/HighCaliber/55Boys.xml
@@ -42,7 +42,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo55BoysBase">
 		<defName>Ammo_55Boys_FMJ</defName>
-		<label>.55 Boys cartridge (FMJ)</label>
+		<label>.55 Boys (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -56,7 +56,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo55BoysBase">
 		<defName>Ammo_55Boys_AP</defName>
-		<label>.55 Boys cartridge (AP)</label>
+		<label>.55 Boys (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -70,7 +70,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo55BoysBase">
 		<defName>Ammo_55Boys_Incendiary</defName>
-		<label>.55 Boys cartridge (AP-I)</label>
+		<label>.55 Boys (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -84,7 +84,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo55BoysBase">
 		<defName>Ammo_55Boys_HE</defName>
-		<label>.55 Boys cartridge (AP-HE)</label>
+		<label>.55 Boys (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -98,7 +98,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo55BoysBase">
 		<defName>Ammo_55Boys_Sabot</defName>
-		<label>.55 Boys cartridge (Sabot)</label>
+		<label>.55 Boys (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/HighCaliber/600NitroExpress.xml
+++ b/Defs/Ammo/HighCaliber/600NitroExpress.xml
@@ -42,7 +42,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo600NitroExpressBase">
 		<defName>Ammo_600NitroExpress_FMJ</defName>
-		<label>.600 Nitro Express cartridge (FMJ)</label>
+		<label>.600 Nitro Express (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -56,7 +56,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo600NitroExpressBase">
 		<defName>Ammo_600NitroExpress_AP</defName>
-		<label>.600 Nitro Express cartridge (AP)</label>
+		<label>.600 Nitro Express (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -70,7 +70,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo600NitroExpressBase">
 		<defName>Ammo_600NitroExpress_Incendiary</defName>
-		<label>.600 Nitro Express cartridge (AP-I)</label>
+		<label>.600 Nitro Express (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -84,7 +84,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo600NitroExpressBase">
 		<defName>Ammo_600NitroExpress_HE</defName>
-		<label>.600 Nitro Express cartridge (AP-HE)</label>
+		<label>.600 Nitro Express (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -98,7 +98,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo600NitroExpressBase">
 		<defName>Ammo_600NitroExpress_Sabot</defName>
-		<label>.600 Nitro Express cartridge (Sabot)</label>
+		<label>.600 Nitro Express (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/HighCaliber/7.92x94mm Patronen.xml
+++ b/Defs/Ammo/HighCaliber/7.92x94mm Patronen.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo792x94mmPatronenBase">
 		<defName>Ammo_792x94mmPatronen_FMJ</defName>
-		<label>7.92x94mm Patronen cartridge (FMJ)</label>
+		<label>7.92x94mm Patronen (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo792x94mmPatronenBase">
 		<defName>Ammo_792x94mmPatronen_AP</defName>
-		<label>7.92x94mm Patronen cartridge (AP)</label>
+		<label>7.92x94mm Patronen (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo792x94mmPatronenBase">
 		<defName>Ammo_792x94mmPatronen_Incendiary</defName>
-		<label>7.92x94mm Patronen cartridge (AP-I)</label>
+		<label>7.92x94mm Patronen (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo792x94mmPatronenBase">
 		<defName>Ammo_792x94mmPatronen_HE</defName>
-		<label>7.92x94mm Patronen cartridge (AP-HE)</label>
+		<label>7.92x94mm Patronen (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo792x94mmPatronenBase">
 		<defName>Ammo_792x94mmPatronen_Sabot</defName>
-		<label>7.92x94mm Patronen cartridge (Sabot)</label>
+		<label>7.92x94mm Patronen (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/HighCaliber/950JDJ.xml
+++ b/Defs/Ammo/HighCaliber/950JDJ.xml
@@ -42,7 +42,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo950JDJBase">
 		<defName>Ammo_950JDJ_FMJ</defName>
-		<label>.950 JDJ cartridge (FMJ)</label>
+		<label>.950 JDJ (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -56,7 +56,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo950JDJBase">
 		<defName>Ammo_950JDJ_AP</defName>
-		<label>.950 JDJ cartridge (AP)</label>
+		<label>.950 JDJ (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -70,7 +70,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo950JDJBase">
 		<defName>Ammo_50JDJ_Incendiary</defName>
-		<label>.950 JDJ cartridge (AP-I)</label>
+		<label>.950 JDJ (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -84,7 +84,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo950JDJBase">
 		<defName>Ammo_50JDJ_HE</defName>
-		<label>.950 JDJ cartridge (AP-HE)</label>
+		<label>.950 JDJ (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -98,7 +98,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo950JDJBase">
 		<defName>Ammo_50JDJ_Sabot</defName>
-		<label>.950 JDJ cartridge (Sabot)</label>
+		<label>.950 JDJ (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/10mmAuto.xml
+++ b/Defs/Ammo/Pistols/10mmAuto.xml
@@ -40,7 +40,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="10mmAutoBase">
 		<defName>Ammo_10mmAuto_FMJ</defName>
-		<label>10mm Auto cartridge (FMJ)</label>
+		<label>10mm Auto (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="10mmAutoBase">
 		<defName>Ammo_10mmAuto_AP</defName>
-		<label>10mm Auto cartridge (AP)</label>
+		<label>10mm Auto (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -68,7 +68,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="10mmAutoBase">
 		<defName>Ammo_10mmAuto_HP</defName>
-		<label>10mm Auto cartridge (HP)</label>
+		<label>10mm Auto (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/13mmGyrojet.xml
+++ b/Defs/Ammo/Pistols/13mmGyrojet.xml
@@ -40,7 +40,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="13mmGyrojetBase">
 		<defName>Ammo_13mmGyrojet_FMJ</defName>
-		<label>13mm Gyrojet rocket (FMJ)</label>
+		<label>13mm Gyrojet (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="13mmGyrojetBase">
 		<defName>Ammo_13mmGyrojet_AP</defName>
-		<label>13mm Gyrojet rocket (AP)</label>
+		<label>13mm Gyrojet (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -68,7 +68,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="13mmGyrojetBase">
 		<defName>Ammo_13mmGyrojet_HP</defName>
-		<label>13mm Gyrojet rocket (HP)</label>
+		<label>13mm Gyrojet (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/22LR.xml
+++ b/Defs/Ammo/Pistols/22LR.xml
@@ -40,7 +40,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="22LRBase">
 		<defName>Ammo_22LR_FMJ</defName>
-		<label>.22 LR cartridge (FMJ)</label>
+		<label>.22 LR (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="22LRBase">
 		<defName>Ammo_22LR_AP</defName>
-		<label>.22 LR cartridge (AP)</label>
+		<label>.22 LR (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -68,7 +68,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="22LRBase">
 		<defName>Ammo_22LR_HP</defName>
-		<label>.22 LR cartridge (HP)</label>
+		<label>.22 LR (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/22Short.xml
+++ b/Defs/Ammo/Pistols/22Short.xml
@@ -40,7 +40,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="22ShortBase">
 		<defName>Ammo_22Short_FMJ</defName>
-		<label>.22 Short cartridge</label>
+		<label>.22 Short (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="22ShortBase">
 		<defName>Ammo_22Short_AP</defName>
-		<label>.22 Short cartridge (AP)</label>
+		<label>.22 Short (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -68,7 +68,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="22ShortBase">
 		<defName>Ammo_22Short_HP</defName>
-		<label>.22 Short cartridge (HP)</label>
+		<label>.22 Short (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/25ACP.xml
+++ b/Defs/Ammo/Pistols/25ACP.xml
@@ -40,7 +40,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="25ACPBase">
 		<defName>Ammo_25ACP_FMJ</defName>
-		<label>.25 ACP cartridge (FMJ)</label>
+		<label>.25 ACP (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="25ACPBase">
 		<defName>Ammo_25ACP_AP</defName>
-		<label>.25 ACP cartridge (AP)</label>
+		<label>.25 ACP (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -68,7 +68,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="25ACPBase">
 		<defName>Ammo_25ACP_HP</defName>
-		<label>.25 ACP cartridge (HP)</label>
+		<label>.25 ACP (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/32ACP.xml
+++ b/Defs/Ammo/Pistols/32ACP.xml
@@ -40,7 +40,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="32ACPBase">
 		<defName>Ammo_32ACP_FMJ</defName>
-		<label>.32 ACP cartridge (FMJ)</label>
+		<label>.32 ACP (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="32ACPBase">
 		<defName>Ammo_32ACP_AP</defName>
-		<label>.32 ACP cartridge (AP)</label>
+		<label>.32 ACP (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -67,7 +67,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="32ACPBase">
 		<defName>Ammo_32ACP_HP</defName>
-		<label>.32 ACP cartridge (HP)</label>
+		<label>.32 ACP (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/357Magnum.xml
+++ b/Defs/Ammo/Pistols/357Magnum.xml
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="357MagnumBase">
 		<defName>Ammo_357Magnum_FMJ</defName>
-		<label>.357 Magnum cartridge (FMJ)</label>
+		<label>.357 Magnum (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Revolver/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -68,7 +68,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="357MagnumBase">
 		<defName>Ammo_357Magnum_AP</defName>
-		<label>.357 Magnum cartridge (AP)</label>
+		<label>.357 Magnum (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Revolver/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -82,7 +82,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="357MagnumBase">
 		<defName>Ammo_357Magnum_HP</defName>
-		<label>.357 Magnum cartridge (HP)</label>
+		<label>.357 Magnum (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Revolver/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/357SIG.xml
+++ b/Defs/Ammo/Pistols/357SIG.xml
@@ -40,7 +40,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="357SIGBase">
 		<defName>Ammo_357SIG_FMJ</defName>
-		<label>.357 SIG cartridge (FMJ)</label>
+		<label>.357 SIG (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="357SIGBase">
 		<defName>Ammo_357SIG_AP</defName>
-		<label>.357 SIG cartridge (AP)</label>
+		<label>.357 SIG (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -68,7 +68,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="357SIGBase">
 		<defName>Ammo_357SIG_HP</defName>
-		<label>.357 SIG cartridge (HP)</label>
+		<label>.357 SIG (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/380ACP.xml
+++ b/Defs/Ammo/Pistols/380ACP.xml
@@ -40,7 +40,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="380ACPBase">
 		<defName>Ammo_380ACP_FMJ</defName>
-		<label>.380 ACP cartridge (FMJ)</label>
+		<label>.380 ACP (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="380ACPBase">
 		<defName>Ammo_380ACP_AP</defName>
-		<label>.380 ACP cartridge (AP)</label>
+		<label>.380 ACP (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -68,7 +68,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="380ACPBase">
 		<defName>Ammo_380ACP_HP</defName>
-		<label>.380 ACP cartridge (HP)</label>
+		<label>.380 ACP (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/38ACP.xml
+++ b/Defs/Ammo/Pistols/38ACP.xml
@@ -40,7 +40,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="38ACPBase">
 		<defName>Ammo_38ACP_FMJ</defName>
-		<label>.38 ACP cartridge (FMJ)</label>
+		<label>.38 ACP (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="38ACPBase">
 		<defName>Ammo_38ACP_AP</defName>
-		<label>.38 ACP cartridge (AP)</label>
+		<label>.38 ACP (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -68,7 +68,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="38ACPBase">
 		<defName>Ammo_38ACP_HP</defName>
-		<label>.38 ACP cartridge (HP)</label>
+		<label>.38 ACP (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/38SW.xml
+++ b/Defs/Ammo/Pistols/38SW.xml
@@ -40,7 +40,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="38SWBase">
 		<defName>Ammo_38SW_FMJ</defName>
-		<label>.38 S&amp;W cartridge (FMJ)</label>
+		<label>.38 S&amp;W (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="38SWBase">
 		<defName>Ammo_38SW_AP</defName>
-		<label>.38 S&amp;W cartridge (AP)</label>
+		<label>.38 S&amp;W (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -68,7 +68,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="38SWBase">
 		<defName>Ammo_38SW_HP</defName>
-		<label>.38 S&amp;W cartridge (HP)</label>
+		<label>.38 S&amp;W (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/38Special.xml
+++ b/Defs/Ammo/Pistols/38Special.xml
@@ -40,7 +40,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="38SpecialBase">
 		<defName>Ammo_38Special_FMJ</defName>
-		<label>.38 Special cartridge (FMJ)</label>
+		<label>.38 Special (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Revolver/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="38SpecialBase">
 		<defName>Ammo_38Special_AP</defName>
-		<label>.38 Special cartridge (AP)</label>
+		<label>.38 Special (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Revolver/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -68,7 +68,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="38SpecialBase">
 		<defName>Ammo_38Special_HP</defName>
-		<label>.38 Special cartridge (HP)</label>
+		<label>.38 Special (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Revolver/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/38Super.xml
+++ b/Defs/Ammo/Pistols/38Super.xml
@@ -40,7 +40,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="38SuperBase">
 		<defName>Ammo_38Super_FMJ</defName>
-		<label>.38 Super cartridge (FMJ)</label>
+		<label>.38 Super (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="38SuperBase">
 		<defName>Ammo_38Super_AP</defName>
-		<label>.38 Super cartridge (AP)</label>
+		<label>.38 Super (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -68,7 +68,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="38SuperBase">
 		<defName>Ammo_38Super_HP</defName>
-		<label>.38 Super cartridge (HP)</label>
+		<label>.38 Super (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/40SW.xml
+++ b/Defs/Ammo/Pistols/40SW.xml
@@ -40,7 +40,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="40SWBase">
 		<defName>Ammo_40SW_FMJ</defName>
-		<label>.40 SW cartridge (FMJ)</label>
+		<label>.40 S&amp;W (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="40SWBase">
 		<defName>Ammo_40SW_AP</defName>
-		<label>.40 SW cartridge (AP)</label>
+		<label>.40 S&amp;W (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -68,7 +68,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="40SWBase">
 		<defName>Ammo_40SW_HP</defName>
-		<label>.40 SW cartridge (HP)</label>
+		<label>.40 S&amp;W (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/41Rimfire.xml
+++ b/Defs/Ammo/Pistols/41Rimfire.xml
@@ -40,7 +40,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="9x19mmParaBase">
 		<defName>Ammo_41Rimfire_FMJ</defName>
-		<label>.41 Rimfire cartridge (FMJ)</label>
+		<label>.41 Rimfire (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="41RimfireBase">
 		<defName>Ammo_41Rimfire_AP</defName>
-		<label>.41 Rimfire cartridge (AP)</label>
+		<label>.41 Rimfire (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -68,7 +68,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="41RimfireBase">
 		<defName>Ammo_41Rimfire_HP</defName>
-		<label>.41 Rimfire cartridge (HP)</label>
+		<label>.41 Rimfire (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/44Magnum.xml
+++ b/Defs/Ammo/Pistols/44Magnum.xml
@@ -65,7 +65,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="44MagnumBase">
 		<defName>Ammo_44Magnum_FMJ</defName>
-		<label>.44 Magnum cartridge (FMJ)</label>
+		<label>.44 Magnum (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Revolver/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -79,7 +79,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="44MagnumBase">
 		<defName>Ammo_44Magnum_AP</defName>
-		<label>.44 Magnum cartridge (AP)</label>
+		<label>.44 Magnum (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Revolver/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -93,7 +93,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="44MagnumBase">
 		<defName>Ammo_44Magnum_HP</defName>
-		<label>.44 Magnum cartridge (HP)</label>
+		<label>.44 Magnum (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Revolver/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/44SWSpecial.xml
+++ b/Defs/Ammo/Pistols/44SWSpecial.xml
@@ -40,7 +40,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="44SWSpecialBase">
 		<defName>Ammo_44SWSpecial_FMJ</defName>
-		<label>.44 S&amp;W Special cartridge (FMJ)</label>
+		<label>.44 S&amp;W Special (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Revolver/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="44SWSpecialBase">
 		<defName>Ammo_44SWSpecial_AP</defName>
-		<label>.44 S&amp;W Special cartridge (AP)</label>
+		<label>.44 S&amp;W Special (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Revolver/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -68,7 +68,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="44SWSpecialBase">
 		<defName>Ammo_44SWSpecial_HP</defName>
-		<label>.44 S&amp;W Special cartridge (HP)</label>
+		<label>.44 S&amp;W Special (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Revolver/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/454Casull.xml
+++ b/Defs/Ammo/Pistols/454Casull.xml
@@ -61,7 +61,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="454CasullBase">
 		<defName>Ammo_454Casull_FMJ</defName>
-		<label>.454 Casull cartridge (FMJ)</label>
+		<label>.454 Casull (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Revolver/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -75,7 +75,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="454CasullBase">
 		<defName>Ammo_454Casull_AP</defName>
-		<label>.454 Casull cartridge (AP)</label>
+		<label>.454 Casull (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Revolver/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -89,7 +89,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="454CasullBase">
 		<defName>Ammo_454Casull_HP</defName>
-		<label>.454 Casull cartridge (HP)</label>
+		<label>.454 Casull (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Revolver/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/455Webley.xml
+++ b/Defs/Ammo/Pistols/455Webley.xml
@@ -40,7 +40,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="455WebleyBase">
 		<defName>Ammo_455Webley_FMJ</defName>
-		<label>.455 Webley cartridge (FMJ)</label>
+		<label>.455 Webley (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Revolver/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="455WebleyBase">
 		<defName>Ammo_455Webley_AP</defName>
-		<label>.455 Webley cartridge (AP)</label>
+		<label>.455 Webley (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Revolver/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -68,7 +68,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="455WebleyBase">
 		<defName>Ammo_455Webley_HP</defName>
-		<label>.455 Webley cartridge (HP)</label>
+		<label>.455 Webley (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Revolver/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/45ACP.xml
+++ b/Defs/Ammo/Pistols/45ACP.xml
@@ -55,7 +55,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="45ACPBase">
 		<defName>Ammo_45ACP_FMJ</defName>
-		<label>.45 ACP cartridge (FMJ)</label>
+		<label>.45 ACP (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -69,7 +69,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="45ACPBase">
 		<defName>Ammo_45ACP_AP</defName>
-		<label>.45 ACP cartridge (AP)</label>
+		<label>.45 ACP (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -83,7 +83,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="45ACPBase">
 		<defName>Ammo_45ACP_HP</defName>
-		<label>.45 ACP cartridge (HP)</label>
+		<label>.45 ACP (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/45Colt.xml
+++ b/Defs/Ammo/Pistols/45Colt.xml
@@ -81,7 +81,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="45ColtBase">
 		<defName>Ammo_45Colt_FMJ</defName>
-		<label>.45 Colt cartridge (FMJ)</label>
+		<label>.45 Colt (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Revolver/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -95,7 +95,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="45ColtBase">
 		<defName>Ammo_45Colt_AP</defName>
-		<label>.45 Colt cartridge (AP)</label>
+		<label>.45 Colt (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Revolver/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -109,7 +109,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="45ColtBase">
 		<defName>Ammo_45Colt_HP</defName>
-		<label>.45 Colt cartridge (HP)</label>
+		<label>.45 Colt (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Revolver/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/45Schofield.xml
+++ b/Defs/Ammo/Pistols/45Schofield.xml
@@ -40,7 +40,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="45SchofieldBase">
 		<defName>Ammo_45Schofield_FMJ</defName>
-		<label>.45 Schofield cartridge (FMJ)</label>
+		<label>.45 Schofield (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Revolver/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="45SchofieldBase">
 		<defName>Ammo_45Schofield_AP</defName>
-		<label>.45 Schofield cartridge (AP)</label>
+		<label>.45 Schofield (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Revolver/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -68,7 +68,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="45SchofieldBase">
 		<defName>Ammo_45Schofield_HP</defName>
-		<label>.45 Schofield cartridge (HP)</label>
+		<label>.45 Schofield (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Revolver/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/460SWMagnum.xml
+++ b/Defs/Ammo/Pistols/460SWMagnum.xml
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="460SWMagnumBase">
 		<defName>Ammo_460SWMagnum_FMJ</defName>
-		<label>.460 S&amp;W Magnum cartridge (FMJ)</label>
+		<label>.460 S&amp;W Magnum (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Revolver/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="460SWMagnumBase">
 		<defName>Ammo_460SWMagnum_AP</defName>
-		<label>.460 S&amp;W Magnum cartridge (AP)</label>
+		<label>.460 S&amp;W Magnum (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Revolver/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="460SWMagnumBase">
 		<defName>Ammo_460SWMagnum_HP</defName>
-		<label>.460 S&amp;W Magnum cartridge (HP)</label>
+		<label>.460 S&amp;W Magnum (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Revolver/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/46x30mm.xml
+++ b/Defs/Ammo/Pistols/46x30mm.xml
@@ -40,7 +40,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="46x30mmBase">
 		<defName>Ammo_46x30mm_FMJ</defName>
-		<label>4.6x30mm cartridge (FMJ)</label>
+		<label>4.6x30mm (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="46x30mmBase">
 		<defName>Ammo_46x30mm_AP</defName>
-		<label>4.6x30mm cartridge (AP)</label>
+		<label>4.6x30mm (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -68,7 +68,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="46x30mmBase">
 		<defName>Ammo_46x30mm_HP</defName>
-		<label>4.6x30mm cartridge (HP)</label>
+		<label>4.6x30mm (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/500SWMagnum.xml
+++ b/Defs/Ammo/Pistols/500SWMagnum.xml
@@ -40,7 +40,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="500SWMagnumBase">
 		<defName>Ammo_500SWMagnum_FMJ</defName>
-		<label>.500 S&amp;W Magnum cartridge (FMJ)</label>
+		<label>.500 S&amp;W Magnum (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Revolver/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="500SWMagnumBase">
 		<defName>Ammo_500SWMagnum_AP</defName>
-		<label>.500 S&amp;W Magnum cartridge (AP)</label>
+		<label>.500 S&amp;W Magnum (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Revolver/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -68,7 +68,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="500SWMagnumBase">
 		<defName>Ammo_500SWMagnum_HP</defName>
-		<label>.500 S&amp;W Magnum cartridge (HP)</label>
+		<label>.500 S&amp;W Magnum (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Revolver/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/50AE.xml
+++ b/Defs/Ammo/Pistols/50AE.xml
@@ -40,7 +40,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="50AEBase">
 		<defName>Ammo_50AE_FMJ</defName>
-		<label>.50 AE cartridge (FMJ)</label>
+		<label>.50 AE (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="50AEBase">
 		<defName>Ammo_50AE_AP</defName>
-		<label>.50 AE cartridge (AP)</label>
+		<label>.50 AE (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -68,7 +68,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="50AEBase">
 		<defName>Ammo_50AE_HP</defName>
-		<label>.50 AE cartridge (HP)</label>
+		<label>.50 AE (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/58x21mmDAP92.xml
+++ b/Defs/Ammo/Pistols/58x21mmDAP92.xml
@@ -40,7 +40,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="58x21mmDAP92Base">
 		<defName>Ammo_58x21mmDAP92_FMJ</defName>
-		<label>5.8x21mm DAP92 cartridge (FMJ)</label>
+		<label>5.8x21mm DAP92 (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="58x21mmDAP92Base">
 		<defName>Ammo_58x21mmDAP92_AP</defName>
-		<label>5.8x21mm DAP92 cartridge (AP)</label>
+		<label>5.8x21mm DAP92 (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -68,7 +68,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="58x21mmDAP92Base">
 		<defName>Ammo_58x21mmDAP92_HP</defName>
-		<label>5.8x21mm DAP92 cartridge (HP)</label>
+		<label>5.8x21mm DAP92 (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/7.5FK.xml
+++ b/Defs/Ammo/Pistols/7.5FK.xml
@@ -40,7 +40,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="75FKBase">
 		<defName>Ammo_75FK_FMJ</defName>
-		<label>7.5 FK cartridge (FMJ)</label>
+		<label>7.5 FK (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="75FKBase">
 		<defName>Ammo_75FK_AP</defName>
-		<label>7.5 FK cartridge (AP)</label>
+		<label>7.5 FK (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -68,7 +68,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="75FKBase">
 		<defName>Ammo_75FK_HP</defName>
-		<label>7.5 FK cartridge (HP)</label>
+		<label>7.5 FK (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/762x25mmTokarev.xml
+++ b/Defs/Ammo/Pistols/762x25mmTokarev.xml
@@ -40,7 +40,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x25mmTokarevBase">
 		<defName>Ammo_762x25mmTokarev_FMJ</defName>
-		<label>7.62x25mm Tokarev cartridge (FMJ)</label>
+		<label>7.62x25mm Tokarev (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x25mmTokarevBase">
 		<defName>Ammo_762x25mmTokarev_AP</defName>
-		<label>7.62x25mm Tokarev cartridge (AP)</label>
+		<label>7.62x25mm Tokarev (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -68,7 +68,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x25mmTokarevBase">
 		<defName>Ammo_762x25mmTokarev_HP</defName>
-		<label>7.62x25mm Tokarev cartridge (HP)</label>
+		<label>7.62x25mm Tokarev (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/762x38mmR.xml
+++ b/Defs/Ammo/Pistols/762x38mmR.xml
@@ -40,7 +40,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x38mmRBase">
 		<defName>Ammo_762x38mmR_FMJ</defName>
-		<label>7.62x38mmR cartridge (FMJ)</label>
+		<label>7.62x38mmR (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x38mmRBase">
 		<defName>Ammo_762x38mmR_AP</defName>
-		<label>7.62x38mmR cartridge (AP)</label>
+		<label>7.62x38mmR (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -68,7 +68,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x38mmRBase">
 		<defName>Ammo_762x38mmR_HP</defName>
-		<label>7.62x38mmR cartridge (HP)</label>
+		<label>7.62x38mmR (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/763x25mmMauser.xml
+++ b/Defs/Ammo/Pistols/763x25mmMauser.xml
@@ -40,7 +40,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="763x25mmMauserBase">
 		<defName>Ammo_763x25mmMauser_FMJ</defName>
-		<label>7.63x25mm Mauser cartridge (FMJ)</label>
+		<label>7.63x25mm Mauser (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="763x25mmMauserBase">
 		<defName>Ammo_763x25mmMauser_AP</defName>
-		<label>7.63x25mm Mauser cartridge (AP)</label>
+		<label>7.63x25mm Mauser (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -68,7 +68,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="763x25mmMauserBase">
 		<defName>Ammo_763x25mmMauser_HP</defName>
-		<label>7.63x25mm Mauser cartridge (HP)</label>
+		<label>7.63x25mm Mauser (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/765x20mmLongue.xml
+++ b/Defs/Ammo/Pistols/765x20mmLongue.xml
@@ -40,7 +40,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="765x20mmLongueBase">
 		<defName>Ammo_765x20mmLongue_FMJ</defName>
-		<label>7.65x20mm Longue cartridge (FMJ)</label>
+		<label>7.65x20mm Longue (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="765x20mmLongueBase">
 		<defName>Ammo_765x20mmLongue_AP</defName>
-		<label>7.65x20mm Longue cartridge (AP)</label>
+		<label>7.65x20mm Longue (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -68,7 +68,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="765x20mmLongueBase">
 		<defName>Ammo_765x20mmLongue_HP</defName>
-		<label>7.65x20mm Longue cartridge (HP)</label>
+		<label>7.65x20mm Longue (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/8x22mmNambu.xml
+++ b/Defs/Ammo/Pistols/8x22mmNambu.xml
@@ -40,7 +40,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="8x22mmNambuBase">
 		<defName>Ammo_8x22mmNambu_FMJ</defName>
-		<label>8x22mm Nambu cartridge (FMJ)</label>
+		<label>8x22mm Nambu (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="8x22mmNambuBase">
 		<defName>Ammo_8x22mmNambu_AP</defName>
-		<label>8x22mm Nambu cartridge (AP)</label>
+		<label>8x22mm Nambu (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -68,7 +68,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="8x22mmNambuBase">
 		<defName>Ammo_8x22mmNambu_HP</defName>
-		<label>8x22mm Nambu cartridge (HP)</label>
+		<label>8x22mm Nambu (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/9x18mmMakarov.xml
+++ b/Defs/Ammo/Pistols/9x18mmMakarov.xml
@@ -40,7 +40,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="9x18mmMakarovBase">
 		<defName>Ammo_9x18mmMakarov_FMJ</defName>
-		<label>9x18mm Makarov cartridge (FMJ)</label>
+		<label>9x18mm Makarov (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="9x18mmMakarovBase">
 		<defName>Ammo_9x18mmMakarov_AP</defName>
-		<label>9x18mm Makarov cartridge (AP)</label>
+		<label>9x18mm Makarov (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -68,7 +68,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="9x18mmMakarovBase">
 		<defName>Ammo_9x18mmMakarov_HP</defName>
-		<label>9x18mm Makarov cartridge (HP)</label>
+		<label>9x18mm Makarov (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/9x19mmPara.xml
+++ b/Defs/Ammo/Pistols/9x19mmPara.xml
@@ -51,7 +51,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="9x19mmParaBase">
 		<defName>Ammo_9x19mmPara_FMJ</defName>
-		<label>9x19mm Para cartridge (FMJ)</label>
+		<label>9x19mm Para (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -65,7 +65,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="9x19mmParaBase">
 		<defName>Ammo_9x19mmPara_AP</defName>
-		<label>9x19mm Para cartridge (AP)</label>
+		<label>9x19mm Para (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -79,7 +79,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="9x19mmParaBase">
 		<defName>Ammo_9x19mmPara_HP</defName>
-		<label>9x19mm Para cartridge (HP)</label>
+		<label>9x19mm Para (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/9x21mmGyurza.xml
+++ b/Defs/Ammo/Pistols/9x21mmGyurza.xml
@@ -40,7 +40,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="9x21mmGyurzaBase">
 		<defName>Ammo_9x21mmGyurza_FMJ</defName>
-		<label>9x21mm Gyurza cartridge (FMJ)</label>
+		<label>9x21mm Gyurza (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="9x21mmGyurzaBase">
 		<defName>Ammo_9x21mmGyurza_AP</defName>
-		<label>9x21mm Gyurza cartridge (AP)</label>
+		<label>9x21mm Gyurza (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -68,7 +68,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="9x21mmGyurzaBase">
 		<defName>Ammo_9x21mmGyurza_HP</defName>
-		<label>9x21mm Gyurza cartridge (HP)</label>
+		<label>9x21mm Gyurza (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Pistols/FN57x28mm.xml
+++ b/Defs/Ammo/Pistols/FN57x28mm.xml
@@ -40,7 +40,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="FN57x29mmBase">
 		<defName>Ammo_FN57x28mm_FMJ</defName>
-		<label>FN 5.7x28mm cartridge (FMJ)</label>
+		<label>FN 5.7x28mm (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="FN57x29mmBase">
 		<defName>Ammo_FN57x28mm_AP</defName>
-		<label>FN 5.7x28mm cartridge (AP)</label>
+		<label>FN 5.7x28mm (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -68,7 +68,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="FN57x29mmBase">
 		<defName>Ammo_FN57x28mm_HP</defName>
-		<label>FN 5.7x28mm cartridge (HP)</label>
+		<label>FN 5.7x28mm (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/127x55mm.xml
+++ b/Defs/Ammo/Rifle/127x55mm.xml
@@ -44,7 +44,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="127x55mmBase">
 		<defName>Ammo_127x55mm_FMJ</defName>
-		<label>12.7x55mm cartridge (FMJ)</label>
+		<label>12.7x55mm (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/SovietLarge/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -58,7 +58,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="127x55mmBase">
 		<defName>Ammo_127x55mm_AP</defName>
-		<label>12.7x55mm cartridge (AP)</label>
+		<label>12.7x55mm (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/SovietLarge/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -72,7 +72,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="127x55mmBase">
 		<defName>Ammo_127x55mm_HP</defName>
-		<label>12.7x55mm cartridge (HP)</label>
+		<label>12.7x55mm (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/SovietLarge/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -86,7 +86,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="127x55mmBase">
 		<defName>Ammo_127x55mm_Incendiary</defName>
-		<label>12.7x55mm cartridge (AP-I)</label>
+		<label>12.7x55mm (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/SovietLarge/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -100,7 +100,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="127x55mmBase">
 		<defName>Ammo_127x55mm_HE</defName>
-		<label>12.7x55mm cartridge (AP-HE)</label>
+		<label>12.7x55mm (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/SovietLarge/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -114,7 +114,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="127x55mmBase">
 		<defName>Ammo_127x55mm_Sabot</defName>
-		<label>12.7x55mm cartridge (Sabot)</label>
+		<label>12.7x55mm (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/SovietLarge/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/17HMR.xml
+++ b/Defs/Ammo/Rifle/17HMR.xml
@@ -40,7 +40,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="17HMRBase">
 		<defName>Ammo_17HMR_FMJ</defName>
-		<label>.17 HMR cartridge (FMJ)</label>
+		<label>.17 HMR (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="17HMRBase">
 		<defName>Ammo_17HMR_AP</defName>
-		<label>.17 HMR cartridge (AP)</label>
+		<label>.17 HMR (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -68,7 +68,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="17HMRBase">
 		<defName>Ammo_17HMR_HP</defName>
-		<label>.17 HMR cartridge (HP)</label>
+		<label>.17 HMR (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/22Hornet.xml
+++ b/Defs/Ammo/Rifle/22Hornet.xml
@@ -40,7 +40,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="22HornetBase">
 		<defName>Ammo_22Hornet_FMJ</defName>
-		<label>.22 Hornet cartridge (FMJ)</label>
+		<label>.22 Hornet (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="22HornetBase">
 		<defName>Ammo_22Hornet_AP</defName>
-		<label>.22 Hornet cartridge (AP)</label>
+		<label>.22 Hornet (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -68,7 +68,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="22HornetBase">
 		<defName>Ammo_22Hornet_HP</defName>
-		<label>.22 Hornet cartridge (HP)</label>
+		<label>.22 Hornet (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/22WMR.xml
+++ b/Defs/Ammo/Rifle/22WMR.xml
@@ -40,7 +40,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="22WMRBase">
 		<defName>Ammo_22WMR_FMJ</defName>
-		<label>.22 WMR cartridge (FMJ)</label>
+		<label>.22 WMR (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="22WMRBase">
 		<defName>Ammo_22WMR_AP</defName>
-		<label>.22 WMR cartridge (AP)</label>
+		<label>.22 WMR (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -68,7 +68,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="22WMRBase">
 		<defName>Ammo_22WMR_HP</defName>
-		<label>.22 WMR cartridge (HP)</label>
+		<label>.22 WMR (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Pistol/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/243Winchester.xml
+++ b/Defs/Ammo/Rifle/243Winchester.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="243WinchesterBase">
 		<defName>Ammo_243Winchester_FMJ</defName>
-		<label>.243 Winchester cartridge (FMJ)</label>
+		<label>.243 Winchester (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="243WinchesterBase">
 		<defName>Ammo_243Winchester_AP</defName>
-		<label>.243 Winchester cartridge (AP)</label>
+		<label>.243 Winchester (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="243WinchesterBase">
 		<defName>Ammo_243Winchester_HP</defName>
-		<label>.243 Winchester cartridge (HP)</label>
+		<label>.243 Winchester (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="243WinchesterBase">
 		<defName>Ammo_243Winchester_Incendiary</defName>
-		<label>.243 Winchester cartridge (AP-I)</label>
+		<label>.243 Winchester (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="243WinchesterBase">
 		<defName>Ammo_243Winchester_HE</defName>
-		<label>.243 Winchester cartridge (AP-HE)</label>
+		<label>.243 Winchester (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -113,7 +113,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="243WinchesterBase">
 		<defName>Ammo_243Winchester_Sabot</defName>
-		<label>.243 Winchester cartridge (Sabot)</label>
+		<label>.243 Winchester (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/277Fury.xml
+++ b/Defs/Ammo/Rifle/277Fury.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="277FuryBase">
 		<defName>Ammo_277Fury_FMJ</defName>
-		<label>.277 Fury cartridge (FMJ)</label>
+		<label>.277 Fury (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="277FuryBase">
 		<defName>Ammo_277Fury_AP</defName>
-		<label>.277 Fury cartridge (AP)</label>
+		<label>.277 Fury (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="277FuryBase">
 		<defName>Ammo_277Fury_HP</defName>
-		<label>.277 Fury cartridge (HP)</label>
+		<label>.277 Fury (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="277FuryBase">
 		<defName>Ammo_277Fury_Incendiary</defName>
-		<label>.277 Fury cartridge (AP-I)</label>
+		<label>.277 Fury (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="277FuryBase">
 		<defName>Ammo_277Fury_HE</defName>
-		<label>.277 Fury cartridge (AP-HE)</label>
+		<label>.277 Fury (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -113,7 +113,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="277FuryBase">
 		<defName>Ammo_277Fury_Sabot</defName>
-		<label>.277 Fury cartridge (Sabot)</label>
+		<label>.277 Fury (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/280British.xml
+++ b/Defs/Ammo/Rifle/280British.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="280BritishBase">
 		<defName>Ammo_280British_FMJ</defName>
-		<label>.280 British cartridge (FMJ)</label>
+		<label>.280 British (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="280BritishBase">
 		<defName>Ammo_280British_AP</defName>
-		<label>.280 British cartridge (AP)</label>
+		<label>.280 British (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="280BritishBase">
 		<defName>Ammo_280British_HP</defName>
-		<label>.280 British cartridge (HP)</label>
+		<label>.280 British (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="280BritishBase">
 		<defName>Ammo_280British_Incendiary</defName>
-		<label>.280 British cartridge (AP-I)</label>
+		<label>.280 British (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="280BritishBase">
 		<defName>Ammo_280British_HE</defName>
-		<label>.280 British cartridge (AP-HE)</label>
+		<label>.280 British (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -113,7 +113,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="280BritishBase">
 		<defName>Ammo_280British_Sabot</defName>
-		<label>.280 British cartridge (Sabot)</label>
+		<label>.280 British (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/30-30Winchester.xml
+++ b/Defs/Ammo/Rifle/30-30Winchester.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="3030WinchesterBase">
 		<defName>Ammo_3030Winchester_FMJ</defName>
-		<label>.30-30 Winchester cartridge (FMJ)</label>
+		<label>.30-30 Winchester (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="3030WinchesterBase">
 		<defName>Ammo_3030Winchester_AP</defName>
-		<label>.30-30 Winchester cartridge (AP)</label>
+		<label>.30-30 Winchester (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="3030WinchesterBase">
 		<defName>Ammo_3030Winchester_HP</defName>
-		<label>.30-30 Winchester cartridge (HP)</label>
+		<label>.30-30 Winchester (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="3030WinchesterBase">
 		<defName>Ammo_3030Winchester_Incendiary</defName>
-		<label>.30-30 Winchester cartridge (AP-I)</label>
+		<label>.30-30 Winchester (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="3030WinchesterBase">
 		<defName>Ammo_3030Winchester_HE</defName>
-		<label>.30-30 Winchester cartridge (AP-HE)</label>
+		<label>.30-30 Winchester (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -113,7 +113,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="3030WinchesterBase">
 		<defName>Ammo_3030Winchester_Sabot</defName>
-		<label>.30-30 Winchester cartridge (Sabot)</label>
+		<label>.30-30 Winchester (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/3006Springfield.xml
+++ b/Defs/Ammo/Rifle/3006Springfield.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="3006SpringfieldBase">
 		<defName>Ammo_3006Springfield_FMJ</defName>
-		<label>.30-06 Springfield cartridge (FMJ)</label>
+		<label>.30-06 Springfield (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="3006SpringfieldBase">
 		<defName>Ammo_3006Springfield_AP</defName>
-		<label>.30-06 Springfield cartridge (AP)</label>
+		<label>.30-06 Springfield (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="3006SpringfieldBase">
 		<defName>Ammo_3006Springfield_HP</defName>
-		<label>.30-06 Springfield cartridge (HP)</label>
+		<label>.30-06 Springfield (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="3006SpringfieldBase">
 		<defName>Ammo_3006Springfield_Incendiary</defName>
-		<label>.30-06 Springfield cartridge (AP-I)</label>
+		<label>.30-06 Springfield (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="3006SpringfieldBase">
 		<defName>Ammo_3006Springfield_HE</defName>
-		<label>.30-06 Springfield cartridge (AP-HE)</label>
+		<label>.30-06 Springfield (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -113,7 +113,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="3006SpringfieldBase">
 		<defName>Ammo_3006Springfield_Sabot</defName>
-		<label>.30-06 Springfield cartridge (Sabot)</label>
+		<label>.30-06 Springfield (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/300AACBlackout.xml
+++ b/Defs/Ammo/Rifle/300AACBlackout.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="300AACBlackoutBase">
 		<defName>Ammo_300AACBlackout_FMJ</defName>
-		<label>.300 AAC Blackout cartridge (FMJ)</label>
+		<label>.300 AAC Blackout (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="300AACBlackoutBase">
 		<defName>Ammo_300AACBlackout_AP</defName>
-		<label>.300 AAC Blackout cartridge (AP)</label>
+		<label>.300 AAC Blackout (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="300AACBlackoutBase">
 		<defName>Ammo_300AACBlackout_HP</defName>
-		<label>.300 AAC Blackout cartridge (HP)</label>
+		<label>.300 AAC Blackout (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="300AACBlackoutBase">
 		<defName>Ammo_300AACBlackout_Incendiary</defName>
-		<label>.300 AAC Blackout cartridge (AP-I)</label>
+		<label>.300 AAC Blackout (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="300AACBlackoutBase">
 		<defName>Ammo_300AACBlackout_HE</defName>
-		<label>.300 AAC Blackout cartridge (AP-HE)</label>
+		<label>.300 AAC Blackout (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -113,7 +113,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="300AACBlackoutBase">
 		<defName>Ammo_300AACBlackout_Sabot</defName>
-		<label>.300 AAC Blackout cartridge (Sabot)</label>
+		<label>.300 AAC Blackout (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/303British.xml
+++ b/Defs/Ammo/Rifle/303British.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="303BritishBase">
 		<defName>Ammo_303British_FMJ</defName>
-		<label>.303 British cartridge (FMJ)</label>
+		<label>.303 British (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="303BritishBase">
 		<defName>Ammo_303British_AP</defName>
-		<label>.303 British cartridge (AP)</label>
+		<label>.303 British (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="303BritishBase">
 		<defName>Ammo_303British_HP</defName>
-		<label>.303 British cartridge (HP)</label>
+		<label>.303 British (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="303BritishBase">
 		<defName>Ammo_303British_Incendiary</defName>
-		<label>.303 British cartridge (AP-I)</label>
+		<label>.303 British (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="303BritishBase">
 		<defName>Ammo_303British_HE</defName>
-		<label>.303 British cartridge (AP-HE)</label>
+		<label>.303 British (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -113,7 +113,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="303BritishBase">
 		<defName>Ammo_303British_Sabot</defName>
-		<label>.303 British cartridge (Sabot)</label>
+		<label>.303 British (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/30Carbine.xml
+++ b/Defs/Ammo/Rifle/30Carbine.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="30CarbineBase">
 		<defName>Ammo_30Carbine_FMJ</defName>
-		<label>.30 Carbine cartridge (FMJ)</label>
+		<label>.30 Carbine (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="30CarbineBase">
 		<defName>Ammo_30Carbine_AP</defName>
-		<label>.30 Carbine cartridge (AP)</label>
+		<label>.30 Carbine (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="30CarbineBase">
 		<defName>Ammo_30Carbine_HP</defName>
-		<label>.30 Carbine cartridge (HP)</label>
+		<label>.30 Carbine (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="30CarbineBase">
 		<defName>Ammo_30Carbine_Incendiary</defName>
-		<label>.30 Carbine cartridge (AP-I)</label>
+		<label>.30 Carbine (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="30CarbineBase">
 		<defName>Ammo_30Carbine_HE</defName>
-		<label>.30 Carbine cartridge (AP-HE)</label>
+		<label>.30 Carbine (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -113,7 +113,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="30CarbineBase">
 		<defName>Ammo_30Carbine_Sabot</defName>
-		<label>.30 Carbine cartridge (Sabot)</label>
+		<label>.30 Carbine (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/38-55Winchester.xml
+++ b/Defs/Ammo/Rifle/38-55Winchester.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="3855WinchesterBase">
 		<defName>Ammo_3855Winchester_FMJ</defName>
-		<label>.38-55 Winchester cartridge (FMJ)</label>
+		<label>.38-55 Winchester (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="3855WinchesterBase">
 		<defName>Ammo_3855Winchester_AP</defName>
-		<label>.38-55 Winchester cartridge (AP)</label>
+		<label>.38-55 Winchester (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="3855WinchesterBase">
 		<defName>Ammo_3855Winchester_HP</defName>
-		<label>.38-55 Winchester cartridge (HP)</label>
+		<label>.38-55 Winchester (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="3855WinchesterBase">
 		<defName>Ammo_3855Winchester_Incendiary</defName>
-		<label>.38-55 Winchester cartridge (AP-I)</label>
+		<label>.38-55 Winchester (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="3855WinchesterBase">
 		<defName>Ammo_3855Winchester_HE</defName>
-		<label>.38-55 Winchester cartridge (AP-HE)</label>
+		<label>.38-55 Winchester (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -113,7 +113,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="3855WinchesterBase">
 		<defName>Ammo_3855Winchester_Sabot</defName>
-		<label>.38-55 Winchester cartridge (Sabot)</label>
+		<label>.38-55 Winchester (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/44-40Winchester.xml
+++ b/Defs/Ammo/Rifle/44-40Winchester.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="44-40WinchesterBase">
 		<defName>Ammo_44-40Winchester_FMJ</defName>
-		<label>.44-40 Winchester cartridge (FMJ)</label>
+		<label>.44-40 Winchester (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="44-40WinchesterBase">
 		<defName>Ammo_44-40Winchester_AP</defName>
-		<label>.44-40 Winchester cartridge (AP)</label>
+		<label>.44-40 Winchester (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="44-40WinchesterBase">
 		<defName>Ammo_44-40Winchester_HP</defName>
-		<label>.44-40 Winchester cartridge (HP)</label>
+		<label>.44-40 Winchester (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="44-40WinchesterBase">
 		<defName>Ammo_44-40Winchester_Incendiary</defName>
-		<label>.44-40 Winchester cartridge (AP-I)</label>
+		<label>.44-40 Winchester (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="44-40WinchesterBase">
 		<defName>Ammo_44-40Winchester_HE</defName>
-		<label>.44-40 Winchester cartridge (AP-HE)</label>
+		<label>.44-40 Winchester (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -113,7 +113,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="44-40WinchesterBase">
 		<defName>Ammo_44-40Winchester_Sabot</defName>
-		<label>.44-40 Winchester cartridge (Sabot)</label>
+		<label>.44-40 Winchester (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/4570Gov.xml
+++ b/Defs/Ammo/Rifle/4570Gov.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="4570GovBase">
 		<defName>Ammo_4570Gov_FMJ</defName>
-		<label>.45-70 Government cartridge (FMJ)</label>
+		<label>.45-70 Government (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="4570GovBase">
 		<defName>Ammo_4570Gov_AP</defName>
-		<label>.45-70 Government cartridge (AP)</label>
+		<label>.45-70 Government (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="4570GovBase">
 		<defName>Ammo_4570Gov_HP</defName>
-		<label>.45-70 Government cartridge (HP)</label>
+		<label>.45-70 Government (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="4570GovBase">
 		<defName>Ammo_4570Gov_Incendiary</defName>
-		<label>.45-70 Government cartridge (AP-I)</label>
+		<label>.45-70 Government (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="4570GovBase">
 		<defName>Ammo_4570Gov_HE</defName>
-		<label>.45-70 Government cartridge (AP-HE)</label>
+		<label>.45-70 Government (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -113,7 +113,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="4570GovBase">
 		<defName>Ammo_4570Gov_Sabot</defName>
-		<label>.45-70 Government cartridge (Sabot)</label>
+		<label>.45-70 Government (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/458SOCOM.xml
+++ b/Defs/Ammo/Rifle/458SOCOM.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="458SOCOMBase">
 		<defName>Ammo_458SOCOM_FMJ</defName>
-		<label>.458 SOCOM cartridge (FMJ)</label>
+		<label>.458 SOCOM (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="458SOCOMBase">
 		<defName>Ammo_458SOCOM_AP</defName>
-		<label>.458 SOCOM cartridge (AP)</label>
+		<label>.458 SOCOM (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="458SOCOMBase">
 		<defName>Ammo_458SOCOM_HP</defName>
-		<label>.458 SOCOM cartridge (HP)</label>
+		<label>.458 SOCOM (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="458SOCOMBase">
 		<defName>Ammo_458SOCOM_Incendiary</defName>
-		<label>.458 SOCOM cartridge (AP-I)</label>
+		<label>.458 SOCOM (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="458SOCOMBase">
 		<defName>Ammo_458SOCOM_HE</defName>
-		<label>.458 SOCOM cartridge (AP-HE)</label>
+		<label>.458 SOCOM (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -113,7 +113,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="458SOCOMBase">
 		<defName>Ammo_458SOCOM_Sabot</defName>
-		<label>.458 SOCOM cartridge (Sabot)</label>
+		<label>.458 SOCOM (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/473x33mmCaseless.xml
+++ b/Defs/Ammo/Rifle/473x33mmCaseless.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="473x33mmCaselessBase">
 		<defName>Ammo_473x33mmCaseless_FMJ</defName>
-		<label>4.73x33mm Caseless cartridge (FMJ)</label>
+		<label>4.73x33mm Caseless (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="473x33mmCaselessBase">
 		<defName>Ammo_473x33mmCaseless_AP</defName>
-		<label>4.73x33mm Caseless cartridge (AP)</label>
+		<label>4.73x33mm Caseless (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="473x33mmCaselessBase">
 		<defName>Ammo_473x33mmCaseless_HP</defName>
-		<label>4.73x33mm Caseless cartridge (HP)</label>
+		<label>4.73x33mm Caseless (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="473x33mmCaselessBase">
 		<defName>Ammo_473x33mmCaseless_Incendiary</defName>
-		<label>4.73x33mm Caseless cartridge (AP-I)</label>
+		<label>4.73x33mm Caseless (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="473x33mmCaselessBase">
 		<defName>Ammo_473x33mmCaseless_HE</defName>
-		<label>4.73x33mm Caseless cartridge (AP-HE)</label>
+		<label>4.73x33mm Caseless (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -113,7 +113,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="473x33mmCaselessBase">
 		<defName>Ammo_473x33mmCaseless_Sabot</defName>
-		<label>4.73x33mm Caseless cartridge (Sabot)</label>
+		<label>4.73x33mm Caseless (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/485x49mm.xml
+++ b/Defs/Ammo/Rifle/485x49mm.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="485x49mmBase">
 		<defName>Ammo_485x49mm_FMJ</defName>
-		<label>4.85x49mm cartridge (FMJ)</label>
+		<label>4.85x49mm (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="485x49mmBase">
 		<defName>Ammo_485x49mm_AP</defName>
-		<label>4.85x49mm cartridge (AP)</label>
+		<label>4.85x49mm (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="485x49mmBase">
 		<defName>Ammo_485x49mm_HP</defName>
-		<label>4.85x49mm cartridge (HP)</label>
+		<label>4.85x49mm (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="485x49mmBase">
 		<defName>Ammo_485x49mm_Incendiary</defName>
-		<label>4.85x49mm cartridge (AP-I)</label>
+		<label>4.85x49mm (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="485x49mmBase">
 		<defName>Ammo_485x49mm_HE</defName>
-		<label>4.85x49mm cartridge (AP-HE)</label>
+		<label>4.85x49mm (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -113,7 +113,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="485x49mmBase">
 		<defName>Ammo_485x49mm_Sabot</defName>
-		<label>4.85x49mm cartridge (Sabot)</label>
+		<label>4.85x49mm (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/50Beowulf.xml
+++ b/Defs/Ammo/Rifle/50Beowulf.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="50BeowulfBase">
 		<defName>Ammo_50Beowulf_FMJ</defName>
-		<label>.50 Beowulf cartridge (FMJ)</label>
+		<label>.50 Beowulf (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="50BeowulfBase">
 		<defName>Ammo_50Beowulf_AP</defName>
-		<label>.50 Beowulf cartridge (AP)</label>
+		<label>.50 Beowulf (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="50BeowulfBase">
 		<defName>Ammo_50Beowulf_HP</defName>
-		<label>.50 Beowulf cartridge (HP)</label>
+		<label>.50 Beowulf (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="50BeowulfBase">
 		<defName>Ammo_50Beowulf_Incendiary</defName>
-		<label>.50 Beowulf cartridge (AP-I)</label>
+		<label>.50 Beowulf (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="50BeowulfBase">
 		<defName>Ammo_50Beowulf_HE</defName>
-		<label>.50 Beowulf cartridge (AP-HE)</label>
+		<label>.50 Beowulf (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -113,7 +113,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="50BeowulfBase">
 		<defName>Ammo_50Beowulf_Sabot</defName>
-		<label>.50 Beowulf cartridge (Sabot)</label>
+		<label>.50 Beowulf (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/545x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/545x39mmSoviet.xml
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="545x39mmSovietBase">
 		<defName>Ammo_545x39mmSoviet_FMJ</defName>
-		<label>5.45x39mm Soviet cartridge (FMJ)</label>
+		<label>5.45x39mm Soviet (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Soviet/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="545x39mmSovietBase">
 		<defName>Ammo_545x39mmSoviet_AP</defName>
-		<label>5.45x39mm Soviet cartridge (AP)</label>
+		<label>5.45x39mm Soviet (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Soviet/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="545x39mmSovietBase">
 		<defName>Ammo_545x39mmSoviet_HP</defName>
-		<label>5.45x39mm Soviet cartridge (HP)</label>
+		<label>5.45x39mm Soviet (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Soviet/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="545x39mmSovietBase">
 		<defName>Ammo_545x39mmSoviet_Incendiary</defName>
-		<label>5.45x39mm Soviet cartridge (AP-I)</label>
+		<label>5.45x39mm Soviet (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Soviet/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -113,7 +113,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="545x39mmSovietBase">
 		<defName>Ammo_545x39mmSoviet_HE</defName>
-		<label>5.45x39mm Soviet cartridge (AP-HE)</label>
+		<label>5.45x39mm Soviet (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Soviet/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -127,7 +127,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="545x39mmSovietBase">
 		<defName>Ammo_545x39mmSoviet_Sabot</defName>
-		<label>5.45x39mm Soviet cartridge (Sabot)</label>
+		<label>5.45x39mm Soviet (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Soviet/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/556x45mmNATO.xml
+++ b/Defs/Ammo/Rifle/556x45mmNATO.xml
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="556x45mmNATOBase">
 		<defName>Ammo_556x45mmNATO_FMJ</defName>
-		<label>5.56x45mm NATO cartridge (FMJ)</label>
+		<label>5.56x45mm NATO (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="556x45mmNATOBase">
 		<defName>Ammo_556x45mmNATO_AP</defName>
-		<label>5.56x45mm NATO cartridge (AP)</label>
+		<label>5.56x45mm NATO (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="556x45mmNATOBase">
 		<defName>Ammo_556x45mmNATO_HP</defName>
-		<label>5.56x45mm NATO cartridge (HP)</label>
+		<label>5.56x45mm NATO (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="556x45mmNATOBase">
 		<defName>Ammo_556x45mmNATO_Incendiary</defName>
-		<label>5.56x45mm NATO cartridge (AP-I)</label>
+		<label>5.56x45mm NATO (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -113,7 +113,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="556x45mmNATOBase">
 		<defName>Ammo_556x45mmNATO_HE</defName>
-		<label>5.56x45mm NATO cartridge (AP-HE)</label>
+		<label>5.56x45mm NATO (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -127,7 +127,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="556x45mmNATOBase">
 		<defName>Ammo_556x45mmNATO_Sabot</defName>
-		<label>5.56x45mm NATO cartridge (Sabot)</label>
+		<label>5.56x45mm NATO (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/56-56Spencer.xml
+++ b/Defs/Ammo/Rifle/56-56Spencer.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="5656SpencerBase">
 		<defName>Ammo_5656Spencer_FMJ</defName>
-		<label>56-56 Spencer cartridge (FMJ)</label>
+		<label>56-56 Spencer (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="5656SpencerBase">
 		<defName>Ammo_5656Spencer_AP</defName>
-		<label>.56-56 Spencer cartridge (AP)</label>
+		<label>.56-56 Spencer (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="5656SpencerBase">
 		<defName>Ammo_5656Spencer_HP</defName>
-		<label>.56-56 Spencer cartridge (HP)</label>
+		<label>.56-56 Spencer (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="5656SpencerBase">
 		<defName>Ammo_5656Spencer_Incendiary</defName>
-		<label>.56-56 Spencer cartridge (AP-I)</label>
+		<label>.56-56 Spencer (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="5656SpencerBase">
 		<defName>Ammo_5656Spencer_HE</defName>
-		<label>.56-56 Spencer cartridge (AP-HE)</label>
+		<label>.56-56 Spencer (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -113,7 +113,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="5656SpencerBase">
 		<defName>Ammo_5656Spencer_Sabot</defName>
-		<label>.56-56 Spencer cartridge (Sabot)</label>
+		<label>.56-56 Spencer (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/58x42mmDBP10.xml
+++ b/Defs/Ammo/Rifle/58x42mmDBP10.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="58x42mmDBP10Base">
 		<defName>Ammo_58x42mmDBP10_FMJ</defName>
-		<label>5.8x42mm DBP10 cartridge (FMJ)</label>
+		<label>5.8x42mm DBP10 (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Soviet/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="58x42mmDBP10Base">
 		<defName>Ammo_58x42mmDBP10_AP</defName>
-		<label>5.8x42mm DBP10 cartridge (AP)</label>
+		<label>5.8x42mm DBP10 (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Soviet/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="58x42mmDBP10Base">
 		<defName>Ammo_58x42mmDBP10_HP</defName>
-		<label>5.8x42mm DBP10 cartridge (HP)</label>
+		<label>5.8x42mm DBP10 (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Soviet/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="58x42mmDBP10Base">
 		<defName>Ammo_58x42mmDBP10_Incendiary</defName>
-		<label>5.8x42mm DBP10 cartridge (AP-I)</label>
+		<label>5.8x42mm DBP10 (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Soviet/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="58x42mmDBP10Base">
 		<defName>Ammo_58x42mmDBP10_HE</defName>
-		<label>5.8x42mm DBP10 cartridge (AP-HE)</label>
+		<label>5.8x42mm DBP10 (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Soviet/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -113,7 +113,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="58x42mmDBP10Base">
 		<defName>Ammo_58x42mmDBP10_Sabot</defName>
-		<label>5.8x42mm DBP10 cartridge (Sabot)</label>
+		<label>5.8x42mm DBP10 (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Soviet/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/5x100mmCaseless.xml
+++ b/Defs/Ammo/Rifle/5x100mmCaseless.xml
@@ -46,7 +46,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="5x100mmCaselessBase">
 		<defName>Ammo_5x100mmCaseless_Sabot</defName>
-		<label>5x100mm Caseless cartridge (Sabot)</label>
+		<label>5x100mm Caseless (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Railgun/Rifle</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/6.5Creedmoor.xml
+++ b/Defs/Ammo/Rifle/6.5Creedmoor.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="65x48mmCreedmoorBase">
 		<defName>Ammo_65x48mmCreedmoor_FMJ</defName>
-		<label>6.5mm Creedmoor cartridge (FMJ)</label>
+		<label>6.5mm Creedmoor (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="65x48mmCreedmoorBase">
 		<defName>Ammo_65x48mmCreedmoor_AP</defName>
-		<label>6.5mm Creedmoor cartridge (AP)</label>
+		<label>6.5mm Creedmoor (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="65x48mmCreedmoorBase">
 		<defName>Ammo_65x48mmCreedmoor_HP</defName>
-		<label>6.5mm Creedmoor cartridge (HP)</label>
+		<label>6.5mm Creedmoor (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="65x48mmCreedmoorBase">
 		<defName>Ammo_65x48mmCreedmoor_Incendiary</defName>
-		<label>6.5mm Creedmoor cartridge (AP-I)</label>
+		<label>6.5mm Creedmoor (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="65x48mmCreedmoorBase">
 		<defName>Ammo_65x48mmCreedmoor_HE</defName>
-		<label>6.5mm Creedmoor cartridge (AP-HE)</label>
+		<label>6.5mm Creedmoor (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -113,7 +113,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="65x48mmCreedmoorBase">
 		<defName>Ammo_65x48mmCreedmoor_Sabot</defName>
-		<label>6.5mm Creedmoor cartridge (Sabot)</label>
+		<label>6.5mm Creedmoor (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/6.5x52mm Carcano.xml
+++ b/Defs/Ammo/Rifle/6.5x52mm Carcano.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="65x52mmCarcanoBase">
 		<defName>Ammo_65x52mmCarcano_FMJ</defName>
-		<label>6.5x52mm Carcano cartridge (FMJ)</label>
+		<label>6.5x52mm Carcano (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="65x52mmCarcanoBase">
 		<defName>Ammo_65x52mmCarcano_AP</defName>
-		<label>6.5x52mm Carcano cartridge (AP)</label>
+		<label>6.5x52mm Carcano (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="65x52mmCarcanoBase">
 		<defName>Ammo_65x52mmCarcano_HP</defName>
-		<label>6.5x52mm Carcano cartridge (HP)</label>
+		<label>6.5x52mm Carcano (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="65x52mmCarcanoBase">
 		<defName>Ammo_65x52mmCarcano_Incendiary</defName>
-		<label>6.5x52mm Carcano cartridge (AP-I)</label>
+		<label>6.5x52mm Carcano (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="65x52mmCarcanoBase">
 		<defName>Ammo_65x52mmCarcano_HE</defName>
-		<label>6.5x52mm Carcano cartridge (AP-HE)</label>
+		<label>6.5x52mm Carcano (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -113,7 +113,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="65x52mmCarcanoBase">
 		<defName>Ammo_65x52mmCarcano_Sabot</defName>
-		<label>6.5x52mm Carcano cartridge (Sabot)</label>
+		<label>6.5x52mm Carcano (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/65x50mmSRArisaka.xml
+++ b/Defs/Ammo/Rifle/65x50mmSRArisaka.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="65x50mmSRArisakaBase">
 		<defName>Ammo_65x50mmSRArisaka_FMJ</defName>
-		<label>6.5x50mmSR Arisaka cartridge (FMJ)</label>
+		<label>6.5x50mmSR Arisaka (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="65x50mmSRArisakaBase">
 		<defName>Ammo_65x50mmSRArisaka_AP</defName>
-		<label>6.5x50mmSR Arisaka cartridge (AP)</label>
+		<label>6.5x50mmSR Arisaka (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="65x50mmSRArisakaBase">
 		<defName>Ammo_65x50mmSRArisaka_HP</defName>
-		<label>6.5x50mmSR Arisaka cartridge (HP)</label>
+		<label>6.5x50mmSR Arisaka (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="65x50mmSRArisakaBase">
 		<defName>Ammo_65x50mmSRArisaka_Incendiary</defName>
-		<label>6.5x50mmSR cartridge (AP-I)</label>
+		<label>6.5x50mmSR Arisaka (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="65x50mmSRArisakaBase">
 		<defName>Ammo_65x50mmSRArisaka_HE</defName>
-		<label>6.5x50mmSR cartridge (AP-HE)</label>
+		<label>6.5x50mmSR Arisaka (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -113,7 +113,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="65x50mmSRArisakaBase">
 		<defName>Ammo_65x50mmSRArisaka_Sabot</defName>
-		<label>6.5x50mmSR cartridge (Sabot)</label>
+		<label>6.5x50mmSR Arisaka (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/7.92x57mmMauser.xml
+++ b/Defs/Ammo/Rifle/7.92x57mmMauser.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="792x57mmMauserBase">
 		<defName>Ammo_792x57mmMauser_FMJ</defName>
-		<label>7.92x57mm Mauser cartridge (FMJ)</label>
+		<label>7.92x57mm Mauser (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="792x57mmMauserBase">
 		<defName>Ammo_792x57mmMauser_AP</defName>
-		<label>7.92x57mm Mauser cartridge (AP)</label>
+		<label>7.92x57mm Mauser (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="792x57mmMauserBase">
 		<defName>Ammo_792x57mmMauser_HP</defName>
-		<label>7.92x57mm Mauser cartridge (HP)</label>
+		<label>7.92x57mm Mauser (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="792x57mmMauserBase">
 		<defName>Ammo_792x57mmMauser_Incendiary</defName>
-		<label>7.92x57mm Mauser cartridge (AP-I)</label>
+		<label>7.92x57mm Mauser (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="792x57mmMauserBase">
 		<defName>Ammo_792x57mmMauser_HE</defName>
-		<label>7.92x57mm Mauser cartridge (AP-HE)</label>
+		<label>7.92x57mm Mauser (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -113,7 +113,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="792x57mmMauserBase">
 		<defName>Ammo_792x57mmMauser_Sabot</defName>
-		<label>7.92x57mm Mauser cartridge (Sabot)</label>
+		<label>7.92x57mm Mauser (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/75x54mmFrench.xml
+++ b/Defs/Ammo/Rifle/75x54mmFrench.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="75x54mmFrenchBase">
 		<defName>Ammo_75x54mmFrench_FMJ</defName>
-		<label>7.5x54mm French cartridge (FMJ)</label>
+		<label>7.5x54mm French (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="75x54mmFrenchBase">
 		<defName>Ammo_75x54mmFrench_AP</defName>
-		<label>7.5x54mm French cartridge (AP)</label>
+		<label>7.5x54mm French (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="75x54mmFrenchBase">
 		<defName>Ammo_75x54mmFrench_HP</defName>
-		<label>7.5x54mm French cartridge (HP)</label>
+		<label>7.5x54mm French (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="75x54mmFrenchBase">
 		<defName>Ammo_75x54mmFrench_Incendiary</defName>
-		<label>7.5x54mm French cartridge (AP-I)</label>
+		<label>7.5x54mm French (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="75x54mmFrenchBase">
 		<defName>Ammo_75x54mmFrench_HE</defName>
-		<label>7.5x54mm French cartridge (AP-HE)</label>
+		<label>7.5x54mm French (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -113,7 +113,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="75x54mmFrenchBase">
 		<defName>Ammo_75x54mmFrench_Sabot</defName>
-		<label>7.5x54mm French cartridge (Sabot)</label>
+		<label>7.5x54mm French (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/762x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/762x39mmSoviet.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x39mmSovietBase">
 		<defName>Ammo_762x39mmSoviet_FMJ</defName>
-		<label>7.62x39mm Soviet cartridge (FMJ)</label>
+		<label>7.62x39mm Soviet (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/SovietLarge/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x39mmSovietBase">
 		<defName>Ammo_762x39mmSoviet_AP</defName>
-		<label>7.62x39mm Soviet cartridge (AP)</label>
+		<label>7.62x39mm Soviet (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/SovietLarge/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x39mmSovietBase">
 		<defName>Ammo_762x39mmSoviet_HP</defName>
-		<label>7.62x39mm Soviet cartridge (HP)</label>
+		<label>7.62x39mm Soviet (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/SovietLarge/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x39mmSovietBase">
 		<defName>Ammo_762x39mmSoviet_Incendiary</defName>
-		<label>7.62x39mm Soviet cartridge (AP-I)</label>
+		<label>7.62x39mm Soviet (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/SovietLarge/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x39mmSovietBase">
 		<defName>Ammo_762x39mmSoviet_HE</defName>
-		<label>7.62x39mm Soviet cartridge (AP-HE)</label>
+		<label>7.62x39mm Soviet (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/SovietLarge/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -113,7 +113,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x39mmSovietBase">
 		<defName>Ammo_762x39mmSoviet_Sabot</defName>
-		<label>7.62x39mm Soviet cartridge (Sabot)</label>
+		<label>7.62x39mm Soviet (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/SovietLarge/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/762x51mmNATO.xml
+++ b/Defs/Ammo/Rifle/762x51mmNATO.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x51mmNATOBase">
 		<defName>Ammo_762x51mmNATO_FMJ</defName>
-		<label>7.62x51mm NATO cartridge (FMJ)</label>
+		<label>7.62x51mm NATO (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x51mmNATOBase">
 		<defName>Ammo_762x51mmNATO_AP</defName>
-		<label>7.62x51mm NATO cartridge (AP)</label>
+		<label>7.62x51mm NATO (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x51mmNATOBase">
 		<defName>Ammo_762x51mmNATO_HP</defName>
-		<label>7.62x51mm NATO cartridge (HP)</label>
+		<label>7.62x51mm NATO (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x51mmNATOBase">
 		<defName>Ammo_762x51mmNATO_Incendiary</defName>
-		<label>7.62x51mm NATO cartridge (AP-I)</label>
+		<label>7.62x51mm NATO (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x51mmNATOBase">
 		<defName>Ammo_762x51mmNATO_HE</defName>
-		<label>7.62x51mm NATO cartridge (AP-HE)</label>
+		<label>7.62x51mm NATO (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -113,7 +113,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x51mmNATOBase">
 		<defName>Ammo_762x51mmNATO_Sabot</defName>
-		<label>7.62x51mm NATO cartridge (Sabot)</label>
+		<label>7.62x51mm NATO (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/762x54mmR.xml
+++ b/Defs/Ammo/Rifle/762x54mmR.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x54mmRBase">
 		<defName>Ammo_762x54mmR_FMJ</defName>
-		<label>7.62x54mmR cartridge (FMJ)</label>
+		<label>7.62x54mmR (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/SovietLarge/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x54mmRBase">
 		<defName>Ammo_762x54mmR_AP</defName>
-		<label>7.62x54mmR cartridge (AP)</label>
+		<label>7.62x54mmR (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/SovietLarge/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x54mmRBase">
 		<defName>Ammo_762x54mmR_HP</defName>
-		<label>7.62x54mmR cartridge (HP)</label>
+		<label>7.62x54mmR (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/SovietLarge/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x54mmRBase">
 		<defName>Ammo_762x54mmR_Incendiary</defName>
-		<label>7.62x54mmR cartridge (AP-I)</label>
+		<label>7.62x54mmR (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/SovietLarge/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x54mmRBase">
 		<defName>Ammo_762x54mmR_HE</defName>
-		<label>7.62x54mmR cartridge (AP-HE)</label>
+		<label>7.62x54mmR (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/SovietLarge/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -113,7 +113,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x54mmRBase">
 		<defName>Ammo_762x54mmR_Sabot</defName>
-		<label>7.62x54mmR cartridge (Sabot)</label>
+		<label>7.62x54mmR (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/SovietLarge/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/77x58mmArisaka.xml
+++ b/Defs/Ammo/Rifle/77x58mmArisaka.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="77x58mmArisakaBase">
 		<defName>Ammo_77x58mmArisaka_FMJ</defName>
-		<label>7.7x58mm Arisaka cartridge (FMJ)</label>
+		<label>7.7x58mm Arisaka (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="77x58mmArisakaBase">
 		<defName>Ammo_77x58mmArisaka_AP</defName>
-		<label>7.7x58mm Arisaka cartridge (AP)</label>
+		<label>7.7x58mm Arisaka (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="77x58mmArisakaBase">
 		<defName>Ammo_77x58mmArisaka_HP</defName>
-		<label>7.7x58mm Arisaka cartridge (HP)</label>
+		<label>7.7x58mm Arisaka (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="77x58mmArisakaBase">
 		<defName>Ammo_77x58mmArisaka_Incendiary</defName>
-		<label>7.7x58mm Arisaka cartridge (AP-I)</label>
+		<label>7.7x58mm Arisaka (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="77x58mmArisakaBase">
 		<defName>Ammo_77x58mmArisaka_HE</defName>
-		<label>7.7x58mm Arisaka cartridge (AP-HE)</label>
+		<label>7.7x58mm Arisaka (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -113,7 +113,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="77x58mmArisakaBase">
 		<defName>Ammo_77x58mmArisaka_Sabot</defName>
-		<label>7.7x58mm Arisaka cartridge (Sabot)</label>
+		<label>7.7x58mm Arisaka (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/792x33mmKurz.xml
+++ b/Defs/Ammo/Rifle/792x33mmKurz.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="792x33mmKurzBase">
 		<defName>Ammo_792x33mmKurz_FMJ</defName>
-		<label>7.92x33mm Kurz cartridge (FMJ)</label>
+		<label>7.92x33mm Kurz (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="792x33mmKurzBase">
 		<defName>Ammo_792x33mmKurz_AP</defName>
-		<label>7.92x33mm Kurz cartridge (AP)</label>
+		<label>7.92x33mm Kurz (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="792x33mmKurzBase">
 		<defName>Ammo_792x33mmKurz_HP</defName>
-		<label>7.92x33mm Kurz cartridge (HP)</label>
+		<label>7.92x33mm Kurz (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="792x33mmKurzBase">
 		<defName>Ammo_792x33mmKurz_Incendiary</defName>
-		<label>7.92x33mm Kurz cartridge (AP-I)</label>
+		<label>7.92x33mm Kurz (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="792x33mmKurzBase">
 		<defName>Ammo_792x33mmKurz_HE</defName>
-		<label>7.92x33mm Kurz cartridge (AP-HE)</label>
+		<label>7.92x33mm Kurz (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -113,7 +113,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="792x33mmKurzBase">
 		<defName>Ammo_792x33mmKurz_Sabot</defName>
-		<label>7.92x33mm Kurz cartridge (Sabot)</label>
+		<label>7.92x33mm Kurz (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/8.6mmBlackout.xml
+++ b/Defs/Ammo/Rifle/8.6mmBlackout.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="86x43mmBlackoutBase">
 		<defName>Ammo_86x43mmBlackout_FMJ</defName>
-		<label>8.6mm Blackout cartridge (FMJ)</label>
+		<label>8.6mm Blackout (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="86x43mmBlackoutBase">
 		<defName>Ammo_86x43mmBlackout_AP</defName>
-		<label>8.6mm Blackout cartridge (AP)</label>
+		<label>8.6mm Blackout (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="86x43mmBlackoutBase">
 		<defName>Ammo_86x43mmBlackout_HP</defName>
-		<label>8.6mm Blackout cartridge (HP)</label>
+		<label>8.6mm Blackout (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="86x43mmBlackoutBase">
 		<defName>Ammo_86x43mmBlackout_Incendiary</defName>
-		<label>8.6mm Blackout cartridge (AP-I)</label>
+		<label>8.6mm Blackout (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="86x43mmBlackoutBase">
 		<defName>Ammo_86x43mmBlackout_HE</defName>
-		<label>8.6mm Blackout cartridge (AP-HE)</label>
+		<label>8.6mm Blackout (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -113,7 +113,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="86x43mmBlackoutBase">
 		<defName>Ammo_86x43mmBlackout_Sabot</defName>
-		<label>8.6mm Blackout cartridge (Sabot)</label>
+		<label>8.6mm Blackout (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Battlerifle/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/8x50mmRLebel.xml
+++ b/Defs/Ammo/Rifle/8x50mmRLebel.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="8x50mmRLebelBase">
 		<defName>Ammo_8x50mmRLebel_FMJ</defName>
-		<label>8x50mmR Lebel cartridge (FMJ)</label>
+		<label>8x50mmR Lebel (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="8x50mmRLebelBase">
 		<defName>Ammo_8x50mmRLebel_AP</defName>
-		<label>8x50mmR Lebel cartridge (AP)</label>
+		<label>8x50mmR Lebel (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="8x50mmRLebelBase">
 		<defName>Ammo_8x50mmRLebel_HP</defName>
-		<label>8x50mmR Lebel cartridge (HP)</label>
+		<label>8x50mmR Lebel (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="8x50mmRLebelBase">
 		<defName>Ammo_8x50mmRLebel_Incendiary</defName>
-		<label>8x50mmR Lebel cartridge (AP-I)</label>
+		<label>8x50mmR Lebel (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="8x50mmRLebelBase">
 		<defName>Ammo_8x50mmRLebel_HE</defName>
-		<label>8x50mmR Lebel cartridge (AP-HE)</label>
+		<label>8x50mmR Lebel (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -113,7 +113,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="8x50mmRLebelBase">
 		<defName>Ammo_8x50mmRLebel_Sabot</defName>
-		<label>8x50mmR Lebel cartridge (Sabot)</label>
+		<label>8x50mmR Lebel (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/8x50mmRMannlicher.xml
+++ b/Defs/Ammo/Rifle/8x50mmRMannlicher.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="8x50mmRMannlicherBase">
 		<defName>Ammo_8x50mmRMannlicher_FMJ</defName>
-		<label>8x50mmR Mannlicher cartridge (FMJ)</label>
+		<label>8x50mmR Mannlicher (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="8x50mmRMannlicherBase">
 		<defName>Ammo_8x50mmRMannlicher_AP</defName>
-		<label>8x50mmR Mannlicher cartridge (AP)</label>
+		<label>8x50mmR Mannlicher (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="8x50mmRMannlicherBase">
 		<defName>Ammo_8x50mmRMannlicher_HP</defName>
-		<label>8x50mmR Mannlicher cartridge (HP)</label>
+		<label>8x50mmR Mannlicher (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="8x50mmRMannlicherBase">
 		<defName>Ammo_8x50mmRMannlicher_Incendiary</defName>
-		<label>8x50mmR Mannlicher cartridge (AP-I)</label>
+		<label>8x50mmR Mannlicher (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="8x50mmRMannlicherBase">
 		<defName>Ammo_8x50mmRMannlicher_HE</defName>
-		<label>8x50mmR Mannlicher cartridge (AP-HE)</label>
+		<label>8x50mmR Mannlicher (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -113,7 +113,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="8x50mmRMannlicherBase">
 		<defName>Ammo_8x50mmRMannlicher_Sabot</defName>
-		<label>8x50mmR Mannlicher cartridge (Sabot)</label>
+		<label>8x50mmR Mannlicher (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Clip/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Rifle/9x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/9x39mmSoviet.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="9x39mmSovietBase">
 		<defName>Ammo_9x39mmSoviet_FMJ</defName>
-		<label>9x39mm Soviet cartridge (FMJ)</label>
+		<label>9x39mm Soviet (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/SovietLarge/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -57,7 +57,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="9x39mmSovietBase">
 		<defName>Ammo_9x39mmSoviet_AP</defName>
-		<label>9x39mm Soviet cartridge (AP)</label>
+		<label>9x39mm Soviet (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/SovietLarge/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -71,7 +71,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="9x39mmSovietBase">
 		<defName>Ammo_9x39mmSoviet_HP</defName>
-		<label>9x39mm Soviet cartridge (HP)</label>
+		<label>9x39mm Soviet (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/SovietLarge/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="9x39mmSovietBase">
 		<defName>Ammo_9x39mmSoviet_Incendiary</defName>
-		<label>9x39mm Soviet cartridge (AP-I)</label>
+		<label>9x39mm Soviet (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/SovietLarge/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="9x39mmSovietBase">
 		<defName>Ammo_9x39mmSoviet_HE</defName>
-		<label>9x39mm Soviet cartridge (AP-HE)</label>
+		<label>9x39mm Soviet (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/SovietLarge/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -113,7 +113,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="9x39mmSovietBase">
 		<defName>Ammo_9x39mmSoviet_Sabot</defName>
-		<label>9x39mm Soviet cartridge (Sabot)</label>
+		<label>9x39mm Soviet (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/SovietLarge/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>


### PR DESCRIPTION
## Changes

- Removed the term "cartridge" and other descriptive terms from ammo labels to shorten their labels.
- Minor housekeeping for ammo labels.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
