### PR TITLE
Casing mote center to gun draw center

### DIFF
--- a/Defs/Effects/Flecks.xml
+++ b/Defs/Effects/Flecks.xml
@@ -1,171 +1,175 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Defs>
+  <FleckDef ParentName="FleckBase" Name="CE_CasingFleckBase" Abstract="True">
+    <fleckSystemClass>CombatExtended.FleckSystem_Casing</fleckSystemClass>
+    <acceleration>(0,0,-5)</acceleration>
+  </FleckDef>
 
-	<!--=============== Thrown Bullet Casings ==============-->
+  <!--=============== Thrown Bullet Casings ==============-->
 
-	<FleckDef ParentName="FleckBase_Thrown">
-		<defName>Fleck_EmptyCasing</defName>
-		<graphicData>
-			<texPath>Things/Flecks/Fleck_BulletCasing</texPath>
-			<renderInstanced>true</renderInstanced>
-		</graphicData>
-		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<solidTime>3.0</solidTime>
-		<fadeOutTime>0.2</fadeOutTime>
-		<landSound>C_Impact_BulletCasing</landSound>
-		<collide>true</collide>
-	</FleckDef>
+  <FleckDef ParentName="CE_CasingFleckBase">
+    <defName>Fleck_EmptyCasing</defName>
+    <graphicData>
+      <texPath>Things/Flecks/Fleck_BulletCasing</texPath>
+      <renderInstanced>true</renderInstanced>
+    </graphicData>
+    <altitudeLayer>MoteOverhead</altitudeLayer>
+    <solidTime>3.0</solidTime>
+    <fadeOutTime>0.2</fadeOutTime>
+    <landSound>C_Impact_BulletCasing</landSound>
+    <collide>true</collide>
+  </FleckDef>
 
-	<FleckDef ParentName="FleckBase_Thrown">
-		<defName>Fleck_PistolAmmoCasings</defName>
-		<graphicData>
-			<texPath>Things/Flecks/Fleck_PistolAmmoCasings</texPath>
-			<renderInstanced>true</renderInstanced>
-		</graphicData>
-		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<solidTime>3.0</solidTime>
-		<fadeOutTime>0.2</fadeOutTime>
-		<landSound>C_Impact_BulletCasing</landSound>
-		<collide>true</collide>
-	</FleckDef>
+  <FleckDef ParentName="CE_CasingFleckBase">
+    <defName>Fleck_PistolAmmoCasings</defName>
+    <graphicData>
+      <texPath>Things/Flecks/Fleck_PistolAmmoCasings</texPath>
+      <renderInstanced>true</renderInstanced>
+    </graphicData>
+    <altitudeLayer>MoteOverhead</altitudeLayer>
+    <solidTime>3.0</solidTime>
+    <fadeOutTime>0.2</fadeOutTime>
+    <landSound>C_Impact_BulletCasing</landSound>
+    <collide>true</collide>
+  </FleckDef>
 
-	<FleckDef ParentName="FleckBase_Thrown">
-		<defName>Fleck_RifleAmmoCasings_Steel</defName>
-		<graphicData>
-			<texPath>Things/Flecks/Fleck_SteelRifleAmmoCasings</texPath>
-			<renderInstanced>true</renderInstanced>
-		</graphicData>
-		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<solidTime>3.0</solidTime>
-		<fadeOutTime>0.2</fadeOutTime>
-		<landSound>C_Impact_BulletCasing</landSound>
-		<collide>true</collide>
-	</FleckDef>
+  <FleckDef ParentName="CE_CasingFleckBase">
+    <defName>Fleck_RifleAmmoCasings_Steel</defName>
+    <graphicData>
+      <texPath>Things/Flecks/Fleck_SteelRifleAmmoCasings</texPath>
+      <renderInstanced>true</renderInstanced>
+    </graphicData>
+    <altitudeLayer>MoteOverhead</altitudeLayer>
+    <solidTime>3.0</solidTime>
+    <fadeOutTime>0.2</fadeOutTime>
+    <landSound>C_Impact_BulletCasing</landSound>
+    <collide>true</collide>
+  </FleckDef>
 
-	<FleckDef ParentName="FleckBase_Thrown">
-		<defName>Fleck_RifleAmmoCasings_HighCal</defName>
-		<graphicData>
-			<texPath>Things/Flecks/Fleck_RifleAmmoCasings_HighCal</texPath>
-			<renderInstanced>true</renderInstanced>
-		</graphicData>
-		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<solidTime>3.0</solidTime>
-		<fadeOutTime>0.2</fadeOutTime>
-		<landSound>C_Impact_BulletCasing</landSound>
-		<collide>true</collide>
-	</FleckDef>
+  <FleckDef ParentName="CE_CasingFleckBase">
+    <defName>Fleck_RifleAmmoCasings_HighCal</defName>
+    <graphicData>
+      <texPath>Things/Flecks/Fleck_RifleAmmoCasings_HighCal</texPath>
+      <renderInstanced>true</renderInstanced>
+    </graphicData>
+    <altitudeLayer>MoteOverhead</altitudeLayer>
+    <solidTime>3.0</solidTime>
+    <fadeOutTime>0.2</fadeOutTime>
+    <landSound>C_Impact_BulletCasing</landSound>
+    <collide>true</collide>
+  </FleckDef>
 
-	<FleckDef ParentName="FleckBase_Thrown">
-		<defName>Fleck_ShotgunShell</defName>
-		<graphicData>
-			<texPath>Things/Flecks/Fleck_ShotgunShell</texPath>
-			<renderInstanced>true</renderInstanced>
-		</graphicData>
-		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<solidTime>3.0</solidTime>
-		<fadeOutTime>0.2</fadeOutTime>
-		<landSound>C_Impact_ShotgunCasingImpact</landSound>
-		<collide>true</collide>
-	</FleckDef>
+  <FleckDef ParentName="CE_CasingFleckBase">
+    <defName>Fleck_ShotgunShell</defName>
+    <graphicData>
+      <texPath>Things/Flecks/Fleck_ShotgunShell</texPath>
+      <renderInstanced>true</renderInstanced>
+    </graphicData>
+    <altitudeLayer>MoteOverhead</altitudeLayer>
+    <solidTime>3.0</solidTime>
+    <fadeOutTime>0.2</fadeOutTime>
+    <landSound>C_Impact_ShotgunCasingImpact</landSound>
+    <collide>true</collide>
+  </FleckDef>
 
-	<FleckDef ParentName="FleckBase_Thrown">
-		<defName>Fleck_ShotgunShell_Green</defName>
-		<graphicData>
-			<texPath>Things/Flecks/Fleck_ShotgunShell_Green</texPath>
-			<renderInstanced>true</renderInstanced>
-		</graphicData>
-		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<solidTime>3.0</solidTime>
-		<fadeOutTime>0.2</fadeOutTime>
-		<landSound>C_Impact_ShotgunCasingImpact</landSound>
-		<collide>true</collide>
-	</FleckDef>
+  <FleckDef ParentName="CE_CasingFleckBase">
+    <defName>Fleck_ShotgunShell_Green</defName>
+    <graphicData>
+      <texPath>Things/Flecks/Fleck_ShotgunShell_Green</texPath>
+      <renderInstanced>true</renderInstanced>
+    </graphicData>
+    <altitudeLayer>MoteOverhead</altitudeLayer>
+    <solidTime>3.0</solidTime>
+    <fadeOutTime>0.2</fadeOutTime>
+    <landSound>C_Impact_ShotgunCasingImpact</landSound>
+    <collide>true</collide>
+  </FleckDef>
 
-	<FleckDef ParentName="FleckBase_Thrown">
-		<defName>Fleck_ShotgunShell_White</defName>
-		<graphicData>
-			<texPath>Things/Flecks/Fleck_ShotgunShell_White</texPath>
-			<renderInstanced>true</renderInstanced>
-		</graphicData>
-		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<solidTime>3.0</solidTime>
-		<fadeOutTime>0.2</fadeOutTime>
-		<landSound>C_Impact_ShotgunCasingImpact</landSound>
-		<collide>true</collide>
-	</FleckDef>
+  <FleckDef ParentName="CE_CasingFleckBase">
+    <defName>Fleck_ShotgunShell_White</defName>
+    <graphicData>
+      <texPath>Things/Flecks/Fleck_ShotgunShell_White</texPath>
+      <renderInstanced>true</renderInstanced>
+    </graphicData>
+    <altitudeLayer>MoteOverhead</altitudeLayer>
+    <solidTime>3.0</solidTime>
+    <fadeOutTime>0.2</fadeOutTime>
+    <landSound>C_Impact_ShotgunCasingImpact</landSound>
+    <collide>true</collide>
+  </FleckDef>
 
-	<FleckDef ParentName="FleckBase_Thrown">
-		<defName>Fleck_ShotgunShell_Black</defName>
-		<graphicData>
-			<texPath>Things/Flecks/Fleck_ShotgunShell_Black</texPath>
-			<renderInstanced>true</renderInstanced>
-		</graphicData>
-		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<solidTime>3.0</solidTime>
-		<fadeOutTime>0.2</fadeOutTime>
-		<landSound>C_Impact_ShotgunCasingImpact</landSound>
-		<collide>true</collide>
-	</FleckDef>
+  <FleckDef ParentName="CE_CasingFleckBase">
+    <defName>Fleck_ShotgunShell_Black</defName>
+    <graphicData>
+      <texPath>Things/Flecks/Fleck_ShotgunShell_Black</texPath>
+      <renderInstanced>true</renderInstanced>
+    </graphicData>
+    <altitudeLayer>MoteOverhead</altitudeLayer>
+    <solidTime>3.0</solidTime>
+    <fadeOutTime>0.2</fadeOutTime>
+    <landSound>C_Impact_ShotgunCasingImpact</landSound>
+    <collide>true</collide>
+  </FleckDef>
 
-	<FleckDef ParentName="FleckBase_Thrown">
-		<defName>Fleck_GrenadeLauncherAmmoCasings</defName>
-		<graphicData>
-			<texPath>Things/Flecks/Fleck_GrenadeLauncherAmmoCasings</texPath>
-			<renderInstanced>true</renderInstanced>
-		</graphicData>
-		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<solidTime>3.0</solidTime>
-		<fadeOutTime>0.2</fadeOutTime>
-		<landSound>C_Impact_CannonShellCasing</landSound>
-		<collide>true</collide>
-	</FleckDef>
+  <FleckDef ParentName="CE_CasingFleckBase">
+    <defName>Fleck_GrenadeLauncherAmmoCasings</defName>
+    <graphicData>
+      <texPath>Things/Flecks/Fleck_GrenadeLauncherAmmoCasings</texPath>
+      <renderInstanced>true</renderInstanced>
+    </graphicData>
+    <altitudeLayer>MoteOverhead</altitudeLayer>
+    <solidTime>3.0</solidTime>
+    <fadeOutTime>0.2</fadeOutTime>
+    <landSound>C_Impact_CannonShellCasing</landSound>
+    <collide>true</collide>
+  </FleckDef>
 
-	<FleckDef ParentName="FleckBase_Thrown">
-		<defName>Fleck_BigShell</defName>
-		<graphicData>
-			<texPath>Things/Flecks/Fleck_BigShell</texPath>
-			<renderInstanced>true</renderInstanced>
-		</graphicData>
-		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<solidTime>3.0</solidTime>
-		<fadeOutTime>0.2</fadeOutTime>
-		<landSound>C_Impact_CannonShellCasing</landSound>
-		<collide>true</collide>
-	</FleckDef>
+  <FleckDef ParentName="CE_CasingFleckBase">
+    <defName>Fleck_BigShell</defName>
+    <graphicData>
+      <texPath>Things/Flecks/Fleck_BigShell</texPath>
+      <renderInstanced>true</renderInstanced>
+    </graphicData>
+    <altitudeLayer>MoteOverhead</altitudeLayer>
+    <solidTime>3.0</solidTime>
+    <fadeOutTime>0.2</fadeOutTime>
+    <landSound>C_Impact_CannonShellCasing</landSound>
+    <collide>true</collide>
+  </FleckDef>
 
-	<FleckDef ParentName="FleckBase_Thrown">
-		<defName>Fleck_GrenadePin</defName>
-		<graphicData>
-			<texPath>Things/Flecks/Fleck_GrenadePin</texPath>
-			<renderInstanced>true</renderInstanced>
-		</graphicData>
-		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<solidTime>3.0</solidTime>
-		<fadeOutTime>0.2</fadeOutTime>
-		<landSound>C_Impact_BulletCasing</landSound>
-		<collide>true</collide>
-	</FleckDef>
+  <FleckDef ParentName="CE_CasingFleckBase">
+    <defName>Fleck_GrenadePin</defName>
+    <graphicData>
+      <texPath>Things/Flecks/Fleck_GrenadePin</texPath>
+      <renderInstanced>true</renderInstanced>
+    </graphicData>
+    <altitudeLayer>MoteOverhead</altitudeLayer>
+    <solidTime>3.0</solidTime>
+    <fadeOutTime>0.2</fadeOutTime>
+    <landSound>C_Impact_BulletCasing</landSound>
+    <collide>true</collide>
+  </FleckDef>
 
-	<FleckDef ParentName="FleckBase_Thrown">
-		<defName>Fleck_DisposableLauncherCasing</defName>
-		<graphicData>
-			<texPath>Things/Filth/Filth_DisposableLauncherCasings/Filth_DisposableLauncherCasings</texPath>
-			<renderInstanced>true</renderInstanced>
-			<drawSize>(1.5,1.5)</drawSize>
-		</graphicData>
-		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<solidTime>3.0</solidTime>
-		<fadeOutTime>0.2</fadeOutTime>
-		<landSound>C_Impact_BulletCasing</landSound>
-		<collide>true</collide>
-	</FleckDef>
+  <FleckDef ParentName="CE_CasingFleckBase">
+    <defName>Fleck_DisposableLauncherCasing</defName>
+    <graphicData>
+      <texPath>Things/Filth/Filth_DisposableLauncherCasings/Filth_DisposableLauncherCasings</texPath>
+      <renderInstanced>true</renderInstanced>
+      <drawSize>(1.5,1.5)</drawSize>
+    </graphicData>
+    <altitudeLayer>MoteOverhead</altitudeLayer>
+    <solidTime>3.0</solidTime>
+    <fadeOutTime>0.2</fadeOutTime>
+    <landSound>C_Impact_BulletCasing</landSound>
+    <collide>true</collide>
+  </FleckDef>
 
-	<!--
+  <!--
 		Keeping these as motes for now
 	-->
 
-	<!-- 
-		<FleckDef ParentName="FleckBase_Thrown">
+  <!-- 
+		<FleckDef ParentName="">
 		<defName>Mote_BigExplode</defName>
 		<graphicData>
 			<texPath>Things/Mote/Mote_BigExplode</texPath>
@@ -177,7 +181,7 @@
 		<growthRate>15</growthRate>
 	</FleckDef>
 
-	<FleckDef ParentName="FleckBase_Thrown">
+	<FleckDef ParentName="">
 		<defName>Mote_Firetrail</defName>
 		<graphicData>
 			<texPath>Things/Mote/Mote_Firetrail</texPath>

--- a/Defs/ThingDefs_Misc/Weapons_Turrets.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Turrets.xml
@@ -1,450 +1,462 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Defs>
 
-	<ThingDef Name="BaseTurretGun" ParentName="BaseGun" Abstract="True">
-		<statBases>
-			<Mass>1</Mass>
-		</statBases>
-		<relicChance>0</relicChance>
-		<soundInteract>Interact_Rifle</soundInteract>
-		<weaponTags>
-			<li>Gun</li>
-			<li>TurretGun</li>
-		</weaponTags>
-		<tradeability>None</tradeability>
-		<destroyOnDrop>True</destroyOnDrop>
-		<generateAllowChance>0</generateAllowChance>
-		<smeltable>false</smeltable>
-		<modExtensions>
-			<li Class="CombatExtended.ThingDefExtensionCE">
-				<MenuHidden>True</MenuHidden>
-			</li>
-		</modExtensions>
-	</ThingDef>
+  <ThingDef Name="BaseTurretGun" ParentName="BaseGun" Abstract="True">
+    <statBases>
+      <Mass>1</Mass>
+    </statBases>
+    <relicChance>0</relicChance>
+    <soundInteract>Interact_Rifle</soundInteract>
+    <weaponTags>
+      <li>Gun</li>
+      <li>TurretGun</li>
+    </weaponTags>
+    <tradeability>None</tradeability>
+    <destroyOnDrop>True</destroyOnDrop>
+    <generateAllowChance>0</generateAllowChance>
+    <smeltable>false</smeltable>
+    <modExtensions>
+      <li Class="CombatExtended.ThingDefExtensionCE">
+        <MenuHidden>True</MenuHidden>
+      </li>
+    </modExtensions>
+  </ThingDef>
 
-	<ThingDef Name="BaseAutoTurretGun" ParentName="BaseTurretGun" Abstract="True">
-		<comps>
-			<li Class="CombatExtended.CompProperties_FireModes">
-				<aiUseBurstMode>FALSE</aiUseBurstMode>
-				<aiAimMode>AimedShot</aiAimMode>
-				<noSnapshot>true</noSnapshot>
-				<noSingleShot>true</noSingleShot>
-			</li>
-		</comps>
-	</ThingDef>
+  <ThingDef Name="BaseAutoTurretGun" ParentName="BaseTurretGun" Abstract="True">
+    <comps>
+      <li Class="CombatExtended.CompProperties_FireModes">
+        <aiUseBurstMode>FALSE</aiUseBurstMode>
+        <aiAimMode>AimedShot</aiAimMode>
+        <noSnapshot>true</noSnapshot>
+        <noSingleShot>true</noSingleShot>
+      </li>
+    </comps>
+  </ThingDef>
 
-	<!-- ================== Blaster Turret ================== -->
+  <!-- ================== Blaster Turret ================== -->
 
-	<ThingDef ParentName="BaseAutoTurretGun">
-		<defName>Gun_BlasterTurret</defName>
-		<label>blaster turret gun</label>
-		<graphicData>
-			<texPath>Things/Building/Turrets/BlasterTurret_Top</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<description>Charge blaster attached to a turret mount.</description>
-		<soundInteract>Interact_ChargeRifle</soundInteract>
-		<statBases>
-			<SightsEfficiency>1</SightsEfficiency>
-			<ShotSpread>0.06</ShotSpread>
-			<SwayFactor>0.86</SwayFactor>
-			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-			<Mass>10</Mass>
-		</statBases>
-		<verbs>
-			<li Class="CombatExtended.VerbPropertiesCE">
-				<recoilAmount>0.90</recoilAmount>
-				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-				<hasStandardCommand>true</hasStandardCommand>
-				<defaultProjectile>Bullet_8x35mmCharged</defaultProjectile>
-				<warmupTime>1.3</warmupTime>
-				<range>55</range>
-				<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
-				<burstShotCount>10</burstShotCount>
-				<soundCast>Shot_ChargeBlaster</soundCast>
-				<soundCastTail>GunTail_Heavy</soundCastTail>
-				<muzzleFlashScale>9</muzzleFlashScale>
-				<recoilPattern>Mounted</recoilPattern>
-			</li>
-		</verbs>
-		<comps>
-			<li Class="CombatExtended.CompProperties_AmmoUser">
-				<magazineSize>100</magazineSize>
-				<reloadTime>7.8</reloadTime>
-				<ammoSet>AmmoSet_8x35mmCharged</ammoSet>
-			</li>
-		</comps>
-	</ThingDef>
+  <ThingDef ParentName="BaseAutoTurretGun">
+    <defName>Gun_BlasterTurret</defName>
+    <label>blaster turret gun</label>
+    <graphicData>
+      <texPath>Things/Building/Turrets/BlasterTurret_Top</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <description>Charge blaster attached to a turret mount.</description>
+    <soundInteract>Interact_ChargeRifle</soundInteract>
+    <statBases>
+      <SightsEfficiency>1</SightsEfficiency>
+      <ShotSpread>0.06</ShotSpread>
+      <SwayFactor>0.86</SwayFactor>
+      <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+      <Mass>10</Mass>
+    </statBases>
+    <verbs>
+      <li Class="CombatExtended.VerbPropertiesCE">
+        <recoilAmount>0.90</recoilAmount>
+        <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+        <hasStandardCommand>true</hasStandardCommand>
+        <defaultProjectile>Bullet_8x35mmCharged</defaultProjectile>
+        <warmupTime>1.3</warmupTime>
+        <range>55</range>
+        <ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+        <burstShotCount>10</burstShotCount>
+        <soundCast>Shot_ChargeBlaster</soundCast>
+        <soundCastTail>GunTail_Heavy</soundCastTail>
+        <muzzleFlashScale>9</muzzleFlashScale>
+        <recoilPattern>Mounted</recoilPattern>
+      </li>
+    </verbs>
+    <comps>
+      <li Class="CombatExtended.CompProperties_AmmoUser">
+        <magazineSize>100</magazineSize>
+        <reloadTime>7.8</reloadTime>
+        <ammoSet>AmmoSet_8x35mmCharged</ammoSet>
+      </li>
+    </comps>
+  </ThingDef>
 
