### PR TITLE
Updates to CheckForCollisionBetween and BlockerRegistry

### DIFF
--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -884,6 +884,31 @@ namespace CombatExtended
         }
 
         /// <summary>
+        /// Calculates whether a line segment intercepts a radius circle. Used to determine if a projectile crosses a shield.
+        /// </summary>
+        /// <param name="center">The center of the circle</param>
+        /// <param name="radius">The radius of the circle</param>
+        /// <param name="pointA">The first point of the line segment</param>
+        /// <param name="pointB">The second point of the line segment</param>
+        /// <returns>True if the line segment intercepts the circle</returns>
+        public static bool IntersectLineSphericalOutline(Vector3 center, float radius, Vector3 pointA, Vector3 pointB)
+        {
+            var pointAInShield = (center - pointA).sqrMagnitude <= Mathf.Pow(radius, 2);
+            var pointBInShield = (center - pointB).sqrMagnitude <= Mathf.Pow(radius, 2);
+
+            if (pointAInShield && pointBInShield)
+            {
+                return false;
+            }
+            if (!pointAInShield && !pointBInShield)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
         /// Calculates body scale factors based on body type
         /// </summary>
         /// <param name="pawn">Which pawn to measure for</param>

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -893,19 +893,14 @@ namespace CombatExtended
         /// <returns>True if the line segment intercepts the circle</returns>
         public static bool IntersectLineSphericalOutline(Vector3 center, float radius, Vector3 pointA, Vector3 pointB)
         {
-            var pointAInShield = (center - pointA).sqrMagnitude <= Mathf.Pow(radius, 2);
-            var pointBInShield = (center - pointB).sqrMagnitude <= Mathf.Pow(radius, 2);
-
-            if (pointAInShield && pointBInShield)
-            {
-                return false;
-            }
-            if (!pointAInShield && !pointBInShield)
-            {
-                return false;
-            }
-
-            return true;
+	    Vector3 displacement = pointB - pointA;
+	    double a = displacement.sqrMagnitude;
+	    double b = 2 * (displacement.x * (pointA.x - center.x) + displacement.y * (pointA.y - center.y) + displacement.z * (pointA.z - center.z));
+            double c = (center - pointA).sqrMagnitude - radius * radius;
+            double det = b * b - 4 * a * c;
+	    return det >= 0;
+//	    var radSq = radius * radius;
+//	    return ((center - pointA).sqrMagnitude > radSq) != ((center - pointB).sqrMagnitude > radSq);
         }
 
         /// <summary>

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -761,9 +761,22 @@ namespace CombatExtended
             {
                 if (CheckIntercept(list[i], list[i].TryGetComp<CompProjectileInterceptor>()))
                 {
-                    this.Destroy(DestroyMode.Vanish);
+                    this.Impact(null);
                     return true;
                 }
+            }
+            (bool intercepted, bool destroyed) = BlockerRegistry.CheckForCollisionBetweenCallback(this, LastPos, ExactPosition);
+            if (intercepted)
+            {
+                if (destroyed)
+                {
+                    this.Destroy(DestroyMode.Vanish);
+                }
+                else
+                {
+                    this.Impact(null);
+                }
+                return true;
             }
 
             #region Sanity checks

--- a/Source/CombatExtended/Compatibility/BlockerRegistry.cs
+++ b/Source/CombatExtended/Compatibility/BlockerRegistry.cs
@@ -12,19 +12,19 @@ namespace CombatExtended.Compatibility
     public static class BlockerRegistry
     {
         private static bool enabled = false;
-        private static List<Func<ProjectileCE, Vector3, Vector3, (bool, bool)>> checkForCollisionBetweenCallbacks;
+        private static List<Func<ProjectileCE, Vector3, Vector3, bool>> checkForCollisionBetweenCallbacks;
         private static List<Func<ProjectileCE, IntVec3, Thing, bool>> checkCellForCollisionCallbacks;
         private static List<Func<ProjectileCE, Thing, bool>> impactSomethingCallbacks;
 
         private static void Enable()
         {
             enabled = true;
-            checkForCollisionBetweenCallbacks = new List<Func<ProjectileCE, Vector3, Vector3, (bool, bool)>>();
+            checkForCollisionBetweenCallbacks = new List<Func<ProjectileCE, Vector3, Vector3, bool>>();
             impactSomethingCallbacks = new List<Func<ProjectileCE, Thing, bool>>();
             checkCellForCollisionCallbacks = new List<Func<ProjectileCE, IntVec3, Thing, bool>>();
         }
 
-        public static void RegisterCheckForCollisionBetweenCallback(Func<ProjectileCE, Vector3, Vector3, (bool, bool)> f)
+        public static void RegisterCheckForCollisionBetweenCallback(Func<ProjectileCE, Vector3, Vector3, bool> f)
         {
             if (!enabled)
             {
@@ -51,21 +51,20 @@ namespace CombatExtended.Compatibility
             impactSomethingCallbacks.Add(f);
         }
 
-        public static (bool, bool) CheckForCollisionBetweenCallback(ProjectileCE projectile, Vector3 from, Vector3 to)
+        public static bool CheckForCollisionBetweenCallback(ProjectileCE projectile, Vector3 from, Vector3 to)
         {
             if (!enabled)
             {
-                return (false, false);
+                return false;
             }
             foreach (var cb in checkForCollisionBetweenCallbacks)
             {
-                (bool intercepted, bool destroyed) = cb(projectile, from, to);
-                if (intercepted)
+                if (cb(projectile, from, to))
                 {
-                    return (intercepted, destroyed);
+                    return true;
                 }
             }
-            return (false, false);
+            return false;
         }
 
         public static bool CheckCellForCollisionCallback(ProjectileCE projectile, IntVec3 cell, Thing launcher)

--- a/Source/CombatExtended/Compatibility/EDShields.cs
+++ b/Source/CombatExtended/Compatibility/EDShields.cs
@@ -33,7 +33,7 @@ namespace CombatExtended.Compatibility
         }
         public void Install()
         {
-            BlockerRegistry.RegisterCheckForCollisionCallback(EDShields.CheckForCollisionCallback);
+            BlockerRegistry.RegisterCheckForCollisionBetweenCallback(EDShields.CheckForCollisionBetweenCallback);
             BlockerRegistry.RegisterImpactSomethingCallback(EDShields.ImpactSomethingCallback);
             Type t = Type.GetType("Jaxxa.EnhancedDevelopment.Shields.Shields.ShieldManagerMapComp, ED-Shields");
             HitSoundDef = (SoundDef)t.GetField("HitSoundDef", BindingFlags.Static | BindingFlags.Public).GetValue(null);
@@ -42,10 +42,14 @@ namespace CombatExtended.Compatibility
         {
             yield break;
         }
-        public static bool CheckForCollisionCallback(ProjectileCE projectile, IntVec3 cell, Thing launcher)
+        public static bool CheckForCollisionBetweenCallback(ProjectileCE projectile, Vector3 from, Vector3 to)
         {
-            /* Check if an active shield can block this projectile, we don't check if the projectile flies overhead, as those projectiles don't call this function
+            /* Check if an active shield can block this projectile
              */
+	    if (projectile.def.projectile.flyOverhead) {
+		return false;
+	    }
+	    Thing launcher = projectile.launcher;
             Map map = projectile.Map;
             Vector3 exactPosition = projectile.ExactPosition;
             IntVec3 origin = projectile.OriginIV3;
@@ -66,33 +70,28 @@ namespace CombatExtended.Compatibility
                     continue;
                 }
                 int fieldRadius = (int)generator.FieldRadius_Active();
+		Vector3 shieldPosition2D = new Vector3(shield.Position.x, 0, shield.Position.z);
+
+		if (!CE_Utility.IntersectLineSphericalOutline(shieldPosition2D, fieldRadius, from, to))
+		{
+		    continue;
+		}
+
                 int fieldRadiusSq = fieldRadius * fieldRadius;
-                float DistanceSq = projectile.Position.DistanceToSquared(shield.Position) - fieldRadiusSq;
-                float originDistanceSq = origin.DistanceToSquared(shield.Position) - fieldRadiusSq;
-                if (DistanceSq > 0)
-                {
-                    continue;
-                }
-                if (originDistanceSq < 0)
-                {
-                    continue;
-                }
-                Vector3 shieldPosition2D = new Vector3(shield.Position.x, 0, shield.Position.z);
+
                 Quaternion targetAngle = projectile.ExactRotation;
                 Quaternion shieldProjAng = Quaternion.LookRotation(exactPosition - shieldPosition2D);
                 if ((Quaternion.Angle(targetAngle, shieldProjAng) > 90))
                 {
-
                     HitSoundDef.PlayOneShot((SoundInfo)new TargetInfo(shield.Position, map, false));
-
 
                     int damage = (projectile.def.projectile.GetDamageAmount(launcher));
 
                     generator.FieldIntegrity_Current -= damage;
 
-                    exactPosition = BlockerRegistry.GetExactPosition(origin.ToVector3(), projectile.ExactPosition, shield.Position.ToVector3(), (fieldRadius - 1) * (fieldRadius - 1));
+                    exactPosition = BlockerRegistry.GetExactPosition(from, to, shieldPosition2D, (fieldRadius - 1) * (fieldRadius - 1));
                     FleckMakerCE.ThrowLightningGlow(exactPosition, map, 0.5f);
-                    projectile.ExactPosition = exactPosition;
+		    projectile.InterceptProjectile(shield, exactPosition, false);
                     return true;
                 }
             }
@@ -133,6 +132,7 @@ namespace CombatExtended.Compatibility
                 FleckMakerCE.ThrowLightningGlow(destination, map, 0.5f);
                 int damage = (projectile.def.projectile.GetDamageAmount(launcher));
                 generator.FieldIntegrity_Current -= damage;
+		projectile.InterceptProjectile(shield, projectile.ExactPosition, true);
                 return true;
             }
             return false;

--- a/Source/CombatExtended/Compatibility/Rimatomics.cs
+++ b/Source/CombatExtended/Compatibility/Rimatomics.cs
@@ -103,7 +103,7 @@ namespace CombatExtended.Compatibility
                     }
 
 
