### PR TITLE
Add calibre info to ammosetdef

### DIFF
--- a/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier1/Bunsen.xml
+++ b/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier1/Bunsen.xml
@@ -1,267 +1,267 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 
-  <Operation Class="PatchOperationFindMod">
-    <mods>
-      <li>Vanilla Vehicles Expanded</li>
-    </mods>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Vehicles Expanded</li>
+		</mods>
 
-    <match Class="PatchOperationSequence">
-      <operations>
+		<match Class="PatchOperationSequence">
+			<operations>
 
-        <!-- Turret -->
+				<!-- Turret -->
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/projectile</xpath>
-          <value>
-            <projectile>Bullet_Flamethrower_Prometheum</projectile>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/projectile</xpath>
+					<value>
+						<projectile>Bullet_Flamethrower_Prometheum</projectile>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/reloadTimer</xpath>
-          <value>
-            <reloadTimer>7.0</reloadTimer>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/reloadTimer</xpath>
+					<value>
+						<reloadTimer>7.0</reloadTimer>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/warmUpTimer</xpath>
-          <value>
-            <warmUpTimer>1.0</warmUpTimer>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/warmUpTimer</xpath>
+					<value>
+						<warmUpTimer>1.0</warmUpTimer>
+					</value>
+				</li>
 
-        <li Class="PatchOperationRemove">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/chargePerAmmoCount</xpath>
-        </li>
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/chargePerAmmoCount</xpath>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/genericAmmo</xpath>
-          <value>
-            <genericAmmo>false</genericAmmo>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/genericAmmo</xpath>
+					<value>
+						<genericAmmo>false</genericAmmo>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/magazineCapacity</xpath>
-          <value>
-            <magazineCapacity>200</magazineCapacity>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/magazineCapacity</xpath>
+					<value>
+						<magazineCapacity>200</magazineCapacity>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/maxRange</xpath>
-          <value>
-            <maxRange>40</maxRange>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/maxRange</xpath>
+					<value>
+						<maxRange>40</maxRange>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/fireModes</xpath>
-          <value>
-            <fireModes>
-              <li>
-                <shotsPerBurst>5</shotsPerBurst>
-                <ticksBetweenShots>3</ticksBetweenShots>
-                <ticksBetweenBursts>60</ticksBetweenBursts>
-                <label>Burst</label>
-                <texPath>UI/Gizmos/FireRate_Burst</texPath>
-              </li>
-              <li>
-                <shotsPerBurst>10</shotsPerBurst>
-                <ticksBetweenShots>3</ticksBetweenShots>
-                <ticksBetweenBursts>60</ticksBetweenBursts>
-                <label>Auto</label>
-                <texPath>UI/Gizmos/FireRate_Auto</texPath>
-              </li>
-            </fireModes>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/fireModes</xpath>
+					<value>
+						<fireModes>
+							<li>
+								<shotsPerBurst>5</shotsPerBurst>
+								<ticksBetweenShots>3</ticksBetweenShots>
+								<ticksBetweenBursts>60</ticksBetweenBursts>
+								<label>Burst</label>
+								<texPath>UI/Gizmos/FireRate_Burst</texPath>
+							</li>
+							<li>
+								<shotsPerBurst>10</shotsPerBurst>
+								<ticksBetweenShots>3</ticksBetweenShots>
+								<ticksBetweenBursts>60</ticksBetweenBursts>
+								<label>Auto</label>
+								<texPath>UI/Gizmos/FireRate_Auto</texPath>
+							</li>
+						</fireModes>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/ammunition/thingDefs</xpath>
-          <value>
-            <thingDefs>
-              <li>Ammo_Flamethrower_Napalm</li>
-              <li>Ammo_Flamethrower_Prometheum</li>
-            </thingDefs>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/ammunition/thingDefs</xpath>
+					<value>
+						<thingDefs>
+							<li>Ammo_Flamethrower_Napalm</li>
+							<li>Ammo_Flamethrower_Prometheum</li>
+						</thingDefs>
+					</value>
+				</li>
 
-        <li Class="PatchOperationAddModExtension">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]</xpath>
-          <value>
-            <li Class="Vehicles.CETurretDataDefModExtension">
-              <ammoSet>AmmoSet_Flamethrower</ammoSet>
-              <shotHeight>2.0</shotHeight>
-              <speed>20</speed>
-              <sway>0.25</sway>
-              <spread>0.30</spread>
-            </li>
-          </value>
-        </li>
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]</xpath>
+					<value>
+						<li Class="Vehicles.CETurretDataDefModExtension">
+							<ammoSet>AmmoSet_Flamethrower</ammoSet>
+							<shotHeight>2.0</shotHeight>
+							<speed>20</speed>
+							<sway>0.25</sway>
+							<spread>0.30</spread>
+						</li>
+					</value>
+				</li>
 
-        <!-- Vehicle -->
-        <li Class="PatchOperationAdd">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]</xpath>
-          <value>
-            <descriptionHyperlinks>
-              <CombatExtended.AmmoSetDef>AmmoSet_Flamethrower</CombatExtended.AmmoSetDef>
-            </descriptionHyperlinks>
-          </value>
-        </li>
+				<!-- Vehicle -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]</xpath>
+					<value>
+						<descriptionHyperlinks>
+							<CombatExtended.AmmoSetDef>AmmoSet_Flamethrower</CombatExtended.AmmoSetDef>
+						</descriptionHyperlinks>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/comps/li[@Class="Vehicles.CompProperties_VehicleTurrets"]</xpath>
-          <value>
-            <li Class="Vehicles.CompProperties_VehicleTurrets">
-              <turrets>
-                <li>
-                  <turretDef>VVE_Bunsen_MainTurret</turretDef>
-                  <renderProperties>
-                    <north>(-0.05, 0.2)</north>
-                    <south>(-0.02, 0.2)</south>
-                    <east>(-0.02, 0.4)</east>
-                  </renderProperties>
-                  <gizmoLabel>Main Turret</gizmoLabel>
-                  <angleRestricted />
-                  <aimPieOffset>(0, 1.5)</aimPieOffset>
-                  <key>mainTurret</key>
-                </li>
-              </turrets>
-            </li>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/comps/li[@Class="Vehicles.CompProperties_VehicleTurrets"]</xpath>
+					<value>
+						<li Class="Vehicles.CompProperties_VehicleTurrets">
+							<turrets>
+								<li>
+									<turretDef>VVE_Bunsen_MainTurret</turretDef>
+									<renderProperties>
+										<north>(-0.05, 0.2)</north>
+										<south>(-0.02, 0.2)</south>
+										<east>(-0.02, 0.4)</east>
+									</renderProperties>
+									<gizmoLabel>Main Turret</gizmoLabel>
+									<angleRestricted />
+									<aimPieOffset>(0, 1.5)</aimPieOffset>
+									<key>mainTurret</key>
+								</li>
+							</turrets>
+						</li>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/comps/li[@Class="Vehicles.CompProperties_FueledTravel"]/fuelCapacity</xpath>
-          <value>
-            <fuelCapacity>120</fuelCapacity>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/comps/li[@Class="Vehicles.CompProperties_FueledTravel"]/fuelCapacity</xpath>
+					<value>
+						<fuelCapacity>120</fuelCapacity>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/statBases/ArmorRating_Blunt</xpath>
-          <value>
-            <ArmorRating_Blunt>10</ArmorRating_Blunt>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>10</ArmorRating_Blunt>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/statBases/ArmorRating_Sharp</xpath>
-          <value>
-            <ArmorRating_Sharp>5</ArmorRating_Sharp>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>5</ArmorRating_Sharp>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="FrontArmorPlating"]/health</xpath>
-          <value>
-            <health>220</health>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="FrontArmorPlating"]/health</xpath>
+					<value>
+						<health>220</health>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Blunt</xpath>
-          <value>
-            <ArmorRating_Blunt>8</ArmorRating_Blunt>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>8</ArmorRating_Blunt>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Sharp</xpath>
-          <value>
-            <ArmorRating_Sharp>4</ArmorRating_Sharp>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>4</ArmorRating_Sharp>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="LeftArmorPlating"]/health</xpath>
-          <value>
-            <health>180</health>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="LeftArmorPlating"]/health</xpath>
+					<value>
+						<health>180</health>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Blunt</xpath>
-          <value>
-            <ArmorRating_Blunt>8</ArmorRating_Blunt>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>8</ArmorRating_Blunt>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Sharp</xpath>
-          <value>
-            <ArmorRating_Sharp>4</ArmorRating_Sharp>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>4</ArmorRating_Sharp>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="RightArmorPlating"]/health</xpath>
-          <value>
-            <health>180</health>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="RightArmorPlating"]/health</xpath>
+					<value>
+						<health>180</health>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Blunt</xpath>
-          <value>
-            <ArmorRating_Blunt>10</ArmorRating_Blunt>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>10</ArmorRating_Blunt>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Sharp</xpath>
-          <value>
-            <ArmorRating_Sharp>5</ArmorRating_Sharp>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>5</ArmorRating_Sharp>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="BackArmorPlating"]/health</xpath>
-          <value>
-            <health>180</health>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="BackArmorPlating"]/health</xpath>
+					<value>
+						<health>180</health>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="BackArmorPlating"]/armor/ArmorRating_Blunt</xpath>
-          <value>
-            <ArmorRating_Blunt>10</ArmorRating_Blunt>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="BackArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>10</ArmorRating_Blunt>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="BackArmorPlating"]/armor/ArmorRating_Sharp</xpath>
-          <value>
-            <ArmorRating_Sharp>5</ArmorRating_Sharp>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="BackArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>5</ArmorRating_Sharp>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="Roof"]/health</xpath>
-          <value>
-            <health>180</health>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="Roof"]/health</xpath>
+					<value>
+						<health>180</health>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="Roof"]/armor/ArmorRating_Blunt</xpath>
-          <value>
-            <ArmorRating_Blunt>8</ArmorRating_Blunt>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="Roof"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>8</ArmorRating_Blunt>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="Roof"]/armor/ArmorRating_Sharp</xpath>
-          <value>
-            <ArmorRating_Sharp>4</ArmorRating_Sharp>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="Roof"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>4</ArmorRating_Sharp>
+					</value>
+				</li>
 
-      </operations>
-    </match>
-  </Operation>
+			</operations>
+		</match>
+	</Operation>
 
 </Patch>

--- a/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier1/Bunsen.xml
+++ b/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier1/Bunsen.xml
@@ -1,258 +1,267 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 
-	<Operation Class="PatchOperationFindMod">
-		<mods>
-			<li>Vanilla Vehicles Expanded</li>
-		</mods>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Vehicles Expanded</li>
+    </mods>
 
-		<match Class="PatchOperationSequence">
-			<operations>
+    <match Class="PatchOperationSequence">
+      <operations>
 
-				<!-- Turret -->
+        <!-- Turret -->
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/projectile</xpath>
-					<value>
-						<projectile>Bullet_Flamethrower_Prometheum</projectile>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/projectile</xpath>
+          <value>
+            <projectile>Bullet_Flamethrower_Prometheum</projectile>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/reloadTimer</xpath>
-					<value>
-						<reloadTimer>7.0</reloadTimer>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/reloadTimer</xpath>
+          <value>
+            <reloadTimer>7.0</reloadTimer>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/warmUpTimer</xpath>
-					<value>
-						<warmUpTimer>1.0</warmUpTimer>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/warmUpTimer</xpath>
+          <value>
+            <warmUpTimer>1.0</warmUpTimer>
+          </value>
+        </li>
 
-				<li Class="PatchOperationRemove">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/chargePerAmmoCount</xpath>
-				</li>
+        <li Class="PatchOperationRemove">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/chargePerAmmoCount</xpath>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/genericAmmo</xpath>
-					<value>
-						<genericAmmo>false</genericAmmo>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/genericAmmo</xpath>
+          <value>
+            <genericAmmo>false</genericAmmo>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/magazineCapacity</xpath>
-					<value>
-						<magazineCapacity>200</magazineCapacity>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/magazineCapacity</xpath>
+          <value>
+            <magazineCapacity>200</magazineCapacity>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/maxRange</xpath>
-					<value>
-						<maxRange>40</maxRange>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/maxRange</xpath>
+          <value>
+            <maxRange>40</maxRange>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/fireModes</xpath>
-					<value>
-						<fireModes>
-							<li>
-								<shotsPerBurst>5</shotsPerBurst>
-								<ticksBetweenShots>3</ticksBetweenShots>
-								<ticksBetweenBursts>60</ticksBetweenBursts>
-								<label>Burst</label>
-								<texPath>UI/Gizmos/FireRate_Burst</texPath>
-							</li>
-							<li>
-								<shotsPerBurst>10</shotsPerBurst>
-								<ticksBetweenShots>3</ticksBetweenShots>
-								<ticksBetweenBursts>60</ticksBetweenBursts>
-								<label>Auto</label>
-								<texPath>UI/Gizmos/FireRate_Auto</texPath>
-							</li>
-						</fireModes>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/fireModes</xpath>
+          <value>
+            <fireModes>
+              <li>
+                <shotsPerBurst>5</shotsPerBurst>
+                <ticksBetweenShots>3</ticksBetweenShots>
+                <ticksBetweenBursts>60</ticksBetweenBursts>
+                <label>Burst</label>
+                <texPath>UI/Gizmos/FireRate_Burst</texPath>
+              </li>
+              <li>
+                <shotsPerBurst>10</shotsPerBurst>
+                <ticksBetweenShots>3</ticksBetweenShots>
+                <ticksBetweenBursts>60</ticksBetweenBursts>
+                <label>Auto</label>
+                <texPath>UI/Gizmos/FireRate_Auto</texPath>
+              </li>
+            </fireModes>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/ammunition/thingDefs</xpath>
-					<value>
-						<thingDefs>
-							<li>Ammo_Flamethrower_Napalm</li>
-							<li>Ammo_Flamethrower_Prometheum</li>
-						</thingDefs>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/ammunition/thingDefs</xpath>
+          <value>
+            <thingDefs>
+              <li>Ammo_Flamethrower_Napalm</li>
+              <li>Ammo_Flamethrower_Prometheum</li>
+            </thingDefs>
+          </value>
+        </li>
 
-				<li Class="PatchOperationAddModExtension">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]</xpath>
-					<value>
-						<li Class="Vehicles.CETurretDataDefModExtension">
-							<ammoSet>AmmoSet_Flamethrower</ammoSet>
-							<shotHeight>2.0</shotHeight>
-							<speed>20</speed>
-							<sway>0.25</sway>
-							<spread>0.30</spread>
-						</li>
-					</value>
-				</li>
+        <li Class="PatchOperationAddModExtension">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]</xpath>
+          <value>
+            <li Class="Vehicles.CETurretDataDefModExtension">
+              <ammoSet>AmmoSet_Flamethrower</ammoSet>
+              <shotHeight>2.0</shotHeight>
+              <speed>20</speed>
+              <sway>0.25</sway>
+              <spread>0.30</spread>
+            </li>
+          </value>
+        </li>
 
-				<!-- Vehicle -->
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/comps/li[@Class="Vehicles.CompProperties_VehicleTurrets"]</xpath>
-					<value>
-						<li Class="Vehicles.CompProperties_VehicleTurrets">
-							<turrets>
-								<li>
-									<turretDef>VVE_Bunsen_MainTurret</turretDef>
-									<renderProperties>
-										<north>(-0.05, 0.2)</north>
-										<south>(-0.02, 0.2)</south>
-										<east>(-0.02, 0.4)</east>
-									</renderProperties>
-									<gizmoLabel>Main Turret</gizmoLabel>
-									<angleRestricted />
-									<aimPieOffset>(0, 1.5)</aimPieOffset>
-									<key>mainTurret</key>
-								</li>
-							</turrets>
-						</li>
-					</value>
-				</li>
+        <!-- Vehicle -->
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]</xpath>
+          <value>
+            <descriptionHyperlinks>
+              <CombatExtended.AmmoSetDef>AmmoSet_Flamethrower</CombatExtended.AmmoSetDef>
+            </descriptionHyperlinks>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/comps/li[@Class="Vehicles.CompProperties_FueledTravel"]/fuelCapacity</xpath>
-					<value>
-						<fuelCapacity>120</fuelCapacity>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/comps/li[@Class="Vehicles.CompProperties_VehicleTurrets"]</xpath>
+          <value>
+            <li Class="Vehicles.CompProperties_VehicleTurrets">
+              <turrets>
+                <li>
+                  <turretDef>VVE_Bunsen_MainTurret</turretDef>
+                  <renderProperties>
+                    <north>(-0.05, 0.2)</north>
+                    <south>(-0.02, 0.2)</south>
+                    <east>(-0.02, 0.4)</east>
+                  </renderProperties>
+                  <gizmoLabel>Main Turret</gizmoLabel>
+                  <angleRestricted />
+                  <aimPieOffset>(0, 1.5)</aimPieOffset>
+                  <key>mainTurret</key>
+                </li>
+              </turrets>
+            </li>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/statBases/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>10</ArmorRating_Blunt>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/comps/li[@Class="Vehicles.CompProperties_FueledTravel"]/fuelCapacity</xpath>
+          <value>
+            <fuelCapacity>120</fuelCapacity>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/statBases/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>5</ArmorRating_Sharp>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/statBases/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>10</ArmorRating_Blunt>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="FrontArmorPlating"]/health</xpath>
-					<value>
-						<health>220</health>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/statBases/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>5</ArmorRating_Sharp>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>8</ArmorRating_Blunt>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="FrontArmorPlating"]/health</xpath>
+          <value>
+            <health>220</health>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>4</ArmorRating_Sharp>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>8</ArmorRating_Blunt>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="LeftArmorPlating"]/health</xpath>
-					<value>
-						<health>180</health>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>4</ArmorRating_Sharp>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>8</ArmorRating_Blunt>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="LeftArmorPlating"]/health</xpath>
+          <value>
+            <health>180</health>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>4</ArmorRating_Sharp>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>8</ArmorRating_Blunt>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="RightArmorPlating"]/health</xpath>
-					<value>
-						<health>180</health>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>4</ArmorRating_Sharp>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>10</ArmorRating_Blunt>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="RightArmorPlating"]/health</xpath>
+          <value>
+            <health>180</health>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>5</ArmorRating_Sharp>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>10</ArmorRating_Blunt>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="BackArmorPlating"]/health</xpath>
-					<value>
-						<health>180</health>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>5</ArmorRating_Sharp>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="BackArmorPlating"]/armor/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>10</ArmorRating_Blunt>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="BackArmorPlating"]/health</xpath>
+          <value>
+            <health>180</health>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="BackArmorPlating"]/armor/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>5</ArmorRating_Sharp>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="BackArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>10</ArmorRating_Blunt>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="Roof"]/health</xpath>
-					<value>
-						<health>180</health>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="BackArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>5</ArmorRating_Sharp>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="Roof"]/armor/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>8</ArmorRating_Blunt>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="Roof"]/health</xpath>
+          <value>
+            <health>180</health>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="Roof"]/armor/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>4</ArmorRating_Sharp>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="Roof"]/armor/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>8</ArmorRating_Blunt>
+          </value>
+        </li>
 
-			</operations>
-		</match>
-	</Operation>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="Roof"]/armor/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>4</ArmorRating_Sharp>
+          </value>
+        </li>
+
+      </operations>
+    </match>
+  </Operation>
 
 </Patch>

--- a/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier1/Highwayman.xml
+++ b/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier1/Highwayman.xml
@@ -1,218 +1,227 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 
-	<Operation Class="PatchOperationFindMod">
-		<mods>
-			<li>Vanilla Vehicles Expanded</li>
-		</mods>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Vehicles Expanded</li>
+    </mods>
 
-		<match Class="PatchOperationSequence">
-			<operations>
+    <match Class="PatchOperationSequence">
+      <operations>
 
-				<!-- Turret -->
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/projectile</xpath>
-					<value>
-						<projectile>Bullet_762x51mmNATO_FMJ</projectile>
-					</value>
-				</li>
+        <!-- Turret -->
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/projectile</xpath>
+          <value>
+            <projectile>Bullet_762x51mmNATO_FMJ</projectile>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/reloadTimer</xpath>
-					<value>
-						<reloadTimer>7.8</reloadTimer>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/reloadTimer</xpath>
+          <value>
+            <reloadTimer>7.8</reloadTimer>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/warmUpTimer</xpath>
-					<value>
-						<warmUpTimer>1.3</warmUpTimer>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/warmUpTimer</xpath>
+          <value>
+            <warmUpTimer>1.3</warmUpTimer>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/magazineCapacity</xpath>
-					<value>
-						<magazineCapacity>200</magazineCapacity>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/magazineCapacity</xpath>
+          <value>
+            <magazineCapacity>200</magazineCapacity>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/genericAmmo</xpath>
-					<value>
-						<genericAmmo>false</genericAmmo>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/genericAmmo</xpath>
+          <value>
+            <genericAmmo>false</genericAmmo>
+          </value>
+        </li>
 
-				<li Class="PatchOperationRemove">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/projectileShifting</xpath>
-				</li>
+        <li Class="PatchOperationRemove">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/projectileShifting</xpath>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/maxRange</xpath>
-					<value>
-						<maxRange>55</maxRange>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/maxRange</xpath>
+          <value>
+            <maxRange>55</maxRange>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/fireModes</xpath>
-					<value>
-						<fireModes>
-							<li>
-								<shotsPerBurst>1</shotsPerBurst>
-								<ticksBetweenShots>6</ticksBetweenShots>
-								<ticksBetweenBursts>60</ticksBetweenBursts>
-								<label>Single</label>
-								<texPath>UI/Gizmos/FireRate_Single</texPath>
-							</li>
-							<li>
-								<shotsPerBurst>5</shotsPerBurst>
-								<ticksBetweenShots>6</ticksBetweenShots>
-								<ticksBetweenBursts>60</ticksBetweenBursts>
-								<label>Burst</label>
-								<texPath>UI/Gizmos/FireRate_Burst</texPath>
-							</li>
-							<li>
-								<shotsPerBurst>10</shotsPerBurst>
-								<ticksBetweenShots>6</ticksBetweenShots>
-								<ticksBetweenBursts>60</ticksBetweenBursts>
-								<label>Auto</label>
-								<texPath>UI/Gizmos/FireRate_Auto</texPath>
-							</li>
-						</fireModes>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/fireModes</xpath>
+          <value>
+            <fireModes>
+              <li>
+                <shotsPerBurst>1</shotsPerBurst>
+                <ticksBetweenShots>6</ticksBetweenShots>
+                <ticksBetweenBursts>60</ticksBetweenBursts>
+                <label>Single</label>
+                <texPath>UI/Gizmos/FireRate_Single</texPath>
+              </li>
+              <li>
+                <shotsPerBurst>5</shotsPerBurst>
+                <ticksBetweenShots>6</ticksBetweenShots>
+                <ticksBetweenBursts>60</ticksBetweenBursts>
+                <label>Burst</label>
+                <texPath>UI/Gizmos/FireRate_Burst</texPath>
+              </li>
+              <li>
+                <shotsPerBurst>10</shotsPerBurst>
+                <ticksBetweenShots>6</ticksBetweenShots>
+                <ticksBetweenBursts>60</ticksBetweenBursts>
+                <label>Auto</label>
+                <texPath>UI/Gizmos/FireRate_Auto</texPath>
+              </li>
+            </fireModes>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/ammunition/thingDefs</xpath>
-					<value>
-						<thingDefs>
-							<li>Ammo_762x51mmNATO_FMJ</li>
-							<li>Ammo_762x51mmNATO_AP</li>
-							<li>Ammo_762x51mmNATO_HP</li>
-							<li>Ammo_762x51mmNATO_Incendiary</li>
-							<li>Ammo_762x51mmNATO_HE</li>
-							<li>Ammo_762x51mmNATO_Sabot</li>
-						</thingDefs>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/ammunition/thingDefs</xpath>
+          <value>
+            <thingDefs>
+              <li>Ammo_762x51mmNATO_FMJ</li>
+              <li>Ammo_762x51mmNATO_AP</li>
+              <li>Ammo_762x51mmNATO_HP</li>
+              <li>Ammo_762x51mmNATO_Incendiary</li>
+              <li>Ammo_762x51mmNATO_HE</li>
+              <li>Ammo_762x51mmNATO_Sabot</li>
+            </thingDefs>
+          </value>
+        </li>
 
-				<li Class="PatchOperationAddModExtension">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]</xpath>
-					<value>
-						<li Class="Vehicles.CETurretDataDefModExtension">
-							<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
-							<shotHeight>2.0</shotHeight>
-							<speed>156</speed>
-							<sway>0.96</sway>
-							<spread>0.04</spread>
-						</li>
-					</value>
-				</li>
+        <li Class="PatchOperationAddModExtension">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]</xpath>
+          <value>
+            <li Class="Vehicles.CETurretDataDefModExtension">
+              <ammoSet>AmmoSet_762x51mmNATO</ammoSet>
+              <shotHeight>2.0</shotHeight>
+              <speed>156</speed>
+              <sway>0.96</sway>
+              <spread>0.04</spread>
+            </li>
+          </value>
+        </li>
 
