### PR TITLE
Fixed Kit's VFE Weapons CE Patch Typo

### DIFF
--- a/Patches/Kit's VFE Weapons/Ammo/Ammo_KitPlasma.xml
+++ b/Patches/Kit's VFE Weapons/Ammo/Ammo_KitPlasma.xml
@@ -6,7 +6,7 @@
 
 				<mods>
 					<li>Kit's VFE Weapons</li>
-					<li>Kit's VFE Weapons Continued</li>
+					<li>Kit's VFE Weapons Continued </li>
 				</mods>
 
 				<match Class="PatchOperationSequence">

--- a/Patches/Kit's VFE Weapons/DamageDefs/DamageDefs_Vikings.xml
+++ b/Patches/Kit's VFE Weapons/DamageDefs/DamageDefs_Vikings.xml
@@ -4,7 +4,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>Kit's VFE Weapons</li>
-			<li>Kit's VFE Weapons Continued</li>
+			<li>Kit's VFE Weapons Continued </li>
 		</mods>
 		<match Class="PatchOperationAdd">
 			<xpath>Defs</xpath>

--- a/Patches/Kit's VFE Weapons/ThingDefs_Misc/Weapons.xml
+++ b/Patches/Kit's VFE Weapons/ThingDefs_Misc/Weapons.xml
@@ -6,7 +6,7 @@
 			<li Class="PatchOperationFindMod">
 				<mods>
 					<li>Kit's VFE Weapons</li>
-					<li>Kit's VFE Weapons Continued</li>
+					<li>Kit's VFE Weapons Continued </li>
 				</mods>
 				<match Class="PatchOperationSequence">
 					<operations>


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- added space to VFE mod listing

## Changes
Added Space to kit's VFE weapon's continued since original mod about.xml contained a space, removing it disabled the patch

## References
Kit's modmetadeta contains a space
![image](https://github.com/CombatExtended-Continued/CombatExtended/assets/57470753/4676095e-bad2-4c92-bef2-135b4cadbc4d)

the patch doesnt
![image](https://github.com/CombatExtended-Continued/CombatExtended/assets/57470753/93bc065d-0165-43aa-a878-29c57805730f)


## Reasoning


## Alternatives

no alternatives unless you ask the mod author to change the name
## Testing

Check tests you have performed:
DO NOT REMOVE THE SPACE IN THE MOD NAME, IT IS INTENDED 