### PR TITLE
assorted turret reload fix

### DIFF
--- a/Source/CombatExtended/CombatExtended/Jobs/JobDriver_ReloadTurret.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobDriver_ReloadTurret.cs
@@ -167,7 +167,7 @@ namespace CombatExtended
             // If ammo system is turned off we just need to go to the turret.
             if (turret.InteractionCell != null)
             {
-                yield return Toils_Goto.GotoCell(turret.InteractionCell, PathEndMode.Touch);
+                yield return Toils_Goto.GotoCell(turret.InteractionCell, PathEndMode.OnCell);
             }
             else
             {

--- a/Source/CombatExtended/CombatExtended/Jobs/JobDriver_ReloadTurret.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobDriver_ReloadTurret.cs
@@ -74,7 +74,7 @@ namespace CombatExtended
         public override string GetReport()
         {
             string text = CE_JobDefOf.ReloadTurret.reportString;
-            string turretType = (turret.def.hasInteractionCell ? "CE_MannedTurret" : "CE_AutoTurret").Translate();
+            string turretType = (turret.TryGetComp<CompMannable>() != null ? "CE_MannedTurret" : "CE_AutoTurret").Translate();
             text = text.Replace("TurretType", turretType);
             text = text.Replace("TargetA", TargetThingA.def.label);
             if (compReloader.UseAmmo)
@@ -165,7 +165,14 @@ namespace CombatExtended
             }
 
             // If ammo system is turned off we just need to go to the turret.
-            yield return Toils_Goto.GotoCell(turret.Position, PathEndMode.Touch);
+            if (turret.InteractionCell != null)
+            {
+                yield return Toils_Goto.GotoCell(turret.InteractionCell, PathEndMode.Touch);
+            }
+            else
+            {
+                yield return Toils_Goto.GotoThing(TargetIndex.A, PathEndMode.Touch);
+            }
 
             //If pawn fails reloading from this point, reset isReloading
             this.AddFinishAction(delegate


### PR DESCRIPTION
## Changes

-Turret reloading jobs will now try to touch turret (instead of turret's center cell), or stand on interact cell if any.
-Reloading inspection string now detect compmannable instead of interact cell presence

## Reasoning

It's dumb.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] Playtested a colony (specify how long)