-	<!-- ================== Heavy Turret ================== -->
+  <!-- ================== Heavy Turret ================== -->
 
-	<ThingDef ParentName="BaseAutoTurretGun">
-		<defName>Gun_HeavyTurret</defName>
-		<label>heavy turret gun</label>
-		<graphicData>
-			<texPath>Things/Building/Turrets/HeavyTurret_Top</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<description>High caliber gun on a turret mount.</description>
-		<statBases>
-			<SightsEfficiency>1</SightsEfficiency>
-			<ShotSpread>0.01</ShotSpread>
-			<SwayFactor>1.31</SwayFactor>
-			<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
-			<Mass>30</Mass>
-		</statBases>
-		<verbs>
-			<li Class="CombatExtended.VerbPropertiesCE">
-				<recoilAmount>1.54</recoilAmount>
-				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-				<hasStandardCommand>true</hasStandardCommand>
-				<defaultProjectile>Bullet_145x114mm_FMJ</defaultProjectile>
-				<warmupTime>1.6</warmupTime>
-				<range>55</range>
-				<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
-				<burstShotCount>5</burstShotCount>
-				<soundCast>HeavyMG</soundCast>
-				<soundCastTail>GunTail_Heavy</soundCastTail>
-				<muzzleFlashScale>16</muzzleFlashScale>
-				<recoilPattern>Mounted</recoilPattern>
-			</li>
-		</verbs>
-		<comps>
-			<li Class="CombatExtended.CompProperties_AmmoUser">
-				<magazineSize>40</magazineSize>
-				<reloadTime>7.8</reloadTime>
-				<ammoSet>AmmoSet_145x114mm</ammoSet>
-			</li>
-		</comps>
-	</ThingDef>
+  <ThingDef ParentName="BaseAutoTurretGun">
+    <defName>Gun_HeavyTurret</defName>
+    <label>heavy turret gun</label>
+    <graphicData>
+      <texPath>Things/Building/Turrets/HeavyTurret_Top</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <description>High caliber gun on a turret mount.</description>
+    <statBases>
+      <SightsEfficiency>1</SightsEfficiency>
+      <ShotSpread>0.01</ShotSpread>
+      <SwayFactor>1.31</SwayFactor>
+      <RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+      <Mass>30</Mass>
+    </statBases>
+    <verbs>
+      <li Class="CombatExtended.VerbPropertiesCE">
+        <recoilAmount>1.54</recoilAmount>
+        <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+        <hasStandardCommand>true</hasStandardCommand>
+        <defaultProjectile>Bullet_145x114mm_FMJ</defaultProjectile>
+        <warmupTime>1.6</warmupTime>
+        <range>55</range>
+        <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+        <burstShotCount>5</burstShotCount>
+        <soundCast>HeavyMG</soundCast>
+        <soundCastTail>GunTail_Heavy</soundCastTail>
+        <muzzleFlashScale>16</muzzleFlashScale>
+        <recoilPattern>Mounted</recoilPattern>
+      </li>
+    </verbs>
+    <comps>
+      <li Class="CombatExtended.CompProperties_AmmoUser">
+        <magazineSize>40</magazineSize>
+        <reloadTime>7.8</reloadTime>
+        <ammoSet>AmmoSet_145x114mm</ammoSet>
+      </li>
+    </comps>
+  </ThingDef>
 
-	<!-- ================== Medium Turret ================== -->
+  <!-- ================== Medium Turret ================== -->
 
-	<ThingDef ParentName="BaseAutoTurretGun">
-		<defName>Gun_MediumTurret</defName>
-		<label>medium turret gun</label>
-		<graphicData>
-			<texPath>Things/Building/Turrets/MediumTurret_Top</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<description>Full powered cartridge gun on a turret mount.</description>
-		<statBases>
-			<SightsEfficiency>1</SightsEfficiency>
-			<ShotSpread>0.05</ShotSpread>
-			<SwayFactor>0.94</SwayFactor>
-			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-			<Mass>15</Mass>
-		</statBases>
-		<verbs>
-			<li Class="CombatExtended.VerbPropertiesCE">
-				<recoilAmount>0.77</recoilAmount>
-				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-				<hasStandardCommand>true</hasStandardCommand>
-				<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
-				<warmupTime>1.3</warmupTime>
-				<range>55</range>
-				<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
-				<burstShotCount>10</burstShotCount>
-				<soundCast>MediumMG</soundCast>
-				<soundCastTail>GunTail_Medium</soundCastTail>
-				<muzzleFlashScale>11</muzzleFlashScale>
-				<recoilPattern>Mounted</recoilPattern>
-			</li>
-		</verbs>
-		<comps>
-			<li Class="CombatExtended.CompProperties_AmmoUser">
-				<magazineSize>80</magazineSize>
-				<reloadTime>7.8</reloadTime>
-				<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
-			</li>
-		</comps>
-	</ThingDef>
+  <ThingDef ParentName="BaseAutoTurretGun">
+    <defName>Gun_MediumTurret</defName>
+    <label>medium turret gun</label>
+    <graphicData>
+      <texPath>Things/Building/Turrets/MediumTurret_Top</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <description>Full powered cartridge gun on a turret mount.</description>
+    <statBases>
+      <SightsEfficiency>1</SightsEfficiency>
+      <ShotSpread>0.05</ShotSpread>
+      <SwayFactor>0.94</SwayFactor>
+      <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+      <Mass>15</Mass>
+    </statBases>
+    <verbs>
+      <li Class="CombatExtended.VerbPropertiesCE">
+        <recoilAmount>0.77</recoilAmount>
+        <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+        <hasStandardCommand>true</hasStandardCommand>
+        <defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
+        <warmupTime>1.3</warmupTime>
+        <range>55</range>
+        <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+        <burstShotCount>10</burstShotCount>
+        <soundCast>MediumMG</soundCast>
+        <soundCastTail>GunTail_Medium</soundCastTail>
+        <muzzleFlashScale>11</muzzleFlashScale>
+        <recoilPattern>Mounted</recoilPattern>
+      </li>
+    </verbs>
+    <comps>
+      <li Class="CombatExtended.CompProperties_AmmoUser">
+        <magazineSize>80</magazineSize>
+        <reloadTime>7.8</reloadTime>
+        <ammoSet>AmmoSet_762x51mmNATO</ammoSet>
+      </li>
+    </comps>
+  </ThingDef>
 
-	<!-- ================== Autocannon Turret ================== -->
+  <!-- ================== Autocannon Turret ================== -->
 
-	<ThingDef ParentName="BaseTurretGun">
-		<defName>Gun_AutocannonTurret</defName>
-		<label>autocannon turret</label>
-		<graphicData>
-			<texPath>Things/Building/Security/TurretAutocannon_Top</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<description>An automated heavy machine gun designed to be mounted on a turret, effective against infantry and light vehicles.</description>
-		<statBases>
-			<SightsEfficiency>1</SightsEfficiency>
-			<ShotSpread>0.01</ShotSpread>
-			<SwayFactor>1.61</SwayFactor>
-			<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
-			<Mass>50</Mass>
-		</statBases>
-		<verbs>
-			<li Class="CombatExtended.VerbPropertiesCE">
-				<recoilAmount>1.50</recoilAmount>
-				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-				<hasStandardCommand>true</hasStandardCommand>
-				<defaultProjectile>Bullet_20x102mmNATO_AP</defaultProjectile>
-				<warmupTime>2.3</warmupTime>
-				<range>78</range>
-				<ticksBetweenBurstShots>7</ticksBetweenBurstShots>
-				<burstShotCount>10</burstShotCount>
-				<soundCast>HeavyMG</soundCast>
-				<soundCastTail>GunTail_Heavy</soundCastTail>
-				<muzzleFlashScale>16</muzzleFlashScale>
-				<recoilPattern>Mounted</recoilPattern>
-			</li>
-		</verbs>
-		<comps>
-			<li Class="CombatExtended.CompProperties_AmmoUser">
-				<magazineSize>100</magazineSize>
-				<reloadTime>7.8</reloadTime>
-				<ammoSet>AmmoSet_20x102mmNATO</ammoSet>
-			</li>
-			<li Class="CombatExtended.CompProperties_FireModes">
-				<aiAimMode>AimedShot</aiAimMode>
-				<noSnapshot>true</noSnapshot>
-				<noSingleShot>true</noSingleShot>
-			</li>
-		</comps>
-	</ThingDef>
+  <ThingDef ParentName="BaseTurretGun">
+    <defName>Gun_AutocannonTurret</defName>
+    <label>autocannon turret</label>
+    <graphicData>
+      <texPath>Things/Building/Security/TurretAutocannon_Top</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <description>An automated heavy machine gun designed to be mounted on a turret, effective against infantry and light vehicles.</description>
+    <statBases>
+      <SightsEfficiency>1</SightsEfficiency>
+      <ShotSpread>0.01</ShotSpread>
+      <SwayFactor>1.61</SwayFactor>
+      <RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+      <Mass>50</Mass>
+    </statBases>
+    <verbs>
+      <li Class="CombatExtended.VerbPropertiesCE">
+        <recoilAmount>1.50</recoilAmount>
+        <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+        <hasStandardCommand>true</hasStandardCommand>
+        <defaultProjectile>Bullet_20x102mmNATO_AP</defaultProjectile>
+        <warmupTime>2.3</warmupTime>
+        <range>78</range>
+        <ticksBetweenBurstShots>7</ticksBetweenBurstShots>
+        <burstShotCount>10</burstShotCount>
+        <soundCast>HeavyMG</soundCast>
+        <soundCastTail>GunTail_Heavy</soundCastTail>
+        <muzzleFlashScale>16</muzzleFlashScale>
+        <recoilPattern>Mounted</recoilPattern>
+      </li>
+    </verbs>
+    <comps>
+      <li Class="CombatExtended.CompProperties_AmmoUser">
+        <magazineSize>100</magazineSize>
+        <reloadTime>7.8</reloadTime>
+        <ammoSet>AmmoSet_20x102mmNATO</ammoSet>
+      </li>
+      <li Class="CombatExtended.CompProperties_FireModes">
+        <aiAimMode>AimedShot</aiAimMode>
+        <noSnapshot>true</noSnapshot>
+        <noSingleShot>true</noSingleShot>
+      </li>
+    </comps>
+  </ThingDef>
 
-	<!-- ================== Sniper turret ================== -->
+  <!-- ================== Sniper turret ================== -->
 
-	<ThingDef ParentName="BaseTurretGun">
-		<defName>Gun_TurretSniper</defName>
-		<label>flak turret</label>
-		<description>A self-loading heavy autocannon designed to attach to a turret.</description>
-		<soundInteract>Artillery_ShellLoaded</soundInteract>
-		<graphicData>
-			<texPath>Things/Building/Security/TurretSniper_Top</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-			<drawSize>(2,2)</drawSize>
-		</graphicData>
-		<statBases>
-			<SightsEfficiency>2.36</SightsEfficiency>
-			<ShotSpread>0.01</ShotSpread>
-			<SwayFactor>1.89</SwayFactor>
-			<RangedWeapon_Cooldown>0.5</RangedWeapon_Cooldown>
-			<Mass>50</Mass>
-		</statBases>
-		<verbs>
-			<li Class="CombatExtended.VerbPropertiesCE">
-				<recoilAmount>4.15</recoilAmount>
-				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-				<hasStandardCommand>true</hasStandardCommand>
-				<defaultProjectile>Bullet_40x311mmR_AP</defaultProjectile>
-				<warmupTime>4.6</warmupTime>
-				<minRange>5</minRange>
-				<range>86</range>
-				<soundCast>Shot_TurretSniper</soundCast>
-				<soundCastTail>GunTail_Heavy</soundCastTail>
-				<muzzleFlashScale>20</muzzleFlashScale>
-				<recoilPattern>Mounted</recoilPattern>
-			</li>
-		</verbs>
-		<comps>
-			<li Class="CombatExtended.CompProperties_AmmoUser">
-				<magazineSize>20</magazineSize>
-				<reloadTime>6.8</reloadTime>
-				<ammoSet>AmmoSet_40x311mmR</ammoSet>
-			</li>
-			<li Class="CombatExtended.CompProperties_FireModes">
-				<aiAimMode>AimedShot</aiAimMode>
-				<noSnapshot>true</noSnapshot>
-			</li>
-		</comps>
-	</ThingDef>
+  <ThingDef ParentName="BaseTurretGun">
+    <defName>Gun_TurretSniper</defName>
+    <label>flak turret</label>
+    <description>A self-loading heavy autocannon designed to attach to a turret.</description>
+    <soundInteract>Artillery_ShellLoaded</soundInteract>
+    <graphicData>
+      <texPath>Things/Building/Security/TurretSniper_Top</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+      <drawSize>(2,2)</drawSize>
+    </graphicData>
+    <statBases>
+      <SightsEfficiency>2.36</SightsEfficiency>
+      <ShotSpread>0.01</ShotSpread>
+      <SwayFactor>1.89</SwayFactor>
+      <RangedWeapon_Cooldown>0.5</RangedWeapon_Cooldown>
+      <Mass>50</Mass>
+    </statBases>
+    <verbs>
+      <li Class="CombatExtended.VerbPropertiesCE">
+        <recoilAmount>4.15</recoilAmount>
+        <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+        <hasStandardCommand>true</hasStandardCommand>
+        <defaultProjectile>Bullet_40x311mmR_AP</defaultProjectile>
+        <warmupTime>4.6</warmupTime>
+        <minRange>5</minRange>
+        <range>86</range>
+        <soundCast>Shot_TurretSniper</soundCast>
+        <soundCastTail>GunTail_Heavy</soundCastTail>
+        <muzzleFlashScale>20</muzzleFlashScale>
+        <recoilPattern>Mounted</recoilPattern>
+      </li>
+    </verbs>
+    <comps>
+      <li Class="CombatExtended.CompProperties_AmmoUser">
+        <magazineSize>20</magazineSize>
+        <reloadTime>6.8</reloadTime>
+        <ammoSet>AmmoSet_40x311mmR</ammoSet>
+      </li>
+      <li Class="CombatExtended.CompProperties_FireModes">
+        <aiAimMode>AimedShot</aiAimMode>
+        <noSnapshot>true</noSnapshot>
+      </li>
+    </comps>
+  </ThingDef>
 
-	<!-- ================== KPV ================== -->
+  <!-- ================== KPV ================== -->
 
-	<ThingDef ParentName="BaseTurretGun">
-		<defName>Gun_KPV</defName>
-		<label>KPV machine gun</label>
-		<graphicData>
-			<texPath>Things/Building/Turrets/KPV_gun</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<description>Heavy machine gun for use against light vehicles.</description>
-		<statBases>
-			<SightsEfficiency>1</SightsEfficiency>
-			<ShotSpread>0.01</ShotSpread>
-			<SwayFactor>1.42</SwayFactor>
-			<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
-			<Mass>35</Mass>
-		</statBases>
-		<verbs>
-			<li Class="CombatExtended.VerbPropertiesCE">
-				<recoilAmount>1.43</recoilAmount>
-				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-				<hasStandardCommand>true</hasStandardCommand>
-				<defaultProjectile>Bullet_145x114mm_FMJ</defaultProjectile>
-				<warmupTime>1.3</warmupTime>
-				<range>75</range>
-				<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
-				<burstShotCount>10</burstShotCount>
-				<soundCast>HeavyMG</soundCast>
-				<soundCastTail>GunTail_Heavy</soundCastTail>
-				<muzzleFlashScale>16</muzzleFlashScale>
-				<recoilPattern>Mounted</recoilPattern>
-			</li>
-		</verbs>
-		<comps>
-			<li Class="CombatExtended.CompProperties_AmmoUser">
-				<magazineSize>50</magazineSize>
-				<reloadTime>7.8</reloadTime>
-				<ammoSet>AmmoSet_145x114mm</ammoSet>
-			</li>
-			<li Class="CombatExtended.CompProperties_FireModes">
-				<aimedBurstShotCount>5</aimedBurstShotCount>
-				<aiAimMode>SuppressFire</aiAimMode>
-			</li>
-		</comps>
-	</ThingDef>
+  <ThingDef ParentName="BaseTurretGun">
+    <defName>Gun_KPV</defName>
+    <label>KPV machine gun</label>
+    <graphicData>
+      <texPath>Things/Building/Turrets/KPV_gun</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <description>Heavy machine gun for use against light vehicles.</description>
+    <statBases>
+      <SightsEfficiency>1</SightsEfficiency>
+      <ShotSpread>0.01</ShotSpread>
+      <SwayFactor>1.42</SwayFactor>
+      <RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+      <Mass>35</Mass>
+    </statBases>
+    <verbs>
+      <li Class="CombatExtended.VerbPropertiesCE">
+        <recoilAmount>1.43</recoilAmount>
+        <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+        <hasStandardCommand>true</hasStandardCommand>
+        <defaultProjectile>Bullet_145x114mm_FMJ</defaultProjectile>
+        <warmupTime>1.3</warmupTime>
+        <range>75</range>
+        <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+        <burstShotCount>10</burstShotCount>
+        <soundCast>HeavyMG</soundCast>
+        <soundCastTail>GunTail_Heavy</soundCastTail>
+        <muzzleFlashScale>16</muzzleFlashScale>
+        <recoilPattern>Mounted</recoilPattern>
+      </li>
+    </verbs>
+    <comps>
+      <li Class="CombatExtended.CompProperties_AmmoUser">
+        <magazineSize>50</magazineSize>
+        <reloadTime>7.8</reloadTime>
+        <ammoSet>AmmoSet_145x114mm</ammoSet>
+      </li>
+      <li Class="CombatExtended.CompProperties_FireModes">
+        <aimedBurstShotCount>5</aimedBurstShotCount>
+        <aiAimMode>SuppressFire</aiAimMode>
+      </li>
+    </comps>
+    <modExtensions>
+      <li Class="CombatExtended.GunDrawExtension">
+        <!--I'm bothered enough to go watch a video and find out KPV ejects towards front-left-->
+        <CasingAngleOffset>-110</CasingAngleOffset>
+      </li>
+    </modExtensions>
+  </ThingDef>
 
-	<!-- ================== M240B ================== -->
+  <!-- ================== M240B ================== -->
 
-	<ThingDef ParentName="BaseTurretGun">
-		<defName>Gun_M240B</defName>
-		<label>M240B machine gun</label>
-		<graphicData>
-			<texPath>Things/Building/Turrets/M240_gun</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<description>M240B machine gun mounted on a tripod.</description>
-		<statBases>
-			<SightsEfficiency>1</SightsEfficiency>
-			<ShotSpread>0.04</ShotSpread>
-			<SwayFactor>0.96</SwayFactor>
-			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-			<Mass>12</Mass>
-		</statBases>
-		<verbs>
-			<li Class="CombatExtended.VerbPropertiesCE">
-				<recoilAmount>0.86</recoilAmount>
-				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-				<hasStandardCommand>true</hasStandardCommand>
-				<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
-				<warmupTime>1.3</warmupTime>
-				<range>62</range>
-				<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
-				<burstShotCount>10</burstShotCount>
-				<soundCast>MediumMG</soundCast>
-				<soundCastTail>GunTail_Medium</soundCastTail>
-				<muzzleFlashScale>10</muzzleFlashScale>
-				<recoilPattern>Mounted</recoilPattern>
-			</li>
-		</verbs>
-		<comps>
-			<li Class="CombatExtended.CompProperties_AmmoUser">
-				<magazineSize>200</magazineSize>
-				<reloadTime>7.8</reloadTime>
-				<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
-			</li>
-			<li Class="CombatExtended.CompProperties_FireModes">
-				<aimedBurstShotCount>5</aimedBurstShotCount>
-				<aiAimMode>SuppressFire</aiAimMode>
-			</li>
-		</comps>
-	</ThingDef>
+  <ThingDef ParentName="BaseTurretGun">
+    <defName>Gun_M240B</defName>
+    <label>M240B machine gun</label>
+    <graphicData>
+      <texPath>Things/Building/Turrets/M240_gun</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <description>M240B machine gun mounted on a tripod.</description>
+    <statBases>
+      <SightsEfficiency>1</SightsEfficiency>
+      <ShotSpread>0.04</ShotSpread>
+      <SwayFactor>0.96</SwayFactor>
+      <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+      <Mass>12</Mass>
+    </statBases>
+    <verbs>
+      <li Class="CombatExtended.VerbPropertiesCE">
+        <recoilAmount>0.86</recoilAmount>
+        <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+        <hasStandardCommand>true</hasStandardCommand>
+        <defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
+        <warmupTime>1.3</warmupTime>
+        <range>62</range>
+        <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+        <burstShotCount>10</burstShotCount>
+        <soundCast>MediumMG</soundCast>
+        <soundCastTail>GunTail_Medium</soundCastTail>
+        <muzzleFlashScale>10</muzzleFlashScale>
+        <recoilPattern>Mounted</recoilPattern>
+      </li>
+    </verbs>
+    <comps>
+      <li Class="CombatExtended.CompProperties_AmmoUser">
+        <magazineSize>200</magazineSize>
+        <reloadTime>7.8</reloadTime>
+        <ammoSet>AmmoSet_762x51mmNATO</ammoSet>
+      </li>
+      <li Class="CombatExtended.CompProperties_FireModes">
+        <aimedBurstShotCount>5</aimedBurstShotCount>
+        <aiAimMode>SuppressFire</aiAimMode>
+      </li>
+    </comps>
+  </ThingDef>
 
