### PR TITLE
Fix paladin reloading

### DIFF
--- a/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Paladin.xml
+++ b/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Paladin.xml
@@ -18,6 +18,13 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
+					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Paladin_MainTurret"]/chargePerAmmoCount</xpath>
+					<value>
+						<chargePerAmmoCount>1</chargePerAmmoCount>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Paladin_MainTurret"]/reloadTimer</xpath>
 					<value>
 						<reloadTimer>7.8</reloadTimer>


### PR DESCRIPTION
## Changes

- Fixed Paladin's `chargePerAmmoCount` to consume one ammo per shot.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded