### PR TITLE
Sight efficiency tweaks

### DIFF
--- a/Biotech/Patches/ThingDefs_Misc/Weapons/RangedIndustrial_Biotech.xml
+++ b/Biotech/Patches/ThingDefs_Misc/Weapons/RangedIndustrial_Biotech.xml
@@ -155,7 +155,7 @@
 			<Bulk>1.05</Bulk>
 			<MarketValue>10.15</MarketValue>
 			<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-			<SightsEfficiency>0.65</SightsEfficiency>
+			<SightsEfficiency>1.0</SightsEfficiency>
 		</statBases>
 		<Properties>
 			<label>throw tox grenade</label>

--- a/Defs/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Grenades.xml
@@ -111,7 +111,7 @@
 			<Mass>0.436</Mass>
 			<Bulk>1.55</Bulk>
 			<MarketValue>12.4</MarketValue>
-			<SightsEfficiency>0.65</SightsEfficiency>
+			<SightsEfficiency>1.0</SightsEfficiency>
 			<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 		</statBases>
 		<generateCommonality>2.0</generateCommonality>
@@ -195,7 +195,7 @@
 			<Mass>0.236</Mass>
 			<Bulk>0.61</Bulk>
 			<MarketValue>8.33</MarketValue>
-			<SightsEfficiency>0.65</SightsEfficiency>
+			<SightsEfficiency>1.0</SightsEfficiency>
 			<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 		</statBases>
 		<weaponTags>
@@ -272,7 +272,7 @@
 			<Mass>1.5</Mass>
 			<Bulk>4.72</Bulk>
 			<MarketValue>20.51</MarketValue>
-			<SightsEfficiency>0.65</SightsEfficiency>
+			<SightsEfficiency>1.0</SightsEfficiency>
 			<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 		</statBases>
 		<weaponTags>
@@ -344,7 +344,7 @@
 			<Mass>0.539</Mass>
 			<Bulk>1.05</Bulk>
 			<MarketValue>10.15</MarketValue>
-			<SightsEfficiency>0.65</SightsEfficiency>
+			<SightsEfficiency>1.0</SightsEfficiency>
 			<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 		</statBases>
 		<weaponTags>
@@ -422,7 +422,7 @@
 			<Mass>0.5</Mass>
 			<Bulk>1.05</Bulk>
 			<MarketValue>11.52</MarketValue>
-			<SightsEfficiency>0.65</SightsEfficiency>
+			<SightsEfficiency>1.0</SightsEfficiency>
 			<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 		</statBases>
 		<weaponTags>

--- a/Defs/ThingDefs_Misc/Weapons_RangedNeolithic.xml
+++ b/Defs/ThingDefs_Misc/Weapons_RangedNeolithic.xml
@@ -50,7 +50,7 @@
 		<soundInteract>Interact_BeatFire</soundInteract>
 		<statBases>
 			<MarketValue>7.0</MarketValue>
-			<SightsEfficiency>0.45</SightsEfficiency>
+			<SightsEfficiency>1.0</SightsEfficiency>
 			<ShotSpread>1.5</ShotSpread>
 			<SwayFactor>2.5</SwayFactor>
 			<Bulk>4.25</Bulk>

--- a/Patches/A Rimworld of Magic/Patch_Ranged.xml
+++ b/Patches/A Rimworld of Magic/Patch_Ranged.xml
@@ -172,7 +172,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>Seer_IceRing</defName>
 					<statBases>
-						<SightsEfficiency>0.35</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 						<ShotSpread>0.14</ShotSpread>
 						<SwayFactor>0.10</SwayFactor>
 						<Bulk>0.5</Bulk>
@@ -223,7 +223,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>Seer_LightningRing</defName>
 					<statBases>
-						<SightsEfficiency>0.35</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 						<ShotSpread>0.14</ShotSpread>
 						<SwayFactor>0.10</SwayFactor>
 						<Bulk>0.5</Bulk>
@@ -276,7 +276,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>Seer_FireRing</defName>
 					<statBases>
-						<SightsEfficiency>0.35</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 						<ShotSpread>0.14</ShotSpread>
 						<SwayFactor>0.10</SwayFactor>
 						<Bulk>0.5</Bulk>

--- a/Patches/AOC The Cleanup Devil/Grenades.xml
+++ b/Patches/AOC The Cleanup Devil/Grenades.xml
@@ -88,7 +88,7 @@
 						<Bulk>1</Bulk>
 						<MarketValue>10.95</MarketValue>
 						<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.65</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 					</statBases>
 					<Properties>
 						<label>throw EMP grenade</label>
@@ -133,7 +133,7 @@
 						<Mass>1</Mass>
 						<Bulk>4</Bulk>
 						<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.65</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 					</statBases>
 					<Properties>
 						<label>throw trash bag</label>

--- a/Patches/AOC The Cleanup Devil/RangedWeapons.xml
+++ b/Patches/AOC The Cleanup Devil/RangedWeapons.xml
@@ -72,7 +72,7 @@
 					<xpath>Defs/ThingDef[defName="AOC_Monojavelin"]/statBases</xpath>
 					<value>
 						<statBases>
-							<SightsEfficiency>0.65</SightsEfficiency>
+							<SightsEfficiency>1.0</SightsEfficiency>
 							<ShotSpread>1.5</ShotSpread>
 							<SwayFactor>2.5</SwayFactor>
 							<Bulk>2.5</Bulk>

--- a/Patches/Advanced Mechanoid Warfare/Patches/Patch_Ranged.xml
+++ b/Patches/Advanced Mechanoid Warfare/Patches/Patch_Ranged.xml
@@ -769,7 +769,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>AMW_Gun_SNomadRifle</defName>
 					<statBases>
-						<SightsEfficiency>0.9</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 						<ShotSpread>0.14</ShotSpread>
 						<SwayFactor>1.56</SwayFactor>
 						<Bulk>7.5</Bulk>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Misc/Weapons.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Misc/Weapons.xml
@@ -468,7 +468,7 @@
 						<statBases>
 							<Mass>20</Mass>
 							<RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
-							<SightsEfficiency>0.8</SightsEfficiency>
+							<SightsEfficiency>1.0</SightsEfficiency>
 							<ShotSpread>4.0</ShotSpread>
 							<SwayFactor>1.33</SwayFactor>
 						</statBases>

--- a/Patches/Alpha Mechs/ThingDefs_Misc/AlphaMechs_RangedMechanoid.xml
+++ b/Patches/Alpha Mechs/ThingDefs_Misc/AlphaMechs_RangedMechanoid.xml
@@ -65,7 +65,7 @@
 					<statBases>
 						<Mass>20</Mass>
 						<RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.8</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 						<ShotSpread>4.0</ShotSpread>
 						<SwayFactor>1.33</SwayFactor>
 					</statBases>
@@ -204,7 +204,7 @@
 					<statBases>
 						<Mass>20</Mass>
 						<RangedWeapon_Cooldown>1.0</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.8</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 						<ShotSpread>1.0</ShotSpread>
 						<SwayFactor>1.33</SwayFactor>
 						<Bulk>1.00</Bulk>

--- a/Patches/Arrow Please/ArrowPlease_Throwable.xml
+++ b/Patches/Arrow Please/ArrowPlease_Throwable.xml
@@ -57,7 +57,7 @@
 					<statBases>
 						<Mass>1.2</Mass>
 						<Bulk>3.3</Bulk>
-						<SightsEfficiency>0.45</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 						<ShotSpread>1.5</ShotSpread>
 						<SwayFactor>2.5</SwayFactor>
 						<RangedWeapon_Cooldown>0.75</RangedWeapon_Cooldown>
@@ -220,7 +220,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>Ranged_Torch</defName>
 					<statBases>
-						<SightsEfficiency>0.45</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 						<ShotSpread>1.5</ShotSpread>
 						<SwayFactor>2.5</SwayFactor>
 						<RangedWeapon_Cooldown>0.75</RangedWeapon_Cooldown>

--- a/Patches/Big and Small/Big and Small Genes/Weapons/ThingDef_RangedNeolithic.xml
+++ b/Patches/Big and Small/Big and Small Genes/Weapons/ThingDef_RangedNeolithic.xml
@@ -45,7 +45,7 @@
 					<defName>BS_JotunJavelin</defName>
 					<statBases>
 						<MarketValue>50</MarketValue>
-						<SightsEfficiency>0.45</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 						<Bulk>5</Bulk>
 						<Mass>5</Mass>
 						<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
@@ -125,7 +125,7 @@
 							<relicChance>0</relicChance>
 							<statBases>
 								<MarketValue>50</MarketValue>
-								<SightsEfficiency>0.45</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 								<ShotSpread>1.5</ShotSpread>
 								<SwayFactor>2.5</SwayFactor>
 								<Bulk>5</Bulk>

--- a/Patches/Biomes Caverns/Weapons/CE_Boomshroom.xml
+++ b/Patches/Biomes Caverns/Weapons/CE_Boomshroom.xml
@@ -56,7 +56,7 @@
 						<Bulk>1.8</Bulk>
 						<MarketValue>3</MarketValue>
 						<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.65</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 					</statBases>
 					<Properties>
 						<label>throw firebomb</label>

--- a/Patches/British Weapons Set/British_weapon_set.xml
+++ b/Patches/British Weapons Set/British_weapon_set.xml
@@ -15,7 +15,7 @@
 					<statBases>
 						<Mass>11</Mass>
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.7</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 						<ShotSpread>0.05</ShotSpread>
 						<SwayFactor>1.53</SwayFactor>
 						<Bulk>12</Bulk>

--- a/Patches/Call of Duty - Zombies Pack/Weapons/Wonder.xml
+++ b/Patches/Call of Duty - Zombies Pack/Weapons/Wonder.xml
@@ -349,7 +349,7 @@
 					<statBases>
 						<Mass>2</Mass>
 						<RangedWeapon_Cooldown>10</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.5</SightsEfficiency>
+						<SightsEfficiency>0.7</SightsEfficiency>
 						<ShotSpread>0.2</ShotSpread>
 						<SwayFactor>0.83</SwayFactor>
 						<Bulk>0.5</Bulk>
@@ -376,7 +376,7 @@
 					<statBases>
 						<Mass>1.36</Mass>
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.5</SightsEfficiency>
+						<SightsEfficiency>0.7</SightsEfficiency>
 						<ShotSpread>0.16</ShotSpread>
 						<SwayFactor>1.67</SwayFactor>
 						<Bulk>3</Bulk>
@@ -441,7 +441,7 @@
 					<statBases>
 						<Mass>1.36</Mass>
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.5</SightsEfficiency>
+						<SightsEfficiency>0.7</SightsEfficiency>
 						<ShotSpread>0.14</ShotSpread>
 						<SwayFactor>2.33</SwayFactor>
 						<Bulk>3</Bulk>
@@ -472,7 +472,7 @@
 					<statBases>
 						<Mass>2.67</Mass>
 						<RangedWeapon_Cooldown>0.96</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.5</SightsEfficiency>
+						<SightsEfficiency>0.7</SightsEfficiency>
 						<ShotSpread>0.2</ShotSpread>
 						<SwayFactor>2.22</SwayFactor>
 						<Bulk>4</Bulk>
@@ -783,7 +783,7 @@
 					<statBases>
 						<Mass>2.63</Mass>
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.5</SightsEfficiency>
+						<SightsEfficiency>0.7</SightsEfficiency>
 						<ShotSpread>0.2</ShotSpread>
 						<SwayFactor>1.88</SwayFactor>
 						<Bulk>3</Bulk>
@@ -814,7 +814,7 @@
 					<statBases>
 						<Mass>2.63</Mass>
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.5</SightsEfficiency>
+						<SightsEfficiency>0.7</SightsEfficiency>
 						<ShotSpread>0.2</ShotSpread>
 						<SwayFactor>1.88</SwayFactor>
 						<Bulk>3</Bulk>

--- a/Patches/Censored Armory/Weapons_Guns.xml
+++ b/Patches/Censored Armory/Weapons_Guns.xml
@@ -1281,7 +1281,7 @@
 						<Bulk>0.36</Bulk>
 						<MarketValue>12.22</MarketValue>
 						<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.65</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 					</statBases>
 					<Properties>
 						<label>throw concussion grenade</label>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
@@ -194,7 +194,7 @@
 			<Bulk>0.87</Bulk>
 			<MarketValue>11.22</MarketValue>
 			<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-			<SightsEfficiency>0.65</SightsEfficiency>
+			<SightsEfficiency>1.0</SightsEfficiency>
 		</statBases>
 		<Properties>
 			<label>throw frag grenade</label>
@@ -315,7 +315,7 @@
 			<Bulk>1.96</Bulk>
 			<MarketValue>7.05</MarketValue>
 			<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-			<SightsEfficiency>0.65</SightsEfficiency>
+			<SightsEfficiency>1.0</SightsEfficiency>
 		</statBases>
 		<Properties>
 			<label>throw molotov</label>
@@ -442,7 +442,7 @@
 			<Bulk>0.87</Bulk>
 			<MarketValue>21.09</MarketValue>
 			<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-			<SightsEfficiency>0.65</SightsEfficiency>
+			<SightsEfficiency>1.0</SightsEfficiency>
 		</statBases>
 		<Properties>
 			<label>throw EMP grenade</label>

--- a/Patches/Core/ThingDefs_Misc/Weapons_RangedNeolithic.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_RangedNeolithic.xml
@@ -22,7 +22,7 @@
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>Bow_Short</defName>
 		<statBases>
-			<SightsEfficiency>0.6</SightsEfficiency>
+			<SightsEfficiency>0.8</SightsEfficiency>
 			<ShotSpread>1</ShotSpread>
 			<SwayFactor>2</SwayFactor>
 			<Bulk>3.00</Bulk>
@@ -70,7 +70,7 @@
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>Bow_Recurve</defName>
 		<statBases>
-			<SightsEfficiency>0.6</SightsEfficiency>
+			<SightsEfficiency>0.8</SightsEfficiency>
 			<ShotSpread>1</ShotSpread>
 			<SwayFactor>2</SwayFactor>
 			<Bulk>4.00</Bulk>
@@ -119,7 +119,7 @@
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>Bow_Great</defName>
 		<statBases>
-			<SightsEfficiency>0.6</SightsEfficiency>
+			<SightsEfficiency>0.8</SightsEfficiency>
 			<ShotSpread>1</ShotSpread>
 			<SwayFactor>2</SwayFactor>
 			<Bulk>5.00</Bulk>

--- a/Patches/Cybernetic Warfare and Special Weapons/CyberneticWarfare_Ranged_Spacer.xml
+++ b/Patches/Cybernetic Warfare and Special Weapons/CyberneticWarfare_Ranged_Spacer.xml
@@ -244,7 +244,7 @@
 					<defName>CW_DualEraser</defName>
 					<statBases>
 						<Bulk>4.5</Bulk>
-						<SightsEfficiency>0.5</SightsEfficiency>
+						<SightsEfficiency>0.7</SightsEfficiency>
 						<ShotSpread>0.75</ShotSpread>
 						<SwayFactor>0.95</SwayFactor>
 						<RangedWeapon_Cooldown>1.5</RangedWeapon_Cooldown>

--- a/Patches/Divine Order/ThingDef_Misc/Weapons/Divine_Order_CE_Grenades.xml
+++ b/Patches/Divine Order/ThingDef_Misc/Weapons/Divine_Order_CE_Grenades.xml
@@ -92,7 +92,7 @@
 						<Bulk>1.8</Bulk>
 						<MarketValue>3</MarketValue>
 						<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.65</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 					</statBases>
 					<Properties>
 						<label>throw cleansing bomb</label>

--- a/Patches/Filthy Orc Invasion/FilthyOrcInvasion_Orc_Weapons.xml
+++ b/Patches/Filthy Orc Invasion/FilthyOrcInvasion_Orc_Weapons.xml
@@ -91,7 +91,7 @@
 							<soundInteract>Interact_BeatFire</soundInteract>
 							<statBases>
 								<MarketValue>7.26</MarketValue>
-								<SightsEfficiency>0.45</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 								<ShotSpread>1.5</ShotSpread>
 								<SwayFactor>2.5</SwayFactor>
 								<Bulk>3.5</Bulk>
@@ -150,7 +150,7 @@
 					<statBases>
 						<Mass>0.5</Mass>
 						<RangedWeapon_Cooldown>2</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.5</SightsEfficiency>
+						<SightsEfficiency>0.8</SightsEfficiency>
 						<ShotSpread>0.1</ShotSpread>
 						<SwayFactor>1</SwayFactor>
 						<Bulk>2</Bulk>

--- a/Patches/Gas Traps and Shells/Patch_Weapons_Grenades.xml
+++ b/Patches/Gas Traps and Shells/Patch_Weapons_Grenades.xml
@@ -52,7 +52,7 @@
 								<Mass>0.539</Mass>
 								<Bulk>1.05</Bulk>
 								<MarketValue>10.15</MarketValue>
-								<SightsEfficiency>0.65</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 								<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 							</statBases>
 							<weaponTags>
@@ -138,7 +138,7 @@
 								<Mass>0.539</Mass>
 								<Bulk>1.05</Bulk>
 								<MarketValue>10.15</MarketValue>
-								<SightsEfficiency>0.65</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 								<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 							</statBases>
 							<weaponTags>
@@ -223,7 +223,7 @@
 								<Mass>0.539</Mass>
 								<Bulk>1.05</Bulk>
 								<MarketValue>10.15</MarketValue>
-								<SightsEfficiency>0.65</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 								<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 							</statBases>
 							<weaponTags>
@@ -308,7 +308,7 @@
 								<Mass>0.539</Mass>
 								<Bulk>1.05</Bulk>
 								<MarketValue>10.15</MarketValue>
-								<SightsEfficiency>0.65</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 								<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 							</statBases>
 							<weaponTags>
@@ -393,7 +393,7 @@
 								<Mass>0.539</Mass>
 								<Bulk>1.05</Bulk>
 								<MarketValue>10.15</MarketValue>
-								<SightsEfficiency>0.65</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 								<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 							</statBases>
 							<weaponTags>
@@ -478,7 +478,7 @@
 								<Mass>0.539</Mass>
 								<Bulk>1.05</Bulk>
 								<MarketValue>10.15</MarketValue>
-								<SightsEfficiency>0.65</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 								<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 							</statBases>
 							<weaponTags>
@@ -564,7 +564,7 @@
 								<Mass>0.539</Mass>
 								<Bulk>1.05</Bulk>
 								<MarketValue>15</MarketValue>
-								<SightsEfficiency>0.65</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 								<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 							</statBases>
 							<weaponTags>
@@ -648,7 +648,7 @@
 								<Mass>0.539</Mass>
 								<Bulk>1.05</Bulk>
 								<MarketValue>10.15</MarketValue>
-								<SightsEfficiency>0.65</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 								<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 							</statBases>
 							<weaponTags>

--- a/Patches/Infinity Rim Ariadna/Weapons/AntipodeWeapon.xml
+++ b/Patches/Infinity Rim Ariadna/Weapons/AntipodeWeapon.xml
@@ -9,7 +9,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>Bow_Antipode</defName>
 					<statBases>
-						<SightsEfficiency>0.6</SightsEfficiency>
+						<SightsEfficiency>0.8</SightsEfficiency>
 						<ShotSpread>1</ShotSpread>
 						<SwayFactor>2</SwayFactor>
 						<Bulk>5.00</Bulk>