-	<!-- ================== Flak cannon ================== -->
+  <!-- ================== Flak cannon ================== -->
 
-	<ThingDef ParentName="BaseTurretGun">
-		<defName>Gun_FlakTurret</defName>
-		<label>Flak gun</label>
-		<description>90mm Flak cannon on a stationary emplacement.</description>
-		<graphicData>
-			<texPath>Things/Building/Turrets/FlakTurret_Top</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<soundInteract>Artillery_ShellLoaded</soundInteract>
-		<statBases>
-			<SightsEfficiency>2.3</SightsEfficiency>
-			<ShotSpread>0.01</ShotSpread>
-			<SwayFactor>1.41</SwayFactor>
-			<RangedWeapon_Cooldown>2.5</RangedWeapon_Cooldown>
-			<Mass>500</Mass>
-		</statBases>
-		<verbs>
-			<li Class="CombatExtended.VerbPropertiesCE">
-				<recoilAmount>4.74</recoilAmount>
-				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-				<hasStandardCommand>true</hasStandardCommand>
-				<defaultProjectile>Bullet_90mmCannonShell_HEAT</defaultProjectile>
-				<warmupTime>3.5</warmupTime>
-				<minRange>16</minRange>
-				<range>92</range>
-				<burstShotCount />
-				<soundCast>120mm</soundCast>
-				<soundCastTail>GunTail_Heavy</soundCastTail>
-				<muzzleFlashScale>20</muzzleFlashScale>
-				<targetParams>
-					<canTargetLocations>true</canTargetLocations>
-				</targetParams>
-				<recoilPattern>Mounted</recoilPattern>
-			</li>
-		</verbs>
-		<comps>
-			<li Class="CombatExtended.CompProperties_AmmoUser">
-				<magazineSize>1</magazineSize>
-				<reloadTime>9.8</reloadTime>
-				<ammoSet>AmmoSet_90mmCannonShell</ammoSet>
-			</li>
-			<li Class="CombatExtended.CompProperties_FireModes">
-				<aiAimMode>AimedShot</aiAimMode>
-			</li>
-		</comps>
-	</ThingDef>
+  <ThingDef ParentName="BaseTurretGun">
+    <defName>Gun_FlakTurret</defName>
+    <label>Flak gun</label>
+    <description>90mm Flak cannon on a stationary emplacement.</description>
+    <graphicData>
+      <texPath>Things/Building/Turrets/FlakTurret_Top</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <soundInteract>Artillery_ShellLoaded</soundInteract>
+    <statBases>
+      <SightsEfficiency>2.3</SightsEfficiency>
+      <ShotSpread>0.01</ShotSpread>
+      <SwayFactor>1.41</SwayFactor>
+      <RangedWeapon_Cooldown>2.5</RangedWeapon_Cooldown>
+      <Mass>500</Mass>
+    </statBases>
+    <verbs>
+      <li Class="CombatExtended.VerbPropertiesCE">
+        <recoilAmount>4.74</recoilAmount>
+        <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+        <hasStandardCommand>true</hasStandardCommand>
+        <defaultProjectile>Bullet_90mmCannonShell_HEAT</defaultProjectile>
+        <warmupTime>3.5</warmupTime>
+        <minRange>16</minRange>
+        <range>92</range>
+        <burstShotCount />
+        <soundCast>120mm</soundCast>
+        <soundCastTail>GunTail_Heavy</soundCastTail>
+        <muzzleFlashScale>20</muzzleFlashScale>
+        <targetParams>
+          <canTargetLocations>true</canTargetLocations>
+        </targetParams>
+        <recoilPattern>Mounted</recoilPattern>
+      </li>
+    </verbs>
+    <comps>
+      <li Class="CombatExtended.CompProperties_AmmoUser">
+        <magazineSize>1</magazineSize>
+        <reloadTime>9.8</reloadTime>
+        <ammoSet>AmmoSet_90mmCannonShell</ammoSet>
+      </li>
+      <li Class="CombatExtended.CompProperties_FireModes">
+        <aiAimMode>AimedShot</aiAimMode>
+      </li>
+    </comps>
+    <modExtensions>
+      <li Class="CombatExtended.GunDrawExtension">
+        <CasingOffset>0,-1</CasingOffset>
+        <CasingAngleOffset>90</CasingAngleOffset>
+      </li>
+    </modExtensions>
+  </ThingDef>
 
-	<!-- ================== AGS-30 ================== -->
+  <!-- ================== AGS-30 ================== -->
 
-	<ThingDef ParentName="BaseTurretGun">
-		<defName>Gun_AGSThirty</defName>
-		<label>AGS-30 grenade launcher</label>
-		<graphicData>
-			<texPath>Things/Building/Turrets/AGS30_gun</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<description>AGS-30 attached to a tripod.</description>
-		<statBases>
-			<SightsEfficiency>2.16</SightsEfficiency>
-			<ShotSpread>0.15</ShotSpread>
-			<SwayFactor>0.92</SwayFactor>
-			<RangedWeapon_Cooldown>0.40</RangedWeapon_Cooldown>
-			<Mass>13</Mass>
-		</statBases>
-		<verbs>
-			<li Class="CombatExtended.VerbPropertiesCE">
-				<recoilAmount>2.38</recoilAmount>
-				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-				<hasStandardCommand>true</hasStandardCommand>
-				<defaultProjectile>Bullet_30x29mmGrenade_HE</defaultProjectile>
-				<warmupTime>1.435</warmupTime>
-				<minRange>8</minRange>
-				<range>62</range>
-				<ticksBetweenBurstShots>9</ticksBetweenBurstShots>
-				<burstShotCount>6</burstShotCount>
-				<soundCast>AGS</soundCast>
-				<soundCastTail>GunTail_Heavy</soundCastTail>
-				<muzzleFlashScale>14</muzzleFlashScale>
-				<targetParams>
-					<canTargetLocations>true</canTargetLocations>
-				</targetParams>
-				<recoilPattern>Mounted</recoilPattern>
-				<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
-			</li>
-		</verbs>
-		<comps>
-			<li Class="CombatExtended.CompProperties_AmmoUser">
-				<magazineSize>30</magazineSize>
-				<reloadTime>7.8</reloadTime>
-				<ammoSet>AmmoSet_30x29mmGrenade</ammoSet>
-			</li>
-			<li Class="CombatExtended.CompProperties_FireModes">
-				<aiUseBurstMode>FALSE</aiUseBurstMode>
-				<aiAimMode>SuppressFire</aiAimMode>
-				<aimedBurstShotCount>3</aimedBurstShotCount>
-			</li>
-		</comps>
-	</ThingDef>
+  <ThingDef ParentName="BaseTurretGun">
+    <defName>Gun_AGSThirty</defName>
+    <label>AGS-30 grenade launcher</label>
+    <graphicData>
+      <texPath>Things/Building/Turrets/AGS30_gun</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <description>AGS-30 attached to a tripod.</description>
+    <statBases>
+      <SightsEfficiency>2.16</SightsEfficiency>
+      <ShotSpread>0.15</ShotSpread>
+      <SwayFactor>0.92</SwayFactor>
+      <RangedWeapon_Cooldown>0.40</RangedWeapon_Cooldown>
+      <Mass>13</Mass>
+    </statBases>
+    <verbs>
+      <li Class="CombatExtended.VerbPropertiesCE">
+        <recoilAmount>2.38</recoilAmount>
+        <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+        <hasStandardCommand>true</hasStandardCommand>
+        <defaultProjectile>Bullet_30x29mmGrenade_HE</defaultProjectile>
+        <warmupTime>1.435</warmupTime>
+        <minRange>8</minRange>
+        <range>62</range>
+        <ticksBetweenBurstShots>9</ticksBetweenBurstShots>
+        <burstShotCount>6</burstShotCount>
+        <soundCast>AGS</soundCast>
+        <soundCastTail>GunTail_Heavy</soundCastTail>
+        <muzzleFlashScale>14</muzzleFlashScale>
+        <targetParams>
+          <canTargetLocations>true</canTargetLocations>
+        </targetParams>
+        <recoilPattern>Mounted</recoilPattern>
+        <ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
+      </li>
+    </verbs>
+    <comps>
+      <li Class="CombatExtended.CompProperties_AmmoUser">
+        <magazineSize>30</magazineSize>
+        <reloadTime>7.8</reloadTime>
+        <ammoSet>AmmoSet_30x29mmGrenade</ammoSet>
+      </li>
+      <li Class="CombatExtended.CompProperties_FireModes">
+        <aiUseBurstMode>FALSE</aiUseBurstMode>
+        <aiAimMode>SuppressFire</aiAimMode>
+        <aimedBurstShotCount>3</aimedBurstShotCount>
+      </li>
+    </comps>
+  </ThingDef>
 
 </Defs>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -1,1496 +1,1500 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Gun_ChargeLance"]</xpath>
