### PR TITLE
Intersection improvment

### DIFF
--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -988,13 +988,19 @@ namespace CombatExtended
         /// <param name="radius">The radius of the circle</param>
         /// <param name="map">Used for debug higlight</param>
         /// <returns><code>Vector3[] { Vector3.zero, Vector3.zero }</code> if there's no intersection, othrewise returns two intersection points</returns>
-        public static bool IntersectionPoint(Vector3 p1, Vector3 p2, Vector3 center, float radius, out Vector3[] sect, Map map = null)
+        public static bool IntersectionPoint(Vector3 p1, Vector3 p2, Vector3 center, float radius, out Vector3[] sect, bool catchOutbound = true, Map map = null)
         {
+            sect = new Vector3[2];
             Log.Clear();
             map?.debugDrawer.debugCells.Clear();
             map?.debugDrawer.debugLines.Clear();
             map?.debugDrawer.DebugDrawerUpdate();
             map?.debugDrawer.FlashLine(p1.ToIntVec3(), p2.ToIntVec3(), color: SimpleColor.Red);
+            float radSq = radius * radius;
+            if (!catchOutbound && (p1 - center).sqrMagnitude < radSq)
+            {
+                return false;
+            }
             Vector3 closestOnLine; //https://stackoverflow.com/questions/67144563/how-to-get-the-shortest-distance-from-a-point-in-space-to-a-line-segment
             if (Vector3.Dot(p1 - p2, center - p1) > 0)
             {
@@ -1010,8 +1016,7 @@ namespace CombatExtended
             }
 
             float distance = (closestOnLine - center).sqrMagnitude;
-            sect = new Vector3[2];
-            float radSq = radius * radius;
+            
 
             Log.Message($"p1 = {p1}, p2 = {p2}, center = {center}, radius = {radius}");
             Log.Message($"closest point on line = {closestOnLine}, clPoint - center = {closestOnLine - center}, distance = {distance}");

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -1007,13 +1007,14 @@ namespace CombatExtended
 
             // direction vector
             Vector3 direction = lp2 - lp1;
-
             float a = direction.sqrMagnitude;
+            float distance = Mathf.Sqrt(a);
 
-            float radSq_a = a + radSq;
+
+            float rad_a_sq = (distance + radius) * (distance + radius);
 
             // either endpoint is farther from the local origin than the projectile moved this tick plus the shield radius
-            if (lp1sq > radSq_a || lp2sq > radSq_a)
+            if (lp1sq > rad_a_sq || lp2sq > rad_a_sq)
             {
                 return false;
             }

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -997,7 +997,7 @@ namespace CombatExtended
             Vector3 lp2 = p2 - center;
 
             // If we obviously don't cross, early out.
-            if (lp1.sqrMagnitude < radSq && lp2.sqrMagnitude < radSq)
+            if (lp1.sqrMagnitude > radSq && lp2.sqrMagnitude > radSq)
             {
                 return false;
             }

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -1016,7 +1016,6 @@ namespace CombatExtended
             }
 
             float distance = (closestOnLine - center).sqrMagnitude;
-            
 
             Log.Message($"p1 = {p1}, p2 = {p2}, center = {center}, radius = {radius}");
             Log.Message($"closest point on line = {closestOnLine}, clPoint - center = {closestOnLine - center}, distance = {distance}");

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -996,8 +996,11 @@ namespace CombatExtended
             Vector3 lp1 = p1 - center;
             Vector3 lp2 = p2 - center;
 
-            // If we obviously don't cross, early out.
-            if (lp1.sqrMagnitude > radSq && lp2.sqrMagnitude > radSq)
+            var lp1sq = lp1.sqrMagnitude;
+            var lp2sq = lp2.sqrMagnitude;
+
+            // If we start and end inside the radius, early out..
+            if (lp1sq < radSq && lp2sq < radSq)
             {
                 return false;
             }
