### PR TITLE
Average of Graphics_Collection

### DIFF
--- a/Source/CombatExtended/CombatExtended/BoundsInjector.cs
+++ b/Source/CombatExtended/CombatExtended/BoundsInjector.cs
@@ -131,9 +131,17 @@ namespace CombatExtended
                        (float)(hBounds.max - hBounds.min) / (float)hWidth,
                        (float)(vBounds.max - vBounds.min) / (float)vHeight);
         }
-
+        private static Vector2 ExctractBoundCollection(Graphic_Collection graphic, GraphicType type)
+        {
+            IEnumerable<Vector2> bounds = graphic.subGraphics.Select(x => ExtractBounds(x, type));
+            return new Vector2(bounds.Average(v => v.x), bounds.Average(v => v.y));
+        }
         private static Vector2 ExtractBounds(Graphic graphic, GraphicType type)
         {
+            if(graphic is Graphic_Collection graphic_collection)
+            {
+                return ExctractBoundCollection(graphic_collection, type);
+            }
             int vWidth;
             int vHeight;
 

--- a/Source/CombatExtended/CombatExtended/BoundsInjector.cs
+++ b/Source/CombatExtended/CombatExtended/BoundsInjector.cs
@@ -138,7 +138,7 @@ namespace CombatExtended
         }
         private static Vector2 ExtractBounds(Graphic graphic, GraphicType type)
         {
-            if(graphic is Graphic_Collection graphic_collection)
+            if (graphic is Graphic_Collection graphic_collection)
             {
                 return ExctractBoundCollection(graphic_collection, type);
             }


### PR DESCRIPTION
## Fixes

- Graphics_Random may return different textures, so the boundaries may change from time to time (as result desync in MP possible)

## Reasoning

- Just calculate average of all sub-textures.


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] Playtested a colony (Launched game few times and checked for differences)



