### PR TITLE
New high caliber charged ammo

### DIFF
--- a/Defs/Ammo/Advanced/12x20mmCharged.xml
+++ b/Defs/Ammo/Advanced/12x20mmCharged.xml
@@ -1,0 +1,279 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+	<ThingCategoryDef>
+		<defName>Ammo12x20mmCharged</defName>
+		<label>12x20mm Charged</label>
+		<parent>AmmoAdvanced</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberCharge</iconPath>
+	</ThingCategoryDef>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_12x20mmCharged</defName>
+		<label>12x20mm Charged</label>
+		<ammoTypes>
+			<Ammo_12x20mmCharged>Bullet_12x20mmCharged</Ammo_12x20mmCharged>
+			<Ammo_12x20mmCharged_AP>Bullet_12x20mmCharged_AP</Ammo_12x20mmCharged_AP>
+			<Ammo_12x20mmCharged_Ion>Bullet_12x20mmCharged_Ion</Ammo_12x20mmCharged_Ion>
+		</ammoTypes>
+		<similarTo>AmmoSet_ChargedPistol</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="12x20mmChargedBase" ParentName="SpacerSmallAmmoBase" Abstract="True">
+		<description>Charged shot ammo used by high caliber magnum charge weapons.</description>
+		<statBases>
+			<Mass>0.21</Mass>
+			<Bulk>0.02</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting_FabricationBench</li>
+		</tradeTags>
+		<thingCategories>
+			<li>Ammo12x20mmCharged</li>
+		</thingCategories>
+		<stackLimit>5000</stackLimit>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="12x20mmChargedBase">
+		<defName>Ammo_12x20mmCharged</defName>
+		<label>12x20mm Charged</label>
+		<graphicData>
+			<texPath>Things/Ammo/Charged/SmallRegular</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>1.21</MarketValue>
+		</statBases>
+		<ammoClass>Charged</ammoClass>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="12x20mmChargedBase">
+		<defName>Ammo_12x20mmCharged_AP</defName>
+		<label>12x20mm Charged (Conc.)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Charged/SmallConc</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>1.21</MarketValue>
+		</statBases>
+		<ammoClass>ChargedAP</ammoClass>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="12x20mmChargedBase">
+		<defName>Ammo_12x20mmCharged_Ion</defName>
+		<label>12x20mm Charged (Ion)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Charged/SmallIon</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>1.21</MarketValue>
+		</statBases>
+		<ammoClass>Ionized</ammoClass>
+		<generateAllowChance>0.5</generateAllowChance>
+	</ThingDef>
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef Name="Base12x20mmChargedBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Charged/ChargeShot</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<drawSize>(1.25,1.25)</drawSize>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>110</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base12x20mmChargedBullet">
+		<defName>Bullet_12x20mmCharged</defName>
+		<label>12x20mm Charged bullet</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>18</damageAmountBase>
+			<secondaryDamage>
+				<li>
+					<def>Bomb_Secondary</def>
+					<amount>5</amount>
+				</li>
+			</secondaryDamage>
+			<armorPenetrationSharp>13</armorPenetrationSharp>
+			<armorPenetrationBlunt>33.08</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base12x20mmChargedBullet">
+		<defName>Bullet_12x20mmCharged_AP</defName>
+		<label>12x20mm Charged bullet (Conc.)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>14</damageAmountBase>
+			<secondaryDamage>
+				<li>
+					<def>Bomb_Secondary</def>
+					<amount>2</amount>
+				</li>
+			</secondaryDamage>
+			<armorPenetrationSharp>26</armorPenetrationSharp>
+			<armorPenetrationBlunt>33.08</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base12x20mmChargedBullet">
+		<defName>Bullet_12x20mmCharged_Ion</defName>
+		<label>12x20mm Charged bullet (Ion)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>14</damageAmountBase>
+			<secondaryDamage>
+				<li>
+					<def>EMP</def>
+					<amount>8</amount>
+				</li>
+			</secondaryDamage>
+			<armorPenetrationSharp>19.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>33.08</armorPenetrationBlunt>
+			<empShieldBreakChance>1</empShieldBreakChance>
+		</projectile>
+	</ThingDef>
+
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="ChargeAmmoRecipeBase">
+		<defName>MakeAmmo_12x20mmCharged</defName>
+		<label>make 12x20mm Charged cartridge x500</label>
+		<description>Craft 500 12x20mm Charged cartridges.</description>
+		<jobString>Making 12x20mm Charged cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Plasteel</li>
+					</thingDefs>
+				</filter>
+				<count>24</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>10</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>11</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Plasteel</li>
+				<li>Steel</li>
+				<li>ComponentIndustrial</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_12x20mmCharged>500</Ammo_12x20mmCharged>
+		</products>
+		<workAmount>17200</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="ChargeAmmoRecipeBase">
+		<defName>MakeAmmo_12x20mmCharged_AP</defName>
+		<label>make 12x20mm Charged (Conc.) cartridge x500</label>
+		<description>Craft 500 12x20mm Charged (Conc.) cartridges.</description>
+		<jobString>Making 12x20mm Charged (Conc.) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Plasteel</li>
+					</thingDefs>
+				</filter>
+				<count>24</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>10</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>11</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Plasteel</li>
+				<li>Steel</li>
+				<li>ComponentIndustrial</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_12x20mmCharged_AP>500</Ammo_12x20mmCharged_AP>
+		</products>
+		<workAmount>17200</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="ChargeAmmoRecipeBase">
+		<defName>MakeAmmo_12x20mmCharged_Ion</defName>
+		<label>make 12x20mm Charged (Ion) cartridge x500</label>
+		<description>Craft 500 12x20mm Charged (Ion) cartridges.</description>
+		<jobString>Making 12x20mm Charged (Ion) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Plasteel</li>
+					</thingDefs>
+				</filter>
+				<count>24</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>10</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>11</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Plasteel</li>
+				<li>Steel</li>
+				<li>ComponentIndustrial</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_12x20mmCharged_Ion>500</Ammo_12x20mmCharged_Ion>
+		</products>
+		<workAmount>17200</workAmount>
+	</RecipeDef>
+
+</Defs>

