### PR TITLE
Mod Menu Keys

### DIFF
--- a/Languages/English/Keyed/ModMenu.xml
+++ b/Languages/English/Keyed/ModMenu.xml
@@ -45,7 +45,7 @@
 	<CE_Settings_PartialStats_Desc>When turned on some armor might have different stats on different body parts</CE_Settings_PartialStats_Desc>
 
 	<CE_Settings_RecoilAnim_Title>Show recoil animations</CE_Settings_RecoilAnim_Title>
-	<CE_Settings_RecoilAnim_Desc>When enabled, weapon and turret sprites will play recoil animations when they fire.</CE_Settings_RecoilAnim_Desc>	
+	<CE_Settings_RecoilAnim_Desc>When enabled, ranged weapons and turrets will play recoil animations when they fire.</CE_Settings_RecoilAnim_Desc>	
 
 	<!-- ========== Ammo settings ========== -->
 

--- a/Languages/English/Keyed/ModMenu.xml
+++ b/Languages/English/Keyed/ModMenu.xml
@@ -30,7 +30,7 @@
 	<CE_Settings_SmokeEffects_Desc>Fire generates dangerous black smoke clouds, causing health complications to anyone not wearing protective gear.</CE_Settings_SmokeEffects_Desc>
 
 	<CE_Settings_MergeExplosions_Title>Merge explosions</CE_Settings_MergeExplosions_Title>
-	<CE_Settings_MergeExplosions_Desc>Nearby explosions are merged into eachother, significantly improving performance during a massive explosives cook-off. Strongly recommended to leave on.</CE_Settings_MergeExplosions_Desc>
+	<CE_Settings_MergeExplosions_Desc>Nearby explosions are merged into each other, significantly improving performance during a massive explosives cook-off. Strongly recommended to leave on.</CE_Settings_MergeExplosions_Desc>
 
 	<CE_Settings_TurretsBreakShields_Title>Disable shield belts while manning turrets</CE_Settings_TurretsBreakShields_Title>
 	<CE_Settings_TurretsBreakShields_Desc>When enabled, shield belts will deactivate while colonists are manning turrets. If disabled, shield belts will instead remain active, offering additional protection.</CE_Settings_TurretsBreakShields_Desc>
@@ -43,6 +43,9 @@
 
 	<CE_Settings_PartialStats_Title>Turn on partial armor</CE_Settings_PartialStats_Title>
 	<CE_Settings_PartialStats_Desc>When turned on some armor might have different stats on different body parts</CE_Settings_PartialStats_Desc>
+
+	<CE_Settings_RecoilAnim_Title>Show recoil animations</CE_Settings_RecoilAnim_Title>
+	<CE_Settings_RecoilAnim_Desc>When enabled, weapon and turret sprites will play recoil animations when they fire.</CE_Settings_RecoilAnim_Desc>	
 
 	<!-- ========== Ammo settings ========== -->
 


### PR DESCRIPTION
## Additions
- Add keys for recoil options in the mod menu.

## Changes
- Fix a typo.

## Reasoning
- Already set up in the code for the translations, just need them added.

## Alternatives
- Leave the setting untranslated, for some reason.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
