### PR TITLE
Patch Vanilla Vehicles Expanded - Tier 3

### DIFF
--- a/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Badger.xml
+++ b/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Badger.xml
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Vehicles Expanded - Tier 3</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<!-- Turret -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Badger_MainTurret"]/projectile</xpath>
+					<value>
+						<projectile>Bullet_25x137mmNATO_AP</projectile>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Badger_MainTurret"]/reloadTimer</xpath>
+					<value>
+						<reloadTimer>8.8</reloadTimer>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Badger_MainTurret"]/warmUpTimer</xpath>
+					<value>
+						<warmUpTimer>1.6</warmUpTimer>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Badger_MainTurret"]/magazineCapacity</xpath>
+					<value>
+						<magazineCapacity>200</magazineCapacity>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Badger_MainTurret"]/genericAmmo</xpath>
+					<value>
+						<genericAmmo>false</genericAmmo>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Badger_MainTurret"]/maxRange</xpath>
+					<value>
+						<maxRange>74</maxRange>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Badger_MainTurret"]/fireModes</xpath>
+					<value>
+						<fireModes>
+							<li>
+								<shotsPerBurst>1</shotsPerBurst>
+								<ticksBetweenShots>6</ticksBetweenShots>
+								<ticksBetweenBursts>60</ticksBetweenBursts>
+								<label>Single</label>
+								<texPath>UI/Gizmos/FireRate_Single</texPath>
+							</li>
+							<li>
+								<shotsPerBurst>5</shotsPerBurst>
+								<ticksBetweenShots>6</ticksBetweenShots>
+								<ticksBetweenBursts>60</ticksBetweenBursts>
+								<label>Burst</label>
+								<texPath>UI/Gizmos/FireRate_Burst</texPath>
+							</li>
+							<li>
+								<shotsPerBurst>10</shotsPerBurst>
+								<ticksBetweenShots>6</ticksBetweenShots>
+								<ticksBetweenBursts>60</ticksBetweenBursts>
+								<label>Auto</label>
+								<texPath>UI/Gizmos/FireRate_Auto</texPath>
+							</li>
+						</fireModes>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Badger_MainTurret"]/ammunition/thingDefs</xpath>
+					<value>
+						<thingDefs>
+							<li>Ammo_25x137mmNATO_AP</li>
+							<li>Ammo_25x137mmNATO_Incendiary</li>
+							<li>Ammo_25x137mmNATO_HE</li>
+							<li>Ammo_25x137mmNATO_Sabot</li>
+						</thingDefs>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Badger_MainTurret"]</xpath>
+					<value>
+						<li Class="Vehicles.CETurretDataDefModExtension">
+							<ammoSet>AmmoSet_25x137mmNATO</ammoSet>
+							<shotHeight>2.0</shotHeight>
+							<speed>192</speed>
+							<sway>1.61</sway>
+							<spread>0.04</spread>
+						</li>
+					</value>
+				</li>
+
+				<!-- Vehicle -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Badger"]</xpath>
+					<value>
+						<descriptionHyperlinks>
+							<CombatExtended.AmmoSetDef>AmmoSet_25x137mmNATO</CombatExtended.AmmoSetDef>
+						</descriptionHyperlinks>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Badger"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>14</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Badger"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>6</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Badger"]/components/li[key="FrontArmorPlating"]/health</xpath>
+					<value>
+						<health>400</health>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Badger"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>24</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Badger"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>12</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Badger"]/components/li[key="LeftArmorPlating"]/health</xpath>
+					<value>
+						<health>240</health>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Badger"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>24</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Badger"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>12</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Badger"]/components/li[key="RightArmorPlating"]/health</xpath>
+					<value>
+						<health>400</health>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Badger"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>24</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Badger"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>12</ArmorRating_Sharp>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Badger.xml
+++ b/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Badger.xml
@@ -81,18 +81,6 @@
 					</value>
 				</li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Badger_MainTurret"]/ammunition/thingDefs</xpath>
-					<value>
-						<thingDefs>
-							<li>Ammo_25x137mmNATO_AP</li>
-							<li>Ammo_25x137mmNATO_Incendiary</li>
-							<li>Ammo_25x137mmNATO_HE</li>
-							<li>Ammo_25x137mmNATO_Sabot</li>
-						</thingDefs>
-					</value>
-				</li>
-
 				<li Class="PatchOperationAddModExtension">
 					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Badger_MainTurret"]</xpath>
 					<value>

