### PR TITLE
Explicitly reference Compatibility.Multiplayer instead of just Multiplayer

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoGiver.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoGiver.cs
@@ -81,7 +81,7 @@ namespace CombatExtended
 
         // Needs to be a sync method for 2 reasons - MP only auto synchronizes jobs through TryTakeOrderedJob/TryTakeOrderedJobPrioritizedWork,
         // and ammoAmountToGive field is set before ordering the job - which means only 1 player would have the value set.
-        [Multiplayer.SyncMethod]
+        [Compatibility.Multiplayer.SyncMethod]
         public void GiveAmmo(Pawn selPawn, Thing ammo, int amount)
         {
             ammoAmountToGive = amount;

--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmosetSwitcher.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmosetSwitcher.cs
@@ -115,7 +115,7 @@ namespace CombatExtended
 
         public bool usingUnderBarrel;
 
-        [Multiplayer.SyncMethod]
+        [Compatibility.Multiplayer.SyncMethod]
         public void SwitchToUB()
         {
             if (!Props.oneAmmoHolder)
@@ -143,7 +143,7 @@ namespace CombatExtended
             usingUnderBarrel = true;
         }
 
-        [Multiplayer.SyncMethod]
+        [Compatibility.Multiplayer.SyncMethod]
         public void SwithToB()
         {
             if (!Props.oneAmmoHolder)

--- a/Source/CombatExtended/CombatExtended/Comps/CompArmorDurability.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompArmorDurability.cs
@@ -229,7 +229,7 @@ namespace CombatExtended
             }
         }
 
-        [Multiplayer.SyncMethod]
+        [Compatibility.Multiplayer.SyncMethod]
         private void StartJob(Pawn selPawn, Thing firstIngredient = null, Thing secondIngredient = null)
         {
             var job = JobMaker.MakeJob(CE_JobDefOf.RepairNaturalArmor);

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -172,7 +172,7 @@ namespace CombatExtended
                             startingTicksToImpactInt = 0f;
                             // During drawing in Multiplayer - impact causes issues. Will get handled inside of the `Tick` call.
                             // In the future, replace this with `!InInterface` call, as it's more fitting here.
-                            if (!Multiplayer.InMultiplayer)
+                            if (!global::CombatExtended.Compatibility.Multiplayer.InMultiplayer)
                             {
                                 ImpactSomething();
                             }

--- a/Source/CombatExtended/Contrib/MechTakeAmmoCE/Core/CompMechAmmo.cs
+++ b/Source/CombatExtended/Contrib/MechTakeAmmoCE/Core/CompMechAmmo.cs
@@ -173,7 +173,7 @@ namespace CombatExtended
             Current.Game.GetComponent<GameComponent_MechLoadoutDialogManger>()?.RegisterCompMechAmmo(this);
         }
 
-        [Multiplayer.SyncMethod]
+        [Compatibility.Multiplayer.SyncMethod]
         public void TakeAmmoNow()
         {
             this.TryMakeAmmoJob(true);

--- a/Source/CombatExtended/Contrib/MechTakeAmmoCE/UI/Dialog_SetMagCount.cs
+++ b/Source/CombatExtended/Contrib/MechTakeAmmoCE/UI/Dialog_SetMagCount.cs
@@ -79,7 +79,7 @@ namespace CombatExtended
             }
         }
 
-        [Multiplayer.SyncMethod]
+        [Compatibility.Multiplayer.SyncMethod]
         private static void SetMagCount(CompMechAmmo mechAmmo, Dictionary<AmmoDef, int> tmpLoadout)
         {
             //copy the loadouts from the tmpLoadout

--- a/Source/CombatExtended/Contrib/MechTakeAmmoCE/UI/Dialog_SetMagCountBatched.cs
+++ b/Source/CombatExtended/Contrib/MechTakeAmmoCE/UI/Dialog_SetMagCountBatched.cs
@@ -100,7 +100,7 @@ namespace CombatExtended
             }
         }
 
-        [Multiplayer.SyncMethod]
+        [Compatibility.Multiplayer.SyncMethod]
         private static void SetMagCount(List<CompMechAmmo> mechAmmoList, Dictionary<AmmoDef, int> tmpLoadouts)
         {
             //set the loadouts for all the comps

--- a/Source/CombatExtended/Harmony/Harmony_Pawn_DraftController.cs
+++ b/Source/CombatExtended/Harmony/Harmony_Pawn_DraftController.cs
@@ -22,7 +22,7 @@ namespace CombatExtended.HarmonyCE
                 // fully. However, because of how Harmony works all prefixes, postfixes, finalizers will still run - which will cause issues
                 // as this postfix will run before it ends up being synchronized in Multiplayer.
                 // Once Multiplayer API exposes `InInterface` method, it should replace this check (as it'll better handle a few edge cases).
-                if (Multiplayer.InMultiplayer && !Multiplayer.IsExecutingCommands)
+                if (global::CombatExtended.Compatibility.Multiplayer.InMultiplayer && !global::CombatExtended.Compatibility.Multiplayer.IsExecutingCommands)
                 {
                     return;
                 }


### PR DESCRIPTION
## Reasoning

When using the makefile to rebuild the project, it references 0Multiplayer.dll left over from the previous build.
This creates an ambiguous match between `Multiplayer`, the class inside `CombatExtended.Compatibility` and `Multiplayer` the namespace from the dll.

## Alternatives

Rename the class.

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [X] Playtested a colony (specify how long)
