### PR TITLE
Generic cannon shell ammo

### DIFF
--- a/Defs/Ammo/GENERIC/Shell_Cannon.xml
+++ b/Defs/Ammo/GENERIC/Shell_Cannon.xml
@@ -27,10 +27,10 @@
 		<defName>AmmoSet_LightCannon</defName>
 		<label>light cannon shell</label>
 		<ammoTypes>
-			<Ammo_LightCannonShell_AP>Bullet_LightCannonShell_AP</Ammo_LightCannonShell_AP>
-			<Ammo_LightCannonShell_HE>Bullet_LightCannonShell_HE</Ammo_LightCannonShell_HE>
-			<Ammo_LightCannonShell_HE_TFuzed>Bullet_LightCannonShell_HE_TFuzed</Ammo_LightCannonShell_HE_TFuzed>
-			<Ammo_LightCannonShell_Sabot>Bullet_LightCannonShell_Sabot</Ammo_LightCannonShell_Sabot>
+			<Ammo_LightCannonShell_AP>Bullet_40x365mmBofors_AP</Ammo_LightCannonShell_AP>
+			<Ammo_LightCannonShell_HE>Bullet_40x365mmBofors_HE</Ammo_LightCannonShell_HE>
+			<Ammo_LightCannonShell_HE_TFuzed>Bullet_40x365mmBofors_HE_TFuzed</Ammo_LightCannonShell_HE_TFuzed>
+			<Ammo_LightCannonShell_Sabot>Bullet_40x365mmBofors_Sabot</Ammo_LightCannonShell_Sabot>
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
 
@@ -38,10 +38,10 @@
 		<defName>AmmoSet_HeavyCannon</defName>
 		<label>heavy cannon shell</label>
 		<ammoTypes>
-			<Ammo_HeavyCannonShell_HEAT>Bullet_HeavyCannonShell_HEAT</Ammo_HeavyCannonShell_HEAT>
-			<Ammo_HeavyCannonShell_HE>Bullet_HeavyCannonShell_HE</Ammo_HeavyCannonShell_HE>
-			<Ammo_HeavyCannonShell_HE_TFuzed>Bullet_HeavyCannonShell_HE_TFuzed</Ammo_HeavyCannonShell_HE_TFuzed>
-			<Ammo_HeavyCannonShell_EMP>Bullet_HeavyCannonShell_EMP</Ammo_HeavyCannonShell_EMP>
+			<Ammo_HeavyCannonShell_HEAT>Bullet_90mmCannonShell_HEAT</Ammo_HeavyCannonShell_HEAT>
+			<Ammo_HeavyCannonShell_HE>Bullet_90mmCannonShell_HE</Ammo_HeavyCannonShell_HE>
+			<Ammo_HeavyCannonShell_HE_TFuzed>Bullet_90mmCannonShell_HE_TFuzed</Ammo_HeavyCannonShell_HE_TFuzed>
+			<Ammo_HeavyCannonShell_EMP>Bullet_90mmCannonShell_EMP</Ammo_HeavyCannonShell_EMP>
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
 
@@ -76,7 +76,7 @@
 			<MarketValue>10.08</MarketValue>
 		</statBases>
 		<ammoClass>ArmorPiercing</ammoClass>
-		<cookOffProjectile>Bullet_LightCannonShell_AP</cookOffProjectile>
+		<cookOffProjectile>Bullet_40x365mmBofors_AP</cookOffProjectile>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoLightCannonShellBase">
@@ -90,7 +90,7 @@
 			<MarketValue>16.36</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHE</ammoClass>
-		<cookOffProjectile>Bullet_LightCannonShell_HE</cookOffProjectile>
+		<cookOffProjectile>Bullet_40x365mmBofors_HE</cookOffProjectile>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoLightCannonShellBase">
@@ -104,7 +104,7 @@
 			<MarketValue>17.66</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHE</ammoClass>
-		<cookOffProjectile>Bullet_LightCannonShell_HE</cookOffProjectile>
+		<cookOffProjectile>Bullet_40x365mmBofors_HE</cookOffProjectile>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoLightCannonShellBase">
@@ -119,7 +119,7 @@
 			<MarketValue>11.12</MarketValue>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
-		<cookOffProjectile>Bullet_LightCannonShell_Sabot</cookOffProjectile>
+		<cookOffProjectile>Bullet_40x365mmBofors_Sabot</cookOffProjectile>
 	</ThingDef>
 
 	<!-- Heavy Shells -->
