### PR TITLE
always replace vehicle ammunition ThingFilter

### DIFF
--- a/Source/VehiclesCompat/VehiclesCompat/VehiclesCompat.cs
+++ b/Source/VehiclesCompat/VehiclesCompat/VehiclesCompat.cs
@@ -78,13 +78,17 @@ namespace CombatExtended.Compatibility.VehiclesCompat
                             if (asd != null)
                             {
                                 cetddme._ammoSet = asd;
-                                HashSet<ThingDef> allowedAmmo = (HashSet<ThingDef>)vtd.ammunition?.AllowedThingDefs;
-                                allowedAmmo.Clear();
+                                var ammunition = vtd.ammunition = new ThingFilter();
+                                vtd.genericAmmo = false;
+                                HashSet<ThingDef> allowedAmmo = (HashSet<ThingDef>)ammunition.AllowedThingDefs;
+
                                 foreach (var al in asd.ammoTypes)
                                 {
                                     allowedAmmo.Add(al.ammo);
                                     yield return al.ammo;
                                 }
+
+                                vtd.ammunition.ResolveReferences();
                             }
                         }
                     }


### PR DESCRIPTION

## Changes

When changing the ammunition allowed in VF vehicles, just replace the ammunition thing filter, and have it resolve its references.  


## Reasoning

Without this, vehicles not supplying an empty `<ammunition/>` node in their turret def would break.  Also, vehicles with only 1 type of ammo would behave oddly when scheduling reload jobs.

## Alternatives

Only add a new node, and try to re-run resolve references.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
