### PR TITLE
Vehicle Framework Expanded - Classic Mech

### DIFF
--- a/Patches/Vehicle Framework Expanded - Classic Mech/Mech_BattleCannon.xml
+++ b/Patches/Vehicle Framework Expanded - Classic Mech/Mech_BattleCannon.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+
+	<Operation Class="PatchOperationSequence">
+		<operations>
+
+			<!-- Main Guns -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_BattleCannon"]/projectile</xpath>
+				<value>
+					<projectile>Bullet_120mmCannonShell_HE</projectile>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_BattleCannon"]/reloadTimer</xpath>
+				<value>
+					<reloadTimer>9.6</reloadTimer>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_BattleCannon"]/warmUpTimer</xpath>
+				<value>
+					<warmUpTimer>3</warmUpTimer>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_BattleCannon"]/magazineCapacity</xpath>
+					<value>
+						<magazineCapacity>20</magazineCapacity>
+					</value>
+				</li>
+
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_BattleCannon"]/chargePerAmmoCount</xpath>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_BattleCannon"]/genericAmmo</xpath>
+				<value>
+					<genericAmmo>false</genericAmmo>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_BattleCannon"]/maxRange</xpath>
+				<value>
+					<maxRange>105</maxRange>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+                <xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_BattleCannon"]/ammunition/thingDefs</xpath>
+                <value>
+                    <thingDefs>
+                        <li>Ammo_120mmCannonShell_HEAT</li>
+                        <li>Ammo_120mmCannonShell_HE</li>
+                    </thingDefs>
+                </value>
+            </li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_BattleCannon"]</xpath>
+				<value>
+					<li Class="Vehicles.CETurretDataDefModExtension">
+						<ammoSet>AmmoSet_120mmCannonShell</ammoSet>
+						<shotHeight>5</shotHeight>
+						<speed>229</speed>
+						<sway>0.82</sway>
+						<spread>0.01</spread>
+					</li>
+				</value>
+			</li>
+		</operations>
+	</Operation>
+
+</Patch>		

--- a/Patches/Vehicle Framework Expanded - Classic Mech/Mech_GatlingCannon.xml
+++ b/Patches/Vehicle Framework Expanded - Classic Mech/Mech_GatlingCannon.xml
@@ -96,8 +96,8 @@
 						<ammoSet>AmmoSet_30x173mmNATO</ammoSet>
 						<shotHeight>5</shotHeight>
 						<speed>181</speed>
-						<sway>1</sway>
-						<spread>0.1</spread>
+						<sway>0.9</sway>
+						<spread>0.08</spread>
 					</li>
 				</value>
 			</li>

--- a/Patches/Vehicle Framework Expanded - Classic Mech/Mech_GatlingCannon.xml
+++ b/Patches/Vehicle Framework Expanded - Classic Mech/Mech_GatlingCannon.xml
@@ -30,7 +30,7 @@
 			<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_GatlingCannon"]/magazineCapacity</xpath>
 					<value>
-						<magazineCapacity>80</magazineCapacity>
+						<magazineCapacity>70</magazineCapacity>
 					</value>
 				</li>
 