@@ -156,7 +156,7 @@
 			<MarketValue>89</MarketValue>
 		</statBases>
 		<ammoClass>RocketHEAT</ammoClass>
-		<detonateProjectile>Bullet_HeavyCannonShell_HEAT</detonateProjectile>
+		<detonateProjectile>Bullet_90mmCannonShell_HEAT</detonateProjectile>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="HeavyCannonShellBase">
@@ -170,7 +170,7 @@
 			<MarketValue>104.83</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHE</ammoClass>
-		<detonateProjectile>Bullet_HeavyCannonShell_HE</detonateProjectile>
+		<detonateProjectile>Bullet_90mmCannonShell_HE</detonateProjectile>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="HeavyCannonShellBase">
@@ -184,7 +184,7 @@
 			<MarketValue>124.33</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHETF</ammoClass>
-		<detonateProjectile>Bullet_HeavyCannonShell_HE</detonateProjectile>
+		<detonateProjectile>Bullet_90mmCannonShell_HE</detonateProjectile>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="HeavyCannonShellBase">
@@ -198,7 +198,7 @@
 			<MarketValue>160.66</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeEMP</ammoClass>
-		<detonateProjectile>Bullet_HeavyCannonShell_EMP</detonateProjectile>
+		<detonateProjectile>Bullet_90mmCannonShell_EMP</detonateProjectile>
 	</ThingDef>
 
 	<!-- ==================== Recipes ========================== -->