-		<value>
-			<relicChance>0</relicChance>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[@Name="BaseWeaponTurret"]</xpath>
-		<value>
-			<relicChance>0</relicChance>
-		</value>
-	</Operation>
-
-	<!-- ========== Tools ========== -->
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Gun_Revolver" or defName="Gun_Autopistol" or defName="Gun_MachinePistol"]/tools</xpath>
-		<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-					<label>grip</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>2</power>
-					<cooldownTime>1.54</cooldownTime>
-					<chanceFactor>1.5</chanceFactor>
-					<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>muzzle</label>
-					<capacities>
-						<li>Poke</li>
-					</capacities>
-					<power>2</power>
-					<cooldownTime>1.54</cooldownTime>
-					<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-				</li>
-			</tools>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>
-			Defs/ThingDef[
-			defName="Gun_PumpShotgun" or
-			defName="Gun_ChainShotgun" or
-			defName="Gun_BoltActionRifle" or
-			defName="Gun_AssaultRifle" or
-			defName="Gun_SniperRifle" or
-			defName="Gun_HeavySMG" or
-			defName="Gun_IncendiaryLauncher" or
-			defName="Gun_LMG" or
-			defName="Gun_ChargeRifle"
-			]/tools
-		</xpath>
-		<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-					<label>stock</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>8</power>
-					<cooldownTime>1.55</cooldownTime>
-					<chanceFactor>1.5</chanceFactor>
-					<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>barrel</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>5</power>
-					<cooldownTime>2.02</cooldownTime>
-					<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>muzzle</label>
-					<capacities>
-						<li>Poke</li>
-					</capacities>
-					<power>8</power>
-					<cooldownTime>1.55</cooldownTime>
-					<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-				</li>
-			</tools>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Gun_TripleRocket" or defName="Gun_DoomsdayRocket"]/tools</xpath>
-		<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-					<label>barrel</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>10</power>
-					<cooldownTime>2.44</cooldownTime>
-					<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-				</li>
-			</tools>
-		</value>
-	</Operation>
-
-	<!-- ========== Revolver ========== -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_Revolver</defName>
-		<statBases>
-			<Mass>1.39</Mass>
-			<RangedWeapon_Cooldown>0.49</RangedWeapon_Cooldown>
-			<SightsEfficiency>0.7</SightsEfficiency>
-			<ShotSpread>0.18</ShotSpread>
-			<SwayFactor>1.27</SwayFactor>
-			<Bulk>2.41</Bulk>
-			<!-- <ToughnessRating>2.5</ToughnessRating> --><!-- Base toughness rating of a weapon -->
-			<WorkToMake>7000</WorkToMake>
-		</statBases>
-		<costList>
-			<Steel>30</Steel>
-			<ComponentIndustrial>2</ComponentIndustrial>
-		</costList>
-		<Properties>
-			<recoilAmount>2.96</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_44Magnum_FMJ</defaultProjectile>
-			<warmupTime>0.6</warmupTime>
-			<range>12</range>
-			<soundCast>Shot_Revolver</soundCast>
-			<soundCastTail>GunTail_Light</soundCastTail>
-			<muzzleFlashScale>9</muzzleFlashScale>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>6</magazineSize>
-			<reloadTime>4.6</reloadTime>
-			<ammoSet>AmmoSet_44Magnum</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aiUseBurstMode>FALSE</aiUseBurstMode>
-			<aiAimMode>Snapshot</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>CE_Sidearm</li>
-			<li>CE_AI_BROOM</li>
-			<li>CE_OneHandedWeapon</li>
-		</weaponTags>
-		<researchPrerequisite>Gunsmithing</researchPrerequisite>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Gun_Revolver"]</xpath>
-		<value>
-			<li Class="CombatExtended.GunDrawExtension">
-				<DrawSize>1.00,1.00</DrawSize>
-				<DrawOffset>0.0,0.0</DrawOffset>
-			</li>
-		</value>
-	</Operation>
-
-	<!-- ========== Autopistol ========== -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_Autopistol</defName>
-		<statBases>
-			<Mass>1.11</Mass>
-			<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
-			<SightsEfficiency>0.7</SightsEfficiency>
-			<ShotSpread>0.17</ShotSpread>
-			<SwayFactor>1.07</SwayFactor>
-			<Bulk>2.10</Bulk>
-			<WorkToMake>7000</WorkToMake>
-		</statBases>
-		<costList>
-			<Steel>25</Steel>
-			<ComponentIndustrial>3</ComponentIndustrial>
-		</costList>
-		<Properties>
-			<recoilAmount>2.72</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
-			<warmupTime>0.6</warmupTime>
-			<range>12</range>
-			<soundCast>Shot_Autopistol</soundCast>
-			<soundCastTail>GunTail_Light</soundCastTail>
-			<muzzleFlashScale>9</muzzleFlashScale>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>7</magazineSize>
-			<reloadTime>4</reloadTime>
-			<ammoSet>AmmoSet_45ACP</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aiUseBurstMode>FALSE</aiUseBurstMode>
-			<aiAimMode>Snapshot</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>CE_Sidearm</li>
-			<li>CE_AI_BROOM</li>
-			<li>CE_OneHandedWeapon</li>
-		</weaponTags>
-		<researchPrerequisite>BlowbackOperation</researchPrerequisite>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Gun_Autopistol"]</xpath>
-		<value>
-			<li Class="CombatExtended.GunDrawExtension">
-				<DrawSize>0.93,0.93</DrawSize>
-				<DrawOffset>0.0,0.0</DrawOffset>
-			</li>
-		</value>
-	</Operation>
-
-	<!-- ========== Pump Shotgun ========== -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_PumpShotgun</defName>
-		<statBases>
-			<Mass>3.00</Mass>
-			<RangedWeapon_Cooldown>1.0</RangedWeapon_Cooldown>
-			<ShotSpread>0.14</ShotSpread>
-			<SwayFactor>1.20</SwayFactor>
-			<Bulk>9.0</Bulk>
-			<SightsEfficiency>1</SightsEfficiency>
-			<WorkToMake>9500</WorkToMake>
-		</statBases>
-		<costList>
-			<Steel>45</Steel>
-			<WoodLog>10</WoodLog>
-			<ComponentIndustrial>1</ComponentIndustrial>
-		</costList>
-		<Properties>
-			<recoilAmount>2.75</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
-			<warmupTime>0.6</warmupTime>
-			<range>16</range>
-			<soundCast>Shot_Shotgun</soundCast>
-			<soundCastTail>GunTail_Heavy</soundCastTail>
-			<muzzleFlashScale>9</muzzleFlashScale>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>5</magazineSize>
-			<reloadOneAtATime>true</reloadOneAtATime>
-			<reloadTime>0.85</reloadTime>
-			<ammoSet>AmmoSet_12Gauge</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aiAimMode>Snapshot</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>SimpleGun</li>
-			<li>CE_AI_BROOM</li>
-		</weaponTags>
-		<researchPrerequisite>Gunsmithing</researchPrerequisite>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Gun_PumpShotgun"]</xpath>
-		<value>
-			<li Class="CombatExtended.GunDrawExtension">
-				<DrawSize>1.03,1.25</DrawSize>
-				<DrawOffset>0.05,0.0</DrawOffset>
-			</li>
-		</value>
-	</Operation>
-
-	<!-- ========== Chain Shotgun ========== -->
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Gun_ChainShotgun"]/description</xpath>
-		<value>
-			<description>A magazine-fed semi-automatic shotgun. It has the same range as a typical shotgun, but is extraordinarily dangerous due to being semi-automatic.</description>
-		</value>
-	</Operation>
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_ChainShotgun</defName>
-		<statBases>
-			<Mass>3.50</Mass>
-			<RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
-			<ShotSpread>0.15</ShotSpread>
-			<SwayFactor>1.26</SwayFactor>
-			<Bulk>6.7</Bulk>
-			<SightsEfficiency>1</SightsEfficiency>
-			<WorkToMake>22500</WorkToMake>
-		</statBases>
-		<costList>
-			<Steel>40</Steel>
-			<ComponentIndustrial>3</ComponentIndustrial>
-			<Chemfuel>10</Chemfuel>
-		</costList>
-		<Properties>
-			<recoilAmount>2.54</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
-			<warmupTime>0.6</warmupTime>
-			<range>16</range>
-			<soundCast>Shot_Shotgun_NoRack</soundCast>
-			<soundCastTail>GunTail_Heavy</soundCastTail>
-			<muzzleFlashScale>9</muzzleFlashScale>
-			<ticksBetweenBurstShots>15</ticksBetweenBurstShots>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>8</magazineSize>
-			<reloadTime>4</reloadTime>
-			<ammoSet>AmmoSet_12Gauge</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aiAimMode>Snapshot</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>CE_AI_BROOM</li>
-		</weaponTags>
-		<researchPrerequisite>GasOperation</researchPrerequisite>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Gun_ChainShotgun"]</xpath>
-		<value>
-			<li Class="CombatExtended.GunDrawExtension">
-				<DrawSize>1.04,1.23</DrawSize>
-				<DrawOffset>0.05,-0.05</DrawOffset>
-			</li>
-		</value>
-	</Operation>
-
-	<!-- ========== Bolt-action rifle ========== -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_BoltActionRifle</defName>
-		<statBases>
-			<Mass>4.19</Mass>
-			<RangedWeapon_Cooldown>1.17</RangedWeapon_Cooldown>
-			<SightsEfficiency>1</SightsEfficiency>
-			<ShotSpread>0.02</ShotSpread>
-			<SwayFactor>1.68</SwayFactor>
-			<Bulk>12.60</Bulk>
-			<WorkToMake>12000</WorkToMake>
-		</statBases>
-		<costList>
-			<Steel>55</Steel>
-			<WoodLog>15</WoodLog>
-			<ComponentIndustrial>1</ComponentIndustrial>
-		</costList>
-		<Properties>
-			<recoilAmount>2.04</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_303British_FMJ</defaultProjectile>
-			<warmupTime>1.1</warmupTime>
-			<range>55</range>
-			<soundCast>Shot_BoltActionRifle</soundCast>
-			<soundCastTail>GunTail_Heavy</soundCastTail>
-			<muzzleFlashScale>9</muzzleFlashScale>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>10</magazineSize>
-			<reloadTime>4.3</reloadTime>
-			<ammoSet>AmmoSet_303British</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aiAimMode>AimedShot</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>SimpleGun</li>
-			<li>CE_AI_SR</li>
-		</weaponTags>
-		<researchPrerequisite>Gunsmithing</researchPrerequisite>
-		<AllowWithRunAndGun>false</AllowWithRunAndGun>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Gun_BoltActionRifle"]</xpath>
-		<value>
-			<li Class="CombatExtended.GunDrawExtension">
-				<DrawSize>1.3,1.3</DrawSize>
-				<DrawOffset>0.12,0.04</DrawOffset>
-			</li>
-		</value>
-	</Operation>
-
-	<!-- ========== Assault rifle ========== -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_AssaultRifle</defName>
-		<statBases>
-			<Mass>3.26</Mass>
-			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-			<SightsEfficiency>1</SightsEfficiency>
-			<ShotSpread>0.07</ShotSpread>
-			<SwayFactor>1.33</SwayFactor>
-			<Bulk>10.03</Bulk>
-			<WorkToMake>30000</WorkToMake>
-		</statBases>
-		<costList>
-			<Steel>50</Steel>
-			<ComponentIndustrial>5</ComponentIndustrial>
-			<Chemfuel>10</Chemfuel>
-		</costList>
-		<Properties>
-			<recoilAmount>1.50</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
-			<warmupTime>1.1</warmupTime>
-			<range>55</range>
-			<burstShotCount>6</burstShotCount>
-			<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
-			<soundCast>Shot_AssaultRifle</soundCast>
-			<soundCastTail>GunTail_Medium</soundCastTail>
-			<muzzleFlashScale>9</muzzleFlashScale>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>30</magazineSize>
-			<reloadTime>4</reloadTime>
-			<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aimedBurstShotCount>3</aimedBurstShotCount>
-			<aiUseBurstMode>TRUE</aiUseBurstMode>
-			<aiAimMode>AimedShot</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>CE_AI_AR</li>
-		</weaponTags>
-		<researchPrerequisite>PrecisionRifling</researchPrerequisite>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Gun_AssaultRifle"]</xpath>
-		<value>
-			<li Class="CombatExtended.GunDrawExtension">
-				<DrawSize>1.16,1.16</DrawSize>
-				<DrawOffset>0.08,0.0</DrawOffset>
-			</li>
-		</value>
-	</Operation>
-
-	<!-- ========== Sniper rifle ========== -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_SniperRifle</defName>
-		<statBases>
-			<Mass>7.30</Mass>
-			<RangedWeapon_Cooldown>1.36</RangedWeapon_Cooldown>
-			<SightsEfficiency>2.6</SightsEfficiency>
-			<ShotSpread>0.05</ShotSpread>
-			<SwayFactor>1.35</SwayFactor>
-			<Bulk>11.92</Bulk>
-			<WorkToMake>30000</WorkToMake>
-		</statBases>
-		<costList>
-			<Steel>60</Steel>
-			<ComponentIndustrial>5</ComponentIndustrial>
-			<Chemfuel>15</Chemfuel>
-		</costList>
-		<Properties>
-			<recoilAmount>1.50</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
-			<warmupTime>1.8</warmupTime>
-			<range>75</range>
-			<soundCast>Shot_SniperRifle</soundCast>
-			<soundCastTail>GunTail_Heavy</soundCastTail>
-			<muzzleFlashScale>9</muzzleFlashScale>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>5</magazineSize>
-			<reloadTime>4</reloadTime>
-			<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aiAimMode>AimedShot</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>CE_AI_SR</li>
-			<li>Bipod_DMR</li>
-		</weaponTags>
-		<researchPrerequisite>PrecisionRifling</researchPrerequisite>
-		<AllowWithRunAndGun>false</AllowWithRunAndGun>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Gun_SniperRifle"]</xpath>
-		<value>
-			<li Class="CombatExtended.GunDrawExtension">
-				<DrawSize>1.25,1.45</DrawSize>
-				<DrawOffset>0.15,-0.05</DrawOffset>
-			</li>
-		</value>
-	</Operation>
-
-	<!-- ========== Machine pistol ========== -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_MachinePistol</defName>
-		<statBases>
-			<Mass>2.84</Mass>
-			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-			<SightsEfficiency>0.7</SightsEfficiency>
-			<ShotSpread>0.16</ShotSpread>
-			<SwayFactor>1.93</SwayFactor>
-			<Bulk>2.95</Bulk>
-			<WorkToMake>24500</WorkToMake>
-		</statBases>
-		<costList>
-			<Steel>35</Steel>
-			<ComponentIndustrial>3</ComponentIndustrial>
-		</costList>
-		<Properties>
-			<recoilAmount>1.71</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
-			<warmupTime>0.6</warmupTime>
-			<range>12</range>
-			<burstShotCount>6</burstShotCount>
-			<ticksBetweenBurstShots>3</ticksBetweenBurstShots>
-			<soundCast>Shot_MachinePistol</soundCast>
-			<soundCastTail>GunTail_Light</soundCastTail>
-			<muzzleFlashScale>9</muzzleFlashScale>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>30</magazineSize>
-			<reloadTime>4</reloadTime>
-			<ammoSet>AmmoSet_45ACP</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aimedBurstShotCount>3</aimedBurstShotCount>
-			<aiUseBurstMode>FALSE</aiUseBurstMode>
-			<aiAimMode>Snapshot</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>CE_SMG</li>
-			<li>CE_AI_BROOM</li>
-			<li>CE_OneHandedWeapon</li>
-		</weaponTags>
-		<researchPrerequisite>BlowbackOperation</researchPrerequisite>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Gun_MachinePistol"]</xpath>
-		<value>
-			<li Class="CombatExtended.GunDrawExtension">
-				<DrawSize>0.84,0.84</DrawSize>
-				<DrawOffset>-0.10,-0.07</DrawOffset>
-			</li>
-		</value>
-	</Operation>
-
-	<!-- ========== Heavy SMG ========== -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_HeavySMG</defName>
-		<statBases>
-			<Mass>2.50</Mass>
-			<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
-			<SightsEfficiency>1.00</SightsEfficiency>
-			<ShotSpread>0.14</ShotSpread>
-			<SwayFactor>0.94</SwayFactor>
-			<Bulk>4.50</Bulk>
-			<WorkToMake>24500</WorkToMake>
-		</statBases>
-		<costList>
-			<Steel>30</Steel>
-			<Chemfuel>10</Chemfuel>
-			<ComponentIndustrial>5</ComponentIndustrial>
-		</costList>
-		<Properties>
-			<recoilAmount>1.79</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
-			<warmupTime>0.6</warmupTime>
-			<range>25</range>
-			<burstShotCount>6</burstShotCount>
-			<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
-			<soundCast>Shot_HeavySMG</soundCast>
-			<soundCastTail>GunTail_Heavy</soundCastTail>
-			<muzzleFlashScale>9</muzzleFlashScale>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>25</magazineSize>
-			<reloadTime>4</reloadTime>
-			<ammoSet>AmmoSet_45ACP</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aimedBurstShotCount>3</aimedBurstShotCount>
-			<aiUseBurstMode>FALSE</aiUseBurstMode>
-			<aiAimMode>Snapshot</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>CE_SMG</li>
-			<li>CE_AI_BROOM</li>
-		</weaponTags>
-		<researchPrerequisite>BlowbackOperation</researchPrerequisite>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Gun_HeavySMG"]</xpath>
-		<value>
-			<li Class="CombatExtended.GunDrawExtension">
-				<DrawSize>0.85,0.85</DrawSize>
-				<DrawOffset>0.00,-0.03</DrawOffset>
-			</li>
-		</value>
-	</Operation>
-
-	<!-- ========== Incendiary launcher ========== -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_IncendiaryLauncher</defName>
-		<statBases>
-			<Mass>8</Mass>
-			<RangedWeapon_Cooldown>0.43</RangedWeapon_Cooldown>
-			<SightsEfficiency>1</SightsEfficiency>
-			<ShotSpread>0.15</ShotSpread>
-			<SwayFactor>1.8</SwayFactor>
-			<Bulk>10</Bulk>
-			<WorkToMake>39500</WorkToMake>
-		</statBases>
-		<costList>
-			<Steel>65</Steel>
-			<Plasteel>30</Plasteel>
-			<ComponentIndustrial>7</ComponentIndustrial>
-			<Chemfuel>10</Chemfuel>
-		</costList>
-		<Properties>
-			<recoilAmount>1.0</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_30x64mmFuel_Incendiary</defaultProjectile>
-			<warmupTime>1.1</warmupTime>
-			<range>40</range>
-			<burstShotCount>0</burstShotCount>
-			<soundCast>Shot_IncendiaryLauncher</soundCast>
-			<soundCastTail>GunTail_Medium</soundCastTail>
-			<muzzleFlashScale>14</muzzleFlashScale>
-			<targetParams>
-				<canTargetLocations>true</canTargetLocations>
-			</targetParams>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>5</magazineSize>
-			<reloadTime>4</reloadTime>
-			<ammoSet>AmmoSet_30x64mmFuel</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aiUseBurstMode>FALSE</aiUseBurstMode>
-			<aiAimMode>SuppressFire</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>CE_AI_AOE</li>
-			<li>EliteGun</li>
-		</weaponTags>
-		<researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
-		<AllowWithRunAndGun>false</AllowWithRunAndGun>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Gun_IncendiaryLauncher"]</xpath>
-		<value>
-			<li Class="CombatExtended.GunDrawExtension">
-				<DrawSize>1.16,1.16</DrawSize>
-				<DrawOffset>0.1,-0.05</DrawOffset>
-			</li>
-		</value>
-	</Operation>
-
-	<!-- ========== LMG ========== -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_LMG</defName>
-		<statBases>
-			<Mass>8.7</Mass>
-			<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
-			<SightsEfficiency>1</SightsEfficiency>
-			<ShotSpread>0.05</ShotSpread>
-			<SwayFactor>1.37</SwayFactor>
-			<Bulk>12.9</Bulk>
-			<WorkToMake>31500</WorkToMake>
-		</statBases>
-		<costList>
-			<Steel>80</Steel>
-			<WoodLog>10</WoodLog>
-			<ComponentIndustrial>5</ComponentIndustrial>
-		</costList>
-		<Properties>
-			<recoilAmount>1.38</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_303British_FMJ</defaultProjectile>
-			<warmupTime>1.3</warmupTime>
-			<range>62</range>
-			<ticksBetweenBurstShots>7</ticksBetweenBurstShots>
-			<burstShotCount>10</burstShotCount>
-			<soundCast>Shot_CE_BattleRifle</soundCast>
-			<soundCastTail>GunTail_Medium</soundCastTail>
-			<muzzleFlashScale>9</muzzleFlashScale>
-			<targetParams>
-				<canTargetLocations>true</canTargetLocations>
-			</targetParams>
-			<recoilPattern>Mounted</recoilPattern>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>50</magazineSize>
-			<reloadTime>4.9</reloadTime>
-			<ammoSet>AmmoSet_303British</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aimedBurstShotCount>5</aimedBurstShotCount>
-			<aiUseBurstMode>FALSE</aiUseBurstMode>
-			<aiAimMode>SuppressFire</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>CE_MachineGun</li>
-			<li>CE_AI_LMG</li>
-			<li>Bipod_LMG</li>
-		</weaponTags>
-		<researchPrerequisite>GasOperation</researchPrerequisite>
-		<AllowWithRunAndGun>false</AllowWithRunAndGun>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Gun_LMG"]</xpath>
-		<value>
-			<li Class="CombatExtended.GunDrawExtension">
-				<DrawSize>1.35,1.18</DrawSize>
-				<DrawOffset>0.13,-0.03</DrawOffset>
-			</li>
-		</value>
-	</Operation>
-
-	<!-- ========== Charge rifle ========== -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_ChargeRifle</defName>
-		<statBases>
-			<Mass>3.0</Mass>
-			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-			<SightsEfficiency>1.10</SightsEfficiency>
-			<ShotSpread>0.08</ShotSpread>
-			<SwayFactor>1.20</SwayFactor>
-			<Bulk>7.00</Bulk>
-			<WorkToMake>49000</WorkToMake>
-		</statBases>
-		<costList>
-			<Steel>45</Steel>
-			<Plasteel>25</Plasteel>
-			<ComponentIndustrial>4</ComponentIndustrial>
-			<ComponentSpacer>1</ComponentSpacer>
-			<Chemfuel>10</Chemfuel>
-		</costList>
-		<Properties>
-			<recoilAmount>1.46</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_6x24mmCharged</defaultProjectile>
-			<warmupTime>1.0</warmupTime>
-			<range>55</range>
-			<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
-			<burstShotCount>6</burstShotCount>
-			<soundCast>Shot_ChargeRifle</soundCast>
-			<soundCastTail>GunTail_Medium</soundCastTail>
-			<muzzleFlashScale>9</muzzleFlashScale>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>30</magazineSize>
-			<reloadTime>4</reloadTime>
-			<ammoSet>AmmoSet_6x24mmCharged</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aimedBurstShotCount>3</aimedBurstShotCount>
-			<aiUseBurstMode>TRUE</aiUseBurstMode>
-			<aiAimMode>AimedShot</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>CE_AI_AR</li>
-			<li>AdvancedGun</li>
-		</weaponTags>
-		<researchPrerequisite>ChargedShot</researchPrerequisite>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Gun_ChargeRifle"]</xpath>
-		<value>
-			<li Class="CombatExtended.GunDrawExtension">
-				<DrawSize>1.03,1.03</DrawSize>
-				<DrawOffset>0.05,0.0</DrawOffset>
-			</li>
-		</value>
-	</Operation>
-
-	<!-- ========== Improvised turret gun ========== -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_MiniTurret</defName>
-		<statBases>
-			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-			<SightsEfficiency>1</SightsEfficiency>
-			<ShotSpread>0.07</ShotSpread>
-			<SwayFactor>0.69</SwayFactor>
-		</statBases>
-		<Properties>
-			<recoilAmount>0.91</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
-			<warmupTime>1.3</warmupTime>
-			<range>48</range>
-			<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
-			<burstShotCount>10</burstShotCount>
-			<soundCast>GunShotA</soundCast>
-			<soundCastTail>GunTail_Light</soundCastTail>
-			<muzzleFlashScale>9</muzzleFlashScale>
-			<recoilPattern>Mounted</recoilPattern>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>100</magazineSize>
-			<reloadTime>7.8</reloadTime>
-			<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aiAimMode>AimedShot</aiAimMode>
-			<noSnapshot>true</noSnapshot>
-			<noSingleShot>true</noSingleShot>
-		</FireModes>
-	</Operation>
-
-	<!-- ========== Minigun ========== -->
-
-	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName ="Gun_Minigun"]/weaponTags/li[.="GunHeavy"]</xpath>
-	</Operation>
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_Minigun</defName>
-		<statBases>
-			<Mass>20.00</Mass>
-			<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
-			<SightsEfficiency>1</SightsEfficiency>
-			<ShotSpread>0.06</ShotSpread>
-			<SwayFactor>3.22</SwayFactor>
-			<Bulk>10</Bulk>
-			<WorkToMake>52000</WorkToMake>
-		</statBases>
-		<costList>
-			<Steel>110</Steel>
-			<ComponentIndustrial>11</ComponentIndustrial>
-		</costList>
-		<Properties>
-			<recoilAmount>0.97</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
-			<warmupTime>2.1</warmupTime>
-			<range>62</range>
-			<burstShotCount>50</burstShotCount>
-			<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
-			<soundCast>Shot_Minigun</soundCast>
-			<soundCastTail>GunTail_Medium</soundCastTail>
-			<muzzleFlashScale>9</muzzleFlashScale>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>250</magazineSize>
-			<reloadTime>9.2</reloadTime>
-			<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aimedBurstShotCount>25</aimedBurstShotCount>
-			<aiAimMode>Snapshot</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>CE_AI_Suppressive</li>
-		</weaponTags>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Gun_Minigun"]/tools</xpath>
-		<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-					<label>barrels</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>10</power>
-					<cooldownTime>2.44</cooldownTime>
-					<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Barrels</linkedBodyPartsGroup>
-				</li>
-			</tools>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="Gun_Minigun"]/equippedStatOffsets</xpath>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Gun_Minigun"]</xpath>
-		<value>
-			<li Class="CombatExtended.GunDrawExtension">
-				<DrawSize>1.00,1.00</DrawSize>
-				<DrawOffset>0.1,-0.15</DrawOffset>
-			</li>
-		</value>
-	</Operation>
-
-	<!-- ========== Doomsday launcher ========== -->
-
-	<!-- Patch both launchers -->
-
-	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="Gun_DoomsdayRocket" or defName="Gun_TripleRocket"]/weaponTags/li[.="Gun"]</xpath>
-	</Operation>
-
-	<Operation Class="PatchOperationAttributeSet">
-		<xpath>Defs/ThingDef[defName="Gun_DoomsdayRocket" or defName="Gun_TripleRocket"]</xpath>
-		<attribute>ParentName</attribute>
-		<value>BaseMakeableGun</value>
-	</Operation>
-
-	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="Gun_DoomsdayRocket" or defName="Gun_TripleRocket"]/statBases/MarketValue</xpath>
-	</Operation>
-
-	<!-- Patch projectile -->
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Bullet_DoomsdayRocket"]/thingClass</xpath>
-		<value>
-			<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Bullet_DoomsdayRocket"]/projectile</xpath>
-		<value>
-			<projectile Class="CombatExtended.ProjectilePropertiesCE">
-				<damageDef>Bomb</damageDef>
-				<damageAmountBase>250</damageAmountBase>
-				<explosionRadius>7.8</explosionRadius>
-				<suppressionFactor>3.0</suppressionFactor>
-				<dangerFactor>2.0</dangerFactor>
-				<speed>100</speed>
-			</projectile>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/ThingDef[defName="Bullet_DoomsdayRocket"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="Bullet_DoomsdayRocket"]</xpath>
-			<value>
-				<comps />
-			</value>
-		</nomatch>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Bullet_DoomsdayRocket"]/comps</xpath>
-		<value>
-			<li Class="CombatExtended.CompProperties_Fragments">
-				<fragSpeedFactor>1</fragSpeedFactor>
-				<fragments>
-					<Fragment_Large>400</Fragment_Large>
-				</fragments>
-			</li>
-		</value>
-	</Operation>
-
-	<!-- Patch stats -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_DoomsdayRocket</defName>
-		<statBases>
-			<Mass>20.00</Mass>
-			<RangedWeapon_Cooldown>1.5</RangedWeapon_Cooldown>
-			<SightsEfficiency>2.24</SightsEfficiency>
-			<ShotSpread>0.2</ShotSpread>
-			<SwayFactor>3.24</SwayFactor>
-			<Bulk>13.0</Bulk>
-			<WorkToMake>49500</WorkToMake>
-		</statBases>
-		<costList>
-			<Steel>125</Steel>
-			<ComponentIndustrial>8</ComponentIndustrial>
-			<FSX>5</FSX>
-		</costList>
-		<Properties>
-			<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_DoomsdayRocket</defaultProjectile>
-			<warmupTime>2.1</warmupTime>
-			<range>48</range>
-			<burstShotCount>1</burstShotCount>
-			<soundCast>InfernoCannon_Fire</soundCast>
-			<soundCastTail>GunTail_Heavy</soundCastTail>
-			<onlyManualCast>true</onlyManualCast>
-			<targetParams>
-				<canTargetLocations>true</canTargetLocations>
-			</targetParams>
-			<muzzleFlashScale>14</muzzleFlashScale>
-		</Properties>
-		<FireModes>
-			<aiAimMode>AimedShot</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>CE_AI_AOE</li>
-		</weaponTags>
-		<researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
-		<AllowWithRunAndGun>false</AllowWithRunAndGun>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Gun_DoomsdayRocket"]</xpath>
-		<value>
-			<li Class="CombatExtended.GunDrawExtension">
-				<DrawSize>1.45,1.45</DrawSize>
-				<DrawOffset>-0.15,0</DrawOffset>
-			</li>
-		</value>
-	</Operation>
-
-	<!-- ========== Triple rocket launcher ========== -->
-
-	<!-- Patch projectile -->
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Bullet_Rocket"]/thingClass</xpath>
-		<value>
-			<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Bullet_Rocket"]/projectile</xpath>
-		<value>
-			<projectile Class="CombatExtended.ProjectilePropertiesCE">
-				<damageDef>Bomb</damageDef>
-				<damageAmountBase>180</damageAmountBase>
-				<explosionRadius>3.0</explosionRadius>
-				<suppressionFactor>3.0</suppressionFactor>
-				<dangerFactor>2.0</dangerFactor>
-				<speed>100</speed>
-			</projectile>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/ThingDef[defName="Bullet_Rocket"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="Bullet_Rocket"]</xpath>
-			<value>
-				<comps />
-			</value>
-		</nomatch>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Bullet_Rocket"]/comps</xpath>
-		<value>
-			<li Class="CombatExtended.CompProperties_Fragments">
-				<fragSpeedFactor>1</fragSpeedFactor>
-				<fragments>
-					<Fragment_Large>150</Fragment_Large>
-				</fragments>
-			</li>
-		</value>
-	</Operation>
-
-	<!-- Patch stats -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_TripleRocket</defName>
-		<statBases>
-			<Mass>12.00</Mass>
-			<RangedWeapon_Cooldown>1.5</RangedWeapon_Cooldown>
-			<SightsEfficiency>1</SightsEfficiency>
-			<ShotSpread>0.2</ShotSpread>
-			<SwayFactor>2.20</SwayFactor>
-			<Bulk>13.00</Bulk>
-			<WorkToMake>43000</WorkToMake>
-		</statBases>
-		<costList>
-			<Steel>90</Steel>
-			<ComponentIndustrial>7</ComponentIndustrial>
-			<FSX>3</FSX>
-		</costList>
-		<Properties>
-			<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_Rocket</defaultProjectile>
-			<warmupTime>1.9</warmupTime>
-			<range>40</range>
-			<ticksBetweenBurstShots>20</ticksBetweenBurstShots>
-			<burstShotCount>3</burstShotCount>
-			<soundCast>InfernoCannon_Fire</soundCast>
-			<soundCastTail>GunTail_Heavy</soundCastTail>
-			<onlyManualCast>true</onlyManualCast>
-			<stopBurstWithoutLos>false</stopBurstWithoutLos>
-			<targetParams>
-				<canTargetLocations>true</canTargetLocations>
-			</targetParams>
-			<muzzleFlashScale>14</muzzleFlashScale>
-		</Properties>
-		<FireModes>
-			<aiAimMode>AimedShot</aiAimMode>
-			<noSingleShot>true</noSingleShot>
-		</FireModes>
-		<weaponTags>
-			<li>CE_AI_AOE</li>
-		</weaponTags>
-		<researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
-		<AllowWithRunAndGun>false</AllowWithRunAndGun>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Gun_TripleRocket"]</xpath>
-		<value>
-			<li Class="CombatExtended.GunDrawExtension">
-				<DrawSize>1.16,1.16</DrawSize>
-				<DrawOffset>-0.25,0</DrawOffset>
-			</li>
-		</value>
-	</Operation>
-
-	<!-- ========== Heavy charge blaster ========== -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_ChargeBlasterHeavy</defName>
-		<statBases>
-			<Mass>35.00</Mass>
-			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-			<SightsEfficiency>1</SightsEfficiency>
-			<ShotSpread>0.01</ShotSpread>
-			<SwayFactor>1.33</SwayFactor>
-			<Bulk>13.00</Bulk>
-		</statBases>
-		<Properties>
-			<recoilAmount>1.08</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_12x64mmCharged</defaultProjectile>
-			<warmupTime>2.3</warmupTime>
-			<range>75</range>
-			<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
-			<burstShotCount>20</burstShotCount>
-			<soundCast>Shot_ChargeBlaster</soundCast>
-			<soundCastTail>GunTail_Heavy</soundCastTail>
-			<muzzleFlashScale>9</muzzleFlashScale>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>100</magazineSize>
-			<reloadTime>9.2</reloadTime>
-			<ammoSet>AmmoSet_12x64mmCharged</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aimedBurstShotCount>10</aimedBurstShotCount>
-			<aiAimMode>Snapshot</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>CE_AI_Suppressive</li>
-			<li>NoSwitch</li>
-		</weaponTags>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[@Name="Gun_ChargeBlasterHeavyBase"]/tools</xpath>
-		<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-					<label>barrel</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>10</power>
-					<cooldownTime>2.44</cooldownTime>
-					<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-				</li>
-			</tools>
-		</value>
-	</Operation>
-
-	<!-- ========== Inferno cannon ========== -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_InfernoCannon</defName>
-		<statBases>
-			<Mass>50.00</Mass>
-			<RangedWeapon_Cooldown>2.54</RangedWeapon_Cooldown>
-			<SightsEfficiency>1</SightsEfficiency>
-			<ShotSpread>0.01</ShotSpread>
-			<SwayFactor>0.14</SwayFactor>
-			<Bulk>20.00</Bulk>
-		</statBases>
-		<Properties>
-			<recoilAmount>2.01</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>
-			<warmupTime>3.5</warmupTime><!-- Intentionally decreased from 4.3s -->
-			<range>86</range>
-			<burstShotCount>1</burstShotCount>
-			<soundCast>InfernoCannon_Fire</soundCast>
-			<soundCastTail>GunTail_Light</soundCastTail>
-			<muzzleFlashScale>14</muzzleFlashScale>
-			<ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
-			<minRange>5</minRange>
-			<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>1</magazineSize>
-			<AmmoGenPerMagOverride>2</AmmoGenPerMagOverride>
-			<reloadTime>9.8</reloadTime>
-			<ammoSet>AmmoSet_80x256mmFuel</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aiAimMode>AimedShot</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>CE_AI_Launcher</li>
-			<li>NoSwitch</li>
-		</weaponTags>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[@Name="Gun_InfernoCannonBase"]/tools</xpath>
-		<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-					<label>barrel</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>10</power>
-					<cooldownTime>2.44</cooldownTime>
-					<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-				</li>
-			</tools>
-		</value>
-	</Operation>
-
-	<!-- ========== Thump cannon ========== -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_ThumpCannon</defName>
-		<statBases>
-			<Mass>75.00</Mass>
-			<RangedWeapon_Cooldown>2.2</RangedWeapon_Cooldown>
-			<SightsEfficiency>1</SightsEfficiency>
-			<ShotSpread>0.01</ShotSpread>
-			<SwayFactor>0.21</SwayFactor>
-			<Bulk>20.00</Bulk>
-		</statBases>
-		<Properties>
-			<recoilAmount>0.1</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_164x284mmDemo</defaultProjectile>
-			<warmupTime>3.3</warmupTime>
-			<range>42</range>
-			<burstShotCount>1</burstShotCount>
-			<soundCast>ThumpCannon_Fire</soundCast>
-			<soundCastTail>GunTail_Heavy</soundCastTail>
-			<muzzleFlashScale>14</muzzleFlashScale>
-			<ai_AvoidFriendlyFireRadius>3</ai_AvoidFriendlyFireRadius>
-			<minRange>4</minRange>
-			<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>1</magazineSize>
-			<AmmoGenPerMagOverride>2</AmmoGenPerMagOverride>
-			<reloadTime>9.8</reloadTime>
-			<ammoSet>AmmoSet_164x284mmDemo</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aiAimMode>AimedShot</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>CE_AI_Launcher</li>
-			<li>NoSwitch</li>
-		</weaponTags>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Gun_ThumpCannon"]/tools</xpath>
-		<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-					<label>barrel</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>10</power>
-					<cooldownTime>2.44</cooldownTime>
-					<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-				</li>
-			</tools>
-		</value>
-	</Operation>
-
-	<!-- ========== Charge lance ========== -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_ChargeLance</defName>
-		<statBases>
-			<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
-			<SightsEfficiency>1</SightsEfficiency>
-			<ShotSpread>0.01</ShotSpread>
-			<SwayFactor>1</SwayFactor>
-			<Bulk>13.00</Bulk>
-		</statBases>
-		<Properties>
-			<recoilAmount>0.75</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_5x35mmCharged</defaultProjectile>
-			<warmupTime>1.3</warmupTime>
-			<range>62</range>
-			<burstShotCount>1</burstShotCount>
-			<soundCast>ChargeLance_Fire</soundCast>
-			<soundCastTail>GunTail_Heavy</soundCastTail>
-			<muzzleFlashScale>9</muzzleFlashScale>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>5</magazineSize>
-			<reloadTime>3</reloadTime>
-			<ammoSet>AmmoSet_5x35mmCharged</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aiAimMode>AimedShot</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>CE_AI_Rifle</li>
-			<li>NoSwitch</li>
-		</weaponTags>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Gun_ChargeLance"]/tools</xpath>
-		<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-					<label>barrel</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>10</power>
-					<cooldownTime>2.44</cooldownTime>
-					<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-				</li>
-			</tools>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Gun_ChargeLance"]</xpath>
-		<value>
-			<li Class="CombatExtended.ThingDefExtensionCE">
-				<MenuHidden>True</MenuHidden>
-			</li>
-		</value>
-	</Operation>
-
-	<!-- Disable for player -->
-	<Operation Class="PatchOperationAttributeSet">
-		<xpath>Defs/ThingDef[defName="Gun_ChargeLance"]</xpath>
-		<attribute>ParentName</attribute>
-		<value>BaseGun</value>
-	</Operation>
-
-	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="Gun_ChargeLance"]/costList</xpath>
-	</Operation>
-
-	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="Gun_ChargeLance"]/recipeMaker</xpath>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Gun_ChargeLance"]/statBases</xpath>
-		<value>
-			<MarketValue>1400</MarketValue>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Gun_ChargeLance"]</xpath>
-		<value>
-			<tradeability>None</tradeability>
-			<destroyOnDrop>True</destroyOnDrop>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="Gun_ChargeLance"]/weaponTags/li[contains(.,"SpacerGun")]</xpath>
-	</Operation>
-
-	<!-- ========== Needle Gun ========== -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_Needle</defName>
-		<statBases>
-			<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
-			<SightsEfficiency>1</SightsEfficiency>
-			<ShotSpread>0.01</ShotSpread>
-			<SwayFactor>0.81</SwayFactor>
-			<Bulk>15.00</Bulk>
-		</statBases>
-		<Properties>
-			<recoilAmount>1.80</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_5x100mmCaseless_Sabot</defaultProjectile>
-			<warmupTime>1.3</warmupTime>
-			<range>75</range>
-			<burstShotCount>1</burstShotCount>
-			<soundCast>Shot_NeedleGun</soundCast>
-			<soundCastTail>GunTail_Heavy</soundCastTail>
-			<muzzleFlashScale>9</muzzleFlashScale>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>10</magazineSize>
-			<reloadTime>4</reloadTime>
-			<ammoSet>AmmoSet_5x100mmCaseless</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aiAimMode>AimedShot</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>CE_AI_Rifle</li>
-			<li>NoSwitch</li>
-		</weaponTags>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Gun_Needle"]/tools</xpath>
-		<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-					<label>barrel</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>10</power>
-					<cooldownTime>2.44</cooldownTime>
-					<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-				</li>
-			</tools>
-		</value>
-	</Operation>
-
-	<!-- Increase Orbital Bombardment Range -->
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="OrbitalTargeterBombardment" or defName="OrbitalTargeterPowerBeam"]/verbs/li/range</xpath>
-		<value>
-			<range>60</range>
-		</value>
-	</Operation>
-
-	<!-- Remove Smoke and EMP Launchers -->
-	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="Gun_SmokeLauncher"]</xpath>
-	</Operation>
-
-	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="Gun_EmpLauncher"]</xpath>
-	</Operation>
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/ThingDef[defName="Gun_ChargeLance"]</xpath>
+    <value>
+      <relicChance>0</relicChance>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/ThingDef[@Name="BaseWeaponTurret"]</xpath>
+    <value>
+      <relicChance>0</relicChance>
+    </value>
+  </Operation>
+
+  <!-- ========== Tools ========== -->
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Gun_Revolver" or defName="Gun_Autopistol" or defName="Gun_MachinePistol"]/tools</xpath>
+    <value>
+      <tools>
+        <li Class="CombatExtended.ToolCE">
+          <label>grip</label>
+          <capacities>
+            <li>Blunt</li>
+          </capacities>
+          <power>2</power>
+          <cooldownTime>1.54</cooldownTime>
+          <chanceFactor>1.5</chanceFactor>
+          <armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+          <linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
+        </li>
+        <li Class="CombatExtended.ToolCE">
+          <label>muzzle</label>
+          <capacities>
+            <li>Poke</li>
+          </capacities>
+          <power>2</power>
+          <cooldownTime>1.54</cooldownTime>
+          <armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+          <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+        </li>
+      </tools>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>
+      Defs/ThingDef[
+      defName="Gun_PumpShotgun" or
+      defName="Gun_ChainShotgun" or
+      defName="Gun_BoltActionRifle" or
+      defName="Gun_AssaultRifle" or
+      defName="Gun_SniperRifle" or
+      defName="Gun_HeavySMG" or
+      defName="Gun_IncendiaryLauncher" or
+      defName="Gun_LMG" or
+      defName="Gun_ChargeRifle"
+      ]/tools
+    </xpath>
+    <value>
+      <tools>
+        <li Class="CombatExtended.ToolCE">
+          <label>stock</label>
+          <capacities>
+            <li>Blunt</li>
+          </capacities>
+          <power>8</power>
+          <cooldownTime>1.55</cooldownTime>
+          <chanceFactor>1.5</chanceFactor>
+          <armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+          <linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+        </li>
+        <li Class="CombatExtended.ToolCE">
+          <label>barrel</label>
+          <capacities>
+            <li>Blunt</li>
+          </capacities>
+          <power>5</power>
+          <cooldownTime>2.02</cooldownTime>
+          <armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+          <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+        </li>
+        <li Class="CombatExtended.ToolCE">
+          <label>muzzle</label>
+          <capacities>
+            <li>Poke</li>
+          </capacities>
+          <power>8</power>
+          <cooldownTime>1.55</cooldownTime>
+          <armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+          <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+        </li>
+      </tools>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Gun_TripleRocket" or defName="Gun_DoomsdayRocket"]/tools</xpath>
+    <value>
+      <tools>
+        <li Class="CombatExtended.ToolCE">
+          <label>barrel</label>
+          <capacities>
+            <li>Blunt</li>
+          </capacities>
+          <power>10</power>
+          <cooldownTime>2.44</cooldownTime>
+          <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+          <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+        </li>
+      </tools>
+    </value>
+  </Operation>
+
+  <!-- ========== Revolver ========== -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_Revolver</defName>
+    <statBases>
+      <Mass>1.39</Mass>
+      <RangedWeapon_Cooldown>0.49</RangedWeapon_Cooldown>
+      <SightsEfficiency>0.7</SightsEfficiency>
+      <ShotSpread>0.18</ShotSpread>
+      <SwayFactor>1.27</SwayFactor>
+      <Bulk>2.41</Bulk>
+      <!-- <ToughnessRating>2.5</ToughnessRating> -->
+      <!-- Base toughness rating of a weapon -->
+      <WorkToMake>7000</WorkToMake>
+    </statBases>
+    <costList>
+      <Steel>30</Steel>
+      <ComponentIndustrial>2</ComponentIndustrial>
+    </costList>
+    <Properties>
+      <recoilAmount>2.96</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_44Magnum_FMJ</defaultProjectile>
+      <warmupTime>0.6</warmupTime>
+      <range>12</range>
+      <soundCast>Shot_Revolver</soundCast>
+      <soundCastTail>GunTail_Light</soundCastTail>
+      <muzzleFlashScale>9</muzzleFlashScale>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>6</magazineSize>
+      <reloadTime>4.6</reloadTime>
+      <ammoSet>AmmoSet_44Magnum</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aiUseBurstMode>FALSE</aiUseBurstMode>
+      <aiAimMode>Snapshot</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>CE_Sidearm</li>
+      <li>CE_AI_BROOM</li>
+      <li>CE_OneHandedWeapon</li>
+    </weaponTags>
+    <researchPrerequisite>Gunsmithing</researchPrerequisite>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Gun_Revolver"]</xpath>
+    <value>
+      <li Class="CombatExtended.GunDrawExtension">
+        <DrawSize>1.00,1.00</DrawSize>
+        <DrawOffset>0.0,0.0</DrawOffset>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- ========== Autopistol ========== -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_Autopistol</defName>
+    <statBases>
+      <Mass>1.11</Mass>
+      <RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
+      <SightsEfficiency>0.7</SightsEfficiency>
+      <ShotSpread>0.17</ShotSpread>
+      <SwayFactor>1.07</SwayFactor>
+      <Bulk>2.10</Bulk>
+      <WorkToMake>7000</WorkToMake>
+    </statBases>
+    <costList>
+      <Steel>25</Steel>
+      <ComponentIndustrial>3</ComponentIndustrial>
+    </costList>
+    <Properties>
+      <recoilAmount>2.72</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
+      <warmupTime>0.6</warmupTime>
+      <range>12</range>
+      <soundCast>Shot_Autopistol</soundCast>
+      <soundCastTail>GunTail_Light</soundCastTail>
+      <muzzleFlashScale>9</muzzleFlashScale>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>7</magazineSize>
+      <reloadTime>4</reloadTime>
+      <ammoSet>AmmoSet_45ACP</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aiUseBurstMode>FALSE</aiUseBurstMode>
+      <aiAimMode>Snapshot</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>CE_Sidearm</li>
+      <li>CE_AI_BROOM</li>
+      <li>CE_OneHandedWeapon</li>
+    </weaponTags>
+    <researchPrerequisite>BlowbackOperation</researchPrerequisite>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Gun_Autopistol"]</xpath>
+    <value>
+      <li Class="CombatExtended.GunDrawExtension">
+        <DrawSize>0.93,0.93</DrawSize>
+        <DrawOffset>0.0,0.0</DrawOffset>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- ========== Pump Shotgun ========== -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_PumpShotgun</defName>
+    <statBases>
+      <Mass>3.00</Mass>
+      <RangedWeapon_Cooldown>1.0</RangedWeapon_Cooldown>
+      <ShotSpread>0.14</ShotSpread>
+      <SwayFactor>1.20</SwayFactor>
+      <Bulk>9.0</Bulk>
+      <SightsEfficiency>1</SightsEfficiency>
+      <WorkToMake>9500</WorkToMake>
+    </statBases>
+    <costList>
+      <Steel>45</Steel>
+      <WoodLog>10</WoodLog>
+      <ComponentIndustrial>1</ComponentIndustrial>
+    </costList>
+    <Properties>
+      <recoilAmount>2.75</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
+      <warmupTime>0.6</warmupTime>
+      <range>16</range>
+      <soundCast>Shot_Shotgun</soundCast>
+      <soundCastTail>GunTail_Heavy</soundCastTail>
+      <muzzleFlashScale>9</muzzleFlashScale>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>5</magazineSize>
+      <reloadOneAtATime>true</reloadOneAtATime>
+      <reloadTime>0.85</reloadTime>
+      <ammoSet>AmmoSet_12Gauge</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aiAimMode>Snapshot</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>SimpleGun</li>
+      <li>CE_AI_BROOM</li>
+    </weaponTags>
+    <researchPrerequisite>Gunsmithing</researchPrerequisite>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Gun_PumpShotgun"]</xpath>
+    <value>
+      <li Class="CombatExtended.GunDrawExtension">
+        <DrawSize>1.03,1.25</DrawSize>
+        <DrawOffset>0.05,0.0</DrawOffset>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- ========== Chain Shotgun ========== -->
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Gun_ChainShotgun"]/description</xpath>
+    <value>
+      <description>A magazine-fed semi-automatic shotgun. It has the same range as a typical shotgun, but is extraordinarily dangerous due to being semi-automatic.</description>
+    </value>
+  </Operation>
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_ChainShotgun</defName>
+    <statBases>
+      <Mass>3.50</Mass>
+      <RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
+      <ShotSpread>0.15</ShotSpread>
+      <SwayFactor>1.26</SwayFactor>
+      <Bulk>6.7</Bulk>
+      <SightsEfficiency>1</SightsEfficiency>
+      <WorkToMake>22500</WorkToMake>
+    </statBases>
+    <costList>
+      <Steel>40</Steel>
+      <ComponentIndustrial>3</ComponentIndustrial>
+      <Chemfuel>10</Chemfuel>
+    </costList>
+    <Properties>
+      <recoilAmount>2.54</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
+      <warmupTime>0.6</warmupTime>
+      <range>16</range>
+      <soundCast>Shot_Shotgun_NoRack</soundCast>
+      <soundCastTail>GunTail_Heavy</soundCastTail>
+      <muzzleFlashScale>9</muzzleFlashScale>
+      <ticksBetweenBurstShots>15</ticksBetweenBurstShots>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>8</magazineSize>
+      <reloadTime>4</reloadTime>
+      <ammoSet>AmmoSet_12Gauge</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aiAimMode>Snapshot</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>CE_AI_BROOM</li>
+    </weaponTags>
+    <researchPrerequisite>GasOperation</researchPrerequisite>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Gun_ChainShotgun"]</xpath>
+    <value>
+      <li Class="CombatExtended.GunDrawExtension">
+        <DrawSize>1.04,1.23</DrawSize>
+        <DrawOffset>0.05,-0.05</DrawOffset>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- ========== Bolt-action rifle ========== -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_BoltActionRifle</defName>
+    <statBases>
+      <Mass>4.19</Mass>
+      <RangedWeapon_Cooldown>1.17</RangedWeapon_Cooldown>
+      <SightsEfficiency>1</SightsEfficiency>
+      <ShotSpread>0.02</ShotSpread>
+      <SwayFactor>1.68</SwayFactor>
+      <Bulk>12.60</Bulk>
+      <WorkToMake>12000</WorkToMake>
+    </statBases>
+    <costList>
+      <Steel>55</Steel>
+      <WoodLog>15</WoodLog>
+      <ComponentIndustrial>1</ComponentIndustrial>
+    </costList>
+    <Properties>
+      <recoilAmount>2.04</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_303British_FMJ</defaultProjectile>
+      <warmupTime>1.1</warmupTime>
+      <range>55</range>
+      <soundCast>Shot_BoltActionRifle</soundCast>
+      <soundCastTail>GunTail_Heavy</soundCastTail>
+      <muzzleFlashScale>9</muzzleFlashScale>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>10</magazineSize>
+      <reloadTime>4.3</reloadTime>
+      <ammoSet>AmmoSet_303British</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aiAimMode>AimedShot</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>SimpleGun</li>
+      <li>CE_AI_SR</li>
+    </weaponTags>
+    <researchPrerequisite>Gunsmithing</researchPrerequisite>
+    <AllowWithRunAndGun>false</AllowWithRunAndGun>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Gun_BoltActionRifle"]</xpath>
+    <value>
+      <li Class="CombatExtended.GunDrawExtension">
+        <DrawSize>1.3,1.3</DrawSize>
+        <DrawOffset>0.12,0.04</DrawOffset>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- ========== Assault rifle ========== -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_AssaultRifle</defName>
+    <statBases>
+      <Mass>3.26</Mass>
+      <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+      <SightsEfficiency>1</SightsEfficiency>
+      <ShotSpread>0.07</ShotSpread>
+      <SwayFactor>1.33</SwayFactor>
+      <Bulk>10.03</Bulk>
+      <WorkToMake>30000</WorkToMake>
+    </statBases>
+    <costList>
+      <Steel>50</Steel>
+      <ComponentIndustrial>5</ComponentIndustrial>
+      <Chemfuel>10</Chemfuel>
+    </costList>
+    <Properties>
+      <recoilAmount>1.50</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+      <warmupTime>1.1</warmupTime>
+      <range>55</range>
+      <burstShotCount>6</burstShotCount>
+      <ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+      <soundCast>Shot_AssaultRifle</soundCast>
+      <soundCastTail>GunTail_Medium</soundCastTail>
+      <muzzleFlashScale>9</muzzleFlashScale>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>30</magazineSize>
+      <reloadTime>4</reloadTime>
+      <ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aimedBurstShotCount>3</aimedBurstShotCount>
+      <aiUseBurstMode>TRUE</aiUseBurstMode>
+      <aiAimMode>AimedShot</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>CE_AI_AR</li>
+    </weaponTags>
+    <researchPrerequisite>PrecisionRifling</researchPrerequisite>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Gun_AssaultRifle"]</xpath>
+    <value>
+      <li Class="CombatExtended.GunDrawExtension">
+        <DrawSize>1.16,1.16</DrawSize>
+        <DrawOffset>0.08,0.0</DrawOffset>
+        <CasingOffset>-0.05,0</CasingOffset>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- ========== Sniper rifle ========== -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_SniperRifle</defName>
+    <statBases>
+      <Mass>7.30</Mass>
+      <RangedWeapon_Cooldown>1.36</RangedWeapon_Cooldown>
+      <SightsEfficiency>2.6</SightsEfficiency>
+      <ShotSpread>0.05</ShotSpread>
+      <SwayFactor>1.35</SwayFactor>
+      <Bulk>11.92</Bulk>
+      <WorkToMake>30000</WorkToMake>
+    </statBases>
+    <costList>
+      <Steel>60</Steel>
+      <ComponentIndustrial>5</ComponentIndustrial>
+      <Chemfuel>15</Chemfuel>
+    </costList>
+    <Properties>
+      <recoilAmount>1.50</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
+      <warmupTime>1.8</warmupTime>
+      <range>75</range>
+      <soundCast>Shot_SniperRifle</soundCast>
+      <soundCastTail>GunTail_Heavy</soundCastTail>
+      <muzzleFlashScale>9</muzzleFlashScale>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>5</magazineSize>
+      <reloadTime>4</reloadTime>
+      <ammoSet>AmmoSet_762x51mmNATO</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aiAimMode>AimedShot</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>CE_AI_SR</li>
+      <li>Bipod_DMR</li>
+    </weaponTags>
+    <researchPrerequisite>PrecisionRifling</researchPrerequisite>
+    <AllowWithRunAndGun>false</AllowWithRunAndGun>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Gun_SniperRifle"]</xpath>
+    <value>
+      <li Class="CombatExtended.GunDrawExtension">
+        <DrawSize>1.25,1.45</DrawSize>
+        <DrawOffset>0.15,-0.05</DrawOffset>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- ========== Machine pistol ========== -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_MachinePistol</defName>
+    <statBases>
+      <Mass>2.84</Mass>
+      <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+      <SightsEfficiency>0.7</SightsEfficiency>
+      <ShotSpread>0.16</ShotSpread>
+      <SwayFactor>1.93</SwayFactor>
+      <Bulk>2.95</Bulk>
+      <WorkToMake>24500</WorkToMake>
+    </statBases>
+    <costList>
+      <Steel>35</Steel>
+      <ComponentIndustrial>3</ComponentIndustrial>
+    </costList>
+    <Properties>
+      <recoilAmount>1.71</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
+      <warmupTime>0.6</warmupTime>
+      <range>12</range>
+      <burstShotCount>6</burstShotCount>
+      <ticksBetweenBurstShots>3</ticksBetweenBurstShots>
+      <soundCast>Shot_MachinePistol</soundCast>
+      <soundCastTail>GunTail_Light</soundCastTail>
+      <muzzleFlashScale>9</muzzleFlashScale>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>30</magazineSize>
+      <reloadTime>4</reloadTime>
+      <ammoSet>AmmoSet_45ACP</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aimedBurstShotCount>3</aimedBurstShotCount>
+      <aiUseBurstMode>FALSE</aiUseBurstMode>
+      <aiAimMode>Snapshot</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>CE_SMG</li>
+      <li>CE_AI_BROOM</li>
+      <li>CE_OneHandedWeapon</li>
+    </weaponTags>
+    <researchPrerequisite>BlowbackOperation</researchPrerequisite>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Gun_MachinePistol"]</xpath>
+    <value>
+      <li Class="CombatExtended.GunDrawExtension">
+        <DrawSize>0.84,0.84</DrawSize>
+        <DrawOffset>-0.10,-0.07</DrawOffset>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- ========== Heavy SMG ========== -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_HeavySMG</defName>
+    <statBases>
+      <Mass>2.50</Mass>
+      <RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+      <SightsEfficiency>1.00</SightsEfficiency>
+      <ShotSpread>0.14</ShotSpread>
+      <SwayFactor>0.94</SwayFactor>
+      <Bulk>4.50</Bulk>
+      <WorkToMake>24500</WorkToMake>
+    </statBases>
+    <costList>
+      <Steel>30</Steel>
+      <Chemfuel>10</Chemfuel>
+      <ComponentIndustrial>5</ComponentIndustrial>
+    </costList>
+    <Properties>
+      <recoilAmount>1.79</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
+      <warmupTime>0.6</warmupTime>
+      <range>25</range>
+      <burstShotCount>6</burstShotCount>
+      <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+      <soundCast>Shot_HeavySMG</soundCast>
+      <soundCastTail>GunTail_Heavy</soundCastTail>
+      <muzzleFlashScale>9</muzzleFlashScale>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>25</magazineSize>
+      <reloadTime>4</reloadTime>
+      <ammoSet>AmmoSet_45ACP</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aimedBurstShotCount>3</aimedBurstShotCount>
+      <aiUseBurstMode>FALSE</aiUseBurstMode>
+      <aiAimMode>Snapshot</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>CE_SMG</li>
+      <li>CE_AI_BROOM</li>
+    </weaponTags>
+    <researchPrerequisite>BlowbackOperation</researchPrerequisite>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Gun_HeavySMG"]</xpath>
+    <value>
+      <li Class="CombatExtended.GunDrawExtension">
+        <DrawSize>0.85,0.85</DrawSize>
+        <DrawOffset>0.00,-0.03</DrawOffset>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- ========== Incendiary launcher ========== -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_IncendiaryLauncher</defName>
+    <statBases>
+      <Mass>8</Mass>
+      <RangedWeapon_Cooldown>0.43</RangedWeapon_Cooldown>
+      <SightsEfficiency>1</SightsEfficiency>
+      <ShotSpread>0.15</ShotSpread>
+      <SwayFactor>1.8</SwayFactor>
+      <Bulk>10</Bulk>
+      <WorkToMake>39500</WorkToMake>
+    </statBases>
+    <costList>
+      <Steel>65</Steel>
+      <Plasteel>30</Plasteel>
+      <ComponentIndustrial>7</ComponentIndustrial>
+      <Chemfuel>10</Chemfuel>
+    </costList>
+    <Properties>
+      <recoilAmount>1.0</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_30x64mmFuel_Incendiary</defaultProjectile>
+      <warmupTime>1.1</warmupTime>
+      <range>40</range>
+      <burstShotCount>0</burstShotCount>
+      <soundCast>Shot_IncendiaryLauncher</soundCast>
+      <soundCastTail>GunTail_Medium</soundCastTail>
+      <muzzleFlashScale>14</muzzleFlashScale>
+      <targetParams>
+        <canTargetLocations>true</canTargetLocations>
+      </targetParams>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>5</magazineSize>
+      <reloadTime>4</reloadTime>
+      <ammoSet>AmmoSet_30x64mmFuel</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aiUseBurstMode>FALSE</aiUseBurstMode>
+      <aiAimMode>SuppressFire</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>CE_AI_AOE</li>
+      <li>EliteGun</li>
+    </weaponTags>
+    <researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
+    <AllowWithRunAndGun>false</AllowWithRunAndGun>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Gun_IncendiaryLauncher"]</xpath>
+    <value>
+      <li Class="CombatExtended.GunDrawExtension">
+        <DrawSize>1.16,1.16</DrawSize>
+        <DrawOffset>0.1,-0.05</DrawOffset>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- ========== LMG ========== -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_LMG</defName>
+    <statBases>
+      <Mass>8.7</Mass>
+      <RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
+      <SightsEfficiency>1</SightsEfficiency>
+      <ShotSpread>0.05</ShotSpread>
+      <SwayFactor>1.37</SwayFactor>
+      <Bulk>12.9</Bulk>
+      <WorkToMake>31500</WorkToMake>
+    </statBases>
+    <costList>
+      <Steel>80</Steel>
+      <WoodLog>10</WoodLog>
+      <ComponentIndustrial>5</ComponentIndustrial>
+    </costList>
+    <Properties>
+      <recoilAmount>1.38</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_303British_FMJ</defaultProjectile>
+      <warmupTime>1.3</warmupTime>
+      <range>62</range>
+      <ticksBetweenBurstShots>7</ticksBetweenBurstShots>
+      <burstShotCount>10</burstShotCount>
+      <soundCast>Shot_CE_BattleRifle</soundCast>
+      <soundCastTail>GunTail_Medium</soundCastTail>
+      <muzzleFlashScale>9</muzzleFlashScale>
+      <targetParams>
+        <canTargetLocations>true</canTargetLocations>
+      </targetParams>
+      <recoilPattern>Mounted</recoilPattern>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>50</magazineSize>
+      <reloadTime>4.9</reloadTime>
+      <ammoSet>AmmoSet_303British</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aimedBurstShotCount>5</aimedBurstShotCount>
+      <aiUseBurstMode>FALSE</aiUseBurstMode>
+      <aiAimMode>SuppressFire</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>CE_MachineGun</li>
+      <li>CE_AI_LMG</li>
+      <li>Bipod_LMG</li>
+    </weaponTags>
+    <researchPrerequisite>GasOperation</researchPrerequisite>
+    <AllowWithRunAndGun>false</AllowWithRunAndGun>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Gun_LMG"]</xpath>
+    <value>
+      <li Class="CombatExtended.GunDrawExtension">
+        <DrawSize>1.35,1.18</DrawSize>
+        <DrawOffset>0.13,-0.03</DrawOffset>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- ========== Charge rifle ========== -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_ChargeRifle</defName>
+    <statBases>
+      <Mass>3.0</Mass>
+      <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+      <SightsEfficiency>1.10</SightsEfficiency>
+      <ShotSpread>0.08</ShotSpread>
+      <SwayFactor>1.20</SwayFactor>
+      <Bulk>7.00</Bulk>
+      <WorkToMake>49000</WorkToMake>
+    </statBases>
+    <costList>
+      <Steel>45</Steel>
+      <Plasteel>25</Plasteel>
+      <ComponentIndustrial>4</ComponentIndustrial>
+      <ComponentSpacer>1</ComponentSpacer>
+      <Chemfuel>10</Chemfuel>
+    </costList>
+    <Properties>
+      <recoilAmount>1.46</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_6x24mmCharged</defaultProjectile>
+      <warmupTime>1.0</warmupTime>
+      <range>55</range>
+      <ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+      <burstShotCount>6</burstShotCount>
+      <soundCast>Shot_ChargeRifle</soundCast>
+      <soundCastTail>GunTail_Medium</soundCastTail>
+      <muzzleFlashScale>9</muzzleFlashScale>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>30</magazineSize>
+      <reloadTime>4</reloadTime>
+      <ammoSet>AmmoSet_6x24mmCharged</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aimedBurstShotCount>3</aimedBurstShotCount>
+      <aiUseBurstMode>TRUE</aiUseBurstMode>
+      <aiAimMode>AimedShot</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>CE_AI_AR</li>
+      <li>AdvancedGun</li>
+    </weaponTags>
+    <researchPrerequisite>ChargedShot</researchPrerequisite>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Gun_ChargeRifle"]</xpath>
+    <value>
+      <li Class="CombatExtended.GunDrawExtension">
+        <DrawSize>1.03,1.03</DrawSize>
+        <DrawOffset>0.05,0.0</DrawOffset>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- ========== Improvised turret gun ========== -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_MiniTurret</defName>
+    <statBases>
+      <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+      <SightsEfficiency>1</SightsEfficiency>
+      <ShotSpread>0.07</ShotSpread>
+      <SwayFactor>0.69</SwayFactor>
+    </statBases>
+    <Properties>
+      <recoilAmount>0.91</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+      <warmupTime>1.3</warmupTime>
+      <range>48</range>
+      <ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+      <burstShotCount>10</burstShotCount>
+      <soundCast>GunShotA</soundCast>
+      <soundCastTail>GunTail_Light</soundCastTail>
+      <muzzleFlashScale>9</muzzleFlashScale>
+      <recoilPattern>Mounted</recoilPattern>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>100</magazineSize>
+      <reloadTime>7.8</reloadTime>
+      <ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aiAimMode>AimedShot</aiAimMode>
+      <noSnapshot>true</noSnapshot>
+      <noSingleShot>true</noSingleShot>
+    </FireModes>
+  </Operation>
+
+  <!-- ========== Minigun ========== -->
+
+  <Operation Class="PatchOperationRemove">
+    <xpath>Defs/ThingDef[defName ="Gun_Minigun"]/weaponTags/li[.="GunHeavy"]</xpath>
+  </Operation>
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_Minigun</defName>
+    <statBases>
+      <Mass>20.00</Mass>
+      <RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
+      <SightsEfficiency>1</SightsEfficiency>
+      <ShotSpread>0.06</ShotSpread>
+      <SwayFactor>3.22</SwayFactor>
+      <Bulk>10</Bulk>
+      <WorkToMake>52000</WorkToMake>
+    </statBases>
+    <costList>
+      <Steel>110</Steel>
+      <ComponentIndustrial>11</ComponentIndustrial>
+    </costList>
+    <Properties>
+      <recoilAmount>0.97</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
+      <warmupTime>2.1</warmupTime>
+      <range>62</range>
+      <burstShotCount>50</burstShotCount>
+      <ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+      <soundCast>Shot_Minigun</soundCast>
+      <soundCastTail>GunTail_Medium</soundCastTail>
+      <muzzleFlashScale>9</muzzleFlashScale>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>250</magazineSize>
+      <reloadTime>9.2</reloadTime>
+      <ammoSet>AmmoSet_762x51mmNATO</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aimedBurstShotCount>25</aimedBurstShotCount>
+      <aiAimMode>Snapshot</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>CE_AI_Suppressive</li>
+    </weaponTags>
+  </Operation>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Gun_Minigun"]/tools</xpath>
+    <value>
+      <tools>
+        <li Class="CombatExtended.ToolCE">
+          <label>barrels</label>
+          <capacities>
+            <li>Blunt</li>
+          </capacities>
+          <power>10</power>
+          <cooldownTime>2.44</cooldownTime>
+          <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+          <linkedBodyPartsGroup>Barrels</linkedBodyPartsGroup>
+        </li>
+      </tools>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationRemove">
+    <xpath>Defs/ThingDef[defName="Gun_Minigun"]/equippedStatOffsets</xpath>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Gun_Minigun"]</xpath>
+    <value>
+      <li Class="CombatExtended.GunDrawExtension">
+        <DrawSize>1.00,1.00</DrawSize>
+        <DrawOffset>0.1,-0.15</DrawOffset>
+        <CasingOffset>-0.2,0</CasingOffset>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- ========== Doomsday launcher ========== -->
+
+  <!-- Patch both launchers -->
+
+  <Operation Class="PatchOperationRemove">
+    <xpath>Defs/ThingDef[defName="Gun_DoomsdayRocket" or defName="Gun_TripleRocket"]/weaponTags/li[.="Gun"]</xpath>
+  </Operation>
+
+  <Operation Class="PatchOperationAttributeSet">
+    <xpath>Defs/ThingDef[defName="Gun_DoomsdayRocket" or defName="Gun_TripleRocket"]</xpath>
+    <attribute>ParentName</attribute>
+    <value>BaseMakeableGun</value>
+  </Operation>
+
+  <Operation Class="PatchOperationRemove">
+    <xpath>Defs/ThingDef[defName="Gun_DoomsdayRocket" or defName="Gun_TripleRocket"]/statBases/MarketValue</xpath>
+  </Operation>
+
+  <!-- Patch projectile -->
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Bullet_DoomsdayRocket"]/thingClass</xpath>
+    <value>
+      <thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Bullet_DoomsdayRocket"]/projectile</xpath>
+    <value>
+      <projectile Class="CombatExtended.ProjectilePropertiesCE">
+        <damageDef>Bomb</damageDef>
+        <damageAmountBase>250</damageAmountBase>
+        <explosionRadius>7.8</explosionRadius>
+        <suppressionFactor>3.0</suppressionFactor>
+        <dangerFactor>2.0</dangerFactor>
+        <speed>100</speed>
+      </projectile>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationConditional">
+    <xpath>Defs/ThingDef[defName="Bullet_DoomsdayRocket"]/comps</xpath>
+    <nomatch Class="PatchOperationAdd">
+      <xpath>Defs/ThingDef[defName="Bullet_DoomsdayRocket"]</xpath>
+      <value>
+        <comps />
+      </value>
+    </nomatch>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/ThingDef[defName="Bullet_DoomsdayRocket"]/comps</xpath>
+    <value>
+      <li Class="CombatExtended.CompProperties_Fragments">
+        <fragSpeedFactor>1</fragSpeedFactor>
+        <fragments>
+          <Fragment_Large>400</Fragment_Large>
+        </fragments>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- Patch stats -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_DoomsdayRocket</defName>
+    <statBases>
+      <Mass>20.00</Mass>
+      <RangedWeapon_Cooldown>1.5</RangedWeapon_Cooldown>
+      <SightsEfficiency>2.24</SightsEfficiency>
+      <ShotSpread>0.2</ShotSpread>
+      <SwayFactor>3.24</SwayFactor>
+      <Bulk>13.0</Bulk>
+      <WorkToMake>49500</WorkToMake>
+    </statBases>
+    <costList>
+      <Steel>125</Steel>
+      <ComponentIndustrial>8</ComponentIndustrial>
+      <FSX>5</FSX>
+    </costList>
+    <Properties>
+      <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_DoomsdayRocket</defaultProjectile>
+      <warmupTime>2.1</warmupTime>
+      <range>48</range>
+      <burstShotCount>1</burstShotCount>
+      <soundCast>InfernoCannon_Fire</soundCast>
+      <soundCastTail>GunTail_Heavy</soundCastTail>
+      <onlyManualCast>true</onlyManualCast>
+      <targetParams>
+        <canTargetLocations>true</canTargetLocations>
+      </targetParams>
+      <muzzleFlashScale>14</muzzleFlashScale>
+    </Properties>
+    <FireModes>
+      <aiAimMode>AimedShot</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>CE_AI_AOE</li>
+    </weaponTags>
+    <researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
+    <AllowWithRunAndGun>false</AllowWithRunAndGun>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Gun_DoomsdayRocket"]</xpath>
+    <value>
+      <li Class="CombatExtended.GunDrawExtension">
+        <DrawSize>1.45,1.45</DrawSize>
+        <DrawOffset>-0.15,0</DrawOffset>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- ========== Triple rocket launcher ========== -->
+
+  <!-- Patch projectile -->
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Bullet_Rocket"]/thingClass</xpath>
+    <value>
+      <thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Bullet_Rocket"]/projectile</xpath>
+    <value>
+      <projectile Class="CombatExtended.ProjectilePropertiesCE">
+        <damageDef>Bomb</damageDef>
+        <damageAmountBase>180</damageAmountBase>
+        <explosionRadius>3.0</explosionRadius>
+        <suppressionFactor>3.0</suppressionFactor>
+        <dangerFactor>2.0</dangerFactor>
+        <speed>100</speed>
+      </projectile>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationConditional">
+    <xpath>Defs/ThingDef[defName="Bullet_Rocket"]/comps</xpath>
+    <nomatch Class="PatchOperationAdd">
+      <xpath>Defs/ThingDef[defName="Bullet_Rocket"]</xpath>
+      <value>
+        <comps />
+      </value>
+    </nomatch>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/ThingDef[defName="Bullet_Rocket"]/comps</xpath>
+    <value>
+      <li Class="CombatExtended.CompProperties_Fragments">
+        <fragSpeedFactor>1</fragSpeedFactor>
+        <fragments>
+          <Fragment_Large>150</Fragment_Large>
+        </fragments>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- Patch stats -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_TripleRocket</defName>
+    <statBases>
+      <Mass>12.00</Mass>
+      <RangedWeapon_Cooldown>1.5</RangedWeapon_Cooldown>
+      <SightsEfficiency>1</SightsEfficiency>
+      <ShotSpread>0.2</ShotSpread>
+      <SwayFactor>2.20</SwayFactor>
+      <Bulk>13.00</Bulk>
+      <WorkToMake>43000</WorkToMake>
+    </statBases>
+    <costList>
+      <Steel>90</Steel>
+      <ComponentIndustrial>7</ComponentIndustrial>
+      <FSX>3</FSX>
+    </costList>
+    <Properties>
+      <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_Rocket</defaultProjectile>
+      <warmupTime>1.9</warmupTime>
+      <range>40</range>
+      <ticksBetweenBurstShots>20</ticksBetweenBurstShots>
+      <burstShotCount>3</burstShotCount>
+      <soundCast>InfernoCannon_Fire</soundCast>
+      <soundCastTail>GunTail_Heavy</soundCastTail>
+      <onlyManualCast>true</onlyManualCast>
+      <stopBurstWithoutLos>false</stopBurstWithoutLos>
+      <targetParams>
+        <canTargetLocations>true</canTargetLocations>
+      </targetParams>
+      <muzzleFlashScale>14</muzzleFlashScale>
+    </Properties>
+    <FireModes>
+      <aiAimMode>AimedShot</aiAimMode>
+      <noSingleShot>true</noSingleShot>
+    </FireModes>
+    <weaponTags>
+      <li>CE_AI_AOE</li>
+    </weaponTags>
+    <researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
+    <AllowWithRunAndGun>false</AllowWithRunAndGun>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Gun_TripleRocket"]</xpath>
+    <value>
+      <li Class="CombatExtended.GunDrawExtension">
+        <DrawSize>1.16,1.16</DrawSize>
+        <DrawOffset>-0.25,0</DrawOffset>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- ========== Heavy charge blaster ========== -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_ChargeBlasterHeavy</defName>
+    <statBases>
+      <Mass>35.00</Mass>
+      <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+      <SightsEfficiency>1</SightsEfficiency>
+      <ShotSpread>0.01</ShotSpread>
+      <SwayFactor>1.33</SwayFactor>
+      <Bulk>13.00</Bulk>
+    </statBases>
+    <Properties>
+      <recoilAmount>1.08</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_12x64mmCharged</defaultProjectile>
+      <warmupTime>2.3</warmupTime>
+      <range>75</range>
+      <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+      <burstShotCount>20</burstShotCount>
+      <soundCast>Shot_ChargeBlaster</soundCast>
+      <soundCastTail>GunTail_Heavy</soundCastTail>
+      <muzzleFlashScale>9</muzzleFlashScale>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>100</magazineSize>
+      <reloadTime>9.2</reloadTime>
+      <ammoSet>AmmoSet_12x64mmCharged</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aimedBurstShotCount>10</aimedBurstShotCount>
+      <aiAimMode>Snapshot</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>CE_AI_Suppressive</li>
+      <li>NoSwitch</li>
+    </weaponTags>
+  </Operation>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[@Name="Gun_ChargeBlasterHeavyBase"]/tools</xpath>
+    <value>
+      <tools>
+        <li Class="CombatExtended.ToolCE">
+          <label>barrel</label>
+          <capacities>
+            <li>Blunt</li>
+          </capacities>
+          <power>10</power>
+          <cooldownTime>2.44</cooldownTime>
+          <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+          <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+        </li>
+      </tools>
+    </value>
+  </Operation>
+
+  <!-- ========== Inferno cannon ========== -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_InfernoCannon</defName>
+    <statBases>
+      <Mass>50.00</Mass>
+      <RangedWeapon_Cooldown>2.54</RangedWeapon_Cooldown>
+      <SightsEfficiency>1</SightsEfficiency>
+      <ShotSpread>0.01</ShotSpread>
+      <SwayFactor>0.14</SwayFactor>
+      <Bulk>20.00</Bulk>
+    </statBases>
+    <Properties>
+      <recoilAmount>2.01</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>
+      <warmupTime>3.5</warmupTime>
+      <!-- Intentionally decreased from 4.3s -->
+      <range>86</range>
+      <burstShotCount>1</burstShotCount>
+      <soundCast>InfernoCannon_Fire</soundCast>
+      <soundCastTail>GunTail_Light</soundCastTail>
+      <muzzleFlashScale>14</muzzleFlashScale>
+      <ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
+      <minRange>5</minRange>
+      <ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>1</magazineSize>
+      <AmmoGenPerMagOverride>2</AmmoGenPerMagOverride>
+      <reloadTime>9.8</reloadTime>
+      <ammoSet>AmmoSet_80x256mmFuel</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aiAimMode>AimedShot</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>CE_AI_Launcher</li>
+      <li>NoSwitch</li>
+    </weaponTags>
+  </Operation>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[@Name="Gun_InfernoCannonBase"]/tools</xpath>
+    <value>
+      <tools>
+        <li Class="CombatExtended.ToolCE">
+          <label>barrel</label>
+          <capacities>
+            <li>Blunt</li>
+          </capacities>
+          <power>10</power>
+          <cooldownTime>2.44</cooldownTime>
+          <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+          <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+        </li>
+      </tools>
+    </value>
+  </Operation>
+
+  <!-- ========== Thump cannon ========== -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_ThumpCannon</defName>
+    <statBases>
+      <Mass>75.00</Mass>
+      <RangedWeapon_Cooldown>2.2</RangedWeapon_Cooldown>
+      <SightsEfficiency>1</SightsEfficiency>
+      <ShotSpread>0.01</ShotSpread>
+      <SwayFactor>0.21</SwayFactor>
+      <Bulk>20.00</Bulk>
+    </statBases>
+    <Properties>
+      <recoilAmount>0.1</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_164x284mmDemo</defaultProjectile>
+      <warmupTime>3.3</warmupTime>
+      <range>42</range>
+      <burstShotCount>1</burstShotCount>
+      <soundCast>ThumpCannon_Fire</soundCast>
+      <soundCastTail>GunTail_Heavy</soundCastTail>
+      <muzzleFlashScale>14</muzzleFlashScale>
+      <ai_AvoidFriendlyFireRadius>3</ai_AvoidFriendlyFireRadius>
+      <minRange>4</minRange>
+      <ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>1</magazineSize>
+      <AmmoGenPerMagOverride>2</AmmoGenPerMagOverride>
+      <reloadTime>9.8</reloadTime>
+      <ammoSet>AmmoSet_164x284mmDemo</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aiAimMode>AimedShot</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>CE_AI_Launcher</li>
+      <li>NoSwitch</li>
+    </weaponTags>
+  </Operation>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Gun_ThumpCannon"]/tools</xpath>
+    <value>
+      <tools>
+        <li Class="CombatExtended.ToolCE">
+          <label>barrel</label>
+          <capacities>
+            <li>Blunt</li>
+          </capacities>
+          <power>10</power>
+          <cooldownTime>2.44</cooldownTime>
+          <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+          <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+        </li>
+      </tools>
+    </value>
+  </Operation>
+
+  <!-- ========== Charge lance ========== -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_ChargeLance</defName>
+    <statBases>
+      <RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
+      <SightsEfficiency>1</SightsEfficiency>
+      <ShotSpread>0.01</ShotSpread>
+      <SwayFactor>1</SwayFactor>
+      <Bulk>13.00</Bulk>
+    </statBases>
+    <Properties>
+      <recoilAmount>0.75</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_5x35mmCharged</defaultProjectile>
+      <warmupTime>1.3</warmupTime>
+      <range>62</range>
+      <burstShotCount>1</burstShotCount>
+      <soundCast>ChargeLance_Fire</soundCast>
+      <soundCastTail>GunTail_Heavy</soundCastTail>
+      <muzzleFlashScale>9</muzzleFlashScale>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>5</magazineSize>
+      <reloadTime>3</reloadTime>
+      <ammoSet>AmmoSet_5x35mmCharged</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aiAimMode>AimedShot</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>CE_AI_Rifle</li>
+      <li>NoSwitch</li>
+    </weaponTags>
+  </Operation>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Gun_ChargeLance"]/tools</xpath>
+    <value>
+      <tools>
+        <li Class="CombatExtended.ToolCE">
+          <label>barrel</label>
+          <capacities>
+            <li>Blunt</li>
+          </capacities>
+          <power>10</power>
+          <cooldownTime>2.44</cooldownTime>
+          <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+          <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+        </li>
+      </tools>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Gun_ChargeLance"]</xpath>
+    <value>
+      <li Class="CombatExtended.ThingDefExtensionCE">
+        <MenuHidden>True</MenuHidden>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- Disable for player -->
+  <Operation Class="PatchOperationAttributeSet">
+    <xpath>Defs/ThingDef[defName="Gun_ChargeLance"]</xpath>
+    <attribute>ParentName</attribute>
+    <value>BaseGun</value>
+  </Operation>
+
+  <Operation Class="PatchOperationRemove">
+    <xpath>Defs/ThingDef[defName="Gun_ChargeLance"]/costList</xpath>
+  </Operation>
+
+  <Operation Class="PatchOperationRemove">
+    <xpath>Defs/ThingDef[defName="Gun_ChargeLance"]/recipeMaker</xpath>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/ThingDef[defName="Gun_ChargeLance"]/statBases</xpath>
+    <value>
+      <MarketValue>1400</MarketValue>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/ThingDef[defName="Gun_ChargeLance"]</xpath>
+    <value>
+      <tradeability>None</tradeability>
+      <destroyOnDrop>True</destroyOnDrop>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationRemove">
+    <xpath>Defs/ThingDef[defName="Gun_ChargeLance"]/weaponTags/li[contains(.,"SpacerGun")]</xpath>
+  </Operation>
+
+  <!-- ========== Needle Gun ========== -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_Needle</defName>
+    <statBases>
+      <RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
+      <SightsEfficiency>1</SightsEfficiency>
+      <ShotSpread>0.01</ShotSpread>
+      <SwayFactor>0.81</SwayFactor>
+      <Bulk>15.00</Bulk>
+    </statBases>
+    <Properties>
+      <recoilAmount>1.80</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_5x100mmCaseless_Sabot</defaultProjectile>
+      <warmupTime>1.3</warmupTime>
+      <range>75</range>
+      <burstShotCount>1</burstShotCount>
+      <soundCast>Shot_NeedleGun</soundCast>
+      <soundCastTail>GunTail_Heavy</soundCastTail>
+      <muzzleFlashScale>9</muzzleFlashScale>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>10</magazineSize>
+      <reloadTime>4</reloadTime>
+      <ammoSet>AmmoSet_5x100mmCaseless</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aiAimMode>AimedShot</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>CE_AI_Rifle</li>
+      <li>NoSwitch</li>
+    </weaponTags>
+  </Operation>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Gun_Needle"]/tools</xpath>
+    <value>
+      <tools>
+        <li Class="CombatExtended.ToolCE">
+          <label>barrel</label>
+          <capacities>
+            <li>Blunt</li>
+          </capacities>
+          <power>10</power>
+          <cooldownTime>2.44</cooldownTime>
+          <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+          <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+        </li>
+      </tools>
+    </value>
+  </Operation>
+
+  <!-- Increase Orbital Bombardment Range -->
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="OrbitalTargeterBombardment" or defName="OrbitalTargeterPowerBeam"]/verbs/li/range</xpath>
+    <value>
+      <range>60</range>
+    </value>
+  </Operation>
+
+  <!-- Remove Smoke and EMP Launchers -->
+  <Operation Class="PatchOperationRemove">
+    <xpath>Defs/ThingDef[defName="Gun_SmokeLauncher"]</xpath>
+  </Operation>
+
+  <Operation Class="PatchOperationRemove">
+    <xpath>Defs/ThingDef[defName="Gun_EmpLauncher"]</xpath>
+  </Operation>
 
 </Patch>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -925,7 +925,7 @@
         <DrawSize>1.00,1.00</DrawSize>
         <DrawOffset>0.1,-0.15</DrawOffset>
         <CasingOffset>-0.2,0</CasingOffset>