@@ -1006,11 +1009,19 @@ namespace CombatExtended
             Vector3 direction = lp2 - lp1;
 
             float a = direction.sqrMagnitude;
+
+            // either endpoint is farther from the local origin than the projectile moved this tick
+            if (lp1sq > a || lp2sq > a)
+            {
+                return false;
+            }
+
             float b = 2 * (direction.x * lp1.x + direction.y * lp1.y + direction.z * lp1.z);
             float c = lp1.sqrMagnitude - radSq;
 
             float det = b * b - 4 * a * c; //b²-4ac
-            if (a < float.Epsilon || det < 0)  // origin and destination are the same, or the determinate is negative
+            // determinate is negative
+            if (det < 0)
             {
                 //  line does not intersect
                 return false;

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -1010,8 +1010,10 @@ namespace CombatExtended
 
             float a = direction.sqrMagnitude;
 
-            // either endpoint is farther from the local origin than the projectile moved this tick
-            if (lp1sq > a || lp2sq > a)
+            float radSq_a = a + radSq;
+
+            // either endpoint is farther from the local origin than the projectile moved this tick plus the shield radius
+            if (lp1sq > radSq_a || lp2sq > radSq_a)
             {
                 return false;
             }

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -886,6 +886,10 @@ namespace CombatExtended
                 // Check for collision
                 if (thing == intendedTargetThing || def.projectile.alwaysFreeIntercept || thing.Position.DistanceTo(OriginIV3) >= minCollisionDistance)
                 {
+                    if (!CanCollideWith(thing, out _))
+                    {
+                        continue;
+                    }
                     if (BlockerRegistry.CheckForCollisionBetweenCallback(this, LastPos, thing.TrueCenter()))
                     {
                         return true;
@@ -894,10 +898,6 @@ namespace CombatExtended
                     var newPosIV3 = thing.TrueCenter().ToIntVec3();
                     // Iterate through all cells between the last and the THING
                     // INCLUDING[!!!] THE LAST AND NEW POSITIONS!
-                    if (!CanCollideWith(thing, out _))
-                    {
-                        continue;
-                    }
                     var cells = GenSight.PointsOnLineOfSight(lastPosIV3, newPosIV3).Union(new[] { lastPosIV3, newPosIV3 }).Distinct().OrderBy(x => (x.ToVector3Shifted() - LastPos).MagnitudeHorizontalSquared());
                     foreach (var _cell in cells)
                     {

--- a/Source/CombatExtended/Compatibility/VanillaPsycastExpanded.cs
+++ b/Source/CombatExtended/Compatibility/VanillaPsycastExpanded.cs
@@ -78,11 +78,7 @@ namespace CombatExtended.Compatibility
             {
                 Vector3 shieldPosition = interceptor.pawn.Position.ToVector3Shifted().Yto0();
                 float radius = interceptor.OverlaySize;
-                if ((new Vector3(projectile.origin.x, 0, projectile.origin.y) - shieldPosition).sqrMagnitude < radius * radius) // Ensure the shield does not block outgoing projectiles
-                {
-                    return false;
-                }
-                if (CE_Utility.IntersectionPoint(from.Yto0(), newExactPos.Yto0(), shieldPosition, radius, out Vector3[] sect))
+                if (CE_Utility.IntersectionPoint(from.Yto0(), newExactPos.Yto0(), shieldPosition, radius, out Vector3[] sect, false, projectile.Map))
                 {
                     OnIntercepted(interceptor, projectile, sect);
                     return true;


### PR DESCRIPTION
## Changes

- Inverted crossing check
- Moved additional collision check after CanCollideWith check (can help to avoid incorrect early interception)

## Reasoning

- Projectiles intercepted instantly:
<img width="1207" alt="image" src="https://github.com/CombatExtended-Continued/CombatExtended/assets/78953324/9450a9ef-2ed0-4b40-beb0-d49beb8c8117">



## Problems

If p1 and p2 outside of shield but line between them intersect shield, then method returns false.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (tested Centurion shields and VPE shield)