--- a/Patches/Infinity Rim Ariadna/Weapons/Shotguns.xml
+++ b/Patches/Infinity Rim Ariadna/Weapons/Shotguns.xml
@@ -105,7 +105,7 @@
 						<ShotSpread>0.2</ShotSpread>
 						<SwayFactor>1.5</SwayFactor>
 						<Bulk>11.0</Bulk>
-						<SightsEfficiency>0.5</SightsEfficiency>
+						<SightsEfficiency>0.8</SightsEfficiency>
 						<WorkToMake>5800</WorkToMake>
 					</statBases>
 					<costList>

--- a/Patches/JDS Castle Walls/ThingDefs_Tower.xml
+++ b/Patches/JDS Castle Walls/ThingDefs_Tower.xml
@@ -40,7 +40,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>Defend_Tower_GreatBow</defName>
 					<statBases>
-						<SightsEfficiency>0.6</SightsEfficiency>
+						<SightsEfficiency>0.8</SightsEfficiency>
 						<ShotSpread>1</ShotSpread>
 						<SwayFactor>2</SwayFactor>
 						<Bulk>5.00</Bulk>

--- a/Patches/K4G Rimworld War 2/ThingDefs_Misc/UnitedStatesWeapons_Ranged.xml
+++ b/Patches/K4G Rimworld War 2/ThingDefs_Misc/UnitedStatesWeapons_Ranged.xml
@@ -16,7 +16,7 @@
 					<statBases>
 						<Mass>0.5</Mass>
 						<RangedWeapon_Cooldown>0.5</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.6</SightsEfficiency>
+						<SightsEfficiency>0.7</SightsEfficiency>
 						<ShotSpread>0.18</ShotSpread>
 						<SwayFactor>1.27</SwayFactor>
 						<Bulk>1.41</Bulk>

--- a/Patches/K4G Rimworld War 2/ThingDefs_Misc/WW2_Grenades.xml
+++ b/Patches/K4G Rimworld War 2/ThingDefs_Misc/WW2_Grenades.xml
@@ -743,7 +743,7 @@
 								<Bulk>0.87</Bulk>
 								<MarketValue>12.22</MarketValue>
 								<RangedWeapon_Cooldown>0.5</RangedWeapon_Cooldown>
-								<SightsEfficiency>0.65</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 							</statBases>
 							<thingCategories>
 								<li>Grenades</li>
@@ -803,7 +803,7 @@
 								<Mass>1.36</Mass>
 								<Bulk>10</Bulk>
 								<MarketValue>25</MarketValue>
-								<SightsEfficiency>0.65</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 								<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 							</statBases>
 							<weaponTags>
@@ -884,7 +884,7 @@
 								<Bulk>10</Bulk>
 								<MarketValue>27</MarketValue>
 								<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-								<SightsEfficiency>0.65</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 							</statBases>
 							<thingCategories>
 								<li>Grenades</li>
@@ -957,7 +957,7 @@
 								<Bulk>0.87</Bulk>
 								<MarketValue>12.22</MarketValue>
 								<RangedWeapon_Cooldown>0.5</RangedWeapon_Cooldown>
-								<SightsEfficiency>0.65</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 							</statBases>
 							<thingCategories>
 								<li>Grenades</li>
@@ -1025,7 +1025,7 @@
 								<Bulk>0.87</Bulk>
 								<MarketValue>12.22</MarketValue>
 								<RangedWeapon_Cooldown>0.5</RangedWeapon_Cooldown>
-								<SightsEfficiency>0.65</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 							</statBases>
 							<thingCategories>
 								<li>Grenades</li>
@@ -1093,7 +1093,7 @@
 								<Bulk>0.87</Bulk>
 								<MarketValue>12.22</MarketValue>
 								<RangedWeapon_Cooldown>0.5</RangedWeapon_Cooldown>
-								<SightsEfficiency>0.65</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 							</statBases>
 							<thingCategories>
 								<li>Grenades</li>
@@ -1161,7 +1161,7 @@
 								<Bulk>0.87</Bulk>
 								<MarketValue>13.22</MarketValue>
 								<RangedWeapon_Cooldown>0.5</RangedWeapon_Cooldown>
-								<SightsEfficiency>0.65</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 							</statBases>
 							<thingCategories>
 								<li>Grenades</li>
@@ -1229,7 +1229,7 @@
 								<Bulk>10</Bulk>
 								<MarketValue>28</MarketValue>
 								<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-								<SightsEfficiency>0.65</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 							</statBases>
 							<thingCategories>
 								<li>Grenades</li>
@@ -1302,7 +1302,7 @@
 								<Bulk>0.87</Bulk>
 								<MarketValue>11.22</MarketValue>
 								<RangedWeapon_Cooldown>0.5</RangedWeapon_Cooldown>
-								<SightsEfficiency>0.65</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 							</statBases>
 							<thingCategories>
 								<li>Grenades</li>
@@ -1368,7 +1368,7 @@
 								<Bulk>0.87</Bulk>
 								<MarketValue>12.22</MarketValue>
 								<RangedWeapon_Cooldown>0.5</RangedWeapon_Cooldown>
-								<SightsEfficiency>0.65</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 							</statBases>
 							<thingCategories>
 								<li>Grenades</li>
@@ -1434,7 +1434,7 @@
 								<Bulk>0.87</Bulk>
 								<MarketValue>13.22</MarketValue>
 								<RangedWeapon_Cooldown>0.5</RangedWeapon_Cooldown>
-								<SightsEfficiency>0.65</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 							</statBases>
 							<thingCategories>
 								<li>Grenades</li>
@@ -1502,7 +1502,7 @@
 								<Bulk>10</Bulk>
 								<MarketValue>25</MarketValue>
 								<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-								<SightsEfficiency>0.65</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 							</statBases>
 							<thingCategories>
 								<li>Grenades</li>
@@ -1575,7 +1575,7 @@
 								<Bulk>0.87</Bulk>
 								<MarketValue>12.22</MarketValue>
 								<RangedWeapon_Cooldown>0.5</RangedWeapon_Cooldown>
-								<SightsEfficiency>0.65</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 							</statBases>
 							<thingCategories>
 								<li>Grenades</li>
@@ -1643,7 +1643,7 @@
 								<Bulk>0.87</Bulk>
 								<MarketValue>11.22</MarketValue>
 								<RangedWeapon_Cooldown>0.5</RangedWeapon_Cooldown>
-								<SightsEfficiency>0.65</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 							</statBases>
 							<thingCategories>
 								<li>Grenades</li>
@@ -1709,7 +1709,7 @@
 								<Bulk>0.87</Bulk>
 								<MarketValue>12.22</MarketValue>
 								<RangedWeapon_Cooldown>0.5</RangedWeapon_Cooldown>
-								<SightsEfficiency>0.65</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 							</statBases>
 							<thingCategories>
 								<li>Grenades</li>
@@ -1775,7 +1775,7 @@
 								<Bulk>0.87</Bulk>
 								<MarketValue>13.22</MarketValue>
 								<RangedWeapon_Cooldown>0.5</RangedWeapon_Cooldown>
-								<SightsEfficiency>0.65</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 							</statBases>
 							<thingCategories>
 								<li>Grenades</li>
@@ -1843,7 +1843,7 @@
 								<Bulk>10</Bulk>
 								<MarketValue>25</MarketValue>
 								<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-								<SightsEfficiency>0.65</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 							</statBases>
 							<thingCategories>
 								<li>Grenades</li>
@@ -1916,7 +1916,7 @@
 								<Bulk>10</Bulk>
 								<MarketValue>27</MarketValue>
 								<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-								<SightsEfficiency>0.65</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 							</statBases>
 							<thingCategories>
 								<li>Grenades</li>
@@ -1989,7 +1989,7 @@
 								<Bulk>10</Bulk>
 								<MarketValue>28</MarketValue>
 								<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-								<SightsEfficiency>0.65</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 							</statBases>
 							<thingCategories>
 								<li>Grenades</li>
@@ -2062,7 +2062,7 @@
 								<Bulk>0.87</Bulk>
 								<MarketValue>12.22</MarketValue>
 								<RangedWeapon_Cooldown>0.5</RangedWeapon_Cooldown>
-								<SightsEfficiency>0.65</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 							</statBases>
 							<thingCategories>
 								<li>Grenades</li>

--- a/Patches/Kaiser Armory/KaiserArmory_Guns.xml
+++ b/Patches/Kaiser Armory/KaiserArmory_Guns.xml
@@ -664,7 +664,7 @@
 						<Bulk>0.36</Bulk>
 						<MarketValue>12.22</MarketValue>
 						<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.65</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 					</statBases>
 					<Properties>
 						<label>throw concussion grenade</label>

--- a/Patches/Kijin 2.0/ThingDef_Misc/Kijin_Weapons_Ranged.xml
+++ b/Patches/Kijin 2.0/ThingDef_Misc/Kijin_Weapons_Ranged.xml
@@ -15,7 +15,7 @@
 						<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 							<defName>Kijin_Fan</defName>
 							<statBases>
-								<SightsEfficiency>0.6</SightsEfficiency>
+								<SightsEfficiency>0.8</SightsEfficiency>
 								<ShotSpread>1</ShotSpread>
 								<SwayFactor>2</SwayFactor>
 								<Bulk>4.00</Bulk>
@@ -83,7 +83,7 @@
 						<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 							<defName>Kijin_FlameBow</defName>
 							<statBases>
-								<SightsEfficiency>0.6</SightsEfficiency>
+								<SightsEfficiency>0.8</SightsEfficiency>
 								<ShotSpread>1</ShotSpread>
 								<SwayFactor>2</SwayFactor>
 								<Bulk>4.00</Bulk>