-        <CasingAngleOffset>45</CasingAngleOffset>
+        <CasingAngleOffset>-30</CasingAngleOffset>
       </li>
     </value>
   </Operation>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -925,6 +925,7 @@
         <DrawSize>1.00,1.00</DrawSize>
         <DrawOffset>0.1,-0.15</DrawOffset>
         <CasingOffset>-0.2,0</CasingOffset>
+        <CasingAngleOffset>45</CasingAngleOffset>
       </li>
     </value>
   </Operation>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -126,8 +126,7 @@
       <ShotSpread>0.18</ShotSpread>
       <SwayFactor>1.27</SwayFactor>
       <Bulk>2.41</Bulk>
-      <!-- <ToughnessRating>2.5</ToughnessRating> -->
-      <!-- Base toughness rating of a weapon -->
+      <!-- <ToughnessRating>2.5</ToughnessRating> --> <!-- Base toughness rating of a weapon -->
       <WorkToMake>7000</WorkToMake>
     </statBases>
     <costList>
@@ -1231,8 +1230,7 @@
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>
-      <warmupTime>3.5</warmupTime>
-      <!-- Intentionally decreased from 4.3s -->
+      <warmupTime>3.5</warmupTime> <!-- Intentionally decreased from 4.3s -->
       <range>86</range>
       <burstShotCount>1</burstShotCount>
       <soundCast>InfernoCannon_Fire</soundCast>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -339,6 +339,8 @@
       <li Class="CombatExtended.GunDrawExtension">
         <DrawSize>1.04,1.23</DrawSize>
         <DrawOffset>0.05,-0.05</DrawOffset>