--- a/Patches/Vehicle Framework Expanded - Classic Mech/Mech_GatlingCannon.xml
+++ b/Patches/Vehicle Framework Expanded - Classic Mech/Mech_GatlingCannon.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+
+	<Operation Class="PatchOperationSequence">
+		<operations>
+
+			<!-- Main Guns -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_GatlingCannon"]/projectile</xpath>
+				<value>
+					<projectile>Bullet_30x173mmNATO_AP</projectile>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_GatlingCannon"]/reloadTimer</xpath>
+				<value>
+					<reloadTimer>7.8</reloadTimer>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_GatlingCannon"]/warmUpTimer</xpath>
+				<value>
+					<warmUpTimer>2.5</warmUpTimer>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_GatlingCannon"]/magazineCapacity</xpath>
+					<value>
+						<magazineCapacity>80</magazineCapacity>
+					</value>
+				</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_GatlingCannon"]/genericAmmo</xpath>
+				<value>
+					<genericAmmo>false</genericAmmo>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_GatlingCannon"]/maxRange</xpath>
+				<value>
+					<maxRange>95</maxRange>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+                <xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_GatlingCannon"]/ammunition/thingDefs</xpath>
+                <value>
+                    <thingDefs>
+                        <li>Ammo_30x173mmNATO_AP</li>
+                        <li>Ammo_30x173mmNATO_Incendiary</li>
+						<li>Ammo_30x173mmNATO_HE</li>
+                        <li>Ammo_30x173mmNATO_Sabot</li>
+                    </thingDefs>
+                </value>
+            </li>
+			
+			<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_GatlingCannon"]/fireModes</xpath>
+					<value>
+						<fireModes>
+							<li>
+								<shotsPerBurst>1</shotsPerBurst>
+								<ticksBetweenShots>6</ticksBetweenShots>
+								<ticksBetweenBursts>60</ticksBetweenBursts>
+								<label>Single</label>
+								<texPath>UI/Gizmos/FireRate_Single</texPath>
+							</li>
+							<li>
+								<shotsPerBurst>4</shotsPerBurst>
+								<ticksBetweenShots>6</ticksBetweenShots>
+								<ticksBetweenBursts>60</ticksBetweenBursts>
+								<label>Burst</label>
+								<texPath>UI/Gizmos/FireRate_Burst</texPath>
+							</li>
+							<li>
+								<shotsPerBurst>8</shotsPerBurst>
+								<ticksBetweenShots>6</ticksBetweenShots>
+								<ticksBetweenBursts>60</ticksBetweenBursts>
+								<label>Auto</label>
+								<texPath>UI/Gizmos/FireRate_Auto</texPath>
+							</li>
+						</fireModes>
+					</value>
+				</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_GatlingCannon"]</xpath>
+				<value>
+					<li Class="Vehicles.CETurretDataDefModExtension">
+						<ammoSet>AmmoSet_30x173mmNATO</ammoSet>
+						<shotHeight>5</shotHeight>
+						<speed>181</speed>
+						<sway>1</sway>
+						<spread>0.1</spread>
+					</li>
+				</value>
+			</li>
+		</operations>
+	</Operation>
+
+</Patch>		

--- a/Patches/Vehicle Framework Expanded - Classic Mech/Mech_MachineGun.xml
+++ b/Patches/Vehicle Framework Expanded - Classic Mech/Mech_MachineGun.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+
+	<Operation Class="PatchOperationSequence">
+		<operations>
+
+			<!-- HMG Sub-->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_MachineGun"]/projectile</xpath>
+				<value>
+					<projectile>Bullet_50BMG_FMJ</projectile>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_MachineGun"]/reloadTimer</xpath>
+				<value>
+					<reloadTimer>3</reloadTimer>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_MachineGun"]/warmUpTimer</xpath>
+				<value>
+					<warmUpTimer>1</warmUpTimer>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_MachineGun"]/magazineCapacity</xpath>
+					<value>
+						<magazineCapacity>200</magazineCapacity>
+					</value>
+				</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_MachineGun"]/genericAmmo</xpath>
+				<value>
+					<genericAmmo>false</genericAmmo>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_MachineGun"]/maxRange</xpath>
+				<value>
+					<maxRange>80</maxRange>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+                <xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_MachineGun"]/ammunition/thingDefs</xpath>
+                <value>
+                    <thingDefs>
+                        <li>Ammo_50BMG_FMJ</li>
+                        <li>Ammo_50BMG_AP</li>
+						<li>Ammo_50BMG_Incendiary</li>
+                        <li>Ammo_50BMG_HE</li>
+						<li>Ammo_50BMG_Sabot</li>
+                    </thingDefs>
+                </value>
+            </li>
+			
+			<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_MachineGun"]/fireModes</xpath>
+					<value>
+						<fireModes>
+							<li>
+								<shotsPerBurst>1</shotsPerBurst>
+								<ticksBetweenShots>6</ticksBetweenShots>
+								<ticksBetweenBursts>60</ticksBetweenBursts>
+								<label>Single</label>
+								<texPath>UI/Gizmos/FireRate_Single</texPath>
+							</li>
+							<li>
+								<shotsPerBurst>5</shotsPerBurst>
+								<ticksBetweenShots>6</ticksBetweenShots>
+								<ticksBetweenBursts>60</ticksBetweenBursts>
+								<label>Burst</label>
+								<texPath>UI/Gizmos/FireRate_Burst</texPath>
+							</li>
+							<li>
+								<shotsPerBurst>10</shotsPerBurst>
+								<ticksBetweenShots>6</ticksBetweenShots>
+								<ticksBetweenBursts>60</ticksBetweenBursts>
+								<label>Auto</label>
+								<texPath>UI/Gizmos/FireRate_Auto</texPath>
+							</li>
+						</fireModes>
+					</value>
+				</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_MachineGun"]</xpath>
+				<value>
+					<li Class="Vehicles.CETurretDataDefModExtension">
+						<ammoSet>AmmoSet_50BMG</ammoSet>
+						<shotHeight>2.5</shotHeight>
+						<speed>163</speed>
+						<sway>1.5</sway>
+						<spread>0.1</spread>
+					</li>
+				</value>
+			</li>
+		</operations>
+	</Operation>
+
+</Patch>		

