### PR TITLE
Alpha Vehicle Neolithic patch

### DIFF
--- a/Patches/Alpha Vehicle/Alpha_Vehicle.xml
+++ b/Patches/Alpha Vehicle/Alpha_Vehicle.xml
@@ -1,0 +1,432 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Alpha Vehicles - Neolithic</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<!-- Chariot -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_Chariot"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>1</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_Chariot"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>2</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_Chariot"]/components/li[key="LeftWheel"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>1</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_Chariot"]/components/li[key="LeftWheel"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_Chariot"]/components/li[key="RightWheel"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>1</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_Chariot"]/components/li[key="RightWheel"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_Chariot"]/components/li[key="WoodenStructure"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>2</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_Chariot"]/components/li[key="WoodenStructure"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>1</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<!-- Covered Carriage -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_CoveredCarriage"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>3.5</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_CoveredCarriage"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>1.65</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_CoveredCarriage"]/components/li[key="FrontLeftWheel"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>1</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_CoveredCarriage"]/components/li[key="FrontLeftWheel"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_CoveredCarriage"]/components/li[key="BackLeftWheel"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>1</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_CoveredCarriage"]/components/li[key="BackLeftWheel"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_CoveredCarriage"]/components/li[key="FrontRightWheel"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>1</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_CoveredCarriage"]/components/li[key="FrontRightWheel"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_CoveredCarriage"]/components/li[key="BackRightWheel"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>1</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_CoveredCarriage"]/components/li[key="BackRightWheel"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_CoveredCarriage"]/components/li[key="WoodenStructure"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>2</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_CoveredCarriage"]/components/li[key="WoodenStructure"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>1</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<!-- Dog Sled -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_DogSled"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>1</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_DogSled"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_DogSled"]/components/li[key="WoodenStructure"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>1</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_DogSled"]/components/li[key="WoodenStructure"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<!-- Outrigger Canoe -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_OutriggerCanoe"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>1</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_OutriggerCanoe"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_OutriggerCanoe"]/components/li[key="WoodenHull"]</xpath>
+					<value>
+						<armor>
+							<ArmorRating_Blunt>1</ArmorRating_Blunt>
+							<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
+						</armor>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_OutriggerCanoe"]/components/li[key="Outrigger"]</xpath>
+					<value>
+						<armor>
+							<ArmorRating_Blunt>1</ArmorRating_Blunt>
+							<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
+						</armor>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_OutriggerCanoe"]/components/li[key="Sail"]</xpath>
+					<value>
+						<armor>
+							<ArmorRating_Blunt>0.015</ArmorRating_Blunt>
+							<ArmorRating_Sharp>0.01</ArmorRating_Sharp>
+						</armor>
+					</value>
+				</li>
+
+				<!-- Ox Cart -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_OxCart"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>2</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_OxCart"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>1</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_OxCart"]/components/li[key="LeftWheel"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>16</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_OxCart"]/components/li[key="LeftWheel"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>8</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_OxCart"]/components/li[key="RightWheel"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>16</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_OxCart"]/components/li[key="RightWheel"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>8</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_OxCart"]/components/li[key="WoodenStructure"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>2</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_OxCart"]/components/li[key="WoodenStructure"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>1</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<!-- Palanquin -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_Palanquin"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>1</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_Palanquin"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_Palanquin"]/components/li[key="WoodenStructure"]</xpath>
+					<value>
+						<armor>
+							<ArmorRating_Blunt>2</ArmorRating_Blunt>
+							<ArmorRating_Sharp>1</ArmorRating_Sharp>
+						</armor>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_Palanquin"]/components/li[key="Handles"]</xpath>
+					<value>
+						<armor>
+							<ArmorRating_Blunt>8</ArmorRating_Blunt>
+							<ArmorRating_Sharp>4</ArmorRating_Sharp>
+						</armor>
+					</value>
+				</li>
+
+				<!-- Rickshaw -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_Rickshaw"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>1</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_Rickshaw"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_Rickshaw"]/components/li[key="WoodenStructure"]</xpath>
+					<value>
+						<armor>
+							<ArmorRating_Blunt>1</ArmorRating_Blunt>
+							<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
+						</armor>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_Rickshaw"]/components/li[key="LeftWheel"]</xpath>
+					<value>
+						<armor>
+							<ArmorRating_Blunt>4</ArmorRating_Blunt>
+							<ArmorRating_Sharp>2</ArmorRating_Sharp>
+						</armor>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_Rickshaw"]/components/li[key="RightWheel"]</xpath>
+					<value>
+						<armor>
+							<ArmorRating_Blunt>4</ArmorRating_Blunt>
+							<ArmorRating_Sharp>2</ArmorRating_Sharp>
+						</armor>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_Rickshaw"]/components/li[key="Handles"]</xpath>
+					<value>
+						<armor>
+							<ArmorRating_Blunt>8</ArmorRating_Blunt>
+							<ArmorRating_Sharp>4</ArmorRating_Sharp>
+						</armor>
+					</value>
+				</li>
+
+				<!-- Wheel Barrow -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_Wheelbarrow"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>1</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_Wheelbarrow"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_Wheelbarrow"]/components/li[key="WoodenStructure"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>2</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_Wheelbarrow"]/components/li[key="WoodenStructure"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>1</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_Wheelbarrow"]/components/li[key="FrontWheel"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>2</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_Wheelbarrow"]/components/li[key="FrontWheel"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>1</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_Wheelbarrow"]/components/li[key="Handles"]</xpath>
+					<value>
+						<armor>
+							<ArmorRating_Blunt>8</ArmorRating_Blunt>
+							<ArmorRating_Sharp>4</ArmorRating_Sharp>
+						</armor>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Alpha Vehicle/Alpha_Vehicle_Hwacha.xml
+++ b/Patches/Alpha Vehicle/Alpha_Vehicle_Hwacha.xml
@@ -67,8 +67,6 @@
 								<label>Full Barrage</label>
 								<texPath>UI/Gizmos/AV_ArrowBarrage</texPath>
 							</li>
-						</fireModes>
-						<fireModes>
 							<li>
 								<shotsPerBurst>32</shotsPerBurst>
 								<ticksBetweenShots>6</ticksBetweenShots>
@@ -76,8 +74,6 @@
 								<label>Half Barrage</label>
 								<texPath>UI/Gizmos/FireRate_Auto</texPath>
 							</li>
-						</fireModes>
-						<fireModes>
 							<li>
 								<shotsPerBurst>8</shotsPerBurst>
 								<ticksBetweenShots>6</ticksBetweenShots>

--- a/Patches/Alpha Vehicle/Alpha_Vehicle_Hwacha.xml
+++ b/Patches/Alpha Vehicle/Alpha_Vehicle_Hwacha.xml
@@ -1,0 +1,289 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Alpha Vehicles - Neolithic</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<!-- Turret -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="AV_Hwacha_Turret"]/projectile</xpath>
+					<value>
+						<projectile>Projectile_GreatArrow_ExplosiveArrow</projectile>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="AV_Hwacha_Turret"]/reloadTimer</xpath>
+					<value>
+						<reloadTimer>12.0</reloadTimer>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="AV_Hwacha_Turret"]/warmUpTimer</xpath>
+					<value>
+						<warmUpTimer>3.0</warmUpTimer>
+					</value>
+				</li>
+
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="AV_Hwacha_Turret"]/chargePerAmmoCount</xpath>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="AV_Hwacha_Turret"]/genericAmmo</xpath>
+					<value>
+						<genericAmmo>false</genericAmmo>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="AV_Hwacha_Turret"]/magazineCapacity</xpath>
+					<value>
+						<magazineCapacity>35</magazineCapacity>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="AV_Hwacha_Turret"]/maxRange</xpath>
+					<value>
+						<maxRange>20</maxRange>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="AV_Hwacha_Turret"]/fireModes</xpath>
+					<value>
+						<fireModes>
+							<li>
+								<shotsPerBurst>35</shotsPerBurst>
+								<ticksBetweenShots>6</ticksBetweenShots>
+								<ticksBetweenBursts>15</ticksBetweenBursts>
+								<label>Rocket Barrage</label>
+								<texPath>UI/Gizmos/FireRate_Auto</texPath>
+							</li>
+						</fireModes>
+						<fireModes>
+							<li>
+								<shotsPerBurst>7</shotsPerBurst>
+								<ticksBetweenShots>6</ticksBetweenShots>
+								<ticksBetweenBursts>15</ticksBetweenBursts>
+								<label>Rocket Burst</label>
+								<texPath>UI/Gizmos/FireRate_Burst</texPath>
+							</li>
+						</fireModes>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="AV_Hwacha_Turret"]/ammunition/thingDefs</xpath>
+					<value>
+						<thingDefs>
+							<li>Ammo_GreatArrow_ExplosiveArrow</li>
+						</thingDefs>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="AV_Hwacha_Turret"]</xpath>
+					<value>
+						<li Class="Vehicles.CETurretDataDefModExtension">
+							<ammoSet>AmmoSet_Hwacha</ammoSet>
+							<shotHeight>2</shotHeight>
+							<speed>30</speed>
+							<sway>10</sway>
+							<spread>0.1</spread>
+							<recoil>30</recoil>
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs</xpath>
+					<value>
+
+						<CombatExtended.AmmoSetDef>
+							<defName>AmmoSet_Hwacha</defName>
+							<label>hwacha arrows</label>
+							<ammoTypes>
+								<!--Ammo_GreatArrow_Flame>Projectile_GreatArrow_Flame</Ammo_GreatArrow_Flame-->
+								<Ammo_GreatArrow_ExplosiveArrow>Projectile_GreatArrow_ExplosiveArrow</Ammo_GreatArrow_ExplosiveArrow>
+							</ammoTypes>
+						</CombatExtended.AmmoSetDef>
+
+						<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoGreatArrowBase">
+							<defName>Ammo_GreatArrow_ExplosiveArrow</defName>
+							<label>hwacha rocket arrow</label>
+							<graphicData>
+								<texPath>Things/Ammo/Neolithic/Arrow/Flame</texPath>
+								<graphicClass>Graphic_StackCount</graphicClass>
+							</graphicData>
+							<statBases>
+								<Mass>0.15</Mass>
+								<MarketValue>1.85</MarketValue>
+							</statBases>
+							<ammoClass>RocketArrow</ammoClass>
+						</ThingDef>
+
+						<ThingDef ParentName="BaseGreatArrowProjectile">
+							<defName>Projectile_GreatArrow_ExplosiveArrow</defName>
+							<label>hwacha rocket arrow</label>
+							<!--thingClass>CombatExtended.ProjectileCE_Explosive</thingClass-->
+							<graphicData>
+								<texPath>Things/Projectiles/AV_ArrowProjectile</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+							</graphicData>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<speed>30</speed>
+								<damageDef>Arrow</damageDef>
+								<damageAmountBase>10</damageAmountBase>
+								<armorPenetrationBlunt>3.18</armorPenetrationBlunt>
+								<armorPenetrationSharp>2</armorPenetrationSharp>
+								<suppressionFactor>3.0</suppressionFactor>
+								<airborneSuppressionFactor>0.42</airborneSuppressionFactor>
+								<dangerFactor>2.0</dangerFactor>
+								<soundExplode>Explosion_Rocket</soundExplode>
+							</projectile>
+							<comps>
+								<li Class="CombatExtended.CompProperties_ExplosiveCE">
+									<damageAmountBase>20</damageAmountBase>
+									<explosiveDamageType>Bomb</explosiveDamageType>
+									<explosiveRadius>0.5</explosiveRadius>
+									<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+								</li>
+							</comps>
+						</ThingDef>
+
+						<RecipeDef ParentName="AmmoRecipeNeolithicBase">
+							<defName>MakeAmmo_GreatArrow_ExplosiveArrow</defName>
+							<label>make hwacha explosive arrows x10</label>
+							<description>Craft 10 hwacha explosive arrows.</description>
+							<jobString>Making hwacha rocket arrows.</jobString>
+							<workAmount>800</workAmount>
+							<ingredients>
+								<li>
+									<filter>
+										<thingDefs>
+											<li>WoodLog</li>
+										</thingDefs>
+									</filter>
+									<count>2</count>
+								</li>
+								<li>
+									<filter>
+										<thingDefs>
+											<li>Steel</li>
+										</thingDefs>
+									</filter>
+									<count>2</count>
+								</li>
+								<li>
+									<filter>
+										<thingDefs>
+											<li>FSX</li>
+										</thingDefs>
+									</filter>
+									<count>1</count>
+								</li>
+								<li>
+									<filter>
+										<thingDefs>
+											<li>Cloth</li>
+										</thingDefs>
+									</filter>
+									<count>1</count>
+								</li>
+							</ingredients>
+							<fixedIngredientFilter>
+								<thingDefs>
+									<li>WoodLog</li>
+									<li>FSX</li>
+									<li>Cloth</li>
+								</thingDefs>
+							</fixedIngredientFilter>
+							<products>
+								<Ammo_GreatArrow_ExplosiveArrow>10</Ammo_GreatArrow_ExplosiveArrow>
+							</products>
+							<researchPrerequisites>
+								<li>CE_Gunpowder</li>
+							</researchPrerequisites>
+						</RecipeDef>
+
+						<CombatExtended.AmmoCategoryDef>
+							<defName>RocketArrow</defName>
+							<label>hwacha rocket arrow</label>
+							<labelShort>hwacha</labelShort>
+							<description>Steel arrowhead with an underslung tube of gunpowder for explosive results.</description>
+							<advanced>true</advanced>
+						</CombatExtended.AmmoCategoryDef>
+
+					</value>
+				</li>
+
+				<!-- Hwacha -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_Hwacha"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>2</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_Hwacha"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>1</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_Hwacha"]/components/li[key="LeftWheel"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>1</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_Hwacha"]/components/li[key="LeftWheel"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_Hwacha"]/components/li[key="RightWheel"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>1</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_Hwacha"]/components/li[key="RightWheel"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_Hwacha"]/components/li[key="WoodenStructure"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>2</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_Hwacha"]/components/li[key="WoodenStructure"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>1</ArmorRating_Sharp>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Alpha Vehicle/Alpha_Vehicle_Hwacha.xml
+++ b/Patches/Alpha Vehicle/Alpha_Vehicle_Hwacha.xml
@@ -45,7 +45,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleTurretDef[defName="AV_Hwacha_Turret"]/magazineCapacity</xpath>
 					<value>
-						<magazineCapacity>35</magazineCapacity>
+						<magazineCapacity>64</magazineCapacity>
 					</value>
 				</li>
 
@@ -61,19 +61,28 @@
 					<value>
 						<fireModes>
 							<li>
-								<shotsPerBurst>35</shotsPerBurst>
+								<shotsPerBurst>64</shotsPerBurst>
 								<ticksBetweenShots>6</ticksBetweenShots>
 								<ticksBetweenBursts>15</ticksBetweenBursts>
-								<label>Rocket Barrage</label>
+								<label>Full Barrage</label>
+								<texPath>UI/Gizmos/AV_ArrowBarrage</texPath>
+							</li>
+						</fireModes>
+						<fireModes>
+							<li>
+								<shotsPerBurst>32</shotsPerBurst>
+								<ticksBetweenShots>6</ticksBetweenShots>
+								<ticksBetweenBursts>15</ticksBetweenBursts>
+								<label>Half Barrage</label>
 								<texPath>UI/Gizmos/FireRate_Auto</texPath>
 							</li>
 						</fireModes>
 						<fireModes>
 							<li>
-								<shotsPerBurst>7</shotsPerBurst>
+								<shotsPerBurst>8</shotsPerBurst>
 								<ticksBetweenShots>6</ticksBetweenShots>
 								<ticksBetweenBursts>15</ticksBetweenBursts>
-								<label>Rocket Burst</label>
+								<label>Burst</label>
 								<texPath>UI/Gizmos/FireRate_Burst</texPath>
 							</li>
 						</fireModes>
@@ -94,7 +103,7 @@
 					<value>
 						<li Class="Vehicles.CETurretDataDefModExtension">
 							<ammoSet>AmmoSet_Hwacha</ammoSet>
-							<shotHeight>2</shotHeight>
+							<shotHeight>2.1</shotHeight>
 							<speed>30</speed>
 							<sway>10</sway>
 							<spread>0.1</spread>
@@ -124,8 +133,8 @@
 								<graphicClass>Graphic_StackCount</graphicClass>
 							</graphicData>
 							<statBases>
-								<Mass>0.15</Mass>
-								<MarketValue>1.85</MarketValue>
+								<Mass>0.05</Mass>
+								<MarketValue>1.16</MarketValue>
 							</statBases>
 							<ammoClass>RocketArrow</ammoClass>
 						</ThingDef>
@@ -172,7 +181,7 @@
 											<li>WoodLog</li>
 										</thingDefs>
 									</filter>
-									<count>2</count>
+									<count>1</count>
 								</li>
 								<li>
 									<filter>
@@ -202,6 +211,7 @@
 							<fixedIngredientFilter>
 								<thingDefs>
 									<li>WoodLog</li>
+									<li>Steel</li>
 									<li>FSX</li>
 									<li>Cloth</li>
 								</thingDefs>

--- a/Patches/Alpha Vehicle/Alpha_Vehicle_WarChariot.xml
+++ b/Patches/Alpha Vehicle/Alpha_Vehicle_WarChariot.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Alpha Vehicles - Neolithic</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+			
+				<!-- Turret -->
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="AV_WarChariot_Turret"]/projectile</xpath>
+					<value>
+						<projectile>Projectile_GreatArrow_Stone</projectile>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="AV_WarChariot_Turret"]/reloadTimer</xpath>
+					<value>
+						<reloadTimer>1.6</reloadTimer>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="AV_WarChariot_Turret"]/warmUpTimer</xpath>
+					<value>
+						<warmUpTimer>1.3</warmUpTimer>
+					</value>
+				</li>
+
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="AV_WarChariot_Turret"]/chargePerAmmoCount</xpath>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="AV_WarChariot_Turret"]/genericAmmo</xpath>
+					<value>
+						<genericAmmo>false</genericAmmo>
+					</value>
+				</li>
+
+				<!--li Class="PatchOperationReplace">
+						<xpath>Defs/Vehicles.VehicleTurretDef[defName="AV_WarChariot"]/magazineCapacity</xpath>
+						<value>
+							<magazineCapacity>35</magazineCapacity>
+						</value>
+					</li-->
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="AV_WarChariot_Turret"]/maxRange</xpath>
+					<value>
+						<maxRange>30</maxRange>
+					</value>
+				</li>
+
+				<!--li Class="PatchOperationReplace">
+						<xpath>Defs/Vehicles.VehicleTurretDef[defName="AV_WarChariot"]/fireModes</xpath>
+						<value>
+							<fireModes>
+								<li>
+									<shotsPerBurst>1</shotsPerBurst>
+									<ticksBetweenBursts>1</ticksBetweenBursts>
+									<spreadRadius>0</spreadRadius>
+									<label>Single Shot</label>
+									<texPath>UI/Gizmos/FireRate_Single</texPath>
+								</li>
+							</fireModes>
+						</value>
+					</li-->
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="AV_WarChariot_Turret"]/ammunition/thingDefs</xpath>
+					<value>
+						<thingDefs>
+							<li>Ammo_GreatArrow_Stone</li>
+							<li>Ammo_GreatArrow_Steel</li>
+							<li>Ammo_GreatArrow_Plasteel</li>
+							<li>Ammo_GreatArrow_Venom</li>
+							<li>Ammo_GreatArrow_Flame</li>
+						</thingDefs>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="AV_WarChariot_Turret"]</xpath>
+					<value>
+						<li Class="Vehicles.CETurretDataDefModExtension">
+							<ammoSet>AmmoSet_GreatArrow</ammoSet>
+							<shotHeight>2</shotHeight>
+							<speed>30</speed>
+							<sway>2</sway>
+							<spread>1</spread>
+						</li>
+					</value>
+				</li>
+
+				<!-- WarChariot -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_WarChariot"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>1</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_WarChariot"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_WarChariot"]/components/li[key="WoodenStructure"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>2</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_WarChariot"]/components/li[key="WoodenStructure"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>1</ArmorRating_Sharp>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_WarChariot"]/components/li[key="LeftWheel"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>2</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_WarChariot"]/components/li[key="LeftWheel"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>1</ArmorRating_Sharp>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_WarChariot"]/components/li[key="RightWheel"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>2</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="AV_WarChariot"]/components/li[key="RightWheel"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>1</ArmorRating_Sharp>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -77,6 +77,7 @@ Alpha Mechs |
 Alpha Memes |
 Alpha Mythology |
 Alpha Ships |
+Alpha Vehicles - Neolithic  |
 Altered Carbon |
 Ancient Blade Cyborg  |
 Ancient Eastern Armory  |


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Compatibility patch for Alpha Vehicle Neolithic

## Reasoning

Why did you choose to implement things this way, e.g.
- Armor of vehicles based on research of thickness of wood used and the CE stats for wood.
- Hwacha ammo capacity based on amount of total arrows the Vanilla can shoot per reload.
- Rocket arrows based on a 50g blackpowder charge for the explosive. Which should be equal to 21.5g of TNT
- Hwacha spread/sway/recoil to give it the area suppression that was used for historically.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