-				<!-- Vehicle -->
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/statBases/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>10</ArmorRating_Blunt>
-					</value>
-				</li>
+        <!-- Vehicle -->
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]</xpath>
+          <value>
+            <descriptionHyperlinks>
+              <CombatExtended.AmmoSetDef>AmmoSet_762x51mmNATO</CombatExtended.AmmoSetDef>
+            </descriptionHyperlinks>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/statBases/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>5</ArmorRating_Sharp>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/statBases/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>10</ArmorRating_Blunt>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="FrontArmorPlating"]/health</xpath>
-					<value>
-						<health>300</health>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/statBases/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>5</ArmorRating_Sharp>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>10</ArmorRating_Blunt>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="FrontArmorPlating"]/health</xpath>
+          <value>
+            <health>300</health>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>5</ArmorRating_Sharp>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>10</ArmorRating_Blunt>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="LeftArmorPlating"]/health</xpath>
-					<value>
-						<health>240</health>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>5</ArmorRating_Sharp>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>10</ArmorRating_Blunt>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="LeftArmorPlating"]/health</xpath>
+          <value>
+            <health>240</health>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>5</ArmorRating_Sharp>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>10</ArmorRating_Blunt>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="RightArmorPlating"]/health</xpath>
-					<value>
-						<health>240</health>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>5</ArmorRating_Sharp>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>10</ArmorRating_Blunt>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="RightArmorPlating"]/health</xpath>
+          <value>
+            <health>240</health>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>5</ArmorRating_Sharp>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>10</ArmorRating_Blunt>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="Roof"]/health</xpath>
-					<value>
-						<health>255</health>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>5</ArmorRating_Sharp>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="Roof"]/armor/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>10</ArmorRating_Blunt>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="Roof"]/health</xpath>
+          <value>
+            <health>255</health>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="Roof"]/armor/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>5</ArmorRating_Sharp>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="Roof"]/armor/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>10</ArmorRating_Blunt>
+          </value>
+        </li>
 
-			</operations>
-		</match>
-	</Operation>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="Roof"]/armor/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>5</ArmorRating_Sharp>
+          </value>
+        </li>
+
+      </operations>
+    </match>
+  </Operation>
 
 </Patch>

--- a/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier1/Highwayman.xml
+++ b/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier1/Highwayman.xml
@@ -1,227 +1,227 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 
-  <Operation Class="PatchOperationFindMod">
-    <mods>
-      <li>Vanilla Vehicles Expanded</li>
-    </mods>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Vehicles Expanded</li>
+		</mods>
 
-    <match Class="PatchOperationSequence">
-      <operations>
+		<match Class="PatchOperationSequence">
+			<operations>
 
-        <!-- Turret -->
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/projectile</xpath>
-          <value>
-            <projectile>Bullet_762x51mmNATO_FMJ</projectile>
-          </value>
-        </li>
+				<!-- Turret -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/projectile</xpath>
+					<value>
+						<projectile>Bullet_762x51mmNATO_FMJ</projectile>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/reloadTimer</xpath>
-          <value>
-            <reloadTimer>7.8</reloadTimer>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/reloadTimer</xpath>
+					<value>
+						<reloadTimer>7.8</reloadTimer>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/warmUpTimer</xpath>
-          <value>
-            <warmUpTimer>1.3</warmUpTimer>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/warmUpTimer</xpath>
+					<value>
+						<warmUpTimer>1.3</warmUpTimer>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/magazineCapacity</xpath>
-          <value>
-            <magazineCapacity>200</magazineCapacity>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/magazineCapacity</xpath>
+					<value>
+						<magazineCapacity>200</magazineCapacity>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/genericAmmo</xpath>
-          <value>
-            <genericAmmo>false</genericAmmo>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/genericAmmo</xpath>
+					<value>
+						<genericAmmo>false</genericAmmo>
+					</value>
+				</li>
 
-        <li Class="PatchOperationRemove">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/projectileShifting</xpath>
-        </li>
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/projectileShifting</xpath>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/maxRange</xpath>
-          <value>
-            <maxRange>55</maxRange>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/maxRange</xpath>
+					<value>
+						<maxRange>55</maxRange>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/fireModes</xpath>
-          <value>
-            <fireModes>
-              <li>
-                <shotsPerBurst>1</shotsPerBurst>
-                <ticksBetweenShots>6</ticksBetweenShots>
-                <ticksBetweenBursts>60</ticksBetweenBursts>
-                <label>Single</label>
-                <texPath>UI/Gizmos/FireRate_Single</texPath>
-              </li>
-              <li>
-                <shotsPerBurst>5</shotsPerBurst>
-                <ticksBetweenShots>6</ticksBetweenShots>
-                <ticksBetweenBursts>60</ticksBetweenBursts>
-                <label>Burst</label>
-                <texPath>UI/Gizmos/FireRate_Burst</texPath>
-              </li>
-              <li>
-                <shotsPerBurst>10</shotsPerBurst>
-                <ticksBetweenShots>6</ticksBetweenShots>
-                <ticksBetweenBursts>60</ticksBetweenBursts>
-                <label>Auto</label>
-                <texPath>UI/Gizmos/FireRate_Auto</texPath>
-              </li>
-            </fireModes>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/fireModes</xpath>
+					<value>
+						<fireModes>
+							<li>
+								<shotsPerBurst>1</shotsPerBurst>
+								<ticksBetweenShots>6</ticksBetweenShots>
+								<ticksBetweenBursts>60</ticksBetweenBursts>
+								<label>Single</label>
+								<texPath>UI/Gizmos/FireRate_Single</texPath>
+							</li>
+							<li>
+								<shotsPerBurst>5</shotsPerBurst>
+								<ticksBetweenShots>6</ticksBetweenShots>
+								<ticksBetweenBursts>60</ticksBetweenBursts>
+								<label>Burst</label>
+								<texPath>UI/Gizmos/FireRate_Burst</texPath>
+							</li>
+							<li>
+								<shotsPerBurst>10</shotsPerBurst>
+								<ticksBetweenShots>6</ticksBetweenShots>
+								<ticksBetweenBursts>60</ticksBetweenBursts>
+								<label>Auto</label>
+								<texPath>UI/Gizmos/FireRate_Auto</texPath>
+							</li>
+						</fireModes>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/ammunition/thingDefs</xpath>
-          <value>
-            <thingDefs>
-              <li>Ammo_762x51mmNATO_FMJ</li>
-              <li>Ammo_762x51mmNATO_AP</li>
-              <li>Ammo_762x51mmNATO_HP</li>
-              <li>Ammo_762x51mmNATO_Incendiary</li>
-              <li>Ammo_762x51mmNATO_HE</li>
-              <li>Ammo_762x51mmNATO_Sabot</li>
-            </thingDefs>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/ammunition/thingDefs</xpath>
+					<value>
+						<thingDefs>
+							<li>Ammo_762x51mmNATO_FMJ</li>
+							<li>Ammo_762x51mmNATO_AP</li>
+							<li>Ammo_762x51mmNATO_HP</li>
+							<li>Ammo_762x51mmNATO_Incendiary</li>
+							<li>Ammo_762x51mmNATO_HE</li>
+							<li>Ammo_762x51mmNATO_Sabot</li>
+						</thingDefs>
+					</value>
+				</li>
 
-        <li Class="PatchOperationAddModExtension">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]</xpath>
-          <value>
-            <li Class="Vehicles.CETurretDataDefModExtension">
-              <ammoSet>AmmoSet_762x51mmNATO</ammoSet>
-              <shotHeight>2.0</shotHeight>
-              <speed>156</speed>
-              <sway>0.96</sway>
-              <spread>0.04</spread>
-            </li>
-          </value>
-        </li>
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]</xpath>
+					<value>
+						<li Class="Vehicles.CETurretDataDefModExtension">
+							<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
+							<shotHeight>2.0</shotHeight>
+							<speed>156</speed>
+							<sway>0.96</sway>
+							<spread>0.04</spread>
+						</li>
+					</value>
+				</li>
 
