### PR TITLE
Fix Typo in ESCP - Spriggans Patch

### DIFF
--- a/Patches/ESCP - Spriggans/ESCP_Spriggan_Scenario.xml
+++ b/Patches/ESCP - Spriggans/ESCP_Spriggan_Scenario.xml
@@ -3,7 +3,7 @@
 
 	<Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>Combat Extended</li>
+			<li>ESCP - Spriggan</li>
 		</mods>
 
 		<match Class="PatchOperationSequence">


### PR DESCRIPTION
## Changes
- Fix a copy-paste error that pointed the FindMod at CE instead of the actual mod.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
