### PR TITLE
Add try/catch around iterating all methods

### DIFF
--- a/Source/CombatExtended/CombatExtended/CE_DebugTooltipHelper.cs
+++ b/Source/CombatExtended/CombatExtended/CE_DebugTooltipHelper.cs
@@ -25,7 +25,17 @@ namespace CombatExtended
             var functions = typeof(CE_DebugTooltipHelper).Assembly
                             .GetTypes()
                             .SelectMany(t => t.GetMethods(AccessTools.all))
-                            .Where(m => m.HasAttribute<CE_DebugTooltip>() && m.IsStatic);
+                            .Where(m =>
+                            {
+                                try
+                                {
+                                    return m.HasAttribute<CE_DebugTooltip>() && m.IsStatic;
+                                }
+                                catch (System.Reflection.TargetInvocationException)
+                                {
+                                    return false;
+                                }
+                            });
             foreach (MethodBase m in functions)
             {
                 CE_DebugTooltip attribute = m.TryGetAttribute<CE_DebugTooltip>();


### PR DESCRIPTION

## Reasoning

CE_DebugTooltipHelper iterates all methods in all classes during its initialization.  The causes type not found errors with mods that expect to lazy-load their methods when optional mods are missing.  This should suppress those errors.  

## Alternatives

Explicitly register the methods which have CE_DebugTooltip somewhere.  This is more robust, as forcing methods to load that were lazy loaded might cause side effects.  But it would require a significant redesign of the debug tooltip subsystem.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