-        <!-- Vehicle -->
-        <li Class="PatchOperationAdd">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]</xpath>
-          <value>
-            <descriptionHyperlinks>
-              <CombatExtended.AmmoSetDef>AmmoSet_762x51mmNATO</CombatExtended.AmmoSetDef>
-            </descriptionHyperlinks>
-          </value>
-        </li>
+				<!-- Vehicle -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]</xpath>
+					<value>
+						<descriptionHyperlinks>
+							<CombatExtended.AmmoSetDef>AmmoSet_762x51mmNATO</CombatExtended.AmmoSetDef>
+						</descriptionHyperlinks>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/statBases/ArmorRating_Blunt</xpath>
-          <value>
-            <ArmorRating_Blunt>10</ArmorRating_Blunt>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>10</ArmorRating_Blunt>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/statBases/ArmorRating_Sharp</xpath>
-          <value>
-            <ArmorRating_Sharp>5</ArmorRating_Sharp>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>5</ArmorRating_Sharp>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="FrontArmorPlating"]/health</xpath>
-          <value>
-            <health>300</health>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="FrontArmorPlating"]/health</xpath>
+					<value>
+						<health>300</health>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Blunt</xpath>
-          <value>
-            <ArmorRating_Blunt>10</ArmorRating_Blunt>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>10</ArmorRating_Blunt>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Sharp</xpath>
-          <value>
-            <ArmorRating_Sharp>5</ArmorRating_Sharp>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>5</ArmorRating_Sharp>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="LeftArmorPlating"]/health</xpath>
-          <value>
-            <health>240</health>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="LeftArmorPlating"]/health</xpath>
+					<value>
+						<health>240</health>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Blunt</xpath>
-          <value>
-            <ArmorRating_Blunt>10</ArmorRating_Blunt>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>10</ArmorRating_Blunt>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Sharp</xpath>
-          <value>
-            <ArmorRating_Sharp>5</ArmorRating_Sharp>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>5</ArmorRating_Sharp>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="RightArmorPlating"]/health</xpath>
-          <value>
-            <health>240</health>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="RightArmorPlating"]/health</xpath>
+					<value>
+						<health>240</health>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Blunt</xpath>
-          <value>
-            <ArmorRating_Blunt>10</ArmorRating_Blunt>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>10</ArmorRating_Blunt>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Sharp</xpath>
-          <value>
-            <ArmorRating_Sharp>5</ArmorRating_Sharp>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>5</ArmorRating_Sharp>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="Roof"]/health</xpath>
-          <value>
-            <health>255</health>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="Roof"]/health</xpath>
+					<value>
+						<health>255</health>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="Roof"]/armor/ArmorRating_Blunt</xpath>
-          <value>
-            <ArmorRating_Blunt>10</ArmorRating_Blunt>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="Roof"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>10</ArmorRating_Blunt>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="Roof"]/armor/ArmorRating_Sharp</xpath>
-          <value>
-            <ArmorRating_Sharp>5</ArmorRating_Sharp>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Highwayman"]/components/li[key="Roof"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>5</ArmorRating_Sharp>
+					</value>
+				</li>
 
-      </operations>
-    </match>
-  </Operation>
+			</operations>
+		</match>
+	</Operation>
 
 </Patch>

--- a/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier1/Roadkill.xml
+++ b/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier1/Roadkill.xml
@@ -1,185 +1,194 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 
-	<Operation Class="PatchOperationFindMod">
-		<mods>
-			<li>Vanilla Vehicles Expanded</li>
-		</mods>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Vehicles Expanded</li>
+    </mods>
 
-		<match Class="PatchOperationSequence">
-			<operations>
+    <match Class="PatchOperationSequence">
+      <operations>
 
-				<!-- Turret -->
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Roadkill_MainTurret"]/projectile</xpath>
-					<value>
-						<projectile>Bullet_57x307mmR_HE</projectile>
-					</value>
-				</li>
+        <!-- Turret -->
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Roadkill_MainTurret"]/projectile</xpath>
+          <value>
+            <projectile>Bullet_57x307mmR_HE</projectile>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Roadkill_MainTurret"]/reloadTimer</xpath>
-					<value>
-						<reloadTimer>8.2</reloadTimer>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Roadkill_MainTurret"]/reloadTimer</xpath>
+          <value>
+            <reloadTimer>8.2</reloadTimer>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Roadkill_MainTurret"]/warmUpTimer</xpath>
-					<value>
-						<warmUpTimer>3.5</warmUpTimer>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Roadkill_MainTurret"]/warmUpTimer</xpath>
+          <value>
+            <warmUpTimer>3.5</warmUpTimer>
+          </value>
+        </li>
 
-				<li Class="PatchOperationRemove">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Roadkill_MainTurret"]/chargePerAmmoCount</xpath>
-				</li>
+        <li Class="PatchOperationRemove">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Roadkill_MainTurret"]/chargePerAmmoCount</xpath>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Roadkill_MainTurret"]/genericAmmo</xpath>
-					<value>
-						<genericAmmo>false</genericAmmo>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Roadkill_MainTurret"]/genericAmmo</xpath>
+          <value>
+            <genericAmmo>false</genericAmmo>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Roadkill_MainTurret"]/maxRange</xpath>
-					<value>
-						<maxRange>62</maxRange>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Roadkill_MainTurret"]/maxRange</xpath>
+          <value>
+            <maxRange>62</maxRange>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Roadkill_MainTurret"]/ammunition/thingDefs</xpath>
-					<value>
-						<thingDefs>
-							<li>Ammo_57x307mmR_AP</li>
-							<li>Ammo_57x307mmR_HE</li>
-						</thingDefs>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Roadkill_MainTurret"]/ammunition/thingDefs</xpath>
+          <value>
+            <thingDefs>
+              <li>Ammo_57x307mmR_AP</li>
+              <li>Ammo_57x307mmR_HE</li>
+            </thingDefs>
+          </value>
+        </li>
 
-				<li Class="PatchOperationAddModExtension">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Roadkill_MainTurret"]</xpath>
-					<value>
-						<li Class="Vehicles.CETurretDataDefModExtension">
-							<ammoSet>AmmoSet_57x307mmR</ammoSet>
-							<shotHeight>2.5</shotHeight>
-							<speed>92</speed>
-							<sway>0.82</sway>
-							<spread>0.01</spread>
-						</li>
-					</value>
-				</li>
+        <li Class="PatchOperationAddModExtension">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Roadkill_MainTurret"]</xpath>
+          <value>
+            <li Class="Vehicles.CETurretDataDefModExtension">
+              <ammoSet>AmmoSet_57x307mmR</ammoSet>
+              <shotHeight>2.5</shotHeight>
+              <speed>92</speed>
+              <sway>0.82</sway>
+              <spread>0.01</spread>
+            </li>
+          </value>
+        </li>
 
-				<!-- Vehicle -->
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/statBases/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>10</ArmorRating_Blunt>
-					</value>
-				</li>
+        <!-- Vehicle -->
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]</xpath>
+          <value>
+            <descriptionHyperlinks>
+              <CombatExtended.AmmoSetDef>AmmoSet_57x307mmR</CombatExtended.AmmoSetDef>
+            </descriptionHyperlinks>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/statBases/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>5</ArmorRating_Sharp>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/statBases/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>10</ArmorRating_Blunt>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/vehicleStats/CargoCapacity</xpath>
-					<value>
-						<CargoCapacity>180</CargoCapacity>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/statBases/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>5</ArmorRating_Sharp>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="FrontArmorPlating"]/health</xpath>
-					<value>
-						<health>300</health>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/vehicleStats/CargoCapacity</xpath>
+          <value>
+            <CargoCapacity>180</CargoCapacity>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>20</ArmorRating_Blunt>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="FrontArmorPlating"]/health</xpath>
+          <value>
+            <health>300</health>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>10</ArmorRating_Sharp>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>20</ArmorRating_Blunt>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="LeftArmorPlating"]/health</xpath>
-					<value>
-						<health>300</health>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>10</ArmorRating_Sharp>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>16</ArmorRating_Blunt>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="LeftArmorPlating"]/health</xpath>
+          <value>
+            <health>300</health>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>8</ArmorRating_Sharp>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>16</ArmorRating_Blunt>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="RightArmorPlating"]/health</xpath>
-					<value>
-						<health>300</health>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>8</ArmorRating_Sharp>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>16</ArmorRating_Blunt>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="RightArmorPlating"]/health</xpath>
+          <value>
+            <health>300</health>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>8</ArmorRating_Sharp>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>16</ArmorRating_Blunt>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="Roof"]/health</xpath>
-					<value>
-						<health>300</health>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>8</ArmorRating_Sharp>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="Roof"]/armor/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>16</ArmorRating_Blunt>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="Roof"]/health</xpath>
+          <value>
+            <health>300</health>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="Roof"]/armor/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>8</ArmorRating_Sharp>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="Roof"]/armor/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>16</ArmorRating_Blunt>
+          </value>
+        </li>
 
-			</operations>
-		</match>
-	</Operation>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="Roof"]/armor/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>8</ArmorRating_Sharp>
+          </value>
+        </li>
+
+      </operations>
+    </match>
+  </Operation>
 
 </Patch>

--- a/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier1/Roadkill.xml
+++ b/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier1/Roadkill.xml
@@ -1,194 +1,194 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 
-  <Operation Class="PatchOperationFindMod">
-    <mods>
-      <li>Vanilla Vehicles Expanded</li>
-    </mods>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Vehicles Expanded</li>
+		</mods>
 
-    <match Class="PatchOperationSequence">
-      <operations>
+		<match Class="PatchOperationSequence">
+			<operations>
 
