### PR TITLE
Buffs fragmentation

### DIFF
--- a/Defs/Ammo/Projectiles_Fragments.xml
+++ b/Defs/Ammo/Projectiles_Fragments.xml
@@ -11,7 +11,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Fragment</damageDef>
 			<damageAmountBase>53</damageAmountBase>
-			<speed>60</speed>
+			<speed>217</speed>
 			<armorPenetrationSharp>4.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>422.5</armorPenetrationBlunt>
 			<gravityFactor>5</gravityFactor>
@@ -28,7 +28,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Fragment</damageDef>
 			<damageAmountBase>18</damageAmountBase>
-			<speed>50</speed>
+			<speed>201</speed>
 			<armorPenetrationSharp>3</armorPenetrationSharp>
 			<armorPenetrationBlunt>30.4</armorPenetrationBlunt>
 			<gravityFactor>5</gravityFactor>

--- a/Defs/Ammo/Projectiles_Fragments.xml
+++ b/Defs/Ammo/Projectiles_Fragments.xml
@@ -10,10 +10,10 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Fragment</damageDef>
-			<damageAmountBase>69</damageAmountBase>
+			<damageAmountBase>53</damageAmountBase>
 			<speed>60</speed>
-			<armorPenetrationSharp>2</armorPenetrationSharp>
-			<armorPenetrationBlunt>757.12</armorPenetrationBlunt>
+			<armorPenetrationSharp>4.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>422.5</armorPenetrationBlunt>
 			<gravityFactor>5</gravityFactor>
 		</projectile>
 	</ThingDef>
@@ -45,9 +45,9 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Fragment</damageDef>
 			<damageAmountBase>17</damageAmountBase>
-			<speed>40</speed>
-			<armorPenetrationSharp>1</armorPenetrationSharp>
-			<armorPenetrationBlunt>54.08</armorPenetrationBlunt>
+			<speed>184</speed>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationBlunt>43.26</armorPenetrationBlunt>
 			<gravityFactor>5</gravityFactor>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Projectiles_Fragments.xml
+++ b/Defs/Ammo/Projectiles_Fragments.xml
@@ -10,10 +10,10 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Fragment</damageDef>
-			<damageAmountBase>27</damageAmountBase>
+			<damageAmountBase>69</damageAmountBase>
 			<speed>60</speed>
-			<armorPenetrationSharp>4.5</armorPenetrationSharp>
-			<armorPenetrationBlunt>62.5</armorPenetrationBlunt>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationBlunt>757.12</armorPenetrationBlunt>
 			<gravityFactor>5</gravityFactor>
 		</projectile>
 	</ThingDef>
@@ -44,10 +44,10 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Fragment</damageDef>
-			<damageAmountBase>9</damageAmountBase>
+			<damageAmountBase>17</damageAmountBase>
 			<speed>40</speed>
-			<armorPenetrationSharp>2</armorPenetrationSharp>
-			<armorPenetrationBlunt>6.4</armorPenetrationBlunt>
+			<armorPenetrationSharp>1</armorPenetrationSharp>
+			<armorPenetrationBlunt>54.08</armorPenetrationBlunt>
 			<gravityFactor>5</gravityFactor>
 		</projectile>
 	</ThingDef>


### PR DESCRIPTION
## Changes

small fragments velocity increased to 1040m/s
medium fragments velocity increased to 1170m/s
large fragments velocity increased to 1300m/s

## Reasoning

explosives do extremely underwhelming damage. the fact that explosive fragmentation is assumed to travel about as fast as a pistol bullet probably has something to do with it.
the old velocities were 400, 450, and 500 respectively. i assumed the steel BBs from the claymore in the video would be equivalent to small fragments, and then applied the same proportional velocity increase to the other fragments
[source](https://youtu.be/AkC7vNrgs6M?si=Lf664N5lnvhqd2A-&t=554)

## Alternatives

- use fractions of detonation velocity for comp-b as projectile velocity
  - values far too high
  - also innacurate

## Testing

i just changed some integer values
