### PR TITLE
Null check def mod extension in ammo injector

### DIFF
--- a/Source/VehiclesCompat/VehiclesCompat/VehiclesCompat.cs
+++ b/Source/VehiclesCompat/VehiclesCompat/VehiclesCompat.cs
@@ -64,23 +64,25 @@ namespace CombatExtended.Compatibility.VehiclesCompat
             {
                 foreach (VehicleTurretDef vtd in DefDatabase<global::Vehicles.VehicleTurretDef>.AllDefs)
                 {
-                    CETurretDataDefModExtension cetddme = vtd.GetModExtension<CETurretDataDefModExtension>();
-                    if (cetddme.ammoSet != null)
+                    if (vtd.GetModExtension<CETurretDataDefModExtension>() is CETurretDataDefModExtension cetddme)
                     {
-                        AmmoSetDef asd = (AmmoSetDef)LookupAmmosetCE(cetddme.ammoSet);
-                        if (Controller.settings.GenericAmmo && asd?.similarTo != null)
+                        if (cetddme.ammoSet != null)
                         {
-                            asd = asd.similarTo;
-                        }
-                        if (asd != null)
-                        {
-                            cetddme._ammoSet = asd;
-                            HashSet<ThingDef> allowedAmmo = (HashSet<ThingDef>)vtd.ammunition?.AllowedThingDefs;
-                            allowedAmmo.Clear();
-                            foreach (var al in asd.ammoTypes)
+                            AmmoSetDef asd = (AmmoSetDef)LookupAmmosetCE(cetddme.ammoSet);
+                            if (Controller.settings.GenericAmmo && asd?.similarTo != null)
                             {
-                                allowedAmmo.Add(al.ammo);
-                                yield return al.ammo;
+                                asd = asd.similarTo;
+                            }
+                            if (asd != null)
+                            {
+                                cetddme._ammoSet = asd;
+                                HashSet<ThingDef> allowedAmmo = (HashSet<ThingDef>)vtd.ammunition?.AllowedThingDefs;
+                                allowedAmmo.Clear();
+                                foreach (var al in asd.ammoTypes)
+                                {
+                                    allowedAmmo.Add(al.ammo);
+                                    yield return al.ammo;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION

## Reasoning

If a vehicle doesn't have a CE Def Mod Extension, but properly defines its ammo and default projectile, it shouldn't break the ammo injector.


## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