--- a/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Badger.xml
+++ b/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Badger.xml
@@ -133,7 +133,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Badger"]/components/li[key="FrontArmorPlating"]/health</xpath>
 					<value>
-						<health>400</health>
+						<health>700</health>
 					</value>
 				</li>
 
@@ -154,7 +154,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Badger"]/components/li[key="LeftArmorPlating"]/health</xpath>
 					<value>
-						<health>240</health>
+						<health>340</health>
 					</value>
 				</li>
 
@@ -175,7 +175,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Badger"]/components/li[key="RightArmorPlating"]/health</xpath>
 					<value>
-						<health>400</health>
+						<health>340</health>
 					</value>
 				</li>
 

--- a/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Marshal.xml
+++ b/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Marshal.xml
@@ -3,69 +3,172 @@
 
 	<Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>Vanilla Vehicles Expanded</li>
+			<li>Vanilla Vehicles Expanded - Tier 3</li>
 		</mods>
 
 		<match Class="PatchOperationSequence">
 			<operations>
 
-				<!-- Turret -->
+				<!-- Main Turret -->
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Bulldog_MainTurret"]/projectile</xpath>
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Marshal_MainTurret"]/projectile</xpath>
 					<value>
-						<projectile>Bullet_75x350mmR_HE</projectile>
+						<projectile>Bullet_105x617mmRCannonShell_HE</projectile>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Bulldog_MainTurret"]/reloadTimer</xpath>
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Marshal_MainTurret"]/reloadTimer</xpath>
 					<value>
-						<reloadTimer>6.2</reloadTimer>
+						<reloadTimer>7.8</reloadTimer>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Bulldog_MainTurret"]/warmUpTimer</xpath>
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Marshal_MainTurret"]/warmUpTimer</xpath>
 					<value>
 						<warmUpTimer>2.8</warmUpTimer>
 					</value>
 				</li>
 
 				<li Class="PatchOperationRemove">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Bulldog_MainTurret"]/chargePerAmmoCount</xpath>
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Marshal_MainTurret"]/chargePerAmmoCount</xpath>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Bulldog_MainTurret"]/genericAmmo</xpath>
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Marshal_MainTurret"]/genericAmmo</xpath>
 					<value>
 						<genericAmmo>false</genericAmmo>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Bulldog_MainTurret"]/maxRange</xpath>
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Marshal_MainTurret"]/maxRange</xpath>
 					<value>
 						<maxRange>86</maxRange>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Bulldog_MainTurret"]/ammunition/thingDefs</xpath>
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Marshal_MainTurret"]/ammunition/thingDefs</xpath>
 					<value>
 						<thingDefs>
-							<li>Ammo_75x350mmR_AP</li>
-							<li>Ammo_75x350mmR_HE</li>
+							<li>Ammo_105x617mmRCannonShell_HEAT</li>
+							<li>Ammo_105x617mmRCannonShell_HE</li>
 						</thingDefs>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAddModExtension">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Bulldog_MainTurret"]</xpath>
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Marshal_MainTurret"]</xpath>
 					<value>
 						<li Class="Vehicles.CETurretDataDefModExtension">
-							<ammoSet>AmmoSet_75x350mmR</ammoSet>
+							<ammoSet>AmmoSet_105x617mmRCannonShell</ammoSet>
 							<shotHeight>2.5</shotHeight>
-							<speed>124</speed>
+							<speed>201</speed>
+							<sway>0.82</sway>
+							<spread>0.01</spread>
+						</li>
+					</value>
+				</li>
+
+				<!-- Mounted Turret -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Marshal_MountedTurret"]/projectile</xpath>
+					<value>
+						<projectile>Bullet_762x51mmNATO_FMJ</projectile>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Marshal_MountedTurret"]/reloadTimer</xpath>
+					<value>
+						<reloadTimer>7.8</reloadTimer>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Marshal_MountedTurret"]/warmUpTimer</xpath>
+					<value>
+						<warmUpTimer>1.3</warmUpTimer>
+					</value>
+				</li>
+
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Marshal_MountedTurret"]/chargePerAmmoCount</xpath>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Marshal_MountedTurret"]/genericAmmo</xpath>
+					<value>
+						<genericAmmo>false</genericAmmo>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Marshal_MountedTurret"]/magazineCapacity</xpath>
+					<value>
+						<magazineCapacity>200</magazineCapacity>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Marshal_MountedTurret"]/maxRange</xpath>
+					<value>
+						<maxRange>62</maxRange>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Marshal_MountedTurret"]/fireModes</xpath>
+					<value>
+						<fireModes>
+							<li>
+								<shotsPerBurst>1</shotsPerBurst>
+								<ticksBetweenShots>6</ticksBetweenShots>
+								<ticksBetweenBursts>60</ticksBetweenBursts>
+								<label>Single</label>
+								<texPath>UI/Gizmos/FireRate_Single</texPath>
+							</li>
+							<li>
+								<shotsPerBurst>5</shotsPerBurst>
+								<ticksBetweenShots>6</ticksBetweenShots>
+								<ticksBetweenBursts>60</ticksBetweenBursts>
+								<label>Burst</label>
+								<texPath>UI/Gizmos/FireRate_Burst</texPath>
+							</li>
+							<li>
+								<shotsPerBurst>10</shotsPerBurst>
+								<ticksBetweenShots>6</ticksBetweenShots>
+								<ticksBetweenBursts>60</ticksBetweenBursts>
+								<label>Auto</label>
+								<texPath>UI/Gizmos/FireRate_Auto</texPath>
+							</li>
+						</fireModes>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Marshal_MountedTurret"]/ammunition/thingDefs</xpath>
+					<value>
+						<thingDefs>
+							<li>Ammo_762x51mmNATO_FMJ</li>
+							<li>Ammo_762x51mmNATO_AP</li>
+							<li>Ammo_762x51mmNATO_HP</li>
+							<li>Ammo_762x51mmNATO_Incendiary</li>
+							<li>Ammo_762x51mmNATO_HE</li>
+							<li>Ammo_762x51mmNATO_Sabot</li>
+						</thingDefs>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Marshal_MountedTurret"]</xpath>
+					<value>
+						<li Class="Vehicles.CETurretDataDefModExtension">
+							<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
+							<shotHeight>2.5</shotHeight>
+							<speed>156</speed>
 							<sway>0.82</sway>
 							<spread>0.01</spread>
 						</li>
@@ -74,121 +177,121 @@
 
 				<!-- Vehicle -->
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]</xpath>
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Marshal"]</xpath>
 					<value>
 						<descriptionHyperlinks>
-							<CombatExtended.AmmoSetDef>AmmoSet_75x350mmR</CombatExtended.AmmoSetDef>
+							<CombatExtended.AmmoSetDef>AmmoSet_105x617mmRCannonShell</CombatExtended.AmmoSetDef>
 						</descriptionHyperlinks>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/statBases/ArmorRating_Blunt</xpath>
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Marshal"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>32</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/statBases/ArmorRating_Sharp</xpath>
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Marshal"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>16</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/vehicleStats/CargoCapacity</xpath>
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Marshal"]/vehicleStats/CargoCapacity</xpath>
 					<value>
 						<CargoCapacity>300</CargoCapacity>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/components/li[key="FrontArmorPlating"]/health</xpath>
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Marshal"]/components/li[key="FrontArmorPlating"]/health</xpath>
+					<value>
+						<health>900</health>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Marshal"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>48</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Marshal"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>24</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Marshal"]/components/li[key="LeftArmorPlating"]/health</xpath>
+					<value>
+						<health>800</health>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Marshal"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>44</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Marshal"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>22</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Marshal"]/components/li[key="RightArmorPlating"]/health</xpath>
+					<value>
+						<health>800</health>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Marshal"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>44</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Marshal"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>22</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Marshal"]/components/li[key="BackArmorPlating"]/health</xpath>
 					<value>
 						<health>600</health>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Marshal"]/components/li[key="Roof"]/health</xpath>