+        <CasingOffset>0,0.2</CasingOffset>
+        <CasingAngleOffset>-30</CasingAngleOffset>
       </li>
     </value>
   </Operation>
@@ -394,6 +396,7 @@
       <li Class="CombatExtended.GunDrawExtension">
         <DrawSize>1.3,1.3</DrawSize>
         <DrawOffset>0.12,0.04</DrawOffset>
+        <CasingOffset>-0.1,0.1</CasingOffset>
       </li>
     </value>
   </Operation>
@@ -507,6 +510,7 @@
       <li Class="CombatExtended.GunDrawExtension">
         <DrawSize>1.25,1.45</DrawSize>
         <DrawOffset>0.15,-0.05</DrawOffset>
+        <CasingOffset>-0.3,0.1</CasingOffset>
       </li>
     </value>
   </Operation>
@@ -565,6 +569,8 @@
       <li Class="CombatExtended.GunDrawExtension">
         <DrawSize>0.84,0.84</DrawSize>
         <DrawOffset>-0.10,-0.07</DrawOffset>
+        <CasingOffset>0.1,0.1</CasingOffset>
+        <CasingAngleOffset>-30</CasingAngleOffset>
       </li>
     </value>
   </Operation>
@@ -623,6 +629,7 @@
       <li Class="CombatExtended.GunDrawExtension">
         <DrawSize>0.85,0.85</DrawSize>
         <DrawOffset>0.00,-0.03</DrawOffset>