-        <!-- Turret -->
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Roadkill_MainTurret"]/projectile</xpath>
-          <value>
-            <projectile>Bullet_57x307mmR_HE</projectile>
-          </value>
-        </li>
+				<!-- Turret -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Roadkill_MainTurret"]/projectile</xpath>
+					<value>
+						<projectile>Bullet_57x307mmR_HE</projectile>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Roadkill_MainTurret"]/reloadTimer</xpath>
-          <value>
-            <reloadTimer>8.2</reloadTimer>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Roadkill_MainTurret"]/reloadTimer</xpath>
+					<value>
+						<reloadTimer>8.2</reloadTimer>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Roadkill_MainTurret"]/warmUpTimer</xpath>
-          <value>
-            <warmUpTimer>3.5</warmUpTimer>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Roadkill_MainTurret"]/warmUpTimer</xpath>
+					<value>
+						<warmUpTimer>3.5</warmUpTimer>
+					</value>
+				</li>
 
-        <li Class="PatchOperationRemove">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Roadkill_MainTurret"]/chargePerAmmoCount</xpath>
-        </li>
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Roadkill_MainTurret"]/chargePerAmmoCount</xpath>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Roadkill_MainTurret"]/genericAmmo</xpath>
-          <value>
-            <genericAmmo>false</genericAmmo>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Roadkill_MainTurret"]/genericAmmo</xpath>
+					<value>
+						<genericAmmo>false</genericAmmo>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Roadkill_MainTurret"]/maxRange</xpath>
-          <value>
-            <maxRange>62</maxRange>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Roadkill_MainTurret"]/maxRange</xpath>
+					<value>
+						<maxRange>62</maxRange>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Roadkill_MainTurret"]/ammunition/thingDefs</xpath>
-          <value>
-            <thingDefs>
-              <li>Ammo_57x307mmR_AP</li>
-              <li>Ammo_57x307mmR_HE</li>
-            </thingDefs>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Roadkill_MainTurret"]/ammunition/thingDefs</xpath>
+					<value>
+						<thingDefs>
+							<li>Ammo_57x307mmR_AP</li>
+							<li>Ammo_57x307mmR_HE</li>
+						</thingDefs>
+					</value>
+				</li>
 
-        <li Class="PatchOperationAddModExtension">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Roadkill_MainTurret"]</xpath>
-          <value>
-            <li Class="Vehicles.CETurretDataDefModExtension">
-              <ammoSet>AmmoSet_57x307mmR</ammoSet>
-              <shotHeight>2.5</shotHeight>
-              <speed>92</speed>
-              <sway>0.82</sway>
-              <spread>0.01</spread>
-            </li>
-          </value>
-        </li>
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Roadkill_MainTurret"]</xpath>
+					<value>
+						<li Class="Vehicles.CETurretDataDefModExtension">
+							<ammoSet>AmmoSet_57x307mmR</ammoSet>
+							<shotHeight>2.5</shotHeight>
+							<speed>92</speed>
+							<sway>0.82</sway>
+							<spread>0.01</spread>
+						</li>
+					</value>
+				</li>
 
-        <!-- Vehicle -->
-        <li Class="PatchOperationAdd">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]</xpath>
-          <value>
-            <descriptionHyperlinks>
-              <CombatExtended.AmmoSetDef>AmmoSet_57x307mmR</CombatExtended.AmmoSetDef>
-            </descriptionHyperlinks>
-          </value>
-        </li>
+				<!-- Vehicle -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]</xpath>
+					<value>
+						<descriptionHyperlinks>
+							<CombatExtended.AmmoSetDef>AmmoSet_57x307mmR</CombatExtended.AmmoSetDef>
+						</descriptionHyperlinks>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/statBases/ArmorRating_Blunt</xpath>
-          <value>
-            <ArmorRating_Blunt>10</ArmorRating_Blunt>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>10</ArmorRating_Blunt>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/statBases/ArmorRating_Sharp</xpath>
-          <value>
-            <ArmorRating_Sharp>5</ArmorRating_Sharp>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>5</ArmorRating_Sharp>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/vehicleStats/CargoCapacity</xpath>
-          <value>
-            <CargoCapacity>180</CargoCapacity>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/vehicleStats/CargoCapacity</xpath>
+					<value>
+						<CargoCapacity>180</CargoCapacity>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="FrontArmorPlating"]/health</xpath>
-          <value>
-            <health>300</health>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="FrontArmorPlating"]/health</xpath>
+					<value>
+						<health>300</health>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Blunt</xpath>
-          <value>
-            <ArmorRating_Blunt>20</ArmorRating_Blunt>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>20</ArmorRating_Blunt>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Sharp</xpath>
-          <value>
-            <ArmorRating_Sharp>10</ArmorRating_Sharp>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>10</ArmorRating_Sharp>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="LeftArmorPlating"]/health</xpath>
-          <value>
-            <health>300</health>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="LeftArmorPlating"]/health</xpath>
+					<value>
+						<health>300</health>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Blunt</xpath>
-          <value>
-            <ArmorRating_Blunt>16</ArmorRating_Blunt>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>16</ArmorRating_Blunt>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Sharp</xpath>
-          <value>
-            <ArmorRating_Sharp>8</ArmorRating_Sharp>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>8</ArmorRating_Sharp>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="RightArmorPlating"]/health</xpath>
-          <value>
-            <health>300</health>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="RightArmorPlating"]/health</xpath>
+					<value>
+						<health>300</health>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Blunt</xpath>
-          <value>
-            <ArmorRating_Blunt>16</ArmorRating_Blunt>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>16</ArmorRating_Blunt>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Sharp</xpath>
-          <value>
-            <ArmorRating_Sharp>8</ArmorRating_Sharp>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>8</ArmorRating_Sharp>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="Roof"]/health</xpath>
-          <value>
-            <health>300</health>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="Roof"]/health</xpath>
+					<value>
+						<health>300</health>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="Roof"]/armor/ArmorRating_Blunt</xpath>
-          <value>
-            <ArmorRating_Blunt>16</ArmorRating_Blunt>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="Roof"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>16</ArmorRating_Blunt>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="Roof"]/armor/ArmorRating_Sharp</xpath>
-          <value>
-            <ArmorRating_Sharp>8</ArmorRating_Sharp>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Roadkill"]/components/li[key="Roof"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>8</ArmorRating_Sharp>
+					</value>
+				</li>
 
-      </operations>
-    </match>
-  </Operation>
+			</operations>
+		</match>
+	</Operation>
 
 </Patch>

--- a/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier2/Bulldog.xml
+++ b/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier2/Bulldog.xml
@@ -73,14 +73,14 @@
 				</li>
 
 				<!-- Vehicle -->
-        <li Class="PatchOperationAdd">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]</xpath>
-          <value>
-            <descriptionHyperlinks>
-              <CombatExtended.AmmoSetDef>AmmoSet_75x350mmR</CombatExtended.AmmoSetDef>
-            </descriptionHyperlinks>
-          </value>
-        </li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]</xpath>
+					<value>
+						<descriptionHyperlinks>
+							<CombatExtended.AmmoSetDef>AmmoSet_75x350mmR</CombatExtended.AmmoSetDef>
+						</descriptionHyperlinks>
+					</value>
+				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/statBases/ArmorRating_Blunt</xpath>

--- a/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier2/Bulldog.xml
+++ b/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier2/Bulldog.xml
@@ -73,6 +73,15 @@
 				</li>
 
 				<!-- Vehicle -->
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]</xpath>
+          <value>
+            <descriptionHyperlinks>
+              <CombatExtended.AmmoSetDef>AmmoSet_75x350mmR</CombatExtended.AmmoSetDef>
+            </descriptionHyperlinks>
+          </value>
+        </li>
+
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/statBases/ArmorRating_Blunt</xpath>
 					<value>

--- a/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier2/Tango.xml
+++ b/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier2/Tango.xml
@@ -1,218 +1,227 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 
-	<Operation Class="PatchOperationFindMod">
-		<mods>
-			<li>Vanilla Vehicles Expanded</li>
-		</mods>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Vehicles Expanded</li>
+    </mods>
 
