### PR TITLE
Add damage of fragments to ammo description

### DIFF
--- a/Source/CombatExtended/CombatExtended/AmmoUtility.cs
+++ b/Source/CombatExtended/CombatExtended/AmmoUtility.cs
@@ -101,6 +101,7 @@ namespace CombatExtended
                 {
                     var fragmentProps = fragmentDef?.thingDef?.projectile as ProjectilePropertiesCE;
                     stringBuilder.AppendLine("   " + "   " + fragmentDef.LabelCap);
+                    stringBuilder.AppendLine("   " + "   " + "   " + "CE_DescDamage".Translate() + ": " + fragmentProps?.damageAmountBase.ToString() + " (" + fragmentProps?.damageDef.LabelCap.ToString() + ")");
                     stringBuilder.AppendLine("   " + "   " + "   " + "CE_DescSharpPenetration".Translate() + ": " + fragmentProps?.armorPenetrationSharp.ToStringByStyle(ToStringStyle.FloatTwo) + " " + "CE_mmRHA".Translate());
                     stringBuilder.AppendLine("   " + "   " + "   " + "CE_DescBluntPenetration".Translate() + ": " + fragmentProps?.armorPenetrationBlunt.ToStringByStyle(ToStringStyle.FloatTwo) + " " + "CE_MPa".Translate());
                 }


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Adds a line that shows how much damage each fragment does to ammo inspection menu.

Example:
![tooltip demo](https://i.imgur.com/85ih6IQ.png)
## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] Playtested a colony (specify how long)
