### PR TITLE
Patch Vanilla Factions Expanded - Tribals

### DIFF
--- a/Patches/Vanilla Factions Expanded - Tribals/Apparel_Tribals.xml
+++ b/Patches/Vanilla Factions Expanded - Tribals/Apparel_Tribals.xml
@@ -30,16 +30,16 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VFET_Apparel_TribalWar"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>0.45</ArmorRating_Sharp>
+						<ArmorRating_Sharp>0.15</ArmorRating_Sharp>
 						<Bulk>5</Bulk>
-						<WornBulk>2</WornBulk>
+						<WornBulk>1.5</WornBulk>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VFET_Apparel_TribalWar"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>0.9</ArmorRating_Blunt>
+						<ArmorRating_Blunt>0.3</ArmorRating_Blunt>
 					</value>
 				</li>
 

--- a/Patches/Vanilla Factions Expanded - Tribals/Apparel_Tribals.xml
+++ b/Patches/Vanilla Factions Expanded - Tribals/Apparel_Tribals.xml
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Factions Expanded - Tribals</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<!-- Light Tribalwear -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VFET_Apparel_TribalLight"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
+						<Bulk>1</Bulk>
+					</value>
+				</li>
+
+				<!-- Heavy Tribalwear -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VFET_Apparel_TribalHeavy"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
+						<Bulk>1</Bulk>
+					</value>
+				</li>
+
+				<!-- War Tribalwear -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VFET_Apparel_TribalWar"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>0.45</ArmorRating_Sharp>
+						<Bulk>5</Bulk>
+						<WornBulk>2</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VFET_Apparel_TribalWar"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>0.9</ArmorRating_Blunt>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Vanilla Factions Expanded - Tribals/ThingDefs_WeaponsMelee.xml
+++ b/Patches/Vanilla Factions Expanded - Tribals/ThingDefs_WeaponsMelee.xml
@@ -1,0 +1,100 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Factions Expanded - Tribals</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<!-- One-handed Tags -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName = "VFET_Stake" or defName="VFET_Chunk"]/weaponTags</xpath>
+					<value>
+						<li>CE_OneHandedWeapon</li>
+					</value>
+				</li>
+
+				<!-- Rock -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VFET_Chunk"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>rock</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>3</power>
+								<cooldownTime>1.66</cooldownTime>
+								<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>0.75</armorPenetrationBlunt>
+							</li>
+						</tools>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VFET_Chunk"]/statBases</xpath>
+					<value>
+						<Bulk>0.5</Bulk>
+						<MeleeCounterParryBonus>0.1</MeleeCounterParryBonus>
+					</value>
+				</li>
+
+				<!-- Stake -->
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VFET_Stake"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>handle</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>4</power>
+								<chanceFactor>0.33</chanceFactor>
+								<cooldownTime>1.4</cooldownTime>
+								<armorPenetrationBlunt>0.65</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>point</label>
+								<capacities>
+									<li>Stab</li>
+								</capacities>
+								<power>6.5</power>
+								<cooldownTime>1.4</cooldownTime>
+								<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>0.28</armorPenetrationSharp>
+								<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+							</li>
+						</tools>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VFET_Stake"]/statBases</xpath>
+					<value>
+						<Bulk>0.25</Bulk>
+						<MeleeCounterParryBonus>0.1</MeleeCounterParryBonus>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VFET_Stake"]</xpath>
+					<value>
+						<equippedStatOffsets>
+							<MeleeCritChance>0.08</MeleeCritChance>
+							<MeleeParryChance>0.12</MeleeParryChance>
+							<MeleeDodgeChance>0.05</MeleeDodgeChance>
+						</equippedStatOffsets>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Vanilla Factions Expanded - Tribals/ThingDefs_WeaponsMelee.xml
+++ b/Patches/Vanilla Factions Expanded - Tribals/ThingDefs_WeaponsMelee.xml
@@ -44,7 +44,6 @@
 				</li>
 
 				<!-- Stake -->
-
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VFET_Stake"]/tools</xpath>
 					<value>

--- a/Patches/Vanilla Factions Expanded - Tribals/ThingDefs_WeaponsRanged.xml
+++ b/Patches/Vanilla Factions Expanded - Tribals/ThingDefs_WeaponsRanged.xml
@@ -8,31 +8,6 @@
 		<match Class="PatchOperationSequence">
 			<operations>
 
-				<!-- === Throwingspike === -->
-	
-				<li Class="PatchOperationAdd">
-					<xpath>Defs</xpath>
-					<value>
-
-						<!-- This dummy parent just provides a workaround so VFE - Tribal can be loaded before CE. -->
-						<ThingDef ParentName="BaseWeaponAndAmmoNeolithic" Name="SpikeBase_VFET" Abstract="True" />
-
-						<ThingDef ParentName="BasePilumProjectile">
-							<defName>Tribal_Spike_Thrown</defName>
-							<label>throwspike</label>
-							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<damageAmountBase>14</damageAmountBase>
-								<speed>10</speed>
-								<armorPenetrationBlunt>6.44</armorPenetrationBlunt>
-								<armorPenetrationSharp>3.5</armorPenetrationSharp>
-								<preExplosionSpawnChance>0.70</preExplosionSpawnChance>
-								<preExplosionSpawnThingDef>VFET_Throwspikes</preExplosionSpawnThingDef>
-							</projectile>
-						</ThingDef>
-
-					</value>
-				</li>
-
 				<!-- One-handed Tags -->
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName = "VFET_Throwspikes"]/weaponTags</xpath>
@@ -90,6 +65,7 @@
 						<verbs>
 							<li Class="CombatExtended.VerbPropertiesCE">
 								<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+								<hasStandardCommand>true</hasStandardCommand>
 								<defaultProjectile>Tribal_Spike_Thrown</defaultProjectile>
 								<warmupTime>1</warmupTime>
 								<range>10</range>
@@ -117,11 +93,27 @@
 					</value>
 				</li>
 
-				<!-- === Add Projectiles and Recipes for the javelin. === -->
+				<!-- === Add Projectiles and Recipes for the throwspikes. === -->
 
 				<li Class="PatchOperationAdd">
 					<xpath>Defs</xpath>
 					<value>
+
+						<!-- This dummy parent just provides a workaround so VFE - Tribal can be loaded before CE. -->
+						<ThingDef ParentName="BaseWeaponAndAmmoNeolithic" Name="SpikeBase_VFET" Abstract="True" />
+
+						<ThingDef ParentName="BasePilumProjectile">
+							<defName>Tribal_Spike_Thrown</defName>
+							<label>throwspike</label>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<damageAmountBase>14</damageAmountBase>
+								<speed>10</speed>
+								<armorPenetrationBlunt>3.44</armorPenetrationBlunt>
+								<armorPenetrationSharp>0.45</armorPenetrationSharp>
+								<preExplosionSpawnChance>0.70</preExplosionSpawnChance>
+								<preExplosionSpawnThingDef>VFET_Throwspikes</preExplosionSpawnThingDef>
+							</projectile>
+						</ThingDef>
 
 						<RecipeDef ParentName="AmmoRecipeNeolithicBase">
 							<defName>MakeAmmo_VFET_Throwspikes</defName>

--- a/Patches/Vanilla Factions Expanded - Tribals/ThingDefs_WeaponsRanged.xml
+++ b/Patches/Vanilla Factions Expanded - Tribals/ThingDefs_WeaponsRanged.xml
@@ -103,6 +103,9 @@
 						<ThingDef ParentName="BaseWeaponAndAmmoNeolithic" Name="SpikeBase_VFET" Abstract="True" />
 
 						<ThingDef ParentName="BasePilumProjectile">
+							<graphicData>
+								<texPath>Projectile/Projectile_Throwspikes</texPath>
+							</graphicData>
 							<defName>Tribal_Spike_Thrown</defName>
 							<label>throwspike</label>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Patches/Vanilla Factions Expanded - Tribals/ThingDefs_WeaponsRanged.xml