-
+		    projectile.InterceptProjectile(shield, exactPosition, true);
 
                     return true;
                 }
@@ -148,6 +148,7 @@ namespace CombatExtended.Compatibility
                     DamageInfo dinfo = new DamageInfo(projectile.def.projectile.damageDef, (float)damage, 0f, -1f, null, null, null, 0, null, true, true);
                     shield.BreakShield(dinfo);
                 }
+		projectile.InterceptProjectile(shield, projectile.ExactPosition, true);
                 return true;
             }
             return false;

--- a/Source/CombatExtended/Compatibility/VanillaFurnitureExpandedSecurity.cs
+++ b/Source/CombatExtended/Compatibility/VanillaFurnitureExpandedSecurity.cs
@@ -70,15 +70,16 @@ namespace CombatExtended.Compatibility
                     continue;
                 }
 
-                projectile.ExactPosition = BlockerRegistry.GetExactPosition(projectile.OriginIV3.ToVector3(),
-                                           exactPosition,
-                                           new Vector3(shield.Position.x, 0, shield.Position.z),
-                                           shield.ShieldRadius * shield.ShieldRadius);
+		exactPosition = BlockerRegistry.GetExactPosition(projectile.OriginIV3.ToVector3(),
+								     exactPosition,
+								     new Vector3(shield.Position.x, 0, shield.Position.z),
+								     shield.ShieldRadius * shield.ShieldRadius);
 
                 if (!(projectile is ProjectileCE_Explosive))
                 {
                     shield.AbsorbDamage(projectile.def.projectile.GetDamageAmount(launcher), projectile.def.projectile.damageDef, projectile.ExactRotation.eulerAngles.y);
                 }
+		projectile.InterceptProjectile(shield, exactPosition, true);
                 return true;
 
             }
@@ -92,9 +93,15 @@ namespace CombatExtended.Compatibility
 
             refreshShields(map);
 
-            var blocked = shields.Any(building => ShieldInterceptsProjectile(building as Building_Shield, projectile, launcher));
-            CELogger.Message($"Blocked {projectile}? -- {blocked}");
-            return blocked;
+	    foreach (var building in shields)
+	    {
+		if (building is Building_Shield bs && ShieldInterceptsProjectile(bs, projectile, launcher))
+		{
+		    projectile.InterceptProjectile(bs, exactPosition, true);
+		    return true;
+		}
+	    }
+	    return false;
         }
 
         private static bool ShieldInterceptsProjectile(Building building, ProjectileCE projectile, Thing launcher)


### PR DESCRIPTION
CheckForCollisionBetween is now consistent with RimWorld 1.4, which causes explosive projectiles to detonate against shields instead of vanishing.

BlockerRegistry has been updated with a proper hook for adding vanilla-style projectile interceptors, including the option to choose whether projectiles should impact or vanish.