+					<value>
+						<health>600</health>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Marshal"]/components/li[key="Roof"]/armor/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>32</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>16</ArmorRating_Sharp>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/components/li[key="LeftArmorPlating"]/health</xpath>
-					<value>
-						<health>600</health>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>32</ArmorRating_Blunt>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>16</ArmorRating_Sharp>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/components/li[key="RightArmorPlating"]/health</xpath>
-					<value>
-						<health>600</health>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>32</ArmorRating_Blunt>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>16</ArmorRating_Sharp>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/components/li[key="BackArmorPlating"]/health</xpath>
-					<value>
-						<health>600</health>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/components/li[key="Roof"]/health</xpath>
-					<value>
-						<health>600</health>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/components/li[key="Roof"]/armor/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>32</ArmorRating_Blunt>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/components/li[key="Roof"]/armor/ArmorRating_Sharp</xpath>
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Marshal"]/components/li[key="Roof"]/armor/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>16</ArmorRating_Sharp>
 					</value>

--- a/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Marshal.xml
+++ b/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Marshal.xml
@@ -138,20 +138,6 @@
 					</value>
 				</li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Marshal_MountedTurret"]/ammunition/thingDefs</xpath>
-					<value>
-						<thingDefs>
-							<li>Ammo_762x51mmNATO_FMJ</li>
-							<li>Ammo_762x51mmNATO_AP</li>
-							<li>Ammo_762x51mmNATO_HP</li>
-							<li>Ammo_762x51mmNATO_Incendiary</li>
-							<li>Ammo_762x51mmNATO_HE</li>
-							<li>Ammo_762x51mmNATO_Sabot</li>
-						</thingDefs>
-					</value>
-				</li>
-
 				<li Class="PatchOperationAddModExtension">
 					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Marshal_MountedTurret"]</xpath>
 					<value>

--- a/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Marshal.xml
+++ b/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Marshal.xml
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Vehicles Expanded</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<!-- Turret -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Bulldog_MainTurret"]/projectile</xpath>
+					<value>
+						<projectile>Bullet_75x350mmR_HE</projectile>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Bulldog_MainTurret"]/reloadTimer</xpath>
+					<value>
+						<reloadTimer>6.2</reloadTimer>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Bulldog_MainTurret"]/warmUpTimer</xpath>
+					<value>
+						<warmUpTimer>2.8</warmUpTimer>
+					</value>
+				</li>
+
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Bulldog_MainTurret"]/chargePerAmmoCount</xpath>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Bulldog_MainTurret"]/genericAmmo</xpath>
+					<value>
+						<genericAmmo>false</genericAmmo>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Bulldog_MainTurret"]/maxRange</xpath>
+					<value>
+						<maxRange>86</maxRange>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Bulldog_MainTurret"]/ammunition/thingDefs</xpath>
+					<value>
+						<thingDefs>
+							<li>Ammo_75x350mmR_AP</li>
+							<li>Ammo_75x350mmR_HE</li>
+						</thingDefs>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Bulldog_MainTurret"]</xpath>
+					<value>
+						<li Class="Vehicles.CETurretDataDefModExtension">
+							<ammoSet>AmmoSet_75x350mmR</ammoSet>
+							<shotHeight>2.5</shotHeight>
+							<speed>124</speed>
+							<sway>0.82</sway>
+							<spread>0.01</spread>
+						</li>
+					</value>
+				</li>
+
+				<!-- Vehicle -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]</xpath>
+					<value>
+						<descriptionHyperlinks>
+							<CombatExtended.AmmoSetDef>AmmoSet_75x350mmR</CombatExtended.AmmoSetDef>
+						</descriptionHyperlinks>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>32</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>16</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/vehicleStats/CargoCapacity</xpath>
+					<value>
+						<CargoCapacity>300</CargoCapacity>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/components/li[key="FrontArmorPlating"]/health</xpath>
+					<value>
+						<health>600</health>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>32</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>16</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/components/li[key="LeftArmorPlating"]/health</xpath>
+					<value>
+						<health>600</health>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>32</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>16</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/components/li[key="RightArmorPlating"]/health</xpath>
+					<value>
+						<health>600</health>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>32</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>16</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/components/li[key="BackArmorPlating"]/health</xpath>
+					<value>
+						<health>600</health>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/components/li[key="Roof"]/health</xpath>
+					<value>
+						<health>600</health>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/components/li[key="Roof"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>32</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/components/li[key="Roof"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>16</ArmorRating_Sharp>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Marshal.xml
+++ b/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Marshal.xml
@@ -49,16 +49,6 @@
 					</value>
 				</li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Marshal_MainTurret"]/ammunition/thingDefs</xpath>
-					<value>
-						<thingDefs>
-							<li>Ammo_105x617mmRCannonShell_HEAT</li>
-							<li>Ammo_105x617mmRCannonShell_HE</li>
-						</thingDefs>
-					</value>
-				</li>
-
 				<li Class="PatchOperationAddModExtension">
 					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Marshal_MainTurret"]</xpath>
 					<value>

--- a/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Marshal.xml
+++ b/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Marshal.xml
@@ -161,6 +161,15 @@
 					</value>
 				</li>
 
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Marshal"]</xpath>
+					<value>
+						<descriptionHyperlinks>
+							<CombatExtended.AmmoSetDef>AmmoSet_762x51mmNATO</CombatExtended.AmmoSetDef>
+						</descriptionHyperlinks>
+					</value>
+				</li>
+
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Marshal"]/statBases/ArmorRating_Blunt</xpath>
 					<value>

--- a/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Paladin.xml
+++ b/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Paladin.xml
@@ -32,16 +32,16 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Paladin_MainTurret"]/magazineCapacity</xpath>
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Paladin_MainTurret"]/genericAmmo</xpath>
 					<value>
-						<magazineCapacity>50</magazineCapacity>
+						<genericAmmo>false</genericAmmo>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Paladin_MainTurret"]/genericAmmo</xpath>
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Paladin_MainTurret"]/magazineCapacity</xpath>
 					<value>
-						<genericAmmo>false</genericAmmo>
+						<magazineCapacity>50</magazineCapacity>
 					</value>
 				</li>
 
@@ -70,13 +70,6 @@
 								<label>Burst</label>
 								<texPath>UI/Gizmos/FireRate_Burst</texPath>
 							</li>
-							<li>
-								<shotsPerBurst>10</shotsPerBurst>
-								<ticksBetweenShots>6</ticksBetweenShots>
-								<ticksBetweenBursts>60</ticksBetweenBursts>
-								<label>Auto</label>
-								<texPath>UI/Gizmos/FireRate_Auto</texPath>
-							</li>
 						</fireModes>
 					</value>
 				</li>
@@ -85,10 +78,11 @@
 					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Paladin_MainTurret"]/ammunition/thingDefs</xpath>
 					<value>
 						<thingDefs>
-							<li>Ammo_25x137mmNATO_AP</li>
-							<li>Ammo_25x137mmNATO_Incendiary</li>
-							<li>Ammo_25x137mmNATO_HE</li>
-							<li>Ammo_25x137mmNATO_Sabot</li>
+							<li>Ammo_40x53mmGrenade_HE</li>
+							<li>Ammo_40x53mmGrenade_HE_TFuzed</li>
+							<li>Ammo_40x53mmGrenade_HEDP</li>
+							<li>Ammo_40x53mmGrenade_EMP</li>
+							<li>Ammo_40x53mmGrenade_Smoke</li>
 						</thingDefs>
 					</value>
 				</li>
@@ -97,21 +91,22 @@
 					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Paladin_MainTurret"]</xpath>
 					<value>
 						<li Class="Vehicles.CETurretDataDefModExtension">
-							<ammoSet>AmmoSet_25x137mmNATO</ammoSet>
+							<ammoSet>AmmoSet_40x53mmGrenade</ammoSet>
 							<shotHeight>2.0</shotHeight>
-							<speed>192</speed>
+							<speed>62</speed>
 							<sway>1.61</sway>
-							<spread>0.04</spread>
+							<spread>0.15</spread>
 						</li>
 					</value>
 				</li>
 
 				<!-- Vehicle -->
+
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Paladin"]</xpath>
 					<value>
 						<descriptionHyperlinks>
-							<CombatExtended.AmmoSetDef>AmmoSet_25x137mmNATO</CombatExtended.AmmoSetDef>
+							<CombatExtended.AmmoSetDef>AmmoSet_40x53mmGrenade</CombatExtended.AmmoSetDef>
 						</descriptionHyperlinks>
 					</value>
 				</li>
@@ -119,77 +114,56 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Paladin"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>16</ArmorRating_Blunt>
+						<ArmorRating_Blunt>18</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Paladin"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>8</ArmorRating_Sharp>
+						<ArmorRating_Sharp>9</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Paladin"]/components/li[key="FrontArmorPlating"]/health</xpath>
 					<value>
-						<health>400</health>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Paladin"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>24</ArmorRating_Blunt>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Paladin"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>12</ArmorRating_Sharp>
+						<health>700</health>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Paladin"]/components/li[key="LeftArmorPlating"]/health</xpath>
 					<value>
-						<health>240</health>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Paladin"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>24</ArmorRating_Blunt>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Paladin"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>12</ArmorRating_Sharp>
+						<health>260</health>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Paladin"]/components/li[key="RightArmorPlating"]/health</xpath>
 					<value>
-						<health>400</health>
+						<health>260</health>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Paladin"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Paladin"]/components/li[key="BackArmorPlating"]/armor/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>24</ArmorRating_Blunt>
+						<ArmorRating_Blunt>12</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Paladin"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Paladin"]/components/li[key="BackArmorPlating"]/armor/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>12</ArmorRating_Sharp>
+						<ArmorRating_Sharp>6</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Paladin"]/components/li[key="BackArmorPlating"]/health</xpath>
+					<value>
+						<health>180</health>
 					</value>
 				</li>
 