--- a/Patches/Vehicle Framework Expanded - Classic Mech/Mech_MachineGun.xml
+++ b/Patches/Vehicle Framework Expanded - Classic Mech/Mech_MachineGun.xml
@@ -97,8 +97,8 @@
 						<ammoSet>AmmoSet_50BMG</ammoSet>
 						<shotHeight>2.5</shotHeight>
 						<speed>163</speed>
-						<sway>1.5</sway>
-						<spread>0.1</spread>
+						<sway>0.7</sway>
+						<spread>0.05</spread>
 					</li>
 				</value>
 			</li>

--- a/Patches/Vehicle Framework Expanded - Classic Mech/Mech_MachineGun.xml
+++ b/Patches/Vehicle Framework Expanded - Classic Mech/Mech_MachineGun.xml
@@ -30,7 +30,7 @@
 			<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_MachineGun"]/magazineCapacity</xpath>
 					<value>
-						<magazineCapacity>200</magazineCapacity>
+						<magazineCapacity>100</magazineCapacity>
 					</value>
 				</li>
 

--- a/Patches/Vehicle Framework Expanded - Classic Mech/Mech_MissileLauncher.xml
+++ b/Patches/Vehicle Framework Expanded - Classic Mech/Mech_MissileLauncher.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+
+	<Operation Class="PatchOperationSequence">
+		<operations>
+
+			<!-- Missile Launcher -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_MissileLauncher"]/projectile</xpath>
+				<value>
+					<projectile>Bullet_83mmSMAW_HEAT</projectile>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_MissileLauncher"]/reloadTimer</xpath>
+				<value>
+					<reloadTimer>18.6</reloadTimer>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_MissileLauncher"]/warmUpTimer</xpath>
+				<value>
+					<warmUpTimer>3</warmUpTimer>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_MissileLauncher"]/magazineCapacity</xpath>
+					<value>
+						<magazineCapacity>16</magazineCapacity>
+					</value>
+				</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_MissileLauncher"]/genericAmmo</xpath>
+				<value>
+					<genericAmmo>false</genericAmmo>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_MissileLauncher"]/chargePerAmmoCount</xpath>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_MissileLauncher"]/maxRange</xpath>
+				<value>
+					<maxRange>75</maxRange>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+                <xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_MissileLauncher"]/ammunition/thingDefs</xpath>
+                <value>
+                    <thingDefs>
+                        <li>Ammo_83mmSMAW_HEAT</li>
+                        <li>Ammo_83mmSMAW_HE</li>
+						<li>Ammo_83mmSMAW_Thermobaric</li>
+                    </thingDefs>
+                </value>
+            </li>
+			
+			<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_MissileLauncher"]/fireModes</xpath>
+					<value>
+						<fireModes>
+							<li>
+								<shotsPerBurst>1</shotsPerBurst>
+								<ticksBetweenShots>6</ticksBetweenShots>
+								<ticksBetweenBursts>60</ticksBetweenBursts>
+								<label>Single</label>
+								<texPath>UI/Gizmos/FireRate_Single</texPath>
+							</li>
+							<li>
+								<shotsPerBurst>4</shotsPerBurst>
+								<ticksBetweenShots>12</ticksBetweenShots>
+								<ticksBetweenBursts>120</ticksBetweenBursts>
+								<label>Burst</label>
+								<texPath>UI/Gizmos/FireRate_Burst</texPath>
+							</li>
+						</fireModes>
+					</value>
+				</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_MissileLauncher"]</xpath>
+				<value>
+					<li Class="Vehicles.CETurretDataDefModExtension">
+						<ammoSet>AmmoSet_83mmSMAW</ammoSet>
+						<shotHeight>3</shotHeight>
+						<speed>58</speed>
+						<sway>0.9</sway>
+						<spread>0.1</spread>
+					</li>
+				</value>
+			</li>
+		</operations>
+	</Operation>
+
+</Patch>		