@@ -150,7 +150,7 @@
 						<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 							<defName>Kijin_PosionBow</defName>
 							<statBases>
-								<SightsEfficiency>0.6</SightsEfficiency>
+								<SightsEfficiency>0.8</SightsEfficiency>
 								<ShotSpread>0.5</ShotSpread>
 								<SwayFactor>1</SwayFactor>
 								<Bulk>4.00</Bulk>
@@ -247,7 +247,7 @@
 										<Mass>0.539</Mass>
 										<Bulk>1.05</Bulk>
 										<MarketValue>8.88</MarketValue>
-										<SightsEfficiency>0.45</SightsEfficiency>
+										<SightsEfficiency>1.0</SightsEfficiency>
 										<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 										<WorkToMake>24000</WorkToMake>
 									</statBases>
@@ -306,7 +306,7 @@
 						<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 							<defName>KijinDarkMatter</defName>
 							<statBases>
-								<SightsEfficiency>0.6</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 								<ShotSpread>1</ShotSpread>
 								<SwayFactor>2</SwayFactor>
 								<Bulk>1</Bulk>

--- a/Patches/Kit's Roman Weapons/Roman_Weapons.xml
+++ b/Patches/Kit's Roman Weapons/Roman_Weapons.xml
@@ -269,7 +269,7 @@
 							<soundInteract>Interact_Grenade</soundInteract>
 							<statBases>
 								<MarketValue>2.36</MarketValue>
-								<SightsEfficiency>0.45</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 								<ShotSpread>1.5</ShotSpread>
 								<SwayFactor>2.5</SwayFactor>
 								<Bulk>3.5</Bulk>

--- a/Patches/Kurin Deluxe Patch/ThingDefs_Misc/DRNTF_Weapon.xml
+++ b/Patches/Kurin Deluxe Patch/ThingDefs_Misc/DRNTF_Weapon.xml
@@ -419,7 +419,7 @@
 					<statBases>
 						<SwayFactor>2.10</SwayFactor>
 						<ShotSpread>3.00</ShotSpread>
-						<SightsEfficiency>0.65</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 						<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
 					</statBases>
 					<Properties>

--- a/Patches/LF Red Dawn/RD_Grenade.xml
+++ b/Patches/LF Red Dawn/RD_Grenade.xml
@@ -277,7 +277,7 @@
 						<Bulk>1.5</Bulk>
 						<MarketValue>4.55</MarketValue>
 						<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.65</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 					</statBases>
 					<Properties>
 						<label>throw grenade</label>
@@ -309,7 +309,7 @@
 						<Bulk>1.5</Bulk>
 						<MarketValue>4.55</MarketValue>
 						<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.65</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 					</statBases>
 					<Properties>
 						<label>throw grenade</label>
@@ -341,7 +341,7 @@
 						<Bulk>1.5</Bulk>
 						<MarketValue>4.55</MarketValue>
 						<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.65</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 					</statBases>
 					<Properties>
 						<label>throw grenade</label>
@@ -373,7 +373,7 @@
 						<Bulk>1.5</Bulk>
 						<MarketValue>4.55</MarketValue>
 						<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.65</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 					</statBases>
 					<Properties>
 						<label>throw grenade</label>
@@ -405,7 +405,7 @@
 						<Bulk>1.5</Bulk>
 						<MarketValue>4.55</MarketValue>
 						<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.65</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 					</statBases>
 					<Properties>
 						<label>throw an AT grenade</label>

--- a/Patches/LTS Military/Weapons.xml
+++ b/Patches/LTS Military/Weapons.xml
@@ -727,7 +727,7 @@
 						<Bulk>0.36</Bulk>
 						<MarketValue>11.22</MarketValue>
 						<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.65</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 					</statBases>
 					<Properties>
 						<label>throw grenade</label>

--- a/Patches/Medieval Overhaul/MO_Weapons_Grenades.xml
+++ b/Patches/Medieval Overhaul/MO_Weapons_Grenades.xml
@@ -114,7 +114,7 @@
 						<Bulk>1.8</Bulk>
 						<MarketValue>3</MarketValue>
 						<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.65</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 					</statBases>
 					<Properties>
 						<label>throw fire pot</label>
@@ -252,7 +252,7 @@
 						<Bulk>1.8</Bulk>
 						<MarketValue>3</MarketValue>
 						<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.65</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 					</statBases>
 					<Properties>
 						<label>throw flash pot</label>
@@ -405,7 +405,7 @@
 						<Bulk>1.8</Bulk>
 						<MarketValue>3</MarketValue>
 						<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.65</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 					</statBases>
 					<Properties>
 						<label>throw smoke pot</label>

--- a/Patches/Medieval Overhaul/MO_Weapons_Ranged.xml
+++ b/Patches/Medieval Overhaul/MO_Weapons_Ranged.xml
@@ -158,7 +158,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>DankPyon_Bow_Hunting</defName>
 					<statBases>
-						<SightsEfficiency>0.6</SightsEfficiency>
+						<SightsEfficiency>0.8</SightsEfficiency>
 						<ShotSpread>1</ShotSpread>
 						<SwayFactor>2</SwayFactor>
 						<Bulk>4.00</Bulk>
@@ -191,7 +191,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>Bow_War</defName>
 					<statBases>
-						<SightsEfficiency>0.6</SightsEfficiency>
+						<SightsEfficiency>0.8</SightsEfficiency>
 						<ShotSpread>1</ShotSpread>
 						<SwayFactor>2</SwayFactor>
 						<Bulk>5.00</Bulk>

--- a/Patches/Morgante Mafia Weapons Pack/Weapons_Guns.xml
+++ b/Patches/Morgante Mafia Weapons Pack/Weapons_Guns.xml
@@ -411,7 +411,7 @@
 						<Bulk>2.55</Bulk>
 						<MarketValue>7.05</MarketValue>
 						<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.65</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 					</statBases>
 					<Properties>
 						<label>throw molotov</label>

--- a/Patches/MorrowRim - Bloodmoon/Hunter_Grenades.xml
+++ b/Patches/MorrowRim - Bloodmoon/Hunter_Grenades.xml
@@ -29,7 +29,7 @@
 								<Mass>0.436</Mass>
 								<Bulk>1.55</Bulk>
 								<MarketValue>12.4</MarketValue>
-								<SightsEfficiency>0.65</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 								<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 							</statBases>
 							<generateCommonality>2.0</generateCommonality>

--- a/Patches/Nihal/ThingDefs_Weapons/Weapons.xml
+++ b/Patches/Nihal/ThingDefs_Weapons/Weapons.xml
@@ -195,7 +195,7 @@
 						<Mass>1.0</Mass>
 						<SwayFactor>1.5</SwayFactor>
 						<ShotSpread>1</ShotSpread>
-						<SightsEfficiency>0.5</SightsEfficiency>
+						<SightsEfficiency>0.8</SightsEfficiency>
 						<RangedWeapon_Cooldown>1.5</RangedWeapon_Cooldown>
 						<WorkToMake>32000</WorkToMake>
 					</statBases>

--- a/Patches/O21 Dragons Not Included/Ranged_Dragon.xml
+++ b/Patches/O21 Dragons Not Included/Ranged_Dragon.xml
@@ -224,7 +224,7 @@
 						<Bulk>2.50</Bulk>
 						<SwayFactor>1.22</SwayFactor>
 						<ShotSpread>0.36</ShotSpread>
-						<SightsEfficiency>0.6</SightsEfficiency>
+						<SightsEfficiency>0.8</SightsEfficiency>
 						<RangedWeapon_Cooldown>0.85</RangedWeapon_Cooldown>
 					</statBases>
 					<Properties>
@@ -257,7 +257,7 @@
 						<Bulk>2.50</Bulk>
 						<SwayFactor>1.22</SwayFactor>
 						<ShotSpread>0.36</ShotSpread>
-						<SightsEfficiency>0.6</SightsEfficiency>
+						<SightsEfficiency>0.8</SightsEfficiency>
 						<RangedWeapon_Cooldown>1.85</RangedWeapon_Cooldown>
 					</statBases>
 					<Properties>

--- a/Patches/O21 Outer Rim Galaxies/Patch_OuterRim_Weapons.xml
+++ b/Patches/O21 Outer Rim Galaxies/Patch_OuterRim_Weapons.xml
@@ -85,7 +85,7 @@
 						<Mass>0.4</Mass>
 						<Bulk>0.87</Bulk>
 						<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.65</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 					</statBases>
 					<Properties>
 						<label>throw thermal detonator</label>

--- a/Patches/O21 Outland - Eastborn/Eastborn_WeaponsRanged.xml
+++ b/Patches/O21 Outland - Eastborn/Eastborn_WeaponsRanged.xml
@@ -12,7 +12,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>Outland_Yumi</defName>
 					<statBases>
-						<SightsEfficiency>0.6</SightsEfficiency>
+						<SightsEfficiency>0.8</SightsEfficiency>
 						<ShotSpread>1</ShotSpread>
 						<SwayFactor>2</SwayFactor>
 						<Bulk>8.00</Bulk>

--- a/Patches/Possesed Weapons/PossessedWeapons_RangedPatch.xml
+++ b/Patches/Possesed Weapons/PossessedWeapons_RangedPatch.xml
@@ -63,7 +63,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>BotchJob_PossessedDragonfireGreatbow</defName>
 					<statBases>
-						<SightsEfficiency>0.6</SightsEfficiency>
+						<SightsEfficiency>0.8</SightsEfficiency>
 						<ShotSpread>1</ShotSpread>
 						<SwayFactor>2</SwayFactor>
 						<Bulk>10.00</Bulk>
@@ -406,7 +406,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>BotchJob_PossessedArchmageStaff</defName>
 					<statBases>
