### PR TITLE
Update Patch_HighRoller_AddonAmmo.xml

### DIFF
--- a/Patches/Vanilla Weapons Expanded - Frontier/Patch_HighRoller_AddonAmmo.xml
+++ b/Patches/Vanilla Weapons Expanded - Frontier/Patch_HighRoller_AddonAmmo.xml
@@ -101,7 +101,7 @@
 
 							<CombatExtended.AmmoSetDef>
 								<defName>AmmoSet_GaussRevolver_HR</defName>
-								<label>Gauss Revolver</label>
+								<label>6mm Railgun</label>
 								<ammoTypes>
 									<Ammo_6mmRailgun_Sabot>Bullet_GaussRevolver_HR</Ammo_6mmRailgun_Sabot>
 								</ammoTypes>
@@ -109,7 +109,7 @@
 
 							<CombatExtended.AmmoSetDef>
 								<defName>AmmoSet_GaussRepeater_HR</defName>
-								<label>Gauss Repeater</label>
+								<label>6mm Railgun</label>
 								<ammoTypes>
 									<Ammo_6mmRailgun_Sabot>Bullet_GaussRepeater_HR</Ammo_6mmRailgun_Sabot>
 								</ammoTypes>
@@ -121,7 +121,7 @@
 
 							<ThingDef Class="CombatExtended.Lasers.LaserBeamDefCE" ParentName="BaseLaserBullet">
 								<defName>Bullet_GaussRevolver_HR</defName>
-								<label>Gauss revolver slug</label>
+								<label>gauss revolver shot</label>
 								<projectile Class="CombatExtended.ProjectilePropertiesCE">
 									<isInstant>true</isInstant>
 									<damageFalloff>False</damageFalloff>
@@ -141,7 +141,7 @@
 
 							<ThingDef Class="CombatExtended.Lasers.LaserBeamDefCE" ParentName="BaseLaserBullet">
 								<defName>Bullet_GaussRepeater_HR</defName>
-								<label>Gauss repeater slug</label>
+								<label>gauss repeater shot</label>
 								<projectile Class="CombatExtended.ProjectilePropertiesCE">
 									<isInstant>true</isInstant>
 									<damageFalloff>False</damageFalloff>
@@ -175,7 +175,7 @@
 
 							<CombatExtended.AmmoSetDef>
 								<defName>AmmoSet_SalvagedLaserRevolver_HR</defName>
-								<label>Salvaged Laser Revolver</label>
+								<label>laser charge</label>
 								<ammoTypes>
 									<Ammo_LaserChargePack>Bullet_Laser_SalvagedLaserRevolver_HR</Ammo_LaserChargePack>
 								</ammoTypes>
@@ -183,7 +183,7 @@
 
 							<CombatExtended.AmmoSetDef>
 								<defName>AmmoSet_SalvagedLaserRepeater_HR</defName>
-								<label>Salvaged Laser Repeater</label>
+								<label>laser charge</label>
 								<ammoTypes>
 									<Ammo_LaserChargePack>Bullet_Laser_SalvagedLaserRepeater_HR</Ammo_LaserChargePack>
 								</ammoTypes>
@@ -191,7 +191,7 @@
 
 							<CombatExtended.AmmoSetDef>
 								<defName>AmmoSet_SalvagedLaserHuntingRifle_HR</defName>
-								<label>Salvaged Laser Hunting Rifle</label>
+								<label>laser charge</label>
 								<ammoTypes>
 									<Ammo_LaserChargePack>Bullet_Laser_SalvagedLaserHuntingRifle_HR</Ammo_LaserChargePack>
 								</ammoTypes>
@@ -203,6 +203,7 @@
 
 							<ThingDef Class="CombatExtended.Lasers.LaserBeamDefCE" ParentName="LaserBulletGreen">
 								<defName>Bullet_Laser_SalvagedLaserRevolver_HR</defName>
+                <label>laser beam</label>
 								<projectile Class="CombatExtended.ProjectilePropertiesCE">
 									<damageDef>Bullet</damageDef>
 									<damageAmountBase>12</damageAmountBase>
@@ -220,6 +221,7 @@
 
 							<ThingDef Class="CombatExtended.Lasers.LaserBeamDefCE" ParentName="LaserBulletGreen">
 								<defName>Bullet_Laser_SalvagedLaserRepeater_HR</defName>
+                <label>laser beam</label>
 								<projectile Class="CombatExtended.ProjectilePropertiesCE">
 									<damageDef>Bullet</damageDef>
 									<damageAmountBase>20</damageAmountBase>
@@ -237,6 +239,7 @@
 
 							<ThingDef Class="CombatExtended.Lasers.LaserBeamDefCE" ParentName="LaserBulletGreen">
 								<defName>Bullet_Laser_SalvagedLaserHuntingRifle_HR</defName>
+                <label>laser beam</label>
 								<projectile Class="CombatExtended.ProjectilePropertiesCE">
 									<damageDef>Bullet</damageDef>
 									<damageAmountBase>24</damageAmountBase>


### PR DESCRIPTION
## Additions

None

## Changes

Changed ammoset labels and bullet labels.

## References

None

## Reasoning

Gauss weapons were displaying their weapon name for a caliber, where they should have been showing 6mm Railgun. Same with lasers and laser charges. 

Bullet labels now match the ones in VWE - Coilguns and VWE - Lasers.

## Alternatives

None

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony 15 minutes (included spawning in all changed items and firing all weapons so bullets were on-screen)