--- a/Patches/Vehicle Framework Expanded - Classic Mech/Mech_MissileLauncher.xml
+++ b/Patches/Vehicle Framework Expanded - Classic Mech/Mech_MissileLauncher.xml
@@ -92,8 +92,8 @@
 						<ammoSet>AmmoSet_83mmSMAW</ammoSet>
 						<shotHeight>3</shotHeight>
 						<speed>58</speed>
-						<sway>0.9</sway>
-						<spread>0.1</spread>
+						<sway>0.82</sway>
+						<spread>0.03</spread>
 					</li>
 				</value>
 			</li>

--- a/Patches/Vehicle Framework Expanded - Classic Mech/Mech_VehiclePawn.xml
+++ b/Patches/Vehicle Framework Expanded - Classic Mech/Mech_VehiclePawn.xml
@@ -21,7 +21,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/Vehicles.VehicleDef[@Name="HighMacsBase"]/vehicleStats/CargoCapacity</xpath>
 				<value>
-					<CargoCapacity>4000</CargoCapacity>
+					<CargoCapacity>3250</CargoCapacity>
 				</value>
 			</li>
 

--- a/Patches/Vehicle Framework Expanded - Classic Mech/Mech_VehiclePawn.xml
+++ b/Patches/Vehicle Framework Expanded - Classic Mech/Mech_VehiclePawn.xml
@@ -21,7 +21,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/Vehicles.VehicleDef[@Name="HighMacsBase"]/vehicleStats/CargoCapacity</xpath>
 				<value>
-					<CargoCapacity>3250</CargoCapacity>
+					<CargoCapacity>2900</CargoCapacity>
 				</value>
 			</li>
 