-						<SightsEfficiency>0.3</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 						<ShotSpread>3</ShotSpread>
 						<SwayFactor>1</SwayFactor>
 						<Bulk>10.00</Bulk>
@@ -1291,7 +1291,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>BotchJob_PossessedGhostlyFlintlock</defName>
 					<statBases>
-						<SightsEfficiency>0.6</SightsEfficiency>
+						<SightsEfficiency>0.5</SightsEfficiency>
 						<ShotSpread>0.42</ShotSpread>
 						<SwayFactor>1.58</SwayFactor>
 						<Mass>1.25</Mass>
@@ -1362,7 +1362,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>BotchJob_PossessedEarthenGauntlet</defName>
 					<statBases>
-						<SightsEfficiency>0.3</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 						<ShotSpread>0.42</ShotSpread>
 						<SwayFactor>1.58</SwayFactor>
 						<Mass>3.5</Mass>

--- a/Patches/Pratt WWII Weapons Pack/PWW2_CE_Patch_Weapons_Grenades.xml
+++ b/Patches/Pratt WWII Weapons Pack/PWW2_CE_Patch_Weapons_Grenades.xml
@@ -153,7 +153,7 @@
 						<Bulk>0.91</Bulk>
 						<MarketValue>9.95</MarketValue>
 						<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.45</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 					</statBases>
 					<Properties>
 						<label>throw frag grenade</label>
@@ -288,7 +288,7 @@
 						<Bulk>4.22</Bulk>
 						<MarketValue>12.41</MarketValue>
 						<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.45</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 					</statBases>
 					<Properties>
 						<label>throw frag grenade</label>
@@ -430,7 +430,7 @@
 						<Bulk>0.57</Bulk>
 						<MarketValue>9.55</MarketValue>
 						<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.45</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 					</statBases>
 					<Properties>
 						<label>throw frag grenade</label>
@@ -565,7 +565,7 @@
 						<Bulk>1.31</Bulk>
 						<MarketValue>10.74</MarketValue>
 						<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.45</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 					</statBases>
 					<Properties>
 						<label>throw frag grenade</label>
@@ -700,7 +700,7 @@
 						<Bulk>0.65</Bulk>
 						<MarketValue>9.95</MarketValue>
 						<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.45</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 					</statBases>
 					<Properties>
 						<label>throw frag grenade</label>
@@ -835,7 +835,7 @@
 						<Bulk>0.84</Bulk>
 						<MarketValue>10.74</MarketValue>
 						<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.45</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 					</statBases>
 					<Properties>
 						<label>throw frag grenade</label>

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_shotguns.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_shotguns.xml
@@ -547,7 +547,7 @@
 					<defName>Gun_TOZ-34_Sawed-off_RWP</defName>
 					<statBases>
 						<WorkToMake>15000</WorkToMake>
-						<SightsEfficiency>0.5</SightsEfficiency>
+						<SightsEfficiency>0.8</SightsEfficiency>
 						<ShotSpread>0.19</ShotSpread>
 						<SwayFactor>0.76</SwayFactor>
 						<Bulk>5.80</Bulk>
@@ -623,7 +623,7 @@
 					<defName>Gun_TOZ-66_Sawed-off_RWP</defName>
 					<statBases>
 						<WorkToMake>15000</WorkToMake>
-						<SightsEfficiency>0.5</SightsEfficiency>
+						<SightsEfficiency>0.8</SightsEfficiency>
 						<ShotSpread>0.20</ShotSpread>
 						<SwayFactor>0.68</SwayFactor>
 						<Bulk>5.09</Bulk>

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_submachineguns.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_submachineguns.xml
@@ -773,7 +773,7 @@
 					<defName>Gun_MP5KA1_RWP</defName>
 					<statBases>
 						<WorkToMake>25500</WorkToMake>
-						<SightsEfficiency>0.6</SightsEfficiency>
+						<SightsEfficiency>0.8</SightsEfficiency>
 						<ShotSpread>0.17</ShotSpread>
 						<SwayFactor>0.53</SwayFactor>
 						<Bulk>3.25</Bulk>

--- a/Patches/Reinforced Mechanoid 2/ThingDefs_Misc/RM_PlasmaWeaponry.xml
+++ b/Patches/Reinforced Mechanoid 2/ThingDefs_Misc/RM_PlasmaWeaponry.xml
@@ -411,7 +411,7 @@
 						<Bulk>3</Bulk>
 						<MarketValue>14.05</MarketValue>
 						<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.65</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 					</statBases>
 					<Properties>
 						<label>throw immolator grenade</label>

--- a/Patches/Revia Race — biotech/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Revia Race — biotech/ThingDefs_Misc/Weapons_Guns.xml
@@ -48,7 +48,7 @@
 						<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 							<defName>ReviaThrowingKnife</defName>
 							<statBases>
-								<SightsEfficiency>0.6</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 								<Bulk>0.35</Bulk>
 								<Mass>0.15</Mass>
 								<RangedWeapon_Cooldown>1.5</RangedWeapon_Cooldown>

--- a/Patches/Revia Race/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Revia Race/ThingDefs_Misc/Weapons_Guns.xml
@@ -48,7 +48,7 @@
 						<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 							<defName>ReviaThrowingKnife</defName>
 							<statBases>
-								<SightsEfficiency>0.6</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 								<Bulk>0.35</Bulk>
 								<Mass>0.15</Mass>
 								<RangedWeapon_Cooldown>1.5</RangedWeapon_Cooldown>

--- a/Patches/Rim Gnoblins/Gnoblins_Grenade.xml
+++ b/Patches/Rim Gnoblins/Gnoblins_Grenade.xml
@@ -98,7 +98,7 @@
 						<Bulk>1.05</Bulk>
 						<MarketValue>7.05</MarketValue>
 						<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.65</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 					</statBases>
 					<Properties>
 						<label>throw grenade</label>

--- a/Patches/RimFantasy - House Doyle/Patch_RFDoyle_Ranged.xml
+++ b/Patches/RimFantasy - House Doyle/Patch_RFDoyle_Ranged.xml
@@ -33,7 +33,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>RF_RangedWeapon_Greatbow_Doyle</defName>
 					<statBases>
-						<SightsEfficiency>0.6</SightsEfficiency>
+						<SightsEfficiency>0.8</SightsEfficiency>
 						<ShotSpread>1</ShotSpread>
 						<SwayFactor>2</SwayFactor>
 						<Bulk>5.00</Bulk>
@@ -66,7 +66,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>RF_RangedWeapon_WarBow_Doyle</defName>
 					<statBases>
-						<SightsEfficiency>0.6</SightsEfficiency>
+						<SightsEfficiency>0.8</SightsEfficiency>
 						<ShotSpread>1</ShotSpread>
 						<SwayFactor>2</SwayFactor>
 						<Bulk>5.00</Bulk>

--- a/Patches/RimFantasy - Medieval Overhaul Edition/Patch_RF_Arcane_Bows.xml
+++ b/Patches/RimFantasy - Medieval Overhaul Edition/Patch_RF_Arcane_Bows.xml
@@ -33,7 +33,7 @@
 							<WorkToMake>18000</WorkToMake>
 							<Mass>2.75</Mass>
 							<Bulk>5.00</Bulk>
-							<SightsEfficiency>0.6</SightsEfficiency>
+							<SightsEfficiency>0.8</SightsEfficiency>
 							<ShotSpread>1</ShotSpread>
 							<SwayFactor>2</SwayFactor>
 							<RangedWeapon_Cooldown>0.7</RangedWeapon_Cooldown>

--- a/Patches/RimFantasy - Medieval Overhaul Edition/Patch_RF_Arcane_Ring.xml
+++ b/Patches/RimFantasy - Medieval Overhaul Edition/Patch_RF_Arcane_Ring.xml
@@ -34,7 +34,7 @@
 							<WorkToMake>18000</WorkToMake>
 							<Mass>1.25</Mass>
 							<Bulk>0.6</Bulk>
-							<SightsEfficiency>0.35</SightsEfficiency>
+							<SightsEfficiency>1.0</SightsEfficiency>
 							<ShotSpread>0.14</ShotSpread>
 							<SwayFactor>0.10</SwayFactor>
 							<RangedWeapon_Cooldown>0.3</RangedWeapon_Cooldown>

--- a/Patches/Rimcraft Collection/Weapons/Patch_WOW_Ranged.xml
+++ b/Patches/Rimcraft Collection/Weapons/Patch_WOW_Ranged.xml
@@ -50,7 +50,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>WoWR_Alliance_Longbow</defName>
 					<statBases>
-						<SightsEfficiency>0.75</SightsEfficiency>
+						<SightsEfficiency>0.8</SightsEfficiency>
 						<ShotSpread>0.8</ShotSpread>
 						<SwayFactor>2</SwayFactor>
 						<Bulk>6.00</Bulk>
@@ -77,7 +77,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>WoWR_NightElf_RecurveBow</defName>
 					<statBases>
-						<SightsEfficiency>0.75</SightsEfficiency>
+						<SightsEfficiency>0.8</SightsEfficiency>
 						<ShotSpread>0.8</ShotSpread>
 						<SwayFactor>2</SwayFactor>
 						<Bulk>4.00</Bulk>
@@ -104,7 +104,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>WoWR_BloodElf_Bow</defName>
 					<statBases>
-						<SightsEfficiency>0.75</SightsEfficiency>
+						<SightsEfficiency>0.8</SightsEfficiency>
 						<ShotSpread>0.8</ShotSpread>
 						<SwayFactor>2</SwayFactor>
 						<Bulk>4.00</Bulk>
@@ -131,7 +131,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>WoWR_BloodElf_HawkBow</defName>
 					<statBases>