--- a/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Paladin.xml
+++ b/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Paladin.xml
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Vehicles Expanded - Tier 3</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<!-- Turret -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Paladin_MainTurret"]/projectile</xpath>
+					<value>
+						<projectile>Bullet_40x53mmGrenade_HE</projectile>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Paladin_MainTurret"]/reloadTimer</xpath>
+					<value>
+						<reloadTimer>7.8</reloadTimer>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Paladin_MainTurret"]/warmUpTimer</xpath>
+					<value>
+						<warmUpTimer>1.5</warmUpTimer>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Paladin_MainTurret"]/magazineCapacity</xpath>
+					<value>
+						<magazineCapacity>50</magazineCapacity>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Paladin_MainTurret"]/genericAmmo</xpath>
+					<value>
+						<genericAmmo>false</genericAmmo>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Paladin_MainTurret"]/maxRange</xpath>
+					<value>
+						<maxRange>74</maxRange>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Paladin_MainTurret"]/fireModes</xpath>
+					<value>
+						<fireModes>
+							<li>
+								<shotsPerBurst>1</shotsPerBurst>
+								<ticksBetweenShots>6</ticksBetweenShots>
+								<ticksBetweenBursts>60</ticksBetweenBursts>
+								<label>Single</label>
+								<texPath>UI/Gizmos/FireRate_Single</texPath>
+							</li>
+							<li>
+								<shotsPerBurst>5</shotsPerBurst>
+								<ticksBetweenShots>6</ticksBetweenShots>
+								<ticksBetweenBursts>60</ticksBetweenBursts>
+								<label>Burst</label>
+								<texPath>UI/Gizmos/FireRate_Burst</texPath>
+							</li>
+							<li>
+								<shotsPerBurst>10</shotsPerBurst>
+								<ticksBetweenShots>6</ticksBetweenShots>
+								<ticksBetweenBursts>60</ticksBetweenBursts>
+								<label>Auto</label>
+								<texPath>UI/Gizmos/FireRate_Auto</texPath>
+							</li>
+						</fireModes>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Paladin_MainTurret"]/ammunition/thingDefs</xpath>
+					<value>
+						<thingDefs>
+							<li>Ammo_25x137mmNATO_AP</li>
+							<li>Ammo_25x137mmNATO_Incendiary</li>
+							<li>Ammo_25x137mmNATO_HE</li>
+							<li>Ammo_25x137mmNATO_Sabot</li>
+						</thingDefs>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Paladin_MainTurret"]</xpath>
+					<value>
+						<li Class="Vehicles.CETurretDataDefModExtension">
+							<ammoSet>AmmoSet_25x137mmNATO</ammoSet>
+							<shotHeight>2.0</shotHeight>
+							<speed>192</speed>
+							<sway>1.61</sway>
+							<spread>0.04</spread>
+						</li>
+					</value>
+				</li>
+
+				<!-- Vehicle -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Paladin"]</xpath>
+					<value>
+						<descriptionHyperlinks>
+							<CombatExtended.AmmoSetDef>AmmoSet_25x137mmNATO</CombatExtended.AmmoSetDef>
+						</descriptionHyperlinks>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Paladin"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>16</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Paladin"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>8</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Paladin"]/components/li[key="FrontArmorPlating"]/health</xpath>
+					<value>
+						<health>400</health>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Paladin"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>24</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Paladin"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>12</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Paladin"]/components/li[key="LeftArmorPlating"]/health</xpath>
+					<value>
+						<health>240</health>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Paladin"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>24</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Paladin"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>12</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Paladin"]/components/li[key="RightArmorPlating"]/health</xpath>
+					<value>
+						<health>400</health>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Paladin"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>24</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Paladin"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>12</ArmorRating_Sharp>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Paladin.xml
+++ b/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Paladin.xml
@@ -74,19 +74,6 @@
 					</value>
 				</li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Paladin_MainTurret"]/ammunition/thingDefs</xpath>
