### PR TITLE
Interceptor comp fix

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -704,9 +704,9 @@ namespace CombatExtended
             {
                 return false;
             }
-            if (!CE_Utility.IntersectionPoint(lastExactPos, newExactPos, shieldPosition, radius, out Vector3[] sect))
+            if (CE_Utility.IntersectionPoint(lastExactPos, newExactPos, shieldPosition, radius, out Vector3[] sect))
             {
-                ExactPosition = newExactPos = sect[0];
+                ExactPosition = newExactPos = sect.OrderBy(x => (OriginIV3.ToVector3() - x).sqrMagnitude).First();
                 landed = true;
             }
             else


### PR DESCRIPTION
## Fixed

- Inverted intersection check
- Fixed hit position

## Reasoning

- Shield's doesn't work compeletly 
- Hit position can be incorrect

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (tested centurion shield)
