### PR TITLE
Misc ammo housekeeping

### DIFF
--- a/Defs/Ammo/Advanced/5x35mmCharged.xml
+++ b/Defs/Ammo/Advanced/5x35mmCharged.xml
@@ -47,7 +47,7 @@
 		<statBases>
 			<MarketValue>0.26</MarketValue>
 		</statBases>
-		<ammoClass>Charged</ammoClass>
+		<ammoClass>ChargedAP</ammoClass>
 	</ThingDef>
 
 	<!-- ================== Projectiles ================== -->

--- a/Defs/Ammo/Advanced/66mmThermalBolt.xml
+++ b/Defs/Ammo/Advanced/66mmThermalBolt.xml
@@ -16,7 +16,7 @@
 		<ammoTypes>
 			<Ammo_66mmThermalBolt_Incendiary>Bullet_66mmThermalBolt_Incendiary</Ammo_66mmThermalBolt_Incendiary>
 		</ammoTypes>
-		<similarTo>AmmoSet_MechShell</similarTo>
+		<similarTo>AmmoSet_MechShell_Incendiary</similarTo>
 	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Advanced/80x256mmFuelCell.xml
+++ b/Defs/Ammo/Advanced/80x256mmFuelCell.xml
@@ -16,7 +16,7 @@
 		<ammoTypes>
 			<Ammo_80x256mmFuel_Incendiary>Bullet_80x256mmFuel_Incendiary</Ammo_80x256mmFuel_Incendiary>
 		</ammoTypes>
-		<similarTo>AmmoSet_MechShell</similarTo>
+		<similarTo>AmmoSet_MechShell_Incendiary</similarTo>
 	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Generic/Charged.xml
+++ b/Defs/Ammo/Generic/Charged.xml
@@ -124,7 +124,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>Ionized</ammoClass>
-		<generateAllowChance>0</generateAllowChance>
+		<generateAllowChance>0.5</generateAllowChance>
 	</ThingDef>
 
 	<!-- Charged Rifle -->
@@ -174,7 +174,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>Ionized</ammoClass>
-		<generateAllowChance>0</generateAllowChance>
+		<generateAllowChance>0.5</generateAllowChance>
 	</ThingDef>
 
 	<!-- Heavy Charged -->
@@ -224,7 +224,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>Ionized</ammoClass>
-		<generateAllowChance>0.25</generateAllowChance>
+		<generateAllowChance>0.5</generateAllowChance>
 	</ThingDef>
 
 	<!-- Charge Shotgun -->
@@ -272,7 +272,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>Ionized</ammoClass>
-		<generateAllowChance>0.25</generateAllowChance>
+		<generateAllowChance>0.5</generateAllowChance>
 	</ThingDef>
 
 	<!-- ==================== Recipes ========================== -->

--- a/Defs/Ammo/Generic/Mech.xml
+++ b/Defs/Ammo/Generic/Mech.xml
@@ -25,21 +25,21 @@
 		<defName>AmmoSet_MechCharged</defName>
 		<label>mech charged ammo</label>
 		<ammoTypes>
-			<Ammo_MechCharged>Bullet_5x35mmCharged</Ammo_MechCharged>
+			<Ammo_Mech_Charged>Bullet_5x35mmCharged</Ammo_Mech_Charged>
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
 
 	<CombatExtended.AmmoSetDef>
-		<defName>AmmoSet_MechShell</defName>
-		<label>mech shell</label>
+		<defName>AmmoSet_MechShell_Incendiary</defName>
+		<label>mech shell (Incendiary)</label>
 		<ammoTypes>
-			<Ammo_MechShell>Bullet_80x256mmFuel_Incendiary</Ammo_MechShell>
+			<Ammo_MechShell_Incendiary>Bullet_80x256mmFuel_Incendiary</Ammo_MechShell_Incendiary>
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
 
 	<CombatExtended.AmmoSetDef>
 		<defName>AmmoSet_MechShell_Demo</defName>
-		<label>mech shell</label>
+		<label>mech shell (Demo)</label>
 		<ammoTypes>
 			<Ammo_MechShell_Demo>Bullet_164x284mmDemo</Ammo_MechShell_Demo>
 		</ammoTypes>
@@ -58,6 +58,7 @@
 		</statBases>
 		<tradeTags>
 			<li>CE_AutoEnableTrade_Sellable</li>
+			<li MayRequire="Ludeon.RimWorld.Biotech">CE_AutoEnableCrafting_FabricationBench</li>
 		</tradeTags>
 		<thingCategories>
 			<li>AmmoMechCharged</li>
@@ -66,7 +67,7 @@
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="MechChargedAmmo">
-		<defName>Ammo_MechCharged</defName>
+		<defName>Ammo_Mech_Charged</defName>
 		<label>Mech Charged cartridge</label>
 		<graphicData>
 			<texPath>Things/Ammo/Charged/MediumMech</texPath>
@@ -86,6 +87,7 @@
 		</statBases>
 		<tradeTags>
 			<li>CE_AutoEnableTrade_Sellable</li>
+			<li MayRequire="Ludeon.RimWorld.Biotech">CE_AutoEnableCrafting_FabricationBench</li>
 		</tradeTags>
 		<thingCategories>
 			<li>AmmoMechShell</li>
@@ -94,13 +96,14 @@
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="MechShellAmmo">
-		<defName>Ammo_MechShell</defName>
-		<label>mechanoid shell</label>
+		<defName>Ammo_MechShell_Incendiary</defName>
+		<label>mechanoid shell (Incendiary)</label>
 		<graphicData>
 			<texPath>Things/Ammo/FuelCell/Large</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>GrenadeIncendiary</ammoClass>
