### PR TITLE
Various XML Fixes

### DIFF
--- a/Defs/Ammo/Advanced/164x284mmDemoShell.xml
+++ b/Defs/Ammo/Advanced/164x284mmDemoShell.xml
@@ -16,7 +16,7 @@
 		<ammoTypes>
 			<Ammo_164x284mmDemo>Bullet_164x284mmDemo</Ammo_164x284mmDemo>
 		</ammoTypes>
-		<similarTo>AmmoSet_MechShell</similarTo>
+		<similarTo>AmmoSet_MechShell_Demo</similarTo>
 	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Generic/Mech.xml
+++ b/Defs/Ammo/Generic/Mech.xml
@@ -37,6 +37,14 @@
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
 
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_MechShell_Demo</defName>
+		<label>mech shell</label>
+		<ammoTypes>
+			<Ammo_MechShell_Demo>Bullet_164x284mmDemo</Ammo_MechShell_Demo>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
+
 	<!-- ============= Ammo ============= -->
 
 	<!-- Mech Charged -->
@@ -87,7 +95,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="MechShellAmmo">
 		<defName>Ammo_MechShell</defName>
-		<label>Mechanoid shell</label>
+		<label>mechanoid shell</label>
 		<graphicData>
 			<texPath>Things/Ammo/FuelCell/Large</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -98,6 +106,32 @@
 				<explosiveRadius>1.9</explosiveRadius>
 				<damageAmountBase>5</damageAmountBase>
 				<explosiveDamageType>PrometheumFlame</explosiveDamageType>
+				<explosiveExpandPerStackcount>0.10</explosiveExpandPerStackcount>
+				<startWickHitPointsPercent>0.33</startWickHitPointsPercent>
+				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+				<explodeOnKilled>True</explodeOnKilled>
+				<wickTicks>60~300</wickTicks>
+			</li>
+		</comps>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="164x284mmDemoBase">
+		<defName>Ammo_MechShell_Demo</defName>
+		<label>mech shell (demo)</label>
+		<graphicData>
+			<texPath>Things/Ammo/FuelCell/Large</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>10.97</MarketValue>
+		</statBases>
+		<ammoClass>Demolition</ammoClass>
+		<detonateProjectile>Bullet_164x284mmDemo</detonateProjectile>
+		<comps>
+			<li Class="CompProperties_Explosive">
+				<explosiveRadius>1</explosiveRadius>
+				<damageAmountBase>18</damageAmountBase>
+				<explosiveDamageType>Thermobaric</explosiveDamageType>
 				<explosiveExpandPerStackcount>0.10</explosiveExpandPerStackcount>
 				<startWickHitPointsPercent>0.33</startWickHitPointsPercent>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
@@ -148,7 +182,7 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_12x64mmCharged>200</Ammo_12x64mmCharged>
+			<Ammo_MechCharged>200</Ammo_MechCharged>
 		</products>
 		<skillRequirements>
 			<Crafting>8</Crafting>
@@ -195,7 +229,54 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_80x256mmFuel_Incendiary>5</Ammo_80x256mmFuel_Incendiary>
+			<Ammo_MechShell>5</Ammo_MechShell>
+		</products>
+		<skillRequirements>
+			<Crafting>8</Crafting>
+		</skillRequirements>
+		<workAmount>3730</workAmount><!-- 10% more work -->
+	</RecipeDef>
+
+	<RecipeDef ParentName="ChargeAmmoRecipeBase" MayRequire="Ludeon.RimWorld.Biotech">
+		<defName>MakeAmmo_MechShell_Demo</defName>
+		<label>make Mech Shell (Demo) x5</label>
+		<description>Craft 5 Mech Shells (Demo).</description>
+		<jobString>Making Mech Shells (Demo).</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>FSX</li>
+					</thingDefs>
+				</filter>
+				<count>3</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>10</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>2</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>FSX</li>
+				<li>Steel</li>
+				<li>ComponentIndustrial</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_MechShell_Demo>5</Ammo_MechShell_Demo>
 		</products>
 		<skillRequirements>
 			<Crafting>8</Crafting>

--- a/Defs/Ammo/Lasers/BaseLaserProjectiles.xml
+++ b/Defs/Ammo/Lasers/BaseLaserProjectiles.xml
@@ -22,16 +22,6 @@
 			<isInstant>true</isInstant>
 			<damageDef>Bullet</damageDef>
 		</projectile>
-		<modExtensions>
-			<li Class="ProjectileImpactFX.EffectProjectileExtension">
-				<explosionMote>true</explosionMote>
-				<explosionMoteSize>0.25</explosionMoteSize>
-				<ImpactMoteDef>Mote_YellowSparkFlash</ImpactMoteDef>
-				<ImpactMoteSize>1</ImpactMoteSize>
-				<ImpactGlowMoteDef>Mote_ExplosionFlash</ImpactGlowMoteDef>
-				<ImpactGlowMoteSize>2.5</ImpactGlowMoteSize>
-			</li>
-		</modExtensions>
 	</ThingDef>
 
 	<!-- ================== White Laser ================== -->

--- a/Defs/HediffDefs/Hediffs_CE.xml
+++ b/Defs/HediffDefs/Hediffs_CE.xml
@@ -11,6 +11,7 @@
 		<description>Wearing a gas mask</description>
 		<makesSickThought>false</makesSickThought>
 		<scenarioCanAdd>false</scenarioCanAdd>
+		<everCurableByItem>false</everCurableByItem>
 		<stages>
 			<li>
 				<label>wearing</label>

--- a/Patches/Halo - UNSC Armoury/Weapons_Laser.xml
+++ b/Patches/Halo - UNSC Armoury/Weapons_Laser.xml
@@ -87,16 +87,6 @@
 									<armorPenetrationBlunt>0.001</armorPenetrationBlunt>
 								</projectile>
 								<seam>2</seam>
-								<modExtensions>
-									<li Class="ProjectileImpactFX.EffectProjectileExtension">
-										<explosionMote>true</explosionMote>
-										<explosionMoteSize>1</explosionMoteSize>
-										<ImpactMoteDef>Mote_SparkFlash</ImpactMoteDef>
-										<ImpactMoteSize>1</ImpactMoteSize>
-										<ImpactGlowMoteDef>Mote_ExplosionFlash</ImpactGlowMoteDef>
-										<ImpactGlowMoteSize>2.5</ImpactGlowMoteSize>
-									</li>
-								</modExtensions>
 							</ThingDef>
 
 							<!-- === Spartan Laser Battery === -->

--- a/Patches/Vanilla Factions Expanded - Deserters/RangedSpacer.xml
+++ b/Patches/Vanilla Factions Expanded - Deserters/RangedSpacer.xml
@@ -167,7 +167,6 @@
 							<ammoTypes>
 								<Ammo_FletcherDart>Bullet_FletchlingDart</Ammo_FletcherDart>
 							</ammoTypes>
-							<similarTo>AmmoSet_ChargedHeavy</similarTo>
 						</CombatExtended.AmmoSetDef>
 
 						<ThingDef ParentName="BaseBulletCE">

--- a/Patches/Vanilla Factions Expanded - Empire/Ammo/FletcherRifleRound.xml
+++ b/Patches/Vanilla Factions Expanded - Empire/Ammo/FletcherRifleRound.xml
@@ -48,7 +48,6 @@
 								<MarketValue>6.78</MarketValue>
 							</statBases>
 							<ammoClass>Fletcher</ammoClass>
-							<isMortarAmmo>true</isMortarAmmo>
 							<modExtensions>
 								<li Class="VFED.ContrabandExtension" MayRequire="OskarPotocki.VFE.Deserters">
 									<category>VFED_Imperial</category>

--- a/Patches/Vanilla Factions Expanded - Empire/Ammo/FletcherRifleRound.xml
+++ b/Patches/Vanilla Factions Expanded - Empire/Ammo/FletcherRifleRound.xml
@@ -48,6 +48,7 @@
 								<MarketValue>6.78</MarketValue>
 							</statBases>
 							<ammoClass>Fletcher</ammoClass>
+							<isMortarAmmo>true</isMortarAmmo>
 							<modExtensions>
 								<li Class="VFED.ContrabandExtension" MayRequire="OskarPotocki.VFE.Deserters">
 									<category>VFED_Imperial</category>

--- a/Patches/Warcaskets - Adeptus Astartes/Ammo/MeltaGun.xml
+++ b/Patches/Warcaskets - Adeptus Astartes/Ammo/MeltaGun.xml
@@ -43,14 +43,6 @@
 						<armorPenetrationSharp>500</armorPenetrationSharp>
 						<armorPenetrationBlunt>0.001</armorPenetrationBlunt><!-- The overall pressure exerted by a laser beam striking something is, unsuprisingly, negligable. -->
 					</projectile>
-					<modExtensions>
-						<li Class="ProjectileImpactFX.EffectProjectileExtension">
-							<explosionMote>true</explosionMote>
-							<explosionMoteSize>0.5</explosionMoteSize>
-							<ImpactMoteDef>Mote_MeltaFlash</ImpactMoteDef>
-							<ImpactMoteSize>2.5</ImpactMoteSize>
-						</li>
-					</modExtensions>
 				</ThingDef>
 
 			</value>


### PR DESCRIPTION
## Changes
- Remove ModExtension for ProjectileFX from a few beam projectiles, as they currently cause errors.
- Fix issue with the 164x284mm Demo shell in Generic Ammo mode caused by the generic ammoset lacking the correct ammo type. Added an appropriate new ammo item for that purpose.
- Fix Gas Mask hediff being "curable" by mech healer serum. Closes #2865.

## Reasoning
- The ProjectileFX errors can probably eventually be fixed, but the offending XML should be removed for the time being, as it'll likely need reformatted anyway, given the new ProjectileFX system.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