-					<value>
-						<thingDefs>
-							<li>Ammo_40x53mmGrenade_HE</li>
-							<li>Ammo_40x53mmGrenade_HE_TFuzed</li>
-							<li>Ammo_40x53mmGrenade_HEDP</li>
-							<li>Ammo_40x53mmGrenade_EMP</li>
-							<li>Ammo_40x53mmGrenade_Smoke</li>
-						</thingDefs>
-					</value>
-				</li>
-
 				<li Class="PatchOperationAddModExtension">
 					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Paladin_MainTurret"]</xpath>
 					<value>

--- a/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Udar.xml
+++ b/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Udar.xml
@@ -1,0 +1,210 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Vehicles Expanded - Tier 3</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Udar_MainTurret"]</xpath>
+					<value>
+						<projectile>Bullet_155mmHowitzerShell_HE</projectile>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Udar_MainTurret"]/reloadTimer</xpath>
+					<value>
+						<reloadTimer>7.8</reloadTimer>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Udar_MainTurret"]/warmUpTimer</xpath>
+					<value>
+						<warmUpTimer>4</warmUpTimer>
+					</value>
+				</li>
+<!--
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Udar_MainTurret"]/maxRange</xpath>
+					<value>
+						<maxRange>500</maxRange>
+					</value>
+				</li>
+-->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Udar_MainTurret"]/fireModes</xpath>
+					<value>
+						<fireModes>
+							<li>
+								<shotsPerBurst>1</shotsPerBurst>
+								<ticksBetweenShots>6</ticksBetweenShots>
+								<ticksBetweenBursts>60</ticksBetweenBursts>
+								<label>Single</label>
+								<texPath>UI/Gizmos/FireRate_Single</texPath>
+							</li>
+						</fireModes>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Udar_MainTurret"]/ammunition</xpath>
+					<value>
+						<ammunition>
+							<thingDefs>
+								<li>Ammo_155mmHowitzerShell_HE</li>
+								<li>Ammo_155mmHowitzerShell_Incendiary</li>
+								<li>Ammo_155mmHowitzerShell_EMP</li>
+								<li>Ammo_155mmHowitzerShell_Smoke</li>
+							</thingDefs>
+						</ammunition>	
+					</value>
+				</li>
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Udar_MainTurret"]</xpath>
+					<value>
+						<li Class="Vehicles.CETurretDataDefModExtension">
+							<ammoSet>AmmoSet_155mmHowitzerShell</ammoSet>
+							<shotHeight>2.25</shotHeight>
+							<speed>155</speed>
+							<sway>1.61</sway>
+							<spread>0.01</spread>
+						</li>
+					</value>
+				</li>
+
+				<!-- Vehicle -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Udar"]</xpath>
+					<value>
+						<descriptionHyperlinks>
+							<CombatExtended.AmmoSetDef>AmmoSet_155mmHowitzerShell</CombatExtended.AmmoSetDef>
+						</descriptionHyperlinks>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Udar"]/vehicleStats/CargoCapacity</xpath>
+					<value>
+						<CargoCapacity>300</CargoCapacity>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Udar"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>24</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Udar"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>12</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Udar"]/components/li[key="FrontArmorPlating"]/health</xpath>
+					<value>
+						<health>660</health>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Udar"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>24</ArmorRating_Blunt>
+					</value>
+				</li>
+
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Udar"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>12</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Udar"]/components/li[key="LeftArmorPlating"]/health</xpath>
+					<value>
+						<health>660</health>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Udar"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>16</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Udar"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>8</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Udar"]/components/li[key="RightArmorPlating"]/health</xpath>
+					<value>
+						<health>660</health>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Udar"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>16</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Udar"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>8</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Udar"]/components/li[key="BackArmorPlating"]/health</xpath>
+					<value>
+						<health>510</health>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Udar"]/components/li[key="BackArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>16</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Udar"]/components/li[key="BackArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>8</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Udar"]/components/li[key="Roof"]/health</xpath>
+					<value>
+						<health>20</health>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Vehicles_Unarmed.xml
+++ b/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Vehicles_Unarmed.xml
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Vehicles Expanded - Tier 3</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<!-- Big Rig -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_BigRig"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>5</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_BigRig"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>2.5</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<!-- Cherokee -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Cherokee"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>10</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Cherokee"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>6</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<!-- Hermano -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Hermano"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>3.25</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Hermano"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>1.5</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<!-- Lightning -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Lightning"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>1.65</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Lightning"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>3.75</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<!-- Louie -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Louie"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>11</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Louie"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>6.5</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<!-- Nomad -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Nomad"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>4</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Nomad"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>2</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Nomad"]/components/li[key="FrontPanel"]/health</xpath>
+					<value>
+						<health>300</health>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Nomad"]/components/li[key="FrontPanel"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>8</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Nomad"]/components/li[key="FrontPanel"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>4</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Nomad"]/components/li[key="LeftSidePanel"]/health</xpath>
+					<value>
+						<health>300</health>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Nomad"]/components/li[key="LeftSidePanel"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>8</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Nomad"]/components/li[key="LeftSidePanel"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>4</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Nomad"]/components/li[key="RightSidePanel"]/health</xpath>
+					<value>
+						<health>300</health>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Nomad"]/components/li[key="RightSidePanel"]/armor/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>8</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Nomad"]/components/li[key="RightSidePanel"]/armor/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>4</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<!-- Springbok -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Springbok"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>5</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Springbok"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>2.5</ArmorRating_Sharp>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier2/Bulldog.xml
+++ b/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier2/Bulldog.xml
@@ -134,14 +134,14 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>32</ArmorRating_Blunt>
+						<ArmorRating_Blunt>28</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>16</ArmorRating_Sharp>
+						<ArmorRating_Sharp>14</ArmorRating_Sharp>
 					</value>
 				</li>
 
