### PR TITLE
Hide armor durability from pawns with default armor amount

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompArmorDurability.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompArmorDurability.cs
@@ -151,7 +151,14 @@ namespace CombatExtended
 
         public override string CompInspectStringExtra()
         {
-            return "CE_ArmorDurability".Translate() + curDurability.ToString() + "/" + maxDurability.ToString() + " (" + curDurabilityPercent.ToStringPercent() + ")";
+            if (maxDurability != 500)
+            {
+                return "CE_ArmorDurability".Translate() + curDurability.ToString() + "/" + maxDurability.ToString() + " (" + curDurabilityPercent.ToStringPercent() + ")";
+            }
+            else
+            {
+                return null;
+            }
         }
 
         public override void PostPreApplyDamage(DamageInfo dinfo, out bool absorbed)


### PR DESCRIPTION

## Changes

Human pawns with only minimal natural armor have 500 pts of natural armor durability.  So if the natural armor max is 500 pts, don't show it.

## Reasoning

Players get confused that basic humanoid pawns, and small animals, have "natural armor".  This is a trivial amount that doesn't actually matter, so displaying it just confuses players.  

## Alternatives

Never show it
Always show it.
Show only a percentage.
Show it only in dev mode.

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [X] Playtested a colony (specify how long)