--- a/Defs/Ammo/Advanced/30x130mmCharged.xml
+++ b/Defs/Ammo/Advanced/30x130mmCharged.xml
@@ -1,0 +1,279 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+	<ThingCategoryDef>
+		<defName>Ammo30x130mmCharged</defName>
+		<label>30x130mm Charged</label>
+		<parent>AmmoAdvanced</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberChargeLarge</iconPath>
+	</ThingCategoryDef>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_30x130mmCharged</defName>
+		<label>30x130mm Charged</label>
+		<ammoTypes>
+			<Ammo_30x130mmCharged>Bullet_30x130mmCharged</Ammo_30x130mmCharged>
+			<Ammo_30x130mmCharged_AP>Bullet_30x130mmCharged_AP</Ammo_30x130mmCharged_AP>
+			<Ammo_30x130mmCharged_Ion>Bullet_30x130mmCharged_Ion</Ammo_30x130mmCharged_Ion>
+		</ammoTypes>
+		<similarTo>AmmoSet_ChargedHeavy</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="30x130mmChargedBase" ParentName="SpacerMediumAmmoBase" Abstract="True">
+		<description>High-caliber charged shot ammo used by advanced autocannons.</description>
+		<statBases>
+			<Mass>0.296</Mass>
+			<Bulk>0.35</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting_FabricationBench</li>
+		</tradeTags>
+		<thingCategories>
+			<li>Ammo30x130mmCharged</li>
+		</thingCategories>
+		<stackLimit>1000</stackLimit>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="30x130mmChargedBase">
+		<defName>Ammo_30x130mmCharged</defName>
+		<label>30x130mm Charged</label>
+		<graphicData>
+			<texPath>Things/Ammo/Charged/LargeRegular</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>21.93</MarketValue>
+		</statBases>
+		<ammoClass>Charged</ammoClass>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="30x130mmChargedBase">
+		<defName>Ammo_30x130mmCharged_AP</defName>
+		<label>30x130mm Charged (Conc.)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Charged/LargeConc</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>21.93</MarketValue>
+		</statBases>
+		<ammoClass>ChargedAP</ammoClass>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="30x130mmChargedBase">
+		<defName>Ammo_30x130mmCharged_Ion</defName>
+		<label>30x130mm Charged (Ion)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Charged/LargeIon</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>21.93</MarketValue>
+		</statBases>
+		<ammoClass>Ionized</ammoClass>
+		<generateAllowChance>0.5</generateAllowChance>
+	</ThingDef>
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef Name="Base30x130mmChargedBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Charged/ChargeShot</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<drawSize>(1.6,1.6)</drawSize>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>192</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base30x130mmChargedBullet">
+		<defName>Bullet_30x130mmCharged</defName>
+		<label>30x130mm Charged bullet</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>116</damageAmountBase>
+			<secondaryDamage>
+				<li>
+					<def>Bomb_Secondary</def>
+					<amount>35</amount>
+				</li>
+			</secondaryDamage>
+			<armorPenetrationSharp>70</armorPenetrationSharp>
+			<armorPenetrationBlunt>3025</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base30x130mmChargedBullet">
+		<defName>Bullet_30x130mmCharged_AP</defName>
+		<label>30x130mm Charged bullet (Conc.)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>92</damageAmountBase>
+			<secondaryDamage>
+				<li>
+					<def>Bomb_Secondary</def>
+					<amount>14</amount>
+				</li>
+			</secondaryDamage>
+			<armorPenetrationSharp>140</armorPenetrationSharp>
+			<armorPenetrationBlunt>3025</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base30x130mmChargedBullet">
+		<defName>Bullet_30x130mmCharged_Ion</defName>
+		<label>30x130mm Charged bullet (Ion)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>92</damageAmountBase>
+			<secondaryDamage>
+				<li>
+					<def>EMP</def>
+					<amount>55</amount>
+				</li>
+			</secondaryDamage>
+			<armorPenetrationSharp>105</armorPenetrationSharp>
+			<armorPenetrationBlunt>3025</armorPenetrationBlunt>
+			<empShieldBreakChance>1</empShieldBreakChance>
+		</projectile>
+	</ThingDef>
+
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="ChargeAmmoRecipeBase">
+		<defName>MakeAmmo_30x130mmCharged</defName>
+		<label>make 30x130mm Charged cartridge x50</label>
+		<description>Craft 50 30x130mm Charged cartridges.</description>
+		<jobString>Making 30x130mm Charged cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Plasteel</li>
+					</thingDefs>
+				</filter>
+				<count>50</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>6</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>19</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Plasteel</li>
+				<li>Steel</li>
+				<li>ComponentIndustrial</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_30x130mmCharged>50</Ammo_30x130mmCharged>
+		</products>
+		<workAmount>32000</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="ChargeAmmoRecipeBase">
+		<defName>MakeAmmo_30x130mmCharged_AP</defName>
+		<label>make 30x130mm Charged (Conc.) cartridge x50</label>
+		<description>Craft 50 30x130mm Charged (Conc.) cartridges.</description>
+		<jobString>Making 30x130mm Charged (Conc.) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Plasteel</li>
+					</thingDefs>
+				</filter>
+				<count>50</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>6</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>19</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Plasteel</li>
+				<li>Steel</li>
+				<li>ComponentIndustrial</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_30x130mmCharged_AP>50</Ammo_30x130mmCharged_AP>
+		</products>
+		<workAmount>32000</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="ChargeAmmoRecipeBase">
+		<defName>MakeAmmo_30x130mmCharged_Ion</defName>
+		<label>make 30x130mm Charged (Ion) cartridge x100</label>
+		<description>Craft 100 30x130mm Charged (Ion) cartridges.</description>
+		<jobString>Making 30x130mm Charged (Ion) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Plasteel</li>
+					</thingDefs>
+				</filter>
+				<count>50</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>6</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>19</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Plasteel</li>
+				<li>Steel</li>
+				<li>ComponentIndustrial</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_30x130mmCharged_Ion>50</Ammo_30x130mmCharged_Ion>
+		</products>
+		<workAmount>32000</workAmount>
+	</RecipeDef>
+
+</Defs>

