### PR TITLE
Patch Vanilla Races Expanded - Archon

### DIFF
--- a/Patches/Vanilla Races Expanded - Archon/Apparel_Various.xml
+++ b/Patches/Vanilla Races Expanded - Archon/Apparel_Various.xml
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Races Expanded - Archon</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- Archoplate -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="VREA_Apparel_Archoplate"]/statBases</xpath>
+				<value>
+					<Bulk>50</Bulk>
+					<WornBulk>5</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VREA_Apparel_Archoplate"]/statBases/MaxHitPoints</xpath>
+				<value>
+					<MaxHitPoints>650</MaxHitPoints>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VREA_Apparel_Archoplate"]/statBases/VEF_EnergyShieldEnergyMaxApparel</xpath>
+				<value>
+					<VEF_EnergyShieldEnergyMaxApparel>7</VEF_EnergyShieldEnergyMaxApparel>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VREA_Apparel_Archoplate"]/statBases/Mass</xpath>
+				<value>
+					<Mass>25</Mass>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VREA_Apparel_Archoplate"]/statBases/Flammability</xpath>
+				<value>
+					<Flammability>0</Flammability>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VREA_Apparel_Archoplate"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>26</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VREA_Apparel_Archoplate"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>54</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="VREA_Apparel_Archoplate"]/equippedStatOffsets</xpath>
+				<value>
+					<CarryWeight>50</CarryWeight>
+					<CarryBulk>20</CarryBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="VREA_Apparel_Archoplate"]/apparel/bodyPartGroups</xpath>
+				<value>
+					<li>Hands</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="VREA_Apparel_Archoplate"]</xpath>
+				<value>
+					<li Class="CombatExtended.PartialArmorExt">
+						<stats>
+							<li>
+								<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+								<parts>
+									<li>Neck</li>
+								</parts>
+							</li>
+							<li>
+								<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+								<parts>
+									<li>Neck</li>
+								</parts>
+							</li>
+							<li>
+								<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+								<parts>
+									<li>Arm</li>
+								</parts>
+							</li>
+							<li>
+								<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+								<parts>
+									<li>Arm</li>
+								</parts>
+							</li>
+							<li>
+								<ArmorRating_Sharp>0.70</ArmorRating_Sharp>
+								<parts>
+									<li>Hand</li>
+								</parts>
+							</li>
+							<li>
+								<ArmorRating_Blunt>0.70</ArmorRating_Blunt>
+								<parts>
+									<li>Hand</li>
+								</parts>
+							</li>
+						</stats>
+					</li>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Vanilla Races Expanded - Archon/Archon_Misc.xml
+++ b/Patches/Vanilla Races Expanded - Archon/Archon_Misc.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Races Expanded - Archon</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- === Patch Leatherskin Armor Values === -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/GeneDef[defName="VRE_Leatherskin"]/statOffsets/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>1.5</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/GeneDef[defName="VRE_Leatherskin"]/statOffsets/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>1</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<!-- === Patch Archon Pawnkinds === -->
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[defName="ArchonWarrior"]</xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+						<primaryMagazineCount>
+							<min>6</min>
+							<max>12</max>
+						</primaryMagazineCount>
+					</li>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Vanilla Races Expanded - Archon/Melee_Archon.xml
+++ b/Patches/Vanilla Races Expanded - Archon/Melee_Archon.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Races Expanded - Archon</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- === Archoblade === -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VREA_MeleeWeapon_ArchobladeBladelink"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>handle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>5</power>
+							<cooldownTime>1.69</cooldownTime>
+							<chanceFactor>0.10</chanceFactor>
+							<armorPenetrationBlunt>0.80</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>edge</label>
+							<capacities>
+								<li>VREA_Sear</li>
+							</capacities>
+							<power>49</power>
+							<cooldownTime>1.37</cooldownTime>
+							<armorPenetrationBlunt>4.06</armorPenetrationBlunt>
+							<armorPenetrationSharp>50</armorPenetrationSharp>
+							<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="VREA_MeleeWeapon_ArchobladeBladelink"]/statBases</xpath>
+				<value>
+					<Bulk>10</Bulk>
+					<MeleeCounterParryBonus>1.42</MeleeCounterParryBonus>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="VREA_MeleeWeapon_ArchobladeBladelink"]</xpath>
+				<value>
+					<equippedStatOffsets>
+						<MeleeCritChance>1.00</MeleeCritChance>
+						<MeleeParryChance>0.60</MeleeParryChance>
+						<MeleeDodgeChance>0.53</MeleeDodgeChance>
+					</equippedStatOffsets>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -510,6 +510,7 @@ Vanilla Plants Expanded - Mushrooms  |
 Vanilla Psycasts Expanded   |
 Vanilla Psycasts Expanded - Hemosage  |
 Vanilla Races Expanded - Android  |
+Vanilla Races Expanded - Archon |
 Vanilla Races Expanded - Highmate  |
 Vanilla Races Expanded - Hussar  |
 Vanilla Races Expanded - Phytokin  |


### PR DESCRIPTION

## Additions
- Add patch for VRE - Archon
**Note:** The Archon shields require #2869 to intercept projectiles properly. 

## Reasoning
- Archon armor has slightly less protection than cataphract armor, but no leg or foot protection. It is lighter and less bulky (owing to superior archotech), making it better suited for melee fighting.
- Archoblade is plasma sword without stabbing attack and very high Sharp AP, as the weapon is described as "phasing through" armor.

## Alternatives
- Could change some armor values.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
