### PR TITLE
Update Rangers_CE_Patch_Spacer.xml

### DIFF
--- a/Patches/RH2 Faction - The Rangers/Rangers_CE_Patch_Spacer.xml
+++ b/Patches/RH2 Faction - The Rangers/Rangers_CE_Patch_Spacer.xml
@@ -30,7 +30,7 @@
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Bullet_6x24mmCharged</defaultProjectile>
 						<warmupTime>0.9</warmupTime>
-						<range>36</range>
+						<range>46</range>
 						<burstShotCount>3</burstShotCount>
 						<ticksBetweenBurstShots>8</ticksBetweenBurstShots>
 						<soundCast>RN2Shot_GenericCharge</soundCast>


### PR DESCRIPTION

## Changes

Rebalanced Charge carbine, slightly lower range than the vanilla charge rifle and slightly inferior in general but cheaper to produce


## Reasoning

Prior charge carbine was using rifle ammo at SMG range, changed to match other carbines and rifles from vanilla and other mods

## Testing

Check tests you have performed:
- [Y] Compiles without warnings
- [Y] Game runs without errors
- [Y] (For compatibility patches) ...with and without patched mod loaded
- [Y] Playtested a colony (specify how long) 2 hours
