### PR TITLE
Vpe shield outgoing interception

### DIFF
--- a/Source/CombatExtended/Compatibility/VanillaPsycastExpanded.cs
+++ b/Source/CombatExtended/Compatibility/VanillaPsycastExpanded.cs
@@ -78,7 +78,7 @@ namespace CombatExtended.Compatibility
             {
                 Vector3 shieldPosition = interceptor.pawn.Position.ToVector3Shifted().Yto0();
                 float radius = interceptor.OverlaySize;
-                if ((new Vector3(projectile.origin.x, 0, projectile.origin.y) - shieldPosition).sqrMagnitude < radius * radius)
+                if ((new Vector3(projectile.origin.x, 0, projectile.origin.y) - shieldPosition).sqrMagnitude < radius * radius) // Ensure the shield does not block outgoing projectiles
                 {
                     return false;
                 }

--- a/Source/CombatExtended/Compatibility/VanillaPsycastExpanded.cs
+++ b/Source/CombatExtended/Compatibility/VanillaPsycastExpanded.cs
@@ -79,7 +79,7 @@ namespace CombatExtended.Compatibility
                 Vector3 shieldPosition = interceptor.pawn.Position.ToVector3ShiftedWithAltitude(0.5f);
                 float radius = interceptor.OverlaySize;
                 float blockRadius = radius + def.projectile.SpeedTilesPerTick + 0.1f;
-                if ((projectile.OriginIV3.ToVector3Shifted().Yto0() - interceptor.pawn.Position.ToVector3Shifted()).sqrMagnitude < radius * radius)
+                if ((new Vector3(projectile.origin.x, 0, projectile.origin.y) - interceptor.pawn.Position.ToVector3Shifted()).sqrMagnitude < radius * radius)
                 {
                     return false;
                 }

--- a/Source/CombatExtended/Compatibility/VanillaPsycastExpanded.cs
+++ b/Source/CombatExtended/Compatibility/VanillaPsycastExpanded.cs
@@ -79,6 +79,10 @@ namespace CombatExtended.Compatibility
                 Vector3 shieldPosition = interceptor.pawn.Position.ToVector3ShiftedWithAltitude(0.5f);
                 float radius = interceptor.OverlaySize;
                 float blockRadius = radius + def.projectile.SpeedTilesPerTick + 0.1f;
+                if ((projectile.OriginIV3.ToVector3Shifted().Yto0() - interceptor.pawn.Position.ToVector3Shifted()).sqrMagnitude < radius * radius)
+                {
+                    return false;
+                }
                 if (CE_Utility.IntersectionPoint(from, newExactPos, shieldPosition, radius, out Vector3[] sect))
                 {
                     OnIntercepted(interceptor, projectile, sect);

--- a/Source/CombatExtended/Compatibility/VanillaPsycastExpanded.cs
+++ b/Source/CombatExtended/Compatibility/VanillaPsycastExpanded.cs
@@ -76,14 +76,13 @@ namespace CombatExtended.Compatibility
                 .SelectMany(x => x.health.hediffSet.hediffs)
                 .Where(x => x is Hediff_Overshield && x.GetType() != typeof(Hediff_Overshield)).Cast<Hediff_Overshield>())
             {
-                Vector3 shieldPosition = interceptor.pawn.Position.ToVector3ShiftedWithAltitude(0.5f);
+                Vector3 shieldPosition = interceptor.pawn.Position.ToVector3Shifted().Yto0();
                 float radius = interceptor.OverlaySize;
-                float blockRadius = radius + def.projectile.SpeedTilesPerTick + 0.1f;
-                if ((new Vector3(projectile.origin.x, 0, projectile.origin.y) - interceptor.pawn.Position.ToVector3Shifted()).sqrMagnitude < radius * radius)
+                if ((new Vector3(projectile.origin.x, 0, projectile.origin.y) - shieldPosition).sqrMagnitude < radius * radius)
                 {
                     return false;
                 }
-                if (CE_Utility.IntersectionPoint(from, newExactPos, shieldPosition, radius, out Vector3[] sect))
+                if (CE_Utility.IntersectionPoint(from.Yto0(), newExactPos.Yto0(), shieldPosition, radius, out Vector3[] sect))
                 {
                     OnIntercepted(interceptor, projectile, sect);
                     return true;


### PR DESCRIPTION
## Changes

- Fixed outgoing projectiles being intercepted
- Removed Y from calculation to avoid incorrect projectile bypass
- Removed useless variable

## Reasoning

- One check was missing since blocker registry changes.

## Alternatives

- parameter "from" can be used instead of "origin" of projectile, but for some reason it wont work

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded (not checked yet)
- [x] Playtested a colony (tested skipbarrier)