+++ b/Patches/Vanilla Factions Expanded - Tribals/ThingDefs_WeaponsRanged.xml
@@ -1,0 +1,166 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Factions Expanded - Tribals</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<!-- === Javelin === -->
+
+	
+				<li Class="PatchOperationAdd">
+					<xpath>Defs</xpath>
+					<value>
+
+						<!-- This dummy parent just provides a workaround so VFE - Tribal can be loaded before CE. -->
+						<ThingDef ParentName="BaseWeaponAndAmmoNeolithic" Name="SpikeBase_VFET" Abstract="True" />
+
+						<ThingDef ParentName="BasePilumProjectile">
+							<defName>Tribal_Spike_Thrown</defName>
+							<label>throwspike</label>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<damageAmountBase>14</damageAmountBase>
+								<speed>10</speed>
+								<armorPenetrationBlunt>6.44</armorPenetrationBlunt>
+								<armorPenetrationSharp>3.5</armorPenetrationSharp>
+								<preExplosionSpawnChance>0.70</preExplosionSpawnChance>
+								<preExplosionSpawnThingDef>VFET_Throwspikes</preExplosionSpawnThingDef>
+							</projectile>
+						</ThingDef>
+
+					</value>
+				</li>
+
+				<!-- One-handed Tags -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName = "VFET_Throwspikes"]/weaponTags</xpath>
+					<value>
+						<li>CE_OneHandedWeapon</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAttributeSet">
+					<xpath>Defs/ThingDef[defName="VFET_Throwspikes"]</xpath>
+					<attribute>ParentName</attribute>
+					<value>SpikeBase_VFET</value>
+				</li>
+
+				<li Class="PatchOperationAttributeAdd">
+					<xpath>Defs/ThingDef[defName="VFET_Throwspikes"]</xpath>
+					<attribute>Class</attribute>
+					<value>CombatExtended.AmmoDef</value>
+				</li>
+
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/ThingDef[defName="VFET_Throwspikes"]/costList</xpath>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VFET_Throwspikes"]</xpath>
+					<value>
+						<techLevel>Neolithic</techLevel>
+					</value>
+				</li>
+
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/ThingDef[defName="VFET_Throwspikes"]/recipeMaker</xpath>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VFET_Throwspikes"]/statBases</xpath>
+					<value>
+						<statBases>
+							<MarketValue>0.7</MarketValue>
+							<SightsEfficiency>1.0</SightsEfficiency>
+							<ShotSpread>1.5</ShotSpread>
+							<SwayFactor>2.5</SwayFactor>
+							<Bulk>1.5</Bulk>
+							<Mass>1</Mass>
+							<RangedWeapon_Cooldown>1.3</RangedWeapon_Cooldown>
+						</statBases>
+						<stackLimit>50</stackLimit>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VFET_Throwspikes"]/verbs</xpath>
+					<value>
+						<verbs>
+							<li Class="CombatExtended.VerbPropertiesCE">
+								<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+								<defaultProjectile>Tribal_Spike_Thrown</defaultProjectile>
+								<warmupTime>1</warmupTime>
+								<range>10</range>
+								<soundCast>Interact_BeatFire</soundCast>
+							</li>
+						</verbs>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VFET_Throwspikes"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>limb</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>4</power>
+								<cooldownTime>1.35</cooldownTime>
+								<armorPenetrationBlunt>1.25</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Shaft</linkedBodyPartsGroup>
+							</li>
+						</tools>
+					</value>
+				</li>
+
+				<!-- === Add Projectiles and Recipes for the javelin. === -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs</xpath>
+					<value>
+
+						<RecipeDef ParentName="AmmoRecipeNeolithicBase">
+							<defName>MakeAmmo_VFET_Throwspikes</defName>
+							<label>make throwspikes x20</label>
+							<description>Craft 20 throwspikes.</description>
+							<workSpeedStat>GeneralLaborSpeed</workSpeedStat>
+							<workSkill>Crafting</workSkill>
+							<recipeUsers>
+								<li>CraftingSpot</li>
+							</recipeUsers>
+							<effectWorking>Smelt</effectWorking>
+							<unfinishedThingDef>UnfinishedWeapon</unfinishedThingDef>
+							<workAmount>800</workAmount>
+							<jobString>Making throwspikes.</jobString>
+							<ingredients>
+								<li>
+									<filter>
+										<thingDefs>
+											<li>WoodLog</li>
+										</thingDefs>
+									</filter>
+									<count>10</count>
+								</li>
+							</ingredients>
+							<fixedIngredientFilter>
+								<thingDefs>
+									<li>WoodLog</li>
+								</thingDefs>
+							</fixedIngredientFilter>
+							<products>
+								<VFET_Throwspikes>20</VFET_Throwspikes>
+							</products>
+						</RecipeDef>
+
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Vanilla Factions Expanded - Tribals/ThingDefs_WeaponsRanged.xml
+++ b/Patches/Vanilla Factions Expanded - Tribals/ThingDefs_WeaponsRanged.xml
@@ -8,8 +8,7 @@
 		<match Class="PatchOperationSequence">
 			<operations>
 
-				<!-- === Javelin === -->
-
+				<!-- === Throwingspike === -->
 	
 				<li Class="PatchOperationAdd">
 					<xpath>Defs</xpath>

--- a/Patches/Vanilla Weapons Expanded - Tribal/Melee_Neolithic.xml
+++ b/Patches/Vanilla Weapons Expanded - Tribal/Melee_Neolithic.xml
@@ -187,7 +187,7 @@
 								<power>4</power>
 								<chanceFactor>0.33</chanceFactor>
 								<cooldownTime>1.2</cooldownTime>
-								<armorPenetration>0.071</armorPenetration>
+								<armorPenetrationBlunt>0.07</armorPenetrationBlunt>
 								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
 							</li>
 							<li Class="CombatExtended.ToolCE">
@@ -197,7 +197,8 @@
 								</capacities>
 								<power>9.5</power>
 								<cooldownTime>1.2</cooldownTime>
-								<armorPenetration>0.208</armorPenetration>
+								<armorPenetrationBlunt>0.45</armorPenetrationBlunt>
+								<armorPenetrationSharp>0.18</armorPenetrationSharp>
 								<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 							</li>
 						</tools>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -499,6 +499,7 @@ Vanilla Factions Expanded - Mechanoids	|
 Vanilla Factions Expanded - Medieval	|
 Vanilla Factions Expanded - Pirates |
 Vanilla Factions Expanded - Settlers	|
+Vanilla Factions Expanded - Tribals |
 Vanilla Factions Expanded - Vikings	|
 Vanilla Furniture Expanded - Production	|
 Vanilla Furniture Expanded -  Security |


### PR DESCRIPTION
## Additions
- Patch for Vanilla Factions Expanded - Tribals

## Changes
- Update armor penetration values in Vanilla Weapons Expanded - Tribal that were using the old armor penetration node.

## Reasoning
- New tribal gear is balanced on par with existing tribalwear and simple weapons.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