-						<SightsEfficiency>0.75</SightsEfficiency>
+						<SightsEfficiency>0.8</SightsEfficiency>
 						<ShotSpread>0.8</ShotSpread>
 						<SwayFactor>2</SwayFactor>
 						<Bulk>4.00</Bulk>
@@ -158,7 +158,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>WoWR_HighElf_Longbow</defName>
 					<statBases>
-						<SightsEfficiency>0.75</SightsEfficiency>
+						<SightsEfficiency>0.8</SightsEfficiency>
 						<ShotSpread>0.8</ShotSpread>
 						<SwayFactor>2</SwayFactor>
 						<Bulk>6.00</Bulk>
@@ -185,7 +185,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>WoWR_HighElf_RecurveBow</defName>
 					<statBases>
-						<SightsEfficiency>0.75</SightsEfficiency>
+						<SightsEfficiency>0.8</SightsEfficiency>
 						<ShotSpread>0.8</ShotSpread>
 						<SwayFactor>2</SwayFactor>
 						<Bulk>4.00</Bulk>
@@ -212,7 +212,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>WoWR_Forsaken_DarkBow</defName>
 					<statBases>
-						<SightsEfficiency>0.75</SightsEfficiency>
+						<SightsEfficiency>0.8</SightsEfficiency>
 						<ShotSpread>0.8</ShotSpread>
 						<SwayFactor>2</SwayFactor>
 						<Bulk>4.00</Bulk>
@@ -267,7 +267,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>WoWR_Draenei_Longbow</defName>
 					<statBases>
-						<SightsEfficiency>0.75</SightsEfficiency>
+						<SightsEfficiency>0.8</SightsEfficiency>
 						<ShotSpread>0.8</ShotSpread>
 						<SwayFactor>2</SwayFactor>
 						<Bulk>6.00</Bulk>

--- a/Patches/Rimedieval - Medieval Royalty/Ranged_Medieval.xml
+++ b/Patches/Rimedieval - Medieval Royalty/Ranged_Medieval.xml
@@ -122,7 +122,7 @@
 						<Bulk>1.8</Bulk>
 						<MarketValue>3</MarketValue>
 						<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.65</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 					</statBases>
 					<Properties>
 						<label>throw firebomb</label>

--- a/Patches/Rimfire/ThingDefs_Misc/RF_Ranged_Neolithic.xml
+++ b/Patches/Rimfire/ThingDefs_Misc/RF_Ranged_Neolithic.xml
@@ -12,7 +12,7 @@
 					<statBases>
 						<Mass>0.8</Mass>
 						<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.6</SightsEfficiency>
+						<SightsEfficiency>0.8</SightsEfficiency>
 						<ShotSpread>1</ShotSpread>
 						<SwayFactor>2</SwayFactor>
 						<Bulk>0.8</Bulk>

--- a/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_Grenades.xml
+++ b/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_Grenades.xml
@@ -133,7 +133,7 @@
 						<Bulk>6.8</Bulk>
 						<MarketValue>184.2</MarketValue>
 						<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.45</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 						<WorkToMake>6000</WorkToMake>
 					</statBases>
 					<costList>

--- a/Patches/Rimsenal Collection/Core/Weapons_GD_CE.xml
+++ b/Patches/Rimsenal Collection/Core/Weapons_GD_CE.xml
@@ -216,7 +216,7 @@
 					<defName>GD_MSST</defName>
 					<statBases>
 						<WorkToMake>50</WorkToMake>
-						<SightsEfficiency>0.6</SightsEfficiency>
+						<SightsEfficiency>0.8</SightsEfficiency>
 						<ShotSpread>0.16</ShotSpread>
 						<SwayFactor>1.17</SwayFactor>
 						<Bulk>2.20</Bulk>
@@ -258,7 +258,7 @@
 					<value>
 						<statBases>
 							<WorkToMake>50</WorkToMake>
-							<SightsEfficiency>0.6</SightsEfficiency>
+							<SightsEfficiency>0.8</SightsEfficiency>
 							<ShotSpread>0.2</ShotSpread>
 							<SwayFactor>1.45</SwayFactor>
 							<Bulk>2.85</Bulk>
@@ -341,7 +341,7 @@
 					<defName>GD_MSSF</defName>
 					<statBases>
 						<WorkToMake>50</WorkToMake>
-						<SightsEfficiency>0.6</SightsEfficiency>
+						<SightsEfficiency>0.7</SightsEfficiency>
 						<ShotSpread>0.36</ShotSpread>
 						<SwayFactor>1.22</SwayFactor>
 						<Bulk>1.90</Bulk>

--- a/Patches/Rimsenal Collection/Core/Weapons_YP_CE.xml
+++ b/Patches/Rimsenal Collection/Core/Weapons_YP_CE.xml
@@ -268,7 +268,7 @@
 					<value>
 						<statBases>
 							<WorkToMake>50500</WorkToMake>
-							<SightsEfficiency>0.5</SightsEfficiency>
+							<SightsEfficiency>0.7</SightsEfficiency>
 							<ShotSpread>0.2</ShotSpread>
 							<SwayFactor>1.5</SwayFactor>
 							<Bulk>4.7</Bulk>

--- a/Patches/Rimsenal Collection/Enhanced Vanilla/Weapons_Ranged_CE.xml
+++ b/Patches/Rimsenal Collection/Enhanced Vanilla/Weapons_Ranged_CE.xml
@@ -101,7 +101,7 @@
 					<xpath>Defs/ThingDef[defName="Gun_ThrowingAxes"]/statBases</xpath>
 					<value>
 						<statBases>
-							<SightsEfficiency>0.8</SightsEfficiency>
+							<SightsEfficiency>1.0</SightsEfficiency>
 							<ShotSpread>0.6</ShotSpread>
 							<SwayFactor>2</SwayFactor>
 							<Bulk>1.25</Bulk>
@@ -191,7 +191,7 @@
 					<xpath>Defs/ThingDef[defName="Gun_ThrowingClubs"]/statBases</xpath>
 					<value>
 						<statBases>
-							<SightsEfficiency>0.8</SightsEfficiency>
+							<SightsEfficiency>1.0</SightsEfficiency>
 							<ShotSpread>0.6</ShotSpread>
 							<SwayFactor>2</SwayFactor>
 							<Bulk>1</Bulk>

--- a/Patches/Rimsenal Collection/Federation/ThingDefs_Misc/Fed_RangedWeapons.xml
+++ b/Patches/Rimsenal Collection/Federation/ThingDefs_Misc/Fed_RangedWeapons.xml
@@ -131,7 +131,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>AD_AuxPistol</defName>
 					<statBases>
-						<SightsEfficiency>0.6</SightsEfficiency>
+						<SightsEfficiency>0.7</SightsEfficiency>
 						<ShotSpread>0.14</ShotSpread>
 						<SwayFactor>1.23</SwayFactor>
 						<Bulk>2.50</Bulk>
@@ -248,7 +248,7 @@
 					<defName>AD_CruciblePistol</defName>
 					<statBases>
 						<WorkToMake>30500</WorkToMake>
-						<SightsEfficiency>0.6</SightsEfficiency>
+						<SightsEfficiency>0.7</SightsEfficiency>
 						<ShotSpread>0.18</ShotSpread>
 						<SwayFactor>1.08</SwayFactor>
 						<Bulk>3.90</Bulk>
@@ -280,7 +280,7 @@
 					<defName>AD_FedPistol</defName>
 					<statBases>
 						<WorkToMake>30500</WorkToMake>
-						<SightsEfficiency>0.6</SightsEfficiency>
+						<SightsEfficiency>0.7</SightsEfficiency>
 						<ShotSpread>0.18</ShotSpread>
 						<SwayFactor>1.08</SwayFactor>
 						<Bulk>3.90</Bulk>

--- a/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_Explosives.xml
+++ b/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_Explosives.xml
@@ -227,7 +227,7 @@
 							<soundInteract>Interact_BeatFire</soundInteract>
 							<statBases>
 								<MarketValue>200</MarketValue>
-								<SightsEfficiency>0.45</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 								<ShotSpread>1.5</ShotSpread>
 								<SwayFactor>2.5</SwayFactor>
 								<Bulk>5.00</Bulk>

--- a/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_MutantWeapons.xml
+++ b/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_MutantWeapons.xml
@@ -94,7 +94,7 @@
 						<ShotSpread>0.25</ShotSpread>
 						<SwayFactor>1.26</SwayFactor>
 						<Bulk>10</Bulk>
-						<SightsEfficiency>0.6</SightsEfficiency>
+						<SightsEfficiency>0.8</SightsEfficiency>
 					</statBases>
 					<Properties>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>

--- a/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_RangedWeapons.xml
+++ b/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_RangedWeapons.xml
@@ -156,7 +156,7 @@
 					<defName>Gun_Scraptooth</defName>
 					<statBases>
 						<WorkToMake>35500</WorkToMake>
-						<SightsEfficiency>0.4</SightsEfficiency>
+						<SightsEfficiency>0.7</SightsEfficiency>
 						<ShotSpread>0.2</ShotSpread>
 						<SwayFactor>1.7</SwayFactor>
 						<Bulk>5</Bulk>
@@ -235,7 +235,7 @@
 					<statBases>
 						<Mass>4.20</Mass>
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.6</SightsEfficiency>
+						<SightsEfficiency>0.8</SightsEfficiency>
 						<ShotSpread>0.67</ShotSpread>
 						<SwayFactor>1.95</SwayFactor>
 						<Bulk>5.8</Bulk>

--- a/Patches/Rimsenal Collection/Marauder/Marauder_Grenades.xml
+++ b/Patches/Rimsenal Collection/Marauder/Marauder_Grenades.xml
@@ -142,7 +142,7 @@
 						<Bulk>1.09</Bulk>
 						<MarketValue>12.22</MarketValue>
 						<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.65</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 					</statBases>
 					<Properties>
 						<label>throw pipe bomb</label>

