### PR TITLE
Pulsefire patch cleanup

### DIFF
--- a/Patches/Pulsefire Turret/PulsefireTurret_CombatExtendedPatch.xml
+++ b/Patches/Pulsefire Turret/PulsefireTurret_CombatExtendedPatch.xml
@@ -27,6 +27,7 @@
 						<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[
 						defName = "PulsefireTurretGun" or
@@ -66,6 +67,11 @@
 						</targetParams>
 						<recoilPattern>Mounted</recoilPattern>
 					</Properties>
+					<AmmoUser>
+						<magazineSize>40</magazineSize>
+						<reloadTime>5.9</reloadTime>
+						<ammoSet>AmmoSet_12x72mmCharged</ammoSet>
+					</AmmoUser>					
 					<FireModes>
 						<aiUseBurstMode>FALSE</aiUseBurstMode>
 						<aiAimMode>AimedShot</aiAimMode>
@@ -96,6 +102,11 @@
 						</targetParams>
 						<recoilPattern>Mounted</recoilPattern>
 					</Properties>
+					<AmmoUser>
+						<magazineSize>80</magazineSize>
+						<reloadTime>5.9</reloadTime>
+						<ammoSet>AmmoSet_12x72mmCharged</ammoSet>
+					</AmmoUser>					
 					<FireModes>
 						<aiUseBurstMode>FALSE</aiUseBurstMode>
 						<aiAimMode>AimedShot</aiAimMode>

--- a/Patches/Pulsefire Turret/PulsefireTurret_CombatExtendedPatch.xml
+++ b/Patches/Pulsefire Turret/PulsefireTurret_CombatExtendedPatch.xml
@@ -27,6 +27,15 @@
 						<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
 					</value>
 				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+						defName = "PulsefireTurretGun" or
+						defName = "PulsefireTwinCannon"
+						]/fillPercent </xpath>
+					<value>
+						<fillPercent>0.85</fillPercent>
+					</value>
+				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName = "PulsefireTurretGun" or defName = "PulsefireTwinCannon"]/statBases/ShootingAccuracyTurret</xpath>
@@ -57,11 +66,6 @@
 						</targetParams>
 						<recoilPattern>Mounted</recoilPattern>
 					</Properties>
-					<AmmoUser>
-						<magazineSize>40</magazineSize>
-						<reloadTime>5.9</reloadTime>
-						<ammoSet>AmmoSet_12x72mmCharged</ammoSet>
-					</AmmoUser>
 					<FireModes>
 						<aiUseBurstMode>FALSE</aiUseBurstMode>
 						<aiAimMode>AimedShot</aiAimMode>
@@ -92,11 +96,6 @@
 						</targetParams>
 						<recoilPattern>Mounted</recoilPattern>
 					</Properties>
-					<AmmoUser>
-						<magazineSize>80</magazineSize>
-						<reloadTime>5.9</reloadTime>
-						<ammoSet>AmmoSet_12x72mmCharged</ammoSet>
-					</AmmoUser>
 					<FireModes>
 						<aiUseBurstMode>FALSE</aiUseBurstMode>
 						<aiAimMode>AimedShot</aiAimMode>
@@ -133,11 +132,6 @@
 						</targetParams>
 						<recoilPattern>Mounted</recoilPattern>
 					</Properties>
-					<AmmoUser>
-						<magazineSize>150</magazineSize>
-						<reloadTime>7.9</reloadTime>
-						<ammoSet>AmmoSet_6x18mmCharged</ammoSet>
-					</AmmoUser>
 					<FireModes>
 						<aiUseBurstMode>FALSE</aiUseBurstMode>
 						<aiAimMode>AimedShot</aiAimMode>
@@ -174,11 +168,6 @@
 						</targetParams>
 						<recoilPattern>Mounted</recoilPattern>
 					</Properties>