--- a/Defs/Ammo/Advanced/40x235mmCharged.xml
+++ b/Defs/Ammo/Advanced/40x235mmCharged.xml
@@ -1,0 +1,279 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+	<ThingCategoryDef>
+		<defName>Ammo40x235mmCharged</defName>
+		<label>40x235mm Charged</label>
+		<parent>AmmoAdvanced</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberChargeLarge</iconPath>
+	</ThingCategoryDef>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_40x235mmCharged</defName>
+		<label>40x235mm Charged</label>
+		<ammoTypes>
+			<Ammo_40x235mmCharged>Bullet_40x235mmCharged</Ammo_40x235mmCharged>
+			<Ammo_40x235mmCharged_AP>Bullet_40x235mmCharged_AP</Ammo_40x235mmCharged_AP>
+			<Ammo_40x235mmCharged_Ion>Bullet_40x235mmCharged_Ion</Ammo_40x235mmCharged_Ion>
+		</ammoTypes>
+		<similarTo>AmmoSet_ChargedHeavy</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="40x235mmChargedBase" ParentName="SpacerMediumAmmoBase" Abstract="True">
+		<description>High-caliber charged shot ammo used by advanced autocannons.</description>
+		<statBases>
+			<Mass>0.808</Mass>
+			<Bulk>0.95</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting_FabricationBench</li>
+		</tradeTags>
+		<thingCategories>
+			<li>Ammo40x235mmCharged</li>
+		</thingCategories>
+		<stackLimit>200</stackLimit>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="40x235mmChargedBase">
+		<defName>Ammo_40x235mmCharged</defName>
+		<label>40x235mm Charged</label>
+		<graphicData>
+			<texPath>Things/Ammo/Charged/LargeRegular</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>62.12</MarketValue>
+		</statBases>
+		<ammoClass>Charged</ammoClass>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="40x235mmChargedBase">
+		<defName>Ammo_40x235mmCharged_AP</defName>
+		<label>40x235mm Charged (Conc.)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Charged/LargeConc</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>62.12</MarketValue>
+		</statBases>
+		<ammoClass>ChargedAP</ammoClass>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="40x235mmChargedBase">
+		<defName>Ammo_40x235mmCharged_Ion</defName>
+		<label>40x235mm Charged (Ion)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Charged/LargeIon</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>62.12</MarketValue>
+		</statBases>
+		<ammoClass>Ionized</ammoClass>
+		<generateAllowChance>0.5</generateAllowChance>
+	</ThingDef>
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef Name="Base40x235mmChargedBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Charged/ChargeShot</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<drawSize>(1.8,1.8)</drawSize>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>192</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base40x235mmChargedBullet">
+		<defName>Bullet_40x235mmCharged</defName>
+		<label>40x235mm Charged bullet</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>188</damageAmountBase>
+			<secondaryDamage>
+				<li>
+					<def>Bomb_Secondary</def>
+					<amount>56</amount>
+				</li>
+			</secondaryDamage>
+			<armorPenetrationSharp>80</armorPenetrationSharp>
+			<armorPenetrationBlunt>9075</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base40x235mmChargedBullet">
+		<defName>Bullet_40x235mmCharged_AP</defName>
+		<label>40x235mm Charged bullet (Conc.)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>148</damageAmountBase>
+			<secondaryDamage>
+				<li>
+					<def>Bomb_Secondary</def>
+					<amount>22</amount>
+				</li>
+			</secondaryDamage>
+			<armorPenetrationSharp>160</armorPenetrationSharp>
+			<armorPenetrationBlunt>9075</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base40x235mmChargedBullet">
+		<defName>Bullet_40x235mmCharged_Ion</defName>
+		<label>40x235mm Charged bullet (Ion)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>148</damageAmountBase>
+			<secondaryDamage>
+				<li>
+					<def>EMP</def>
+					<amount>89</amount>
+				</li>
+			</secondaryDamage>
+			<armorPenetrationSharp>120</armorPenetrationSharp>
+			<armorPenetrationBlunt>9075</armorPenetrationBlunt>
+			<empShieldBreakChance>1</empShieldBreakChance>
+		</projectile>
+	</ThingDef>
+
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="ChargeAmmoRecipeBase">
+		<defName>MakeAmmo_40x235mmCharged</defName>
+		<label>make 40x235mm Charged cartridge x25</label>
+		<description>Craft 25 40x235mm Charged cartridges.</description>
+		<jobString>Making 40x235mm Charged cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Plasteel</li>
+					</thingDefs>
+				</filter>
+				<count>75</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>4</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>26</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Plasteel</li>
+				<li>Steel</li>
+				<li>ComponentIndustrial</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_40x235mmCharged>25</Ammo_40x235mmCharged>
+		</products>
+		<workAmount>46000</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="ChargeAmmoRecipeBase">
+		<defName>MakeAmmo_40x235mmCharged_AP</defName>
+		<label>make 40x235mm Charged (Conc.) cartridge x25</label>
+		<description>Craft 25 40x235mm Charged (Conc.) cartridges.</description>
+		<jobString>Making 40x235mm Charged (Conc.) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Plasteel</li>
+					</thingDefs>
+				</filter>
+				<count>75</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>4</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>26</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Plasteel</li>
+				<li>Steel</li>
+				<li>ComponentIndustrial</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_40x235mmCharged_AP>25</Ammo_40x235mmCharged_AP>
+		</products>
+		<workAmount>46000</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="ChargeAmmoRecipeBase">
+		<defName>MakeAmmo_40x235mmCharged_Ion</defName>
+		<label>make 40x235mm Charged (Ion) cartridge x25</label>
+		<description>Craft 25 40x235mm Charged (Ion) cartridges.</description>
+		<jobString>Making 40x235mm Charged (Ion) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Plasteel</li>
+					</thingDefs>
+				</filter>
+				<count>75</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>4</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>26</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Plasteel</li>
+				<li>Steel</li>
+				<li>ComponentIndustrial</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_40x235mmCharged_Ion>25</Ammo_40x235mmCharged_Ion>
+		</products>
+		<workAmount>46000</workAmount>
+	</RecipeDef>
+
+</Defs>


### PR DESCRIPTION
## Additions

- Added the following charged ammo:
  - 12x20mm
  - 30x130mm
  - 40x235mm

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070

## Reasoning

- They were made and were sitting there gathering bit rot for a while, the recent developments warranted their addition.
- There were never a true magnum pistol cartridge counterpart for something like .500 S&W/.460/.454, the existing 10x18mm is too small and anemic for that in case of a magnum charge revolver needing a proper ammo type.
- With the emergence of vehicle mods, it's inevitable that a spacer vehicle requires a high caliber autocannon ammo which the new 30mm and 40mm charged ammo types will cover that need.

## Alternatives

- Not add the new ammo types.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] Playtested a colony (specify how long)