--- a/Patches/Rimworld-Style Pilas And Bows Strapped With Grenades and Shells Extended/Javelin.xml
+++ b/Patches/Rimworld-Style Pilas And Bows Strapped With Grenades and Shells Extended/Javelin.xml
@@ -39,7 +39,7 @@
 							<soundInteract>Interact_BeatFire</soundInteract>
 							<statBases>
 								<MarketValue>62.35</MarketValue>
-								<SightsEfficiency>0.45</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 								<ShotSpread>1.5</ShotSpread>
 								<SwayFactor>2.5</SwayFactor>
 								<Bulk>3.5</Bulk>
@@ -108,7 +108,7 @@
 							<soundInteract>Interact_BeatFire</soundInteract>
 							<statBases>
 								<MarketValue>49.6</MarketValue>
-								<SightsEfficiency>0.45</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 								<ShotSpread>1.5</ShotSpread>
 								<SwayFactor>2.5</SwayFactor>
 								<Bulk>3.5</Bulk>
@@ -141,7 +141,7 @@
 							<soundInteract>Interact_BeatFire</soundInteract>
 							<statBases>
 								<MarketValue>119.68</MarketValue>
-								<SightsEfficiency>0.45</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 								<ShotSpread>1.5</ShotSpread>
 								<SwayFactor>2.5</SwayFactor>
 								<Bulk>3.5</Bulk>
@@ -174,7 +174,7 @@
 							<soundInteract>Interact_BeatFire</soundInteract>
 							<statBases>
 								<MarketValue>44.29</MarketValue>
-								<SightsEfficiency>0.45</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 								<ShotSpread>1.5</ShotSpread>
 								<SwayFactor>2.5</SwayFactor>
 								<Bulk>3.5</Bulk>
@@ -208,7 +208,7 @@
 							<soundInteract>Interact_BeatFire</soundInteract>
 							<statBases>
 								<MarketValue>44.29</MarketValue>
-								<SightsEfficiency>0.45</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 								<ShotSpread>1.5</ShotSpread>
 								<SwayFactor>2.5</SwayFactor>
 								<Bulk>3.5</Bulk>
@@ -242,7 +242,7 @@
 							<soundInteract>Interact_BeatFire</soundInteract>
 							<statBases>
 								<MarketValue>1507.26</MarketValue>
-								<SightsEfficiency>0.45</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 								<ShotSpread>1.5</ShotSpread>
 								<SwayFactor>2.5</SwayFactor>
 								<Bulk>3.5</Bulk>

--- a/Patches/Save Our Ship 2/Weapons_Grenades.xml
+++ b/Patches/Save Our Ship 2/Weapons_Grenades.xml
@@ -111,7 +111,7 @@
 									<Bulk>2.55</Bulk>
 									<MarketValue>7.05</MarketValue>
 									<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-									<SightsEfficiency>0.65</SightsEfficiency>
+									<SightsEfficiency>1.0</SightsEfficiency>
 								</statBases>
 								<Properties>
 									<label>throw molotov</label>

--- a/Patches/Simple Ogre Race/CE_Ogre_Race_Wep.xml
+++ b/Patches/Simple Ogre Race/CE_Ogre_Race_Wep.xml
@@ -123,7 +123,7 @@
 					<value>
 						<statBases>
 							<MarketValue>0.1</MarketValue>
-							<SightsEfficiency>0.5</SightsEfficiency>
+							<SightsEfficiency>0.7</SightsEfficiency>
 							<ShotSpread>1.4</ShotSpread>
 							<SwayFactor>2.4</SwayFactor>
 							<Bulk>7</Bulk>

--- a/Patches/Star Wars - Factions/Patch_Ranged.xml
+++ b/Patches/Star Wars - Factions/Patch_Ranged.xml
@@ -503,7 +503,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>PJ_LauncherP</defName>
 					<statBases>
-						<SightsEfficiency>0.35</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 						<ShotSpread>1.34</ShotSpread>
 						<SwayFactor>4.64</SwayFactor>
 						<Bulk>5.50</Bulk>

--- a/Patches/T's Samurai Faction/T_Samurai_Weapons_Ranged.xml
+++ b/Patches/T's Samurai Faction/T_Samurai_Weapons_Ranged.xml
@@ -174,7 +174,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>TSF_Yumi</defName>
 					<statBases>
-						<SightsEfficiency>0.6</SightsEfficiency>
+						<SightsEfficiency>0.8</SightsEfficiency>
 						<ShotSpread>1</ShotSpread>
 						<SwayFactor>2</SwayFactor>
 						<Bulk>8.00</Bulk>
@@ -294,7 +294,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>TSF_Shuriken</defName>
 					<statBases>
-						<SightsEfficiency>0.4</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 						<Bulk>0.20</Bulk>
 						<Mass>0.30</Mass>
 						<RangedWeapon_Cooldown>0.6</RangedWeapon_Cooldown>

--- a/Patches/The GiantRace/ThingDefs_Misc/GiantWeapons_Ranged.xml
+++ b/Patches/The GiantRace/ThingDefs_Misc/GiantWeapons_Ranged.xml
@@ -564,7 +564,7 @@
 								<Mass>8</Mass>
 								<Bulk>5</Bulk>
 								<MarketValue>0.09</MarketValue>
-								<SightsEfficiency>0.6</SightsEfficiency>
+								<SightsEfficiency>0.8</SightsEfficiency>
 								<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 								<ShotSpread>1.5</ShotSpread>
 								<SwayFactor>2.5</SwayFactor>
@@ -609,7 +609,7 @@
 								<Mass>8</Mass>
 								<Bulk>5</Bulk>
 								<MarketValue>0.09</MarketValue>
-								<SightsEfficiency>0.6</SightsEfficiency>
+								<SightsEfficiency>0.8</SightsEfficiency>
 								<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 								<ShotSpread>1.5</ShotSpread>
 								<SwayFactor>2.5</SwayFactor>
@@ -652,7 +652,7 @@
 								<Mass>10.2</Mass>
 								<Bulk>12</Bulk>
 								<MarketValue>0.09</MarketValue>
-								<SightsEfficiency>0.6</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 								<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 								<ShotSpread>1.5</ShotSpread>
 								<SwayFactor>2.5</SwayFactor>
@@ -708,7 +708,7 @@
 								<Mass>6.6</Mass>
 								<Bulk>5</Bulk>
 								<MarketValue>0.09</MarketValue>
-								<SightsEfficiency>0.6</SightsEfficiency>
+								<SightsEfficiency>0.8</SightsEfficiency>
 								<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 								<ShotSpread>10</ShotSpread>
 								<SwayFactor>2.5</SwayFactor>
@@ -750,7 +750,7 @@
 								<Mass>18</Mass>
 								<Bulk>14</Bulk>
 								<MarketValue>0.09</MarketValue>
-								<SightsEfficiency>0.6</SightsEfficiency>
+								<SightsEfficiency>0.8</SightsEfficiency>
 								<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 								<ShotSpread>1.5</ShotSpread>
 								<SwayFactor>2.5</SwayFactor>
@@ -792,7 +792,7 @@
 								<Mass>18</Mass>
 								<Bulk>14</Bulk>
 								<MarketValue>0.09</MarketValue>
-								<SightsEfficiency>0.6</SightsEfficiency>
+								<SightsEfficiency>0.8</SightsEfficiency>
 								<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 								<ShotSpread>1.5</ShotSpread>
 								<SwayFactor>2.5</SwayFactor>
@@ -834,7 +834,7 @@
 								<Mass>10.2</Mass>
 								<Bulk>12</Bulk>
 								<MarketValue>0.09</MarketValue>
-								<SightsEfficiency>0.6</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 								<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 								<ShotSpread>1.5</ShotSpread>
 								<SwayFactor>2.5</SwayFactor>
@@ -890,7 +890,7 @@
 								<Mass>8.6</Mass>
 								<Bulk>12</Bulk>
 								<MarketValue>0.09</MarketValue>
-								<SightsEfficiency>0.6</SightsEfficiency>
+								<SightsEfficiency>1.0</SightsEfficiency>
 								<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 								<ShotSpread>1.5</ShotSpread>
 								<SwayFactor>1.5</SwayFactor>

--- a/Patches/Thog's Guns - More Brukka Pack/Ranged_Industrial.xml
+++ b/Patches/Thog's Guns - More Brukka Pack/Ranged_Industrial.xml
@@ -904,7 +904,7 @@
 					<statBases>
 						<Mass>4.26</Mass>
 						<RangedWeapon_Cooldown>0.65</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.4</SightsEfficiency>
+						<SightsEfficiency>0.8</SightsEfficiency>
 						<ShotSpread>0.20</ShotSpread>
 						<SwayFactor>0.43</SwayFactor>
 						<Bulk>3.54</Bulk>
@@ -1205,7 +1205,7 @@
 					<statBases>
 						<Mass>2.84</Mass>
 						<RangedWeapon_Cooldown>1.25</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.5</SightsEfficiency>
+						<SightsEfficiency>0.8</SightsEfficiency>
 						<ShotSpread>0.12</ShotSpread>
 						<SwayFactor>0.34</SwayFactor>
 						<Bulk>6.10</Bulk>

--- a/Patches/Tribal Warrior Set/TribalWarrior_Apparel.xml
+++ b/Patches/Tribal Warrior Set/TribalWarrior_Apparel.xml
@@ -117,7 +117,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>Gunmar_War_Bow</defName>
 					<statBases>
-						<SightsEfficiency>0.6</SightsEfficiency>
+						<SightsEfficiency>0.8</SightsEfficiency>
 						<ShotSpread>1</ShotSpread>
 						<SwayFactor>2</SwayFactor>
 						<Bulk>5.00</Bulk>

