### PR TITLE
Add explosion radius highlight

### DIFF
--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -1089,6 +1089,10 @@ namespace CombatExtended
             return true;
         }
 
+        /// <summary>
+        /// Highlight the explosion radius for this projectile.
+        /// This is mostly a carbon copy of the corresponding vanilla logic.
+        /// </summary>
         public override float HighlightFieldRadiusAroundTarget(out bool needLOSToCenter)
         {
             needLOSToCenter = true;
@@ -1097,13 +1101,13 @@ namespace CombatExtended
             {
                 return 0f;
             }
-            float num = projectile.projectile.explosionRadius + projectile.projectile.explosionRadiusDisplayPadding;
+            float explosionRadiusForDisplay = projectile.projectile.explosionRadius + projectile.projectile.explosionRadiusDisplayPadding;
             float forcedMissRadius = this.verbProps.ForcedMissRadius;
             if (forcedMissRadius > 0f && this.verbProps.burstShotCount > 1)
             {
-                num += forcedMissRadius;
+                explosionRadiusForDisplay += forcedMissRadius;
             }
-            return num;
+            return explosionRadiusForDisplay;
         }
 
         private float GetMinCollisionDistance(float targetDistance)

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -1089,6 +1089,23 @@ namespace CombatExtended
             return true;
         }
 
+        public override float HighlightFieldRadiusAroundTarget(out bool needLOSToCenter)
+        {
+            needLOSToCenter = true;
+            ThingDef projectile = this.Projectile;
+            if (projectile == null)
+            {
+                return 0f;
+            }
+            float num = projectile.projectile.explosionRadius + projectile.projectile.explosionRadiusDisplayPadding;
+            float forcedMissRadius = this.verbProps.ForcedMissRadius;
+            if (forcedMissRadius > 0f && this.verbProps.burstShotCount > 1)
+            {
+                num += forcedMissRadius;
+            }
+            return num;
+        }
+
         private float GetMinCollisionDistance(float targetDistance)
         {
             var shortRangeMinCollisionDistance = 1.5f;


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Adds a radius highlight when aiming area of effect weapons. I didn't write this code, it was all in vanilla's `Verb_LaunchProjectile`

![img](https://i.imgur.com/BPzSOsL.png)

## Reasoning

Why did you choose to implement things this way, e.g.
- Easier to see how big the explosion will be

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] Playtested a colony (specify how long)
