### PR TITLE
Update Vulpine pack patch

### DIFF
--- a/Patches/Vulpine Pack/Race_Frij.xml
+++ b/Patches/Vulpine Pack/Race_Frij.xml
@@ -26,6 +26,23 @@
 					</value>
 				</li>
 
+        <!-- ========== Gives Gun Gizmos to Fennex HUD thing ========== -->
+				<!-- ========== Also Makes Em Suppressable		   ========== -->
+				<li Class="PatchOperationAdd">
+					<!-- === Shouldn't need to change this at all		  === -->
+					<!-- === Unless you changed the name of your BasePawn === -->
+					<!-- === In which case change "BasePawn" to that name === -->
+					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Frijjid"]</xpath>
+					<value>
+						<comps>
+							<li>
+								<compClass>CombatExtended.CompPawnGizmo</compClass>
+							</li>
+							<li Class="CombatExtended.CompProperties_Suppressable" />
+						</comps>
+					</value>
+				</li>
+        
 				<!-- === Patch Fennex default melee attacks === -->
 				<!-- === For the most part, it adds the CE melee handler thing 	=== -->
 				<!-- === And also defines armor penetration, which allows them	=== -->


### PR DESCRIPTION
add missing pawncomp and Suppressable comp to a race patch
## Additions

Describe new functionality added by your code, e.g.
- Tribal smoke bombs
- New tribal smoke bomb sprite
- Tribal smoke bomb recipes at smithing bench and crafting spot using prometheum

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased regular smoke bomb radius

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