--- a/Defs/Ammo/GENERIC/Shell_Cannon.xml
+++ b/Defs/Ammo/GENERIC/Shell_Cannon.xml
@@ -1,0 +1,562 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+	<!-- ==================== Categories ========================== -->
+
+	<!-- Relabeled 40x365mm Bofors Shell -->
+
+	<ThingCategoryDef>
+		<defName>AmmoLightCannonShell</defName>
+		<label>light cannon shell</label>
+		<parent>AmmoShells</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberAutocannonLarge</iconPath>
+	</ThingCategoryDef>
+
+	<!-- Relabeled 90mm Shell -->
+
+	<ThingCategoryDef>
+		<defName>AmmoHeavyCannonShell</defName>
+		<label>heavy cannon shell</label>
+		<parent>AmmoShells</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberCannon</iconPath>
+	</ThingCategoryDef>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_LightCannon</defName>
+		<label>light cannon shell</label>
+		<ammoTypes>
+			<Ammo_LightCannonShell_AP>Bullet_LightCannonShell_AP</Ammo_LightCannonShell_AP>
+			<Ammo_LightCannonShell_HE>Bullet_LightCannonShell_HE</Ammo_LightCannonShell_HE>
+			<Ammo_LightCannonShell_HE_TFuzed>Bullet_LightCannonShell_HE_TFuzed</Ammo_LightCannonShell_HE_TFuzed>
+			<Ammo_LightCannonShell_Sabot>Bullet_LightCannonShell_Sabot</Ammo_LightCannonShell_Sabot>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_HeavyCannon</defName>
+		<label>heavy cannon shell</label>
+		<ammoTypes>
+			<Ammo_HeavyCannonShell_HEAT>Bullet_HeavyCannonShell_HEAT</Ammo_HeavyCannonShell_HEAT>
+			<Ammo_HeavyCannonShell_HE>Bullet_HeavyCannonShell_HE</Ammo_HeavyCannonShell_HE>
+			<Ammo_HeavyCannonShell_HE_TFuzed>Bullet_HeavyCannonShell_HE_TFuzed</Ammo_HeavyCannonShell_HE_TFuzed>
+			<Ammo_HeavyCannonShell_EMP>Bullet_HeavyCannonShell_EMP</Ammo_HeavyCannonShell_EMP>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<!-- Light Shells -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="AmmoLightCannonShellBase" ParentName="HeavyAmmoBase" Abstract="True">
+		<description>Large caliber shell used by autocannons and anti-aircraft cannons.</description>
+		<statBases>
+			<Mass>2.5</Mass>
+			<Bulk>4.69</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting_TableMachining</li>
+		</tradeTags>
+		<thingCategories>
+			<li>AmmoLightCannonShell</li>
+		</thingCategories>
+		<stackLimit>25</stackLimit>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoLightCannonShellBase">
+		<defName>Ammo_LightCannonShell_AP</defName>
+		<label>light cannon shell (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/Bofors/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>10.08</MarketValue>
+		</statBases>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_LightCannonShell_AP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoLightCannonShellBase">
+		<defName>Ammo_LightCannonShell_HE</defName>
+		<label>light cannon shell (HE)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/Bofors/HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>16.36</MarketValue>
+		</statBases>
+		<ammoClass>GrenadeHE</ammoClass>
+		<cookOffProjectile>Bullet_LightCannonShell_HE</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoLightCannonShellBase">
+		<defName>Ammo_LightCannonShell_HE_TFuzed</defName>
+		<label>light cannon shell (HE Time Fuzed)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/Bofors/HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>17.66</MarketValue>
+		</statBases>
+		<ammoClass>GrenadeHE</ammoClass>
+		<cookOffProjectile>Bullet_LightCannonShell_HE</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoLightCannonShellBase">
+		<defName>Ammo_LightCannonShell_Sabot</defName>
+		<label>light cannon shell (Sabot)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/Bofors/Sabot</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<Mass>2.088</Mass>
+			<MarketValue>11.12</MarketValue>
+		</statBases>
+		<ammoClass>Sabot</ammoClass>
+		<cookOffProjectile>Bullet_LightCannonShell_Sabot</cookOffProjectile>
+	</ThingDef>
+
+	<!-- Heavy Shells -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="HeavyCannonShellBase" ParentName="HeavyAmmoBase" Abstract="True">
+		<description>High-caliber cannon shell typically used by anti-armor weaponry.</description>
+		<thingCategories>
+			<li>AmmoHeavyCannonShell</li>
+		</thingCategories>
+		<stackLimit>25</stackLimit>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting_TableMachining</li>
+		</tradeTags>
+		<statBases>
+			<MaxHitPoints>200</MaxHitPoints>
+			<Mass>19</Mass>
+			<Bulk>22.41</Bulk>
+		</statBases>
+		<cookOffFlashScale>30</cookOffFlashScale>
+		<cookOffSound>MortarBomb_Explode</cookOffSound>
+		<isMortarAmmo>true</isMortarAmmo>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="HeavyCannonShellBase">
+		<defName>Ammo_HeavyCannonShell_HEAT</defName>
+		<label>heavy cannon shell (HEAT)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Cannon/Tank/HEAT</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<Mass>15.8</Mass>
+			<MarketValue>89</MarketValue>
+		</statBases>
+		<ammoClass>RocketHEAT</ammoClass>
+		<detonateProjectile>Bullet_HeavyCannonShell_HEAT</detonateProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="HeavyCannonShellBase">
+		<defName>Ammo_HeavyCannonShell_HE</defName>
+		<label>heavy cannon shell (HE)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Cannon/Tank/HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>104.83</MarketValue>
+		</statBases>
+		<ammoClass>GrenadeHE</ammoClass>
+		<detonateProjectile>Bullet_HeavyCannonShell_HE</detonateProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="HeavyCannonShellBase">
+		<defName>Ammo_HeavyCannonShell_HE_TFuzed</defName>
+		<label>heavy cannon shell (HE Time-Fuzed)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Cannon/Tank/HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>124.33</MarketValue>
+		</statBases>
+		<ammoClass>GrenadeHETF</ammoClass>
+		<detonateProjectile>Bullet_HeavyCannonShell_HE</detonateProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="HeavyCannonShellBase">
+		<defName>Ammo_HeavyCannonShell_EMP</defName>
+		<label>heavy cannon shell (EMP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Cannon/Tank/EMP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>160.66</MarketValue>
+		</statBases>
+		<ammoClass>GrenadeEMP</ammoClass>
+		<detonateProjectile>Bullet_HeavyCannonShell_EMP</detonateProjectile>
+	</ThingDef>
+
+	<!-- ==================== Recipes ========================== -->
+
+	<!-- Light Shells -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_LightCannonShell_AP</defName>
+		<label>make light cannon (AP) shell x25</label>
+		<description>Craft 25 light cannon (AP) shells.</description>
+		<jobString>Making light cannon (AP) shells.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>126</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_LightCannonShell_AP>25</Ammo_LightCannonShell_AP>
+		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
+		<workAmount>15120</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_LightCannonShell_HE</defName>
+		<label>make light cannon (HE) shell x25</label>
+		<description>Craft 25 light cannon (HE) shells.</description>
+		<jobString>Making light cannon (HE) shells.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>126</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>2</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>FSX</li>
+					</thingDefs>
+				</filter>
+				<count>12</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>ComponentIndustrial</li>
+				<li>FSX</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_LightCannonShell_HE>25</Ammo_LightCannonShell_HE>
+		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
+		<workAmount>18600</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_LightCannonShell_HE_TFuzed</defName>
+		<label>make light cannon Time-Fuzed shell x25</label>
+		<description>Craft 25 light cannon Time-Fuzed shells.</description>
+		<jobString>Making light cannon Time-Fuzed shells.</jobString>
+		<researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>126</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>5</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>FSX</li>
+					</thingDefs>
+				</filter>
+				<count>12</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>ComponentIndustrial</li>
+				<li>FSX</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_LightCannonShell_HE_TFuzed>25</Ammo_LightCannonShell_HE_TFuzed>
+		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
+		<workAmount>20400</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_LightCannonShell_Sabot</defName>
+		<label>make light cannon (Sabot) shell x25</label>
+		<description>Craft 25 light cannon (Sabot) shells.</description>
+		<jobString>Making light cannon (Sabot) shells.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>78</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Uranium</li>
+					</thingDefs>
+				</filter>
+				<count>14</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Chemfuel</li>
+					</thingDefs>
+				</filter>
+				<count>14</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Uranium</li>
+				<li>Chemfuel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_LightCannonShell_Sabot>25</Ammo_LightCannonShell_Sabot>
+		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
+		<workAmount>16200</workAmount>
+	</RecipeDef>
+
+	<!-- Heavy Shells -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_HeavyCannonShell_HEAT</defName>
+		<label>make heavy HEAT cannon shells x5</label>
+		<description>Craft 5 heavy HEAT cannon shells.</description>
+		<jobString>Making heavy HEAT cannon shells.</jobString>
+		<workAmount>20400</workAmount>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>160</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>FSX</li>
+					</thingDefs>
+				</filter>
+				<count>8</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>2</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>FSX</li>
+				<li>ComponentIndustrial</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_HeavyCannonShell_HEAT>5</Ammo_HeavyCannonShell_HEAT>
+		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_HeavyCannonShell_HE</defName>
+		<label>make heavy HE cannon shells x5</label>
+		<description>Craft 5 heavy HE cannon shells.</description>
+		<jobString>Making heavy HE cannon shells.</jobString>
+		<workAmount>24400</workAmount>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>192</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>FSX</li>
+					</thingDefs>
+				</filter>
+				<count>10</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>2</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>FSX</li>
+				<li>ComponentIndustrial</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_HeavyCannonShell_HE>5</Ammo_HeavyCannonShell_HE>
+		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_HeavyCannonShell_HE_TFuzed</defName>
+		<label>make heavy HE Time-Fuzed cannon shells x5</label>
+		<description>Craft 5 heavy HE Time-Fuzed cannon shells.</description>
+		<jobString>Making heavy HE Time-Fuzed cannon shells.</jobString>
+		<workAmount>26400</workAmount>
+		<researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>192</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>FSX</li>
+					</thingDefs>
+				</filter>
+				<count>10</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>5</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>FSX</li>
+				<li>ComponentIndustrial</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_HeavyCannonShell_HE_TFuzed>5</Ammo_HeavyCannonShell_HE_TFuzed>
+		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_HeavyCannonShell_EMP</defName>
+		<label>make heavy EMP cannon shells x5</label>
+		<description>Craft 5 heavy EMP cannon shells.</description>
+		<jobString>Making heavy EMP cannon shells.</jobString>
+		<researchPrerequisite>MicroelectronicsBasics</researchPrerequisite>
+		<workAmount>27000</workAmount>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>192</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>13</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>ComponentIndustrial</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_HeavyCannonShell_EMP>5</Ammo_HeavyCannonShell_EMP>
+		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
+	</RecipeDef>
+
+</Defs>

--- a/Defs/Ammo/Shell/100x695mmR.xml
+++ b/Defs/Ammo/Shell/100x695mmR.xml
@@ -17,6 +17,7 @@
 			<Ammo_100x695mmRCannonShell_HEAT>Bullet_100x695mmRCannonShell_HEAT</Ammo_100x695mmRCannonShell_HEAT>
 			<Ammo_100x695mmRCannonShell_HE>Bullet_100x695mmRCannonShell_HE</Ammo_100x695mmRCannonShell_HE>
 		</ammoTypes>
+		<similarTo>AmmoSet_HeavyCannon</similarTo>
 	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Shell/105x607mmR.xml
+++ b/Defs/Ammo/Shell/105x607mmR.xml
@@ -17,6 +17,7 @@
 			<Ammo_105x607mmRCannonShell_HEAT>Bullet_105x607mmRCannonShell_HEAT</Ammo_105x607mmRCannonShell_HEAT>
 			<Ammo_105x607mmRCannonShell_HE>Bullet_105x607mmRCannonShell_HE</Ammo_105x607mmRCannonShell_HE>
 		</ammoTypes>
+		<similarTo>AmmoSet_HeavyCannon</similarTo>
 	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Shell/105x617mmR.xml
+++ b/Defs/Ammo/Shell/105x617mmR.xml
@@ -17,6 +17,7 @@
 			<Ammo_105x617mmRCannonShell_HEAT>Bullet_105x617mmRCannonShell_HEAT</Ammo_105x617mmRCannonShell_HEAT>
 			<Ammo_105x617mmRCannonShell_HE>Bullet_105x617mmRCannonShell_HE</Ammo_105x617mmRCannonShell_HE>
 		</ammoTypes>
+		<similarTo>AmmoSet_HeavyCannon</similarTo>
 	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Shell/120mmCannon.xml
+++ b/Defs/Ammo/Shell/120mmCannon.xml
@@ -17,6 +17,7 @@
 			<Ammo_120mmCannonShell_HEAT>Bullet_120mmCannonShell_HEAT</Ammo_120mmCannonShell_HEAT>
 			<Ammo_120mmCannonShell_HE>Bullet_120mmCannonShell_HE</Ammo_120mmCannonShell_HE>
 		</ammoTypes>
+		<similarTo>AmmoSet_HeavyCannon</similarTo>
 	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Shell/28cmSpgr.xml
+++ b/Defs/Ammo/Shell/28cmSpgr.xml
@@ -16,6 +16,7 @@
 		<ammoTypes>
 			<Ammo_28cmSpgrShell_HE>Bullet_28cmSpgrShell_HE</Ammo_28cmSpgrShell_HE>
 		</ammoTypes>
+		<similarTo>AmmoSet_HeavyCannon</similarTo>
 	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Shell/37x223mmR.xml
+++ b/Defs/Ammo/Shell/37x223mmR.xml
@@ -17,6 +17,7 @@
 			<Ammo_37x223mmR_AP>Bullet_37x223mmR_AP</Ammo_37x223mmR_AP>
 			<Ammo_37x223mmR_HE>Bullet_37x223mmR_HE</Ammo_37x223mmR_HE>
 		</ammoTypes>
+		<similarTo>AmmoSet_LightCannon</similarTo>
 	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Shell/40x365mmBofors.xml
+++ b/Defs/Ammo/Shell/40x365mmBofors.xml
@@ -19,6 +19,7 @@
 			<Ammo_40x365mmBofors_HE_TFuzed>Bullet_40x365mmBofors_HE_TFuzed</Ammo_40x365mmBofors_HE_TFuzed>
 			<Ammo_40x365mmBofors_Sabot>Bullet_40x365mmBofors_Sabot</Ammo_40x365mmBofors_Sabot>
 		</ammoTypes>
+		<similarTo>AmmoSet_LightCannon</similarTo>
 	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Shell/50mmType89Mortar.xml
+++ b/Defs/Ammo/Shell/50mmType89Mortar.xml
@@ -19,6 +19,7 @@
 			<Ammo_50mmType89MortarShell_EMP>Bullet_50mmType89MortarShell_EMP</Ammo_50mmType89MortarShell_EMP>
 			<Ammo_50mmType89MortarShell_Smoke>Bullet_50mmType89MortarShell_Smoke</Ammo_50mmType89MortarShell_Smoke>
 		</ammoTypes>
+		<isMortarAmmoSet>true</isMortarAmmoSet>
 	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Shell/57x307mmR.xml
+++ b/Defs/Ammo/Shell/57x307mmR.xml
@@ -17,6 +17,7 @@
 			<Ammo_57x307mmR_AP>Bullet_57x307mmR_AP</Ammo_57x307mmR_AP>
 			<Ammo_57x307mmR_HE>Bullet_57x307mmR_HE</Ammo_57x307mmR_HE>
 		</ammoTypes>
+		<similarTo>AmmoSet_LightCannon</similarTo>
 	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Shell/57x483mmBofors.xml
+++ b/Defs/Ammo/Shell/57x483mmBofors.xml
@@ -16,6 +16,7 @@
 		<ammoTypes>
 			<Ammo_57x483mmBofors_HE>Bullet_57x483mmBofors_HE</Ammo_57x483mmBofors_HE>
 		</ammoTypes>
+		<similarTo>AmmoSet_LightCannon</similarTo>
 	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Shell/60mmMortar.xml
+++ b/Defs/Ammo/Shell/60mmMortar.xml
@@ -20,6 +20,7 @@
 			<Shell_60mmMortar_Firefoam>Bullet_60mmMortarShell_Firefoam</Shell_60mmMortar_Firefoam>
 			<Shell_60mmMortar_Smoke>Bullet_60mmMortarShell_Smoke</Shell_60mmMortar_Smoke>
 		</ammoTypes>
+		<isMortarAmmoSet>true</isMortarAmmoSet>
 	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Shell/75x350mmR.xml
+++ b/Defs/Ammo/Shell/75x350mmR.xml
@@ -17,6 +17,7 @@
 			<Ammo_75x350mmR_AP>Bullet_75x350mmR_AP</Ammo_75x350mmR_AP>
 			<Ammo_75x350mmR_HE>Bullet_75x350mmR_HE</Ammo_75x350mmR_HE>
 		</ammoTypes>
+		<similarTo>AmmoSet_LightCannon</similarTo>
 	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Shell/762x385mmRCannon.xml
+++ b/Defs/Ammo/Shell/762x385mmRCannon.xml
@@ -18,6 +18,7 @@
 			<Ammo_762x385mmRCannonShell_HE>Bullet_762x385mmRCannonShell_HE</Ammo_762x385mmRCannonShell_HE>
 			<Ammo_762x385mmRCannonShell_EMP>Bullet_762x385mmRCannonShell_EMP</Ammo_762x385mmRCannonShell_EMP>
 		</ammoTypes>
+		<similarTo>AmmoSet_HeavyCannon</similarTo>
 	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Shell/762x539mmR.xml
+++ b/Defs/Ammo/Shell/762x539mmR.xml
@@ -17,6 +17,7 @@
 			<Ammo_762x539mmR_AP>Bullet_762x539mmR_AP</Ammo_762x539mmR_AP>
 			<Ammo_762x539mmR_HE>Bullet_762x539mmR_HE</Ammo_762x539mmR_HE>
 		</ammoTypes>
+		<similarTo>AmmoSet_LightCannon</similarTo>
 	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Shell/90mmCannon.xml
+++ b/Defs/Ammo/Shell/90mmCannon.xml
@@ -19,7 +19,7 @@
 			<Ammo_90mmCannonShell_HE_TFuzed>Bullet_90mmCannonShell_HE_TFuzed</Ammo_90mmCannonShell_HE_TFuzed>
 			<Ammo_90mmCannonShell_EMP>Bullet_90mmCannonShell_EMP</Ammo_90mmCannonShell_EMP>
 		</ammoTypes>
-		<isMortarAmmoSet>true</isMortarAmmoSet>
+		<similarTo>AmmoSet_HeavyCannon</similarTo>
 	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->


### PR DESCRIPTION
## Additions

- Added generic shell ammo types (light and heavy) based on 40mm Bofors and 90mm shells, the more commonly used and complete in terms of ammo types among different shells.

## Reasoning

- With the emergence of vehicles and high caliber shells finally getting used more commonly, and with the apparent implementation of generic ammo compatibility for vehicles, it's was time generic shells were added to the mod.
- The ammo was added in two (Light and Heavy) variants due to ammo type differences, caliber differences/gaps and also crafting costs. Shells were grouped into each category based on their ammo types and size.

## Alternatives

- Leave shells without a generic ammo type.

## To do/To consider

- Indirect-fire ammo types being mortar and howitzer shells (direct-fire howitzer shells too, generic shells don't have incendiary and smoke shell types currently) are not included here, should they and can they even be included in generic ammo types?
- The labels and other flavor text are placeholder and are chosen based on what made more sense, the chosen 40mm and 90mm baseline shells too, they are open to being changed.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] Playtested a colony (specify how long)