@@ -155,14 +155,14 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>32</ArmorRating_Blunt>
+						<ArmorRating_Blunt>28</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>16</ArmorRating_Sharp>
+						<ArmorRating_Sharp>14</ArmorRating_Sharp>
 					</value>
 				</li>
 
@@ -176,21 +176,21 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/components/li[key="Roof"]/health</xpath>
 					<value>
-						<health>600</health>
+						<health>400</health>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/components/li[key="Roof"]/armor/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>32</ArmorRating_Blunt>
+						<ArmorRating_Blunt>20</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bulldog"]/components/li[key="Roof"]/armor/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>16</ArmorRating_Sharp>
+						<ArmorRating_Sharp>10</ArmorRating_Sharp>
 					</value>
 				</li>
 

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -516,6 +516,7 @@ Vanilla Races Expanded - Sanguophage  |
 Vanilla Races Expanded - Saurid  |
 Vanilla Skills Expanded  |
 Vanilla Vehicles Expanded	|
+Vanilla Vehicles Expanded - Tier 3  |
 Vanilla Weapons Expanded |
 Vanilla Weapons Expanded - Coilguns |
 Vanilla Weapons Expanded - Frontier	|


### PR DESCRIPTION
## Additions
- Adds a patch for VVE - T3.
  - The Udar works in direct-fire, but currently can't target LOS. Will probably need re-visited when VF eventually supports that.

## Changes
- Adjusts some armor values for VVE.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (10 min.)