--- a/Patches/Vehicle Framework Expanded - Classic Mech/Mech_VehiclePawn.xml
+++ b/Patches/Vehicle Framework Expanded - Classic Mech/Mech_VehiclePawn.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+
+	<Operation Class="PatchOperationSequence">
+		<operations>
+
+			<!-- Main Vehicle -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/Vehicles.VehicleDef[@Name="HighMacsBase"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>20</ArmorRating_Blunt>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/Vehicles.VehicleDef[@Name="HighMacsBase"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>10</ArmorRating_Sharp>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/Vehicles.VehicleDef[@Name="HighMacsBase"]/vehicleStats/CargoCapacity</xpath>
+				<value>
+					<CargoCapacity>4000</CargoCapacity>
+				</value>
+			</li>
+
+			<!-- Front Armor -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/Vehicles.VehicleDef[@Name="HighMacsBase"]/components/li [key="FrontArmor"]/health</xpath>
+				<value>
+					<health>200</health>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[@Name="HighMacsBase"]/components/li [key="FrontArmor"]/armor</xpath>
+					<value>
+						<armor>
+							<ArmorRating_Blunt>80</ArmorRating_Blunt>
+							<ArmorRating_Sharp>40</ArmorRating_Sharp>
+						</armor>
+					</value>
+				</li>
+				
+			<!-- Left Armor -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/Vehicles.VehicleDef[@Name="HighMacsBase"]/components/li [key="LeftArmor"]/health</xpath>
+				<value>
+					<health>200</health>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[@Name="HighMacsBase"]/components/li [key="LeftArmor"]/armor</xpath>
+					<value>
+						<armor>
+							<ArmorRating_Blunt>64</ArmorRating_Blunt>
+							<ArmorRating_Sharp>32</ArmorRating_Sharp>
+						</armor>
+					</value>
+				</li>
+				
+			<!-- Right Armor -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/Vehicles.VehicleDef[@Name="HighMacsBase"]/components/li [key="RightArmor"]/health</xpath>
+				<value>
+					<health>200</health>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[@Name="HighMacsBase"]/components/li [key="RightArmor"]/armor</xpath>
+					<value>
+						<armor>
+							<ArmorRating_Blunt>64</ArmorRating_Blunt>
+							<ArmorRating_Sharp>32</ArmorRating_Sharp>
+						</armor>
+					</value>
+				</li>
+
+			<!-- Back Armor -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/Vehicles.VehicleDef[@Name="HighMacsBase"]/components/li [key="BackArmor"]/health</xpath>
+				<value>
+					<health>200</health>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[@Name="HighMacsBase"]/components/li [key="BackArmor"]/armor</xpath>
+					<value>
+						<armor>
+							<ArmorRating_Blunt>64</ArmorRating_Blunt>
+							<ArmorRating_Sharp>32</ArmorRating_Sharp>
+						</armor>
+					</value>
+				</li>
+			
+			<!-- Leg Armor -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/Vehicles.VehicleDef[@Name="HighMacsBase"]/components/li[key="FrontLeftLeg" or key="FrontRightLeg"]/health</xpath>
+				<value>
+					<health>150</health>
+				</value>
+			</li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/Vehicles.VehicleDef[@Name="HighMacsBase"]/components/li[key="FrontLeftLeg" or key="FrontRightLeg"]</xpath>
+				<value>
+					<armor>
+						<ArmorRating_Sharp>15</ArmorRating_Sharp>
+						<ArmorRating_Blunt>12</ArmorRating_Blunt>
+					</armor>
+				</value>
+			</li>
+		</operations>
+	</Operation>
+
+</Patch>		

--- a/Patches/Vehicle Framework Expanded - Classic Mech/Mech_VehiclePawn.xml
+++ b/Patches/Vehicle Framework Expanded - Classic Mech/Mech_VehiclePawn.xml
@@ -63,7 +63,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/Vehicles.VehicleDef[@Name="HighMacsBase"]/components/li [key="RightArmor"]/health</xpath>
 				<value>
-					<health>200</health>
+					<health>150</health>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -80,19 +80,19 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/Vehicles.VehicleDef[@Name="HighMacsBase"]/components/li [key="BackArmor"]/health</xpath>
 				<value>
-					<health>200</health>
+					<health>150</health>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleDef[@Name="HighMacsBase"]/components/li [key="BackArmor"]/armor</xpath>
 					<value>
 						<armor>
-							<ArmorRating_Blunt>64</ArmorRating_Blunt>
-							<ArmorRating_Sharp>32</ArmorRating_Sharp>
+							<ArmorRating_Blunt>52</ArmorRating_Blunt>
+							<ArmorRating_Sharp>24</ArmorRating_Sharp>
 						</armor>
 					</value>
 				</li>
-			
+
 			<!-- Leg Armor -->
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/Vehicles.VehicleDef[@Name="HighMacsBase"]/components/li[key="FrontLeftLeg" or key="FrontRightLeg"]/health</xpath>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -521,6 +521,7 @@ Vanilla Weapons Expanded - Tribal	|
 Vanilla Storytellers Expanded - Perry Persistent |
 Vanilla Storytellers Expanded - Winston Waves |
 Vanilla XCOM Weapons  |
+Vehicle Framework Expanded - Classic Mech  |
 VFE - Mechanoids : Drones |
 VFE - Mechanoids : Unoffical Add-On |
 VGP Fabrics |


### PR DESCRIPTION
## Additions

- Ammo for MACS weapons
- Armor values for armor plating & legs

## Changes

- Cargo Capacity buffed to 2900

## References

N/A

## Reasoning

- Ammo sets were as close as the description/origin mod referenced, couldn't find anything on the rockets used, so went with 83mm.
- Armor values mimic AOBA's mobile worker as I thought it'd be a good baseline for mechs that only require one operator, plus with the fire power both models sport, having it have too much armor could be a problem. 
- Cargo capacity was buffed to allow for what I would think would be a standard loadout for an arguable T4-T5 vehicle, as the mechs from Gungriffon are similar to Armored Core and Gundam mechas imo. 400 .50 cal rounds (4x100 mags), 48 83mmSMAW rockets (3x16 mags), 100 30x173 (5x20 mags) would be something realistic the mech would be able to bring into battle. The total weight of that loadout comes to about 2579.6 of mass out of 2900, allowing for someone to pack extra ammo/gear for an assault. Very expensive to keep constantly outfitted.

## Performance in Combat
- Very strong, as expected of a giant mecha. Can absolutely tear into pawns that are ill-equipped to fight it. Very strong at range, much more susceptible if pawns are able to enclose it and use weapons that can set the mech on fire/punch through the armor and hit the internal parts.

## Alternatives

- Lowering the mag capacities/cargo capacity for Rimworld balance, but I wanted this as a baseline considering how advanced the mech is. Whenever Warwalkers/more mech mods get released, might revisit this and make changes as needed.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (30 days, multiple raids against mechanoids/regular pawns)