+		<detonateProjectile>Bullet_80x256mmFuel_Incendiary</detonateProjectile>
 		<comps>
 			<li Class="CompProperties_Explosive">
 				<explosiveRadius>1.9</explosiveRadius>
@@ -115,9 +118,9 @@
 		</comps>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="164x284mmDemoBase">
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="MechShellAmmo">
 		<defName>Ammo_MechShell_Demo</defName>
-		<label>mech shell (demo)</label>
+		<label>mech shell (Demo)</label>
 		<graphicData>
 			<texPath>Things/Ammo/FuelCell/Large</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -144,7 +147,7 @@
 	<!-- ==================== Recipes ========================== -->
 
 	<RecipeDef ParentName="ChargeAmmoRecipeBase" MayRequire="Ludeon.RimWorld.Biotech">
-		<defName>MakeAmmo_MechCharged</defName>
+		<defName>MakeAmmo_Mech_Charged</defName>
 		<label>make Mech Charged cartridge x200</label>
 		<description>Craft 200 Mech Charged cartridges.</description>
 		<jobString>Making Mech Charged cartridges.</jobString>
@@ -182,7 +185,7 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_MechCharged>200</Ammo_MechCharged>
+			<Ammo_Mech_Charged>200</Ammo_Mech_Charged>
 		</products>
 		<skillRequirements>
 			<Crafting>8</Crafting>
@@ -191,10 +194,10 @@
 	</RecipeDef>
 
 	<RecipeDef ParentName="ChargeAmmoRecipeBase" MayRequire="Ludeon.RimWorld.Biotech">
-		<defName>MakeAmmo_MechShell</defName>
-		<label>make Mech Shell x5</label>
-		<description>Craft 5 Mech Shells.</description>
-		<jobString>Making Mech Shells.</jobString>
+		<defName>MakeAmmo_MechShell_Incendiary</defName>
+		<label>make Mech Shell (Incendiary) x5</label>
+		<description>Craft 5 Mech Shells (Incendiary).</description>
+		<jobString>Making Mech Shells (Incendiary).</jobString>
 		<ingredients>
 			<li>
 				<filter>
@@ -229,7 +232,7 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_MechShell>5</Ammo_MechShell>
+			<Ammo_MechShell_Incendiary>5</Ammo_MechShell_Incendiary>
 		</products>
 		<skillRequirements>
 			<Crafting>8</Crafting>

--- a/Defs/RecipeDefs/Recipes_Production.xml
+++ b/Defs/RecipeDefs/Recipes_Production.xml
@@ -87,7 +87,7 @@
 						<li>Ammo_5x35mmCharged</li>
 						<li>Ammo_6x22mmCharged</li>
 						<li>Ammo_12x64mmCharged</li>
-						<li>Ammo_MechCharged</li>
+						<li>Ammo_Mech_Charged</li>
 					</thingDefs>
 				</filter>
 				<count>200</count>
@@ -98,7 +98,7 @@
 				<li>Ammo_5x35mmCharged</li>
 				<li>Ammo_6x22mmCharged</li>
 				<li>Ammo_12x64mmCharged</li>
-				<li>Ammo_MechCharged</li>
+				<li>Ammo_Mech_Charged</li>
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
@@ -127,7 +127,7 @@
 						<li>Ammo_5x35mmCharged</li>
 						<li>Ammo_6x22mmCharged</li>
 						<li>Ammo_12x64mmCharged</li>
-						<li>Ammo_MechCharged</li>
+						<li>Ammo_Mech_Charged</li>
 					</thingDefs>
 				</filter>
 				<count>200</count>
@@ -138,7 +138,7 @@
 				<li>Ammo_5x35mmCharged</li>
 				<li>Ammo_6x22mmCharged</li>
 				<li>Ammo_12x64mmCharged</li>
-				<li>Ammo_MechCharged</li>
+				<li>Ammo_Mech_Charged</li>
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
@@ -167,7 +167,8 @@
 						<li>Ammo_66mmThermalBolt_Incendiary</li>
 						<li>Ammo_80x256mmFuel_Incendiary</li>
 						<li>Ammo_164x284mmDemo</li>
-						<li>Ammo_MechShell</li>
+						<li>Ammo_MechShell_Incendiary</li>
+						<li>Ammo_MechShell_Demo</li>
 					</thingDefs>
 				</filter>
 				<count>5</count>
@@ -178,7 +179,8 @@
 				<li>Ammo_66mmThermalBolt_Incendiary</li>
 				<li>Ammo_80x256mmFuel_Incendiary</li>
 				<li>Ammo_164x284mmDemo</li>
-				<li>Ammo_MechShell</li>
+				<li>Ammo_MechShell_Incendiary</li>
+				<li>Ammo_MechShell_Demo</li>
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>


### PR DESCRIPTION
## Changes

- Various small changes and housekeeping for mechanoid ammo types and their generic ammo variants.

## References

- Closes #2873 

    _Despite trying various changes and cross-referencing the Demo mech shell with other generic ammo types and making sure things are consistent, none of the mechanoid ammo types get converted into their generic ammo type correctly. 80mm and 66mm ones stay as is and other ammo types like 5x35mm and 12x64mm get converted into manmade generic ammo types instead of the correct mech charged generic ammo type **despite the similarTo tag being assigned correctly**._
    _The issue described in # 2873 is apparently caused by a fundamental problem with the system since none of the various tried xml solutions could fix the issue. Simply replacing the generic ammo type to a working one does not fix the problem properly._

    -None of the generic mech ammo types except the Demo shells appear ingame inside the dev tools either, it's like they are not being recognized by the ammo injector or something.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] Playtested a colony (specify how long)