-					<AmmoUser>
-						<magazineSize>150</magazineSize>
-						<reloadTime>7.9</reloadTime>
-						<ammoSet>AmmoSet_6x18mmCharged</ammoSet>
-					</AmmoUser>
 					<FireModes>
 						<aiUseBurstMode>FALSE</aiUseBurstMode>
 						<aiAimMode>AimedShot</aiAimMode>

--- a/Patches/Pulsefire Turret/PulsefireTurret_CombatExtendedPatch.xml
+++ b/Patches/Pulsefire Turret/PulsefireTurret_CombatExtendedPatch.xml
@@ -106,7 +106,7 @@
 						<magazineSize>80</magazineSize>
 						<reloadTime>5.9</reloadTime>
 						<ammoSet>AmmoSet_12x72mmCharged</ammoSet>
-					</AmmoUser>					
+					</AmmoUser>
 					<FireModes>
 						<aiUseBurstMode>FALSE</aiUseBurstMode>
 						<aiAimMode>AimedShot</aiAimMode>
@@ -143,6 +143,11 @@
 						</targetParams>
 						<recoilPattern>Mounted</recoilPattern>
 					</Properties>
+					<AmmoUser>
+						<magazineSize>150</magazineSize>
+						<reloadTime>7.9</reloadTime>
+						<ammoSet>AmmoSet_6x18mmCharged</ammoSet>
+					</AmmoUser>
 					<FireModes>
 						<aiUseBurstMode>FALSE</aiUseBurstMode>
 						<aiAimMode>AimedShot</aiAimMode>
@@ -179,6 +184,11 @@
 						</targetParams>
 						<recoilPattern>Mounted</recoilPattern>
 					</Properties>
+					<AmmoUser>
+						<magazineSize>150</magazineSize>
+						<reloadTime>7.9</reloadTime>
+						<ammoSet>AmmoSet_6x18mmCharged</ammoSet>
+					</AmmoUser>
 					<FireModes>
 						<aiUseBurstMode>FALSE</aiUseBurstMode>
 						<aiAimMode>AimedShot</aiAimMode>

--- a/Patches/Pulsefire Turret/PulsefireTurret_CombatExtendedPatch.xml
+++ b/Patches/Pulsefire Turret/PulsefireTurret_CombatExtendedPatch.xml
@@ -140,7 +140,7 @@
 					</AmmoUser>
 					<FireModes>
 						<aiUseBurstMode>FALSE</aiUseBurstMode>
-						<aiAimMode>SuppressFire</aiAimMode>
+						<aiAimMode>AimedShot</aiAimMode>
 						<noSnapshot>true</noSnapshot>
 						<noSingleShot>true</noSingleShot>
 					</FireModes>
@@ -181,7 +181,7 @@
 					</AmmoUser>
 					<FireModes>
 						<aiUseBurstMode>FALSE</aiUseBurstMode>
-						<aiAimMode>SuppressFire</aiAimMode>
+						<aiAimMode>AimedShot</aiAimMode>
 						<noSnapshot>true</noSnapshot>
 						<noSingleShot>true</noSingleShot>
 					</FireModes>

--- a/Patches/Pulsefire Turret/PulsefireTurret_CombatExtendedPatch.xml
+++ b/Patches/Pulsefire Turret/PulsefireTurret_CombatExtendedPatch.xml
@@ -71,7 +71,7 @@
 						<magazineSize>40</magazineSize>
 						<reloadTime>5.9</reloadTime>
 						<ammoSet>AmmoSet_12x72mmCharged</ammoSet>
-					</AmmoUser>					
+					</AmmoUser>
 					<FireModes>
 						<aiUseBurstMode>FALSE</aiUseBurstMode>
 						<aiAimMode>AimedShot</aiAimMode>


### PR DESCRIPTION
## Additions

Fixed Erroneous aiming, changing from suppression to aimed turret shots would disable the turrets entirely. Set default to aimed shot and added fill percent

## Testing

Check tests you have performed:
- [Y] Compiles without warnings
- [Y] Game runs without errors
- [Y] (For compatibility patches) ...with and without patched mod loaded
- [Y] Playtested a colony (specify how long)
