### PR TITLE
Dynamically add ammo items to vehicle ammo ThingFilter

### DIFF
--- a/Source/VehiclesCompat/VehiclesCompat/VehiclesCompat.cs
+++ b/Source/VehiclesCompat/VehiclesCompat/VehiclesCompat.cs
@@ -13,7 +13,6 @@ using UnityEngine;
 
 namespace CombatExtended.Compatibility.VehiclesCompat
 {
-    [StaticConstructorOnStartup]
     public class VehiclesCompat : IModPart
     {
         public Type GetSettingsType()
@@ -32,6 +31,31 @@ namespace CombatExtended.Compatibility.VehiclesCompat
             VehicleTurret.LookupProjectileCountAndSpreadCE = LookupProjectileCountAndSpreadCE;
             global::CombatExtended.Compatibility.Patches.RegisterCollisionBodyFactorCallback(_GetCollisionBodyFactors);
             global::CombatExtended.Compatibility.Patches.UsedAmmoCallbacks.Add(_GetUsedAmmo);
+	    if (Controller.settings.EnableAmmoSystem)
+	    {
+		foreach (VehicleTurretDef vtd in DefDatabase<global::Vehicles.VehicleTurretDef>.AllDefs)
+		{
+		    CETurretDataDefModExtension cetddme = vtd.GetModExtension<CETurretDataDefModExtension>();
+		    if (cetddme.ammoSet != null)
+		    {
+			AmmoSetDef asd = (AmmoSetDef) LookupAmmosetCE(cetddme.ammoSet);
+			if (Controller.settings.GenericAmmo && asd?.similarTo != null)
+			{
+			    asd = asd.similarTo;
+			}
+			if (asd != null)
+			{
+			    cetddme._ammoSet = asd;
+			    HashSet<ThingDef> allowedAmmo = (HashSet<ThingDef>) vtd.ammunition?.AllowedThingDefs;
+			    allowedAmmo.Clear();
+			    foreach (var al in asd.ammoTypes)
+			    {
+				allowedAmmo.Add(al.ammo);
+			    }
+			}
+		    }
+		}
+	    }
         }
 
         public static Tuple<int, float> LookupProjectileCountAndSpreadCE(ThingDef _ammoDef, Def _ammosetDef, float spread)

--- a/Source/VehiclesCompat/VehiclesCompat/VehiclesCompat.cs
+++ b/Source/VehiclesCompat/VehiclesCompat/VehiclesCompat.cs
@@ -38,7 +38,7 @@ namespace CombatExtended.Compatibility.VehiclesCompat
                     CETurretDataDefModExtension cetddme = vtd.GetModExtension<CETurretDataDefModExtension>();
                     if (cetddme.ammoSet != null)
                     {
-                        AmmoSetDef asd = (AmmoSetDef) LookupAmmosetCE(cetddme.ammoSet);
+                        AmmoSetDef asd = (AmmoSetDef)LookupAmmosetCE(cetddme.ammoSet);
                         if (Controller.settings.GenericAmmo && asd?.similarTo != null)
                         {
                             asd = asd.similarTo;
@@ -46,7 +46,7 @@ namespace CombatExtended.Compatibility.VehiclesCompat
                         if (asd != null)
                         {
                             cetddme._ammoSet = asd;
-                            HashSet<ThingDef> allowedAmmo = (HashSet<ThingDef>) vtd.ammunition?.AllowedThingDefs;
+                            HashSet<ThingDef> allowedAmmo = (HashSet<ThingDef>)vtd.ammunition?.AllowedThingDefs;
                             allowedAmmo.Clear();
                             foreach (var al in asd.ammoTypes)
                             {

--- a/Source/VehiclesCompat/VehiclesCompat/VehiclesCompat.cs
+++ b/Source/VehiclesCompat/VehiclesCompat/VehiclesCompat.cs
@@ -31,31 +31,31 @@ namespace CombatExtended.Compatibility.VehiclesCompat
             VehicleTurret.LookupProjectileCountAndSpreadCE = LookupProjectileCountAndSpreadCE;
             global::CombatExtended.Compatibility.Patches.RegisterCollisionBodyFactorCallback(_GetCollisionBodyFactors);
             global::CombatExtended.Compatibility.Patches.UsedAmmoCallbacks.Add(_GetUsedAmmo);
-	    if (Controller.settings.EnableAmmoSystem)
-	    {
-		foreach (VehicleTurretDef vtd in DefDatabase<global::Vehicles.VehicleTurretDef>.AllDefs)
-		{
-		    CETurretDataDefModExtension cetddme = vtd.GetModExtension<CETurretDataDefModExtension>();
-		    if (cetddme.ammoSet != null)
-		    {
-			AmmoSetDef asd = (AmmoSetDef) LookupAmmosetCE(cetddme.ammoSet);
-			if (Controller.settings.GenericAmmo && asd?.similarTo != null)
-			{
-			    asd = asd.similarTo;
-			}
-			if (asd != null)
-			{
-			    cetddme._ammoSet = asd;
-			    HashSet<ThingDef> allowedAmmo = (HashSet<ThingDef>) vtd.ammunition?.AllowedThingDefs;
-			    allowedAmmo.Clear();
-			    foreach (var al in asd.ammoTypes)
-			    {
-				allowedAmmo.Add(al.ammo);
-			    }
-			}
-		    }
-		}
-	    }
+            if (Controller.settings.EnableAmmoSystem)
+            {
+                foreach (VehicleTurretDef vtd in DefDatabase<global::Vehicles.VehicleTurretDef>.AllDefs)
+                {
+                    CETurretDataDefModExtension cetddme = vtd.GetModExtension<CETurretDataDefModExtension>();
+                    if (cetddme.ammoSet != null)
+                    {
+                        AmmoSetDef asd = (AmmoSetDef) LookupAmmosetCE(cetddme.ammoSet);
+                        if (Controller.settings.GenericAmmo && asd?.similarTo != null)
+                        {
+                            asd = asd.similarTo;
+                        }
+                        if (asd != null)
+                        {
+                            cetddme._ammoSet = asd;
+                            HashSet<ThingDef> allowedAmmo = (HashSet<ThingDef>) vtd.ammunition?.AllowedThingDefs;
+                            allowedAmmo.Clear();
+                            foreach (var al in asd.ammoTypes)
+                            {
+                                allowedAmmo.Add(al.ammo);
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         public static Tuple<int, float> LookupProjectileCountAndSpreadCE(ThingDef _ammoDef, Def _ammosetDef, float spread)

--- a/Source/VehiclesCompat/VehiclesCompat/VehiclesCompat.cs
+++ b/Source/VehiclesCompat/VehiclesCompat/VehiclesCompat.cs
@@ -31,31 +31,6 @@ namespace CombatExtended.Compatibility.VehiclesCompat
             VehicleTurret.LookupProjectileCountAndSpreadCE = LookupProjectileCountAndSpreadCE;
             global::CombatExtended.Compatibility.Patches.RegisterCollisionBodyFactorCallback(_GetCollisionBodyFactors);
             global::CombatExtended.Compatibility.Patches.UsedAmmoCallbacks.Add(_GetUsedAmmo);
-            if (Controller.settings.EnableAmmoSystem)
-            {
-                foreach (VehicleTurretDef vtd in DefDatabase<global::Vehicles.VehicleTurretDef>.AllDefs)
-                {
-                    CETurretDataDefModExtension cetddme = vtd.GetModExtension<CETurretDataDefModExtension>();
-                    if (cetddme.ammoSet != null)
-                    {
-                        AmmoSetDef asd = (AmmoSetDef)LookupAmmosetCE(cetddme.ammoSet);
-                        if (Controller.settings.GenericAmmo && asd?.similarTo != null)
-                        {
-                            asd = asd.similarTo;
-                        }
-                        if (asd != null)
-                        {
-                            cetddme._ammoSet = asd;
-                            HashSet<ThingDef> allowedAmmo = (HashSet<ThingDef>)vtd.ammunition?.AllowedThingDefs;
-                            allowedAmmo.Clear();
-                            foreach (var al in asd.ammoTypes)
-                            {
-                                allowedAmmo.Add(al.ammo);
-                            }
-                        }
-                    }
-                }
-            }
         }
 
         public static Tuple<int, float> LookupProjectileCountAndSpreadCE(ThingDef _ammoDef, Def _ammosetDef, float spread)
@@ -85,13 +60,29 @@ namespace CombatExtended.Compatibility.VehiclesCompat
 
         public static IEnumerable<ThingDef> _GetUsedAmmo()
         {
-            foreach (VehicleTurretDef vtd in DefDatabase<global::Vehicles.VehicleTurretDef>.AllDefs)
+            if (Controller.settings.EnableAmmoSystem)
             {
-                foreach (ThingDef td in vtd?.ammunition?.AllowedThingDefs)
+                foreach (VehicleTurretDef vtd in DefDatabase<global::Vehicles.VehicleTurretDef>.AllDefs)
                 {
-                    if (td is AmmoDef ad)
+                    CETurretDataDefModExtension cetddme = vtd.GetModExtension<CETurretDataDefModExtension>();
+                    if (cetddme.ammoSet != null)
                     {
-                        yield return td;
+                        AmmoSetDef asd = (AmmoSetDef)LookupAmmosetCE(cetddme.ammoSet);
+                        if (Controller.settings.GenericAmmo && asd?.similarTo != null)
+                        {
+                            asd = asd.similarTo;
+                        }
+                        if (asd != null)
+                        {
+                            cetddme._ammoSet = asd;
+                            HashSet<ThingDef> allowedAmmo = (HashSet<ThingDef>)vtd.ammunition?.AllowedThingDefs;
+                            allowedAmmo.Clear();
+                            foreach (var al in asd.ammoTypes)
+                            {
+                                allowedAmmo.Add(al.ammo);
+                                yield return al.ammo;
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Respects generic ammo, and no ammo modes.

## Changes

Vehicle patches should no longer manually assign ammos, they are auto assigned from the ammoset if one is specified and ammo is enabled.


## Reasoning

The previous approach duplicated information, allowing data to be out of sync.  It also made generic ammo support difficult.

## Alternatives

Manually specify both


## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