-		<match Class="PatchOperationSequence">
-			<operations>
+    <match Class="PatchOperationSequence">
+      <operations>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]/projectile</xpath>
-					<value>
-						<projectile>Bullet_20x102mmNATO_AP</projectile>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]/projectile</xpath>
+          <value>
+            <projectile>Bullet_20x102mmNATO_AP</projectile>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]/reloadTimer</xpath>
-					<value>
-						<reloadTimer>7.8</reloadTimer>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]/reloadTimer</xpath>
+          <value>
+            <reloadTimer>7.8</reloadTimer>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]/warmUpTimer</xpath>
-					<value>
-						<warmUpTimer>2.3</warmUpTimer>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]/warmUpTimer</xpath>
+          <value>
+            <warmUpTimer>2.3</warmUpTimer>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]/magazineCapacity</xpath>
-					<value>
-						<magazineCapacity>50</magazineCapacity>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]/magazineCapacity</xpath>
+          <value>
+            <magazineCapacity>50</magazineCapacity>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]/genericAmmo</xpath>
-					<value>
-						<genericAmmo>false</genericAmmo>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]/genericAmmo</xpath>
+          <value>
+            <genericAmmo>false</genericAmmo>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]/maxRange</xpath>
-					<value>
-						<maxRange>78</maxRange>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]/maxRange</xpath>
+          <value>
+            <maxRange>78</maxRange>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]/fireModes</xpath>
-					<value>
-						<fireModes>
-							<li>
-								<shotsPerBurst>1</shotsPerBurst>
-								<ticksBetweenShots>6</ticksBetweenShots>
-								<ticksBetweenBursts>60</ticksBetweenBursts>
-								<label>Single</label>
-								<texPath>UI/Gizmos/FireRate_Single</texPath>
-							</li>
-							<li>
-								<shotsPerBurst>2</shotsPerBurst>
-								<ticksBetweenShots>6</ticksBetweenShots>
-								<ticksBetweenBursts>60</ticksBetweenBursts>
-								<label>Burst</label>
-								<texPath>UI/Gizmos/FireRate_Burst</texPath>
-							</li>
-							<li>
-								<shotsPerBurst>5</shotsPerBurst>
-								<ticksBetweenShots>6</ticksBetweenShots>
-								<ticksBetweenBursts>60</ticksBetweenBursts>
-								<label>Auto</label>
-								<texPath>UI/Gizmos/FireRate_Auto</texPath>
-							</li>
-						</fireModes>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]/fireModes</xpath>
+          <value>
+            <fireModes>
+              <li>
+                <shotsPerBurst>1</shotsPerBurst>
+                <ticksBetweenShots>6</ticksBetweenShots>
+                <ticksBetweenBursts>60</ticksBetweenBursts>
+                <label>Single</label>
+                <texPath>UI/Gizmos/FireRate_Single</texPath>
+              </li>
+              <li>
+                <shotsPerBurst>2</shotsPerBurst>
+                <ticksBetweenShots>6</ticksBetweenShots>
+                <ticksBetweenBursts>60</ticksBetweenBursts>
+                <label>Burst</label>
+                <texPath>UI/Gizmos/FireRate_Burst</texPath>
+              </li>
+              <li>
+                <shotsPerBurst>5</shotsPerBurst>
+                <ticksBetweenShots>6</ticksBetweenShots>
+                <ticksBetweenBursts>60</ticksBetweenBursts>
+                <label>Auto</label>
+                <texPath>UI/Gizmos/FireRate_Auto</texPath>
+              </li>
+            </fireModes>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]/ammunition/thingDefs</xpath>
-					<value>
-						<thingDefs>
-							<li>Ammo_20x102mmNATO_AP</li>
-							<li>Ammo_20x102mmNATO_Incendiary</li>
-							<li>Ammo_20x102mmNATO_HE</li>
-							<li>Ammo_20x102mmNATO_Sabot</li>
-						</thingDefs>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]/ammunition/thingDefs</xpath>
+          <value>
+            <thingDefs>
+              <li>Ammo_20x102mmNATO_AP</li>
+              <li>Ammo_20x102mmNATO_Incendiary</li>
+              <li>Ammo_20x102mmNATO_HE</li>
+              <li>Ammo_20x102mmNATO_Sabot</li>
+            </thingDefs>
+          </value>
+        </li>
 
-				<li Class="PatchOperationAddModExtension">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]</xpath>
-					<value>
-						<li Class="Vehicles.CETurretDataDefModExtension">
-							<ammoSet>AmmoSet_20x102mmNATO</ammoSet>
-							<shotHeight>2.25</shotHeight>
-							<speed>182</speed>
-							<sway>1.61</sway>
-							<spread>0.01</spread>
-						</li>
-					</value>
-				</li>
+        <li Class="PatchOperationAddModExtension">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]</xpath>
+          <value>
+            <li Class="Vehicles.CETurretDataDefModExtension">
+              <ammoSet>AmmoSet_20x102mmNATO</ammoSet>
+              <shotHeight>2.25</shotHeight>
+              <speed>182</speed>
+              <sway>1.61</sway>
+              <spread>0.01</spread>
+            </li>
+          </value>
+        </li>
 
-				<!-- Vehicle -->
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/statBases/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>16</ArmorRating_Blunt>
-					</value>
-				</li>
+        <!-- Vehicle -->
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]</xpath>
+          <value>
+            <descriptionHyperlinks>
+              <CombatExtended.AmmoSetDef>AmmoSet_20x102mmNATO</CombatExtended.AmmoSetDef>
+            </descriptionHyperlinks>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/statBases/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>8</ArmorRating_Sharp>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/statBases/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>16</ArmorRating_Blunt>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="FrontArmorPlating"]/health</xpath>
-					<value>
-						<health>660</health>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/statBases/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>8</ArmorRating_Sharp>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>16</ArmorRating_Blunt>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="FrontArmorPlating"]/health</xpath>
+          <value>
+            <health>660</health>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>8</ArmorRating_Sharp>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>16</ArmorRating_Blunt>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="LeftArmorPlating"]/health</xpath>
-					<value>
-						<health>660</health>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>8</ArmorRating_Sharp>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>16</ArmorRating_Blunt>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="LeftArmorPlating"]/health</xpath>
+          <value>
+            <health>660</health>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>8</ArmorRating_Sharp>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>16</ArmorRating_Blunt>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="RightArmorPlating"]/health</xpath>
-					<value>
-						<health>660</health>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>8</ArmorRating_Sharp>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>16</ArmorRating_Blunt>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="RightArmorPlating"]/health</xpath>
+          <value>
+            <health>660</health>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>8</ArmorRating_Sharp>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>16</ArmorRating_Blunt>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="BackArmorPlating"]/health</xpath>
-					<value>
-						<health>510</health>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>8</ArmorRating_Sharp>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="Roof"]/health</xpath>
-					<value>
-						<health>390</health>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="BackArmorPlating"]/health</xpath>
+          <value>
+            <health>510</health>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="Roof"]/armor/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>16</ArmorRating_Blunt>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="Roof"]/health</xpath>
+          <value>
+            <health>390</health>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="Roof"]/armor/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>8</ArmorRating_Sharp>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="Roof"]/armor/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>16</ArmorRating_Blunt>
+          </value>
+        </li>
 
-			</operations>
-		</match>
-	</Operation>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="Roof"]/armor/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>8</ArmorRating_Sharp>
+          </value>
+        </li>
+
+      </operations>
+    </match>
+  </Operation>
 
 </Patch>

--- a/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier2/Tango.xml
+++ b/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier2/Tango.xml
@@ -1,227 +1,227 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 
-  <Operation Class="PatchOperationFindMod">
-    <mods>
-      <li>Vanilla Vehicles Expanded</li>
-    </mods>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Vehicles Expanded</li>
+		</mods>
 