+        <CasingOffset>0.1,0</CasingOffset>
       </li>
     </value>
   </Operation>

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -736,13 +736,13 @@ namespace CombatExtended
         #endregion Misc
 
         #region MoteThrower
-        public static void GenerateAmmoCasings(ProjectilePropertiesCE projProps, Vector3 drawPosition, Map map, float shotRotation = -180f, float recoilAmount = 2f)
+        public static void GenerateAmmoCasings(ProjectilePropertiesCE projProps, Vector3 drawPosition, Map map, float shotRotation = -180f, float recoilAmount = 2f, bool fromPawn = false, float casingAngleOffset = 0)
         {
             if (projProps.dropsCasings)
             {
                 if (Controller.settings.ShowCasings)
                 {
-                    ThrowEmptyCasing(drawPosition, map, DefDatabase<FleckDef>.GetNamed(projProps.casingMoteDefname), recoilAmount, shotRotation);
+                    ThrowEmptyCasing(drawPosition, map, DefDatabase<FleckDef>.GetNamed(projProps.casingMoteDefname), recoilAmount, shotRotation, 1f, fromPawn, casingAngleOffset);
                 }
                 if (Controller.settings.CreateCasingsFilth)
                 {
@@ -752,7 +752,7 @@ namespace CombatExtended
         }
 
 
-        public static void ThrowEmptyCasing(Vector3 loc, Map map, FleckDef casingFleckDef, float recoilAmount, float shotRotation, float size = 1f)
+        public static void ThrowEmptyCasing(Vector3 loc, Map map, FleckDef casingFleckDef, float recoilAmount, float shotRotation, float size = 1f, bool fromPawn = false, float casingAngleOffset = 0)
         {
             if (!loc.ShouldSpawnMotesAt(map) || map.moteCounter.SaturatedLowPriority)
             {
@@ -772,8 +772,13 @@ namespace CombatExtended
             //shotRotation goes from -270 to +90, while fleck angle uses 0 to 360 degrees (0 deg being North for both cases), so a conversion is used
             //^ not anymore, now it gets aiming angle instead
             //+90 makes casings fly to gun's right side
-            creationData.velocityAngle = shotRotation + 90 + randomAngle;
-            creationData.rotation = creationData.velocityAngle + Rand.Range(-3f, 4f);
+            bool flip = false;
+            if (fromPawn && shotRotation > 200f && shotRotation < 340f)
+            {
+                flip = true;
+            }
+            creationData.velocityAngle = flip ? shotRotation - 90 - casingAngleOffset + randomAngle : shotRotation + 90 + casingAngleOffset + randomAngle;
+            creationData.rotation = creationData.velocityAngle + (flip ? 180 : 0) + Rand.Range(-3f, 4f);
             creationData.rotationRate = (float)Rand.Range(-150, 150) / recoilAmount;
             map.flecks.CreateFleck(creationData);
             Rand.PopState();

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -764,10 +764,10 @@ namespace CombatExtended
             }
             Rand.PushState();
             FleckCreationData creationData = FleckMaker.GetDataStatic(loc, map, casingFleckDef);
-            creationData.airTimeLeft = Rand.Range(0.5f, 1.5f);
+            creationData.velocitySpeed = Rand.Range(1.5f, 2f) * recoilAmount;
+            creationData.airTimeLeft = Rand.Range(1f, 1.5f) / creationData.velocitySpeed;
             creationData.scale = Rand.Range(0.5f, 0.3f) * size;
             creationData.spawnPosition = loc;
-            creationData.velocitySpeed = Rand.Range(0.6f, 0.4f) * recoilAmount;
             int randomAngle = Rand.Range(-20, 20);
             //shotRotation goes from -270 to +90, while fleck angle uses 0 to 360 degrees (0 deg being North for both cases), so a conversion is used
             //^ not anymore, now it gets aiming angle instead
@@ -778,7 +778,7 @@ namespace CombatExtended
                 flip = true;
             }
             creationData.velocityAngle = flip ? shotRotation - 90 - casingAngleOffset + randomAngle : shotRotation + 90 + casingAngleOffset + randomAngle;
-            creationData.rotation = creationData.velocityAngle + (flip ? 180 : 0) + Rand.Range(-3f, 4f);
+            creationData.rotation = (flip ? shotRotation - 90 : shotRotation + 90) + Rand.Range(-3f, 4f);
             creationData.rotationRate = (float)Rand.Range(-150, 150) / recoilAmount;
             map.flecks.CreateFleck(creationData);
             Rand.PopState();

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -770,8 +770,9 @@ namespace CombatExtended
             creationData.velocitySpeed = Rand.Range(0.6f, 0.4f) * recoilAmount;
             int randomAngle = Rand.Range(-20, 20);
             //shotRotation goes from -270 to +90, while fleck angle uses 0 to 360 degrees (0 deg being North for both cases), so a conversion is used
+            //^ not anymore, now it gets aiming angle instead
             //+90 makes casings fly to gun's right side
-            creationData.velocityAngle = shotRotation - 90 + randomAngle;
+            creationData.velocityAngle = shotRotation + 90 + randomAngle;
             creationData.rotation = creationData.velocityAngle + Rand.Range(-3f, 4f);
             creationData.rotationRate = (float)Rand.Range(-150, 150) / recoilAmount;
             map.flecks.CreateFleck(creationData);

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -764,14 +764,14 @@ namespace CombatExtended
             }
             Rand.PushState();
             FleckCreationData creationData = FleckMaker.GetDataStatic(loc, map, casingFleckDef);
-            creationData.airTimeLeft = 1.5f;
+            creationData.airTimeLeft = Rand.Range(0.5f, 1.5f);
             creationData.scale = Rand.Range(0.5f, 0.3f) * size;
             creationData.spawnPosition = loc;
             creationData.velocitySpeed = Rand.Range(0.6f, 0.4f) * recoilAmount;
             int randomAngle = Rand.Range(-20, 20);
             //shotRotation goes from -270 to +90, while fleck angle uses 0 to 360 degrees (0 deg being North for both cases), so a conversion is used
             //+90 makes casings fly to gun's right side
-            creationData.velocityAngle = shotRotation > 0 ? 360 - shotRotation + 90 + randomAngle : 0 - shotRotation + 90 + randomAngle;
+            creationData.velocityAngle = shotRotation - 90 + randomAngle;
             creationData.rotation = creationData.velocityAngle + Rand.Range(-3f, 4f);
             creationData.rotationRate = (float)Rand.Range(-150, 150) / recoilAmount;
             map.flecks.CreateFleck(creationData);

--- a/Source/CombatExtended/CombatExtended/Defs/GunDrawExtension.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/GunDrawExtension.cs
@@ -7,5 +7,8 @@ namespace CombatExtended
     {
         public Vector2 DrawSize = Vector2.one;
         public Vector2 DrawOffset = Vector2.zero;
+
+        public Vector2 CasingOffset = Vector2.zero;
+        public float CasingAngleOffset = 0;
     }
 }