--- a/Patches/Tsar Armory/TsarArmory_Guns.xml
+++ b/Patches/Tsar Armory/TsarArmory_Guns.xml
@@ -367,7 +367,7 @@
 						<Bulk>0.235</Bulk>
 						<MarketValue>12.22</MarketValue>
 						<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.65</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 					</statBases>
 					<Properties>
 						<label>throw concussion grenade</label>

--- a/Patches/Vanilla Factions Expanded - Classical/ThingDefs_WeaponsRanged.xml
+++ b/Patches/Vanilla Factions Expanded - Classical/ThingDefs_WeaponsRanged.xml
@@ -50,7 +50,7 @@
 					<value>
 						<statBases>
 							<MarketValue>7.26</MarketValue>
-							<SightsEfficiency>0.45</SightsEfficiency>
+							<SightsEfficiency>1.0</SightsEfficiency>
 							<ShotSpread>1.5</ShotSpread>
 							<SwayFactor>2.5</SwayFactor>
 							<Bulk>3.5</Bulk>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VFEVRangedWarcasket.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VFEVRangedWarcasket.xml
@@ -36,7 +36,7 @@
 							<Bulk>20</Bulk>
 							<SwayFactor>2.10</SwayFactor>
 							<ShotSpread>3.00</ShotSpread>
-							<SightsEfficiency>0.85</SightsEfficiency>
+							<SightsEfficiency>1.0</SightsEfficiency>
 							<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
 						</statBases>
 						<Properties>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VWENLRangedWarcasket.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VWENLRangedWarcasket.xml
@@ -36,7 +36,7 @@
 							<Bulk>25</Bulk>
 							<SwayFactor>1.31</SwayFactor>
 							<ShotSpread>0.18</ShotSpread>
-							<SightsEfficiency>0.65</SightsEfficiency>
+							<SightsEfficiency>1.0</SightsEfficiency>
 							<RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
 						</statBases>
 						<Properties>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VWEQRangedWarcasket.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VWEQRangedWarcasket.xml
@@ -34,7 +34,7 @@
 						<defName>VFEP_WarcasketGun_FoldingGun</defName>
 						<statBases>
 							<RangedWeapon_Cooldown>0.6</RangedWeapon_Cooldown>
-							<SightsEfficiency>0.85</SightsEfficiency>
+							<SightsEfficiency>1.0</SightsEfficiency>
 							<ShotSpread>0.10</ShotSpread>
 							<SwayFactor>2.32</SwayFactor>
 							<Bulk>15</Bulk>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Ranged_Warcaskets.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Ranged_Warcaskets.xml
@@ -195,7 +195,7 @@
 					<defName>VFEP_WarcasketGun_Minigun</defName>
 					<statBases>
 						<RangedWeapon_Cooldown>0.6</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.9</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 						<ShotSpread>0.08</ShotSpread>
 						<SwayFactor>2.32</SwayFactor>
 						<Bulk>25</Bulk>
@@ -235,7 +235,7 @@
 						<Bulk>20</Bulk>
 						<SwayFactor>2.10</SwayFactor>
 						<ShotSpread>3.00</ShotSpread>
-						<SightsEfficiency>0.65</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 						<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
 					</statBases>
 					<Properties>
@@ -310,7 +310,7 @@
 						<Bulk>20</Bulk>
 						<SwayFactor>1.24</SwayFactor>
 						<ShotSpread>0.10</ShotSpread>
-						<SightsEfficiency>0.5</SightsEfficiency>
+						<SightsEfficiency>0.7</SightsEfficiency>
 						<RangedWeapon_Cooldown>1.5</RangedWeapon_Cooldown>
 					</statBases>
 					<Properties>

--- a/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Misc/Weapons/RangedIndustrialGrenades.xml
+++ b/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Misc/Weapons/RangedIndustrialGrenades.xml
@@ -100,7 +100,7 @@
 						<MarketValue>5.05</MarketValue>
 						<Mass>0.4</Mass>
 						<Bulk>0.87</Bulk>
-						<SightsEfficiency>0.65</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 						<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 					</statBases>
 					<Properties>

--- a/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Misc/Weapons/RangedMedieval.xml
+++ b/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Misc/Weapons/RangedMedieval.xml
@@ -101,7 +101,7 @@
 					<statBases>
 						<Mass>1.2</Mass>
 						<Bulk>3.3</Bulk>
-						<SightsEfficiency>0.45</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 						<ShotSpread>1.5</ShotSpread>
 						<SwayFactor>2.5</SwayFactor>
 						<RangedWeapon_Cooldown>0.75</RangedWeapon_Cooldown>

--- a/Patches/Vanilla Factions Expanded - Vikings/Weapons_Medieval.xml
+++ b/Patches/Vanilla Factions Expanded - Vikings/Weapons_Medieval.xml
@@ -222,7 +222,7 @@
 					<xpath>Defs/ThingDef[defName="VFE_ThrowingAxe"]/statBases</xpath>
 					<value>
 						<statBases>
-							<SightsEfficiency>0.5</SightsEfficiency>
+							<SightsEfficiency>1.0</SightsEfficiency>
 							<ShotSpread>1.5</ShotSpread>
 							<SwayFactor>2.5</SwayFactor>
 							<Bulk>1.25</Bulk>
@@ -320,7 +320,7 @@
 					<value>
 						<statBases>
 							<MarketValue>7.26</MarketValue>
-							<SightsEfficiency>0.45</SightsEfficiency>
+							<SightsEfficiency>1.0</SightsEfficiency>
 							<ShotSpread>1.5</ShotSpread>
 							<SwayFactor>2.5</SwayFactor>
 							<Bulk>3</Bulk>

--- a/Patches/Vanilla Weapons Expanded - Tribal/Ranged_Neolithic.xml
+++ b/Patches/Vanilla Weapons Expanded - Tribal/Ranged_Neolithic.xml
@@ -12,7 +12,7 @@
 				<li Class='CombatExtended.PatchOperationMakeGunCECompatible'>
 					<defName>VWE_Sling</defName>
 					<statBases>
-						<SightsEfficiency>0.6</SightsEfficiency>
+						<SightsEfficiency>0.8</SightsEfficiency>
 						<ShotSpread>1</ShotSpread>
 						<SwayFactor>2</SwayFactor>
 						<Bulk>0.8</Bulk>
@@ -137,7 +137,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>VWE_Throwing_Shards</defName>
 					<statBases>
-						<SightsEfficiency>0.45</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 						<Bulk>0.35</Bulk>
 						<Mass>0.15</Mass>
 						<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
@@ -297,7 +297,7 @@
 						<Bulk>1.8</Bulk>
 						<MarketValue>3</MarketValue>
 						<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-						<SightsEfficiency>0.65</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 					</statBases>
 					<Properties>
 						<label>throw firebomb</label>

--- a/Patches/Vanilla Weapons Expanded/Medieval_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded/Medieval_Ranged.xml
@@ -150,7 +150,7 @@
 						<Bulk>3.90</Bulk>
 						<SwayFactor>1.22</SwayFactor>
 						<ShotSpread>0.36</ShotSpread>
-						<SightsEfficiency>0.7</SightsEfficiency>
+						<SightsEfficiency>0.5</SightsEfficiency>
 						<RangedWeapon_Cooldown>0.85</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
@@ -312,7 +312,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>VWE_Throwing_Knives</defName>
 					<statBases>
-						<SightsEfficiency>0.5</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 						<ShotSpread>1.5</ShotSpread>
 						<SwayFactor>2</SwayFactor>
 						<Bulk>0.35</Bulk>

--- a/Patches/Vanilla Weapons Expanded/Neolithic_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded/Neolithic_Ranged.xml
@@ -13,7 +13,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>VWE_Bow_Long</defName>
 					<statBases>
-						<SightsEfficiency>0.7</SightsEfficiency>
+						<SightsEfficiency>0.8</SightsEfficiency>
 						<ShotSpread>1</ShotSpread>
 						<SwayFactor>2</SwayFactor>
 						<Bulk>5.50</Bulk>

--- a/Patches/Warcaskets - Adeptus Astartes/Ranged_Astartes.xml
+++ b/Patches/Warcaskets - Adeptus Astartes/Ranged_Astartes.xml
@@ -42,7 +42,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>HP_WarcasketGun_Bolter</defName>
 					<statBases>
-						<SightsEfficiency>0.7</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 						<ShotSpread>0.07</ShotSpread>
 						<SwayFactor>2.58</SwayFactor><!-- Sway has been reduced, given the wielders. -->
 						<Bulk>7.5</Bulk>
@@ -159,7 +159,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>HP_WarcasketGun_StormBolter</defName>
 					<statBases>
-						<SightsEfficiency>0.7</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 						<ShotSpread>0.07</ShotSpread>
 						<SwayFactor>2.92</SwayFactor>
 						<Bulk>7.5</Bulk>

--- a/Patches/Weapons+/WeaponsPlus_RangedWeapons.xml
+++ b/Patches/Weapons+/WeaponsPlus_RangedWeapons.xml
@@ -100,7 +100,7 @@
 						<statBases>
 							<WorkToMake>1000</WorkToMake>
 							<MarketValue>4</MarketValue>
-							<SightsEfficiency>0.45</SightsEfficiency>
+							<SightsEfficiency>1.0</SightsEfficiency>
 							<ShotSpread>1.5</ShotSpread>
 							<SwayFactor>2.5</SwayFactor>
 							<Bulk>1.00</Bulk>


### PR DESCRIPTION
## Changes

- Throwables like grenades and javelins have 1.0 sight efficiency instead of 0.65 now as it's the skill of the thrower that determines their accuracy and not non-existent sights which nerfs them horribly.
- Bows in general now have 0.8 SE (crude sights) instead of 0.6 which was too low.
- Various misc consistency checks and housekeeping changes.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