-    <match Class="PatchOperationSequence">
-      <operations>
+		<match Class="PatchOperationSequence">
+			<operations>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]/projectile</xpath>
-          <value>
-            <projectile>Bullet_20x102mmNATO_AP</projectile>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]/projectile</xpath>
+					<value>
+						<projectile>Bullet_20x102mmNATO_AP</projectile>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]/reloadTimer</xpath>
-          <value>
-            <reloadTimer>7.8</reloadTimer>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]/reloadTimer</xpath>
+					<value>
+						<reloadTimer>7.8</reloadTimer>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]/warmUpTimer</xpath>
-          <value>
-            <warmUpTimer>2.3</warmUpTimer>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]/warmUpTimer</xpath>
+					<value>
+						<warmUpTimer>2.3</warmUpTimer>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]/magazineCapacity</xpath>
-          <value>
-            <magazineCapacity>50</magazineCapacity>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]/magazineCapacity</xpath>
+					<value>
+						<magazineCapacity>50</magazineCapacity>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]/genericAmmo</xpath>
-          <value>
-            <genericAmmo>false</genericAmmo>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]/genericAmmo</xpath>
+					<value>
+						<genericAmmo>false</genericAmmo>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]/maxRange</xpath>
-          <value>
-            <maxRange>78</maxRange>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]/maxRange</xpath>
+					<value>
+						<maxRange>78</maxRange>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]/fireModes</xpath>
-          <value>
-            <fireModes>
-              <li>
-                <shotsPerBurst>1</shotsPerBurst>
-                <ticksBetweenShots>6</ticksBetweenShots>
-                <ticksBetweenBursts>60</ticksBetweenBursts>
-                <label>Single</label>
-                <texPath>UI/Gizmos/FireRate_Single</texPath>
-              </li>
-              <li>
-                <shotsPerBurst>2</shotsPerBurst>
-                <ticksBetweenShots>6</ticksBetweenShots>
-                <ticksBetweenBursts>60</ticksBetweenBursts>
-                <label>Burst</label>
-                <texPath>UI/Gizmos/FireRate_Burst</texPath>
-              </li>
-              <li>
-                <shotsPerBurst>5</shotsPerBurst>
-                <ticksBetweenShots>6</ticksBetweenShots>
-                <ticksBetweenBursts>60</ticksBetweenBursts>
-                <label>Auto</label>
-                <texPath>UI/Gizmos/FireRate_Auto</texPath>
-              </li>
-            </fireModes>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]/fireModes</xpath>
+					<value>
+						<fireModes>
+							<li>
+								<shotsPerBurst>1</shotsPerBurst>
+								<ticksBetweenShots>6</ticksBetweenShots>
+								<ticksBetweenBursts>60</ticksBetweenBursts>
+								<label>Single</label>
+								<texPath>UI/Gizmos/FireRate_Single</texPath>
+							</li>
+							<li>
+								<shotsPerBurst>2</shotsPerBurst>
+								<ticksBetweenShots>6</ticksBetweenShots>
+								<ticksBetweenBursts>60</ticksBetweenBursts>
+								<label>Burst</label>
+								<texPath>UI/Gizmos/FireRate_Burst</texPath>
+							</li>
+							<li>
+								<shotsPerBurst>5</shotsPerBurst>
+								<ticksBetweenShots>6</ticksBetweenShots>
+								<ticksBetweenBursts>60</ticksBetweenBursts>
+								<label>Auto</label>
+								<texPath>UI/Gizmos/FireRate_Auto</texPath>
+							</li>
+						</fireModes>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]/ammunition/thingDefs</xpath>
-          <value>
-            <thingDefs>
-              <li>Ammo_20x102mmNATO_AP</li>
-              <li>Ammo_20x102mmNATO_Incendiary</li>
-              <li>Ammo_20x102mmNATO_HE</li>
-              <li>Ammo_20x102mmNATO_Sabot</li>
-            </thingDefs>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]/ammunition/thingDefs</xpath>
+					<value>
+						<thingDefs>
+							<li>Ammo_20x102mmNATO_AP</li>
+							<li>Ammo_20x102mmNATO_Incendiary</li>
+							<li>Ammo_20x102mmNATO_HE</li>
+							<li>Ammo_20x102mmNATO_Sabot</li>
+						</thingDefs>
+					</value>
+				</li>
 
-        <li Class="PatchOperationAddModExtension">
-          <xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]</xpath>
-          <value>
-            <li Class="Vehicles.CETurretDataDefModExtension">
-              <ammoSet>AmmoSet_20x102mmNATO</ammoSet>
-              <shotHeight>2.25</shotHeight>
-              <speed>182</speed>
-              <sway>1.61</sway>
-              <spread>0.01</spread>
-            </li>
-          </value>
-        </li>
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]</xpath>
+					<value>
+						<li Class="Vehicles.CETurretDataDefModExtension">
+							<ammoSet>AmmoSet_20x102mmNATO</ammoSet>
+							<shotHeight>2.25</shotHeight>
+							<speed>182</speed>
+							<sway>1.61</sway>
+							<spread>0.01</spread>
+						</li>
+					</value>
+				</li>
 
-        <!-- Vehicle -->
-        <li Class="PatchOperationAdd">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]</xpath>
-          <value>
-            <descriptionHyperlinks>
-              <CombatExtended.AmmoSetDef>AmmoSet_20x102mmNATO</CombatExtended.AmmoSetDef>
-            </descriptionHyperlinks>
-          </value>
-        </li>
+				<!-- Vehicle -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]</xpath>
+					<value>
+						<descriptionHyperlinks>
+							<CombatExtended.AmmoSetDef>AmmoSet_20x102mmNATO</CombatExtended.AmmoSetDef>
+						</descriptionHyperlinks>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/statBases/ArmorRating_Blunt</xpath>
-          <value>
-            <ArmorRating_Blunt>16</ArmorRating_Blunt>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>16</ArmorRating_Blunt>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/statBases/ArmorRating_Sharp</xpath>
-          <value>
-            <ArmorRating_Sharp>8</ArmorRating_Sharp>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>8</ArmorRating_Sharp>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="FrontArmorPlating"]/health</xpath>
-          <value>
-            <health>660</health>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="FrontArmorPlating"]/health</xpath>
+					<value>
+						<health>660</health>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Blunt</xpath>
-          <value>
-            <ArmorRating_Blunt>16</ArmorRating_Blunt>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>16</ArmorRating_Blunt>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Sharp</xpath>
-          <value>
-            <ArmorRating_Sharp>8</ArmorRating_Sharp>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>8</ArmorRating_Sharp>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="LeftArmorPlating"]/health</xpath>
-          <value>
-            <health>660</health>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="LeftArmorPlating"]/health</xpath>
+					<value>
+						<health>660</health>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Blunt</xpath>
-          <value>
-            <ArmorRating_Blunt>16</ArmorRating_Blunt>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>16</ArmorRating_Blunt>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Sharp</xpath>
-          <value>
-            <ArmorRating_Sharp>8</ArmorRating_Sharp>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>8</ArmorRating_Sharp>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="RightArmorPlating"]/health</xpath>
-          <value>
-            <health>660</health>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="RightArmorPlating"]/health</xpath>
+					<value>
+						<health>660</health>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Blunt</xpath>
-          <value>
-            <ArmorRating_Blunt>16</ArmorRating_Blunt>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>16</ArmorRating_Blunt>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Sharp</xpath>
-          <value>
-            <ArmorRating_Sharp>8</ArmorRating_Sharp>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>8</ArmorRating_Sharp>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="BackArmorPlating"]/health</xpath>
-          <value>
-            <health>510</health>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="BackArmorPlating"]/health</xpath>
+					<value>
+						<health>510</health>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="Roof"]/health</xpath>
-          <value>
-            <health>390</health>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="Roof"]/health</xpath>
+					<value>
+						<health>390</health>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="Roof"]/armor/ArmorRating_Blunt</xpath>
-          <value>
-            <ArmorRating_Blunt>16</ArmorRating_Blunt>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="Roof"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>16</ArmorRating_Blunt>
+					</value>
+				</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="Roof"]/armor/ArmorRating_Sharp</xpath>
-          <value>
-            <ArmorRating_Sharp>8</ArmorRating_Sharp>
-          </value>
-        </li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Tango"]/components/li[key="Roof"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>8</ArmorRating_Sharp>
+					</value>
+				</li>
 
-      </operations>
-    </match>
-  </Operation>
+			</operations>
+		</match>
+	</Operation>
 
 </Patch>

--- a/Source/CombatExtended/CombatExtended/Defs/AmmoSetDef.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/AmmoSetDef.cs
@@ -15,5 +15,16 @@ namespace CombatExtended
         public bool isMortarAmmoSet = false;
 
         public AmmoSetDef similarTo;
+
+        public override IEnumerable<StatDrawEntry> SpecialDisplayStats(StatRequest req)
+        {
+            foreach (StatDrawEntry entry in base.SpecialDisplayStats(req)) { yield return entry; }
+
+            foreach (AmmoLink link in ammoTypes)
+            {
+
+                yield return new StatDrawEntry(StatCategoryDefOf.BasicsImportant, link.ammo.label, "", link.projectile.GetProjectileReadout(null), 1, hyperlinks: new List<Dialog_InfoCard.Hyperlink>() { new Dialog_InfoCard.Hyperlink(link.ammo) });
+            }
+        }
     }
 }


### PR DESCRIPTION
## Additions

added the infomation of ammo and projectile into the ammoset's info tab.
![image](https://github.com/CombatExtended-Continued/CombatExtended/assets/62052103/55cd7dc1-04f2-4faa-a9dc-196577f238fb)


## Reasoning

I figured I could display the calibres used by a vehicle via vanilla hyperlinks, it turned out fine but the ammoset info tab doesn't provide anything meaningful other than a name. So I made it happen.

## Alternatives

- a handful of people every day coming and asking about "what ammo that vehicle uses"

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