--- a/Source/CombatExtended/CombatExtended/Things/Fleck_Casing.cs
+++ b/Source/CombatExtended/CombatExtended/Things/Fleck_Casing.cs
@@ -1,0 +1,166 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using RimWorld;
+using UnityEngine;
+using Verse;
+using Verse.Sound;
+
+namespace CombatExtended
+{
+    public class FleckSystem_Casing : FleckSystemBase<Fleck_Casing>
+    {
+    }
+    public struct Fleck_Casing : IFleck
+    {
+        public FleckStatic baseData;
+
+        public float airTimeLeft;
+
+        public Vector3 velocity;
+
+        public float rotationRate;
+
+        public float delay;
+
+        public bool Flying => airTimeLeft > 0f;
+
+        public Vector3 Velocity
+        {
+            get
+            {
+                return velocity;
+            }
+            set
+            {
+                velocity = value;
+            }
+        }
+
+        public float MoveAngle
+        {
+            get
+            {
+                return velocity.AngleFlat();
+            }
+            set
+            {
+                SetVelocity(value, Speed);
+            }
+        }
+
+        public float Speed
+        {
+            get
+            {
+                return velocity.MagnitudeHorizontal();
+            }
+            set
+            {
+                if (value == 0f)
+                {
+                    velocity = Vector3.zero;
+                }
+                else if (velocity == Vector3.zero)
+                {
+                    velocity = new Vector3(value, 0f, 0f);
+                }
+                else
+                {
+                    velocity = velocity.normalized * value;
+                }
+            }
+        }
+
+        public void Setup(FleckCreationData creationData)
+        {
+            baseData = default(FleckStatic);
+            baseData.Setup(creationData);
+            airTimeLeft = creationData.airTimeLeft ?? 999999f;
+            baseData.exactPosition += creationData.def.attachedDrawOffset;
+            rotationRate = creationData.rotationRate;
+            SetVelocity(creationData.velocityAngle, creationData.velocitySpeed);
+            if (creationData.velocity.HasValue)
+            {
+                velocity += creationData.velocity.Value;
+            }
+        }
+
+        public bool TimeInterval(float deltaTime, Map map)
+        {
+            if (baseData.TimeInterval(deltaTime, map))
+            {
+                return true;
+            }
+            if (!Flying)
+            {
+                return false;
+            }
+            Vector3 vector = NextExactPosition(deltaTime);
+            IntVec3 intVec = new IntVec3(vector);
+            if (intVec != new IntVec3(baseData.exactPosition))
+            {
+                if (!intVec.InBounds(map))
+                {
+                    return true;
+                }
+                if (baseData.def.collide && intVec.Filled(map))
+                {
+                    WallHit();
+                    return false;
+                }
+            }
+            baseData.exactPosition = vector;
+            if (baseData.def.speedPerTime != FloatRange.Zero)
+            {
+                Speed = Mathf.Max(Speed + baseData.def.speedPerTime.RandomInRange * deltaTime, 0f);
+            }
+            if (airTimeLeft > 0f)
+            {
+                if (baseData.def.rotateTowardsMoveDirection && velocity != default(Vector3))
+                {
+                    baseData.exactRotation = velocity.AngleFlat() + baseData.def.rotateTowardsMoveDirectionExtraAngle;
+                }
+                else
+                {
+                    baseData.exactRotation += rotationRate * deltaTime;
+                }
+                velocity += baseData.def.acceleration * deltaTime;
+                airTimeLeft -= deltaTime;
+                if (airTimeLeft < 0f)
+                {
+                    airTimeLeft = 0f;
+                }
+                if (airTimeLeft <= 0f && !baseData.def.landSound.NullOrUndefined())
+                {
+                    baseData.def.landSound.PlayOneShot(new TargetInfo(new IntVec3(baseData.exactPosition), map));
+                }
+            }
+            return false;
+        }
+
+        private Vector3 NextExactPosition(float deltaTime)
+        {
+            return baseData.exactPosition + velocity * deltaTime;
+        }
+
+        public void SetVelocity(float angle, float speed)
+        {
+            velocity = Quaternion.AngleAxis(angle, Vector3.up) * Vector3.forward * speed;
+        }
+
+        public void Draw(DrawBatch batch)
+        {
+            baseData.Draw(batch);
+        }
+
+        private void WallHit()
+        {
+            airTimeLeft = 0f;
+            Speed = 0f;
+            rotationRate = 0f;
+        }
+    }
+}

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -376,29 +376,18 @@ namespace CombatExtended
         }
         protected virtual bool OnCastSuccessful()
         {
-            Vector3 casingPos = caster.DrawPos;
-            float casingAngle = AimAngle;
-            float casingAngleOffset = EquipmentSource?.def.GetModExtension<GunDrawExtension>()?.CasingAngleOffset ?? 0;
+            bool fromPawn = false;
             //Required since Verb_Shoot does this but Verb_LaunchProjectileCE doesn't when calling base.TryCastShot() because Shoot isn't its base
-            if (ShooterPawn != null && drawPos != Vector3.zero)
+            if (ShooterPawn != null)
             {
                 ShooterPawn.records.Increment(RecordDefOf.ShotsFired);
-                casingPos = drawPos;
-                if (casingAngle > 200f && casingAngle < 340f)
-                {
-                    casingAngle -= 180f;
-                    casingAngle -= casingAngleOffset;
-                }
-                else
-                {
-                    casingAngle += casingAngleOffset;
-                }
+                fromPawn = drawPos != Vector3.zero;
             }
 
             //Drop casings
             if (VerbPropsCE.ejectsCasings)
             {
-                CE_Utility.GenerateAmmoCasings(projectilePropsCE, casingPos, caster.Map, casingAngle, VerbPropsCE.recoilAmount);
+                CE_Utility.GenerateAmmoCasings(projectilePropsCE, fromPawn ? drawPos : caster.DrawPos, caster.Map, AimAngle, VerbPropsCE.recoilAmount, fromPawn: fromPawn, casingAngleOffset: EquipmentSource?.def.GetModExtension<GunDrawExtension>()?.CasingAngleOffset ?? 0);
             }
             // This needs to here for weapons without magazine to ensure their last shot plays sounds
             if (CompAmmo != null && !CompAmmo.HasMagazine && CompAmmo.UseAmmo)

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -378,14 +378,20 @@ namespace CombatExtended
         {
             Vector3 casingPos = caster.DrawPos;
             float casingAngle = AimAngle;
+            float casingAngleOffset = EquipmentSource?.def.GetModExtension<GunDrawExtension>()?.CasingAngleOffset ?? 0;
             //Required since Verb_Shoot does this but Verb_LaunchProjectileCE doesn't when calling base.TryCastShot() because Shoot isn't its base
             if (ShooterPawn != null && drawPos != Vector3.zero)
             {
                 ShooterPawn.records.Increment(RecordDefOf.ShotsFired);
                 casingPos = drawPos;
-                if (casingAngle > 20f && casingAngle < 160f)
+                if (casingAngle > 200f && casingAngle < 340f)
                 {
                     casingAngle -= 180f;
+                    casingAngle -= casingAngleOffset;
+                }
+                else
+                {
+                    casingAngle += casingAngleOffset;
                 }
             }
 

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -377,6 +377,7 @@ namespace CombatExtended
         protected virtual bool OnCastSuccessful()
         {
             bool fromPawn = false;
+            GunDrawExtension ext = EquipmentSource.def.GetModExtension<GunDrawExtension>();
             //Required since Verb_Shoot does this but Verb_LaunchProjectileCE doesn't when calling base.TryCastShot() because Shoot isn't its base
             if (ShooterPawn != null)
             {
@@ -387,7 +388,7 @@ namespace CombatExtended
             //Drop casings
             if (VerbPropsCE.ejectsCasings)
             {
-                CE_Utility.GenerateAmmoCasings(projectilePropsCE, fromPawn ? drawPos : caster.DrawPos, caster.Map, AimAngle, VerbPropsCE.recoilAmount, fromPawn: fromPawn, casingAngleOffset: EquipmentSource?.def.GetModExtension<GunDrawExtension>()?.CasingAngleOffset ?? 0);
+                CE_Utility.GenerateAmmoCasings(projectilePropsCE, fromPawn ? drawPos : caster.DrawPos + CasingOffsetRotated(ext), caster.Map, AimAngle, VerbPropsCE.recoilAmount, fromPawn: fromPawn, casingAngleOffset: EquipmentSource?.def.GetModExtension<GunDrawExtension>()?.CasingAngleOffset ?? 0);
             }
             // This needs to here for weapons without magazine to ensure their last shot plays sounds
             if (CompAmmo != null && !CompAmmo.HasMagazine && CompAmmo.UseAmmo)
@@ -417,6 +418,16 @@ namespace CombatExtended
                 return CompAmmo.Notify_PostShotFired();
             }
             return true;
+        }
+
+        Vector3 CasingOffsetRotated(GunDrawExtension ext)
+        {
+            if (ext == null || ext.CasingOffset == Vector2.zero)
+            {
+                return Vector3.zero;
+            }
+            return new Vector3(ext.CasingOffset.x, 0, ext.CasingOffset.y).RotatedBy(AimAngle);
+
         }
         #endregion
     }

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -29,6 +29,8 @@ namespace CombatExtended
 
         private bool _isAiming;
 
+        public Vector3 drawPos;
+
         #endregion
 
         #region Properties
@@ -356,15 +358,17 @@ namespace CombatExtended
         }
         protected virtual bool OnCastSuccessful()
         {
+            Vector3 casingPos = caster.DrawPos;
             //Required since Verb_Shoot does this but Verb_LaunchProjectileCE doesn't when calling base.TryCastShot() because Shoot isn't its base
             if (ShooterPawn != null)
             {
                 ShooterPawn.records.Increment(RecordDefOf.ShotsFired);
+                casingPos = drawPos;
             }
             //Drop casings
             if (VerbPropsCE.ejectsCasings)
             {
-                CE_Utility.GenerateAmmoCasings(projectilePropsCE, caster.DrawPos, caster.Map, shotRotation, VerbPropsCE.recoilAmount);
+                CE_Utility.GenerateAmmoCasings(projectilePropsCE, casingPos, caster.Map, shotRotation, VerbPropsCE.recoilAmount);
             }
             // This needs to here for weapons without magazine to ensure their last shot plays sounds
             if (CompAmmo != null && !CompAmmo.HasMagazine && CompAmmo.UseAmmo)

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -105,6 +105,24 @@ namespace CombatExtended
             }
         }
 
+        public float AimAngle
+        {
+            get
+            {
+                if (this.CurrentTarget == null)
+                {
+                    return 143f;
+                }
+                Vector3 vector = (CurrentTarget.Thing == null ? CurrentTarget.Cell.ToVector3Shifted() : CurrentTarget.Thing.DrawPos);
+                float num = 143f;
+                if ((vector - caster.DrawPos).MagnitudeHorizontalSquared() > 0.001f)
+                {
+                    num = (vector - caster.DrawPos).AngleFlat();
+                }
+                return num;
+            }
+        }
+
         public float SpreadDegrees
         {
             get
@@ -359,17 +377,18 @@ namespace CombatExtended
         protected virtual bool OnCastSuccessful()
         {
             Vector3 casingPos = caster.DrawPos;
-            float casingAngle = shotRotation;
+            float casingAngle = AimAngle;
             //Required since Verb_Shoot does this but Verb_LaunchProjectileCE doesn't when calling base.TryCastShot() because Shoot isn't its base
             if (ShooterPawn != null && drawPos != Vector3.zero)
             {
                 ShooterPawn.records.Increment(RecordDefOf.ShotsFired);
                 casingPos = drawPos;
-                if (casingAngle < -200f || casingAngle > 20f)
+                if (casingAngle > 20f && casingAngle < 160f)
                 {
                     casingAngle -= 180f;
                 }
             }
+
             //Drop casings
             if (VerbPropsCE.ejectsCasings)
             {

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -359,16 +359,21 @@ namespace CombatExtended
         protected virtual bool OnCastSuccessful()
         {
             Vector3 casingPos = caster.DrawPos;
+            float casingAngle = shotRotation;
             //Required since Verb_Shoot does this but Verb_LaunchProjectileCE doesn't when calling base.TryCastShot() because Shoot isn't its base
-            if (ShooterPawn != null)
+            if (ShooterPawn != null && drawPos != Vector3.zero)
             {
                 ShooterPawn.records.Increment(RecordDefOf.ShotsFired);
                 casingPos = drawPos;
+                if (casingAngle < -200f || casingAngle > 20f)
+                {
+                    casingAngle -= 180f;
+                }
             }
             //Drop casings
             if (VerbPropsCE.ejectsCasings)
             {
-                CE_Utility.GenerateAmmoCasings(projectilePropsCE, casingPos, caster.Map, shotRotation, VerbPropsCE.recoilAmount);
+                CE_Utility.GenerateAmmoCasings(projectilePropsCE, casingPos, caster.Map, casingAngle, VerbPropsCE.recoilAmount);
             }
             // This needs to here for weapons without magazine to ensure their last shot plays sounds
             if (CompAmmo != null && !CompAmmo.HasMagazine && CompAmmo.UseAmmo)

--- a/Source/CombatExtended/Harmony/Harmony_PawnRenderer.cs
+++ b/Source/CombatExtended/Harmony/Harmony_PawnRenderer.cs
@@ -422,15 +422,17 @@ namespace CombatExtended.HarmonyCE
                 if (drawData.DrawSize == Vector2.one) { drawData.DrawSize = eq.def.graphicData.drawSize; }
                 Vector3 scale = new Vector3(drawData.DrawSize.x, 1, drawData.DrawSize.y);
                 Vector3 posVec = new Vector3(drawData.DrawOffset.x, 0, drawData.DrawOffset.y);
+                Vector3 casingOffset = new Vector3(drawData.CasingOffset.x, 0, drawData.CasingOffset.y);
                 if (aimAngle > 200 && aimAngle < 340)
                 {
                     posVec.x *= -1;
+                    casingOffset.x *= -1;
                 }
                 matrix.SetTRS(position + posVec.RotatedBy(matrix.rotation.eulerAngles.y), matrix.rotation, scale);
                 CompEquippable compEquippable = eq.TryGetComp<CompEquippable>();
                 if (compEquippable != null && compEquippable.PrimaryVerb is Verb_ShootCE verbCE)
                 {
-                    verbCE.drawPos = casingDrawPos + posVec.RotatedBy(matrix.rotation.eulerAngles.y);
+                    verbCE.drawPos = casingDrawPos + (casingOffset + posVec).RotatedBy(matrix.rotation.eulerAngles.y);
                 }
                 if (eq is WeaponPlatform platform)
                 {

--- a/Source/CombatExtended/Harmony/Harmony_PawnRenderer.cs
+++ b/Source/CombatExtended/Harmony/Harmony_PawnRenderer.cs
@@ -403,14 +403,17 @@ namespace CombatExtended.HarmonyCE
 
             private static Pawn pawn;
 
+            private static Vector3 casingDrawPos;
+
             private static readonly Matrix4x4 TBot5 = Matrix4x4.Translate(new Vector3(0, -0.006f, 0));
 
             private static readonly Matrix4x4 TBot3 = Matrix4x4.Translate(new Vector3(0, -0.004f, 0));
 
-            public static void Prefix(PawnRenderer __instance, Thing eq)
+            public static void Prefix(PawnRenderer __instance, Thing eq, Vector3 drawLoc)
             {
                 pawn = __instance.pawn;
                 equipment = eq;
+                casingDrawPos = drawLoc;
             }
 
             private static void DrawMesh(Mesh mesh, Matrix4x4 matrix, Material mat, int layer, Thing eq, Vector3 position, float aimAngle)
@@ -424,6 +427,11 @@ namespace CombatExtended.HarmonyCE
                     posVec.x *= -1;
                 }
                 matrix.SetTRS(position + posVec.RotatedBy(matrix.rotation.eulerAngles.y), matrix.rotation, scale);
+                CompEquippable compEquippable = eq.TryGetComp<CompEquippable>();
+                if (compEquippable != null && compEquippable.PrimaryVerb is Verb_ShootCE verbCE)
+                {
+                    verbCE.drawPos = casingDrawPos + posVec.RotatedBy(matrix.rotation.eulerAngles.y);
+                }
                 if (eq is WeaponPlatform platform)
                 {
                     platform.DrawPlatform(matrix, mesh == MeshPool.plane10Flip, layer);


### PR DESCRIPTION
## Changes

Make casing mote originate from where gun draw center is. Works perfect for AR, LMG, pistol and shotguns, sub-optimal but acceptable on SMG, rifle and sniper rifle, a bit hilarous on minigun
Also fixed casing velocity on handheld weapons when firing towards right side
Added casing offset to gundrawextension
Made casing mote life span randomize from 0.5 to 1.5, because the original looked awful when not firing east/west.
before:
![CasingImprovePre](https://github.com/CombatExtended-Continued/CombatExtended/assets/62052103/4a53f127-f026-4551-80b1-43583b09cd8a)
after:
![CasingImprove2](https://github.com/CombatExtended-Continued/CombatExtended/assets/62052103/85477c5f-f884-40e2-93b0-ad3ffb27ecdd)
![CasingImprove4](https://github.com/CombatExtended-Continued/CombatExtended/assets/62052103/c9239e83-62bd-464f-8522-74aaeaeaa2de)


## Reasoning

We CE people don't pull ammo out of our butts like vanilla does, so casings shouldn't either.

## Alternatives

Shit hot brass.

## To do
-I actually hated the implementation but I couldn't come up with a better one, unless I copy a good chunk of code from pawnrenderer. Probably need a look from a coder better than me.
-Another modextension for angle offset?

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (a mag with all vanilla guns)
