### PR TITLE
Patch Rim-Elves

### DIFF
--- a/Patches/Rim-Elves/Ammo_Elves.xml
+++ b/Patches/Rim-Elves/Ammo_Elves.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Rim-Elves</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs</xpath>
+				<value>
+
+				<!-- Custom Ammoset -->
+				<CombatExtended.AmmoSetDef>
+					<defName>AmmoSet_ChargedGreatArrow</defName>
+					<label>plasteel great arrows</label>
+					<ammoTypes>
+						<Ammo_GreatArrow_Plasteel>Projectile_ChargedGreatArrow_Plasteel</Ammo_GreatArrow_Plasteel>
+					</ammoTypes>
+				</CombatExtended.AmmoSetDef>
+
+				<!-- Custom Projectile -->
+				<ThingDef ParentName="BaseGreatArrowProjectile">
+					<defName>Projectile_ChargedGreatArrow_Plasteel</defName>
+					<label>charged great arrow</label>
+					<graphicData>
+						<texPath>Things/Projectile/Arrows/Arrow_Plasteel</texPath>
+						<graphicClass>Graphic_Single</graphicClass>
+					</graphicData>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<damageAmountBase>19</damageAmountBase>
+						<secondaryDamage>
+							<li>
+								<def>Bomb_Secondary</def>
+								<amount>6</amount>
+							</li>
+						</secondaryDamage>
+						<speed>151</speed>
+						<armorPenetrationSharp>16</armorPenetrationSharp>
+						<armorPenetrationBlunt>57.6</armorPenetrationBlunt>
+						<preExplosionSpawnChance>0.25</preExplosionSpawnChance><!-- 40 arrows per resource -->
+						<preExplosionSpawnThingDef>Ammo_GreatArrow_Plasteel</preExplosionSpawnThingDef>
+					</projectile>
+				</ThingDef>
+
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Rim-Elves/GeneDefs_Elves.xml
+++ b/Patches/Rim-Elves/GeneDefs_Elves.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Rim-Elves</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/GeneDef[defName="Size_Gigantism"]/statOffsets/CarryingCapacity</xpath>
+				<value>
+					<CarryWeight>15</CarryWeight>
+					<CarryBulk>10</CarryBulk>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Rim-Elves/PawnKinds_Elves.xml
+++ b/Patches/Rim-Elves/PawnKinds_Elves.xml
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Rim-Elves</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- Medieval Pawnkinds -->
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[defName="RE_Elven_Archer"] </xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+						<primaryMagazineCount>
+							<min>14</min>
+							<max>24</max>
+						</primaryMagazineCount>
+						<sidearms>
+							<li>
+								<sidearmMoney>
+									<min>80</min>
+									<max>160</max>
+								</sidearmMoney>
+								<weaponTags>
+									<li>NeolithicMeleeBasic</li>
+								</weaponTags>
+							</li>
+						</sidearms>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[defName="RE_Elven_Levy"] </xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+						<shieldMoney>
+							<min>80</min>
+							<max>110</max>
+						</shieldMoney>
+						<shieldTags>
+							<li>TribalShield</li>
+						</shieldTags>
+						<shieldChance>0.25</shieldChance>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[defName="RE_Elven_Swordsman"] </xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+						<shieldMoney>
+							<min>100</min>
+							<max>140</max>
+						</shieldMoney>
+						<shieldTags>
+							<li>TribalShield</li>
+						</shieldTags>
+						<shieldChance>0.25</shieldChance>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[defName="RE_Elven_Ranger"] </xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+						<primaryMagazineCount>
+							<min>20</min>
+							<max>40</max>
+						</primaryMagazineCount>
+						<sidearms>
+							<li>
+								<sidearmMoney>
+									<min>120</min>
+									<max>180</max>
+								</sidearmMoney>
+								<weaponTags>
+									<li>MedievalMeleeBasic</li>	
+									<li>NeolithicMeleeDecent</li>
+								</weaponTags>
+							</li>
+						</sidearms>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[defName="RE_Elven_Knight"] </xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+						<shieldMoney>
+							<min>120</min>
+							<max>180</max>
+						</shieldMoney>
+						<shieldTags>
+							<li>TribalShield</li>
+						</shieldTags>
+						<shieldChance>0.4</shieldChance>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[defName="Elven_Supreme_NobleRanged"] </xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+						<primaryMagazineCount>
+							<min>20</min>
+							<max>40</max>
+						</primaryMagazineCount>
+						<sidearms>
+							<li>
+								<sidearmMoney>
+									<min>150</min>
+									<max>240</max>
+								</sidearmMoney>
+								<weaponTags>
+									<li>ElvenMedievalMelee</li>
+									<li>MedievalMeleeAdvanced</li>
+								</weaponTags>
+							</li>
+						</sidearms>
+					</li>
+				</value>
+			</li>
+
+			<!-- Spacer Pawnkinds -->
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[@Name="ElvenSoldierBase" or @Name="ElvenKnightBase"] </xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+						<primaryMagazineCount>
+							<min>6</min>
+							<max>10</max>
+						</primaryMagazineCount>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[defName="Elven_Soldier_Grenadier"] </xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+						<primaryMagazineCount>
+							<min>6</min>
+							<max>12</max>
+						</primaryMagazineCount>
+						<sidearms>
+							<li>
+								<generateChance>0.8</generateChance>
+								<sidearmMoney>
+									<min>10</min>
+									<max>100</max>
+								</sidearmMoney>
+								<weaponTags>
+									<li>CE_Sidearm</li>
+								</weaponTags>
+								<magazineCount>
+									<min>3</min>
+									<max>6</max>
+								</magazineCount>
+							</li>
+						</sidearms>						
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[defName="Elven_Soldier_Lancer"] </xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+						<primaryMagazineCount>
+							<min>20</min>
+							<max>40</max>
+						</primaryMagazineCount>
+					</li>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Rim-Elves/Weapons_Elves.xml
+++ b/Patches/Rim-Elves/Weapons_Elves.xml
@@ -46,7 +46,7 @@
 						</li>
 					</tools>
 				</value>
-			</li>		
+			</li>
 
 			<!-- ========== Elven Scimitar ========== -->
 
@@ -119,7 +119,45 @@
 			</li>
 
 			<!-- ========== Elven Chargebow ========== -->
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>Bow_ElvenCharge</defName>
+				<statBases>
+					<SightsEfficiency>1.2</SightsEfficiency>
+					<ShotSpread>0.05</ShotSpread>
+					<SwayFactor>1.8</SwayFactor>
+					<Bulk>3.5</Bulk>
+					<RangedWeapon_Cooldown>0.85</RangedWeapon_Cooldown>
+				</statBases>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Projectile_ChargedGreatArrow_Plasteel</defaultProjectile>
+					<warmupTime>0.85</warmupTime>
+					<range>55</range>
+					<soundCast>ChargeBowElven_Fire</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+				</Properties>
+				<AmmoUser>
+					<ammoSet>AmmoSet_ChargedGreatArrow</ammoSet>
+				</AmmoUser>
+				<FireModes />
+			</li>
 
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Bow_ElvenCharge"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>5</power>
+							<cooldownTime>1.6</cooldownTime>
+							<armorPenetrationBlunt>0.6</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
 
 			<!-- ========== Elven Banebrand ========== -->
 

--- a/Patches/Rim-Elves/Weapons_Elves.xml
+++ b/Patches/Rim-Elves/Weapons_Elves.xml
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Rim-Elves</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- ========== Elven Longbow ========== -->
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>Bow_ElvenLong</defName>
+				<statBases>
+					<SightsEfficiency>0.85</SightsEfficiency>
+					<ShotSpread>0.8</ShotSpread>
+					<SwayFactor>1.8</SwayFactor>
+					<Bulk>4.00</Bulk>
+					<RangedWeapon_Cooldown>0.85</RangedWeapon_Cooldown>
+				</statBases>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Projectile_GreatArrow_Stone</defaultProjectile>
+					<warmupTime>1.9</warmupTime>
+					<range>33</range>
+					<soundCast>Bow_Large</soundCast>
+				</Properties>
+				<AmmoUser>
+					<ammoSet>AmmoSet_GreatArrow</ammoSet>
+				</AmmoUser>
+				<FireModes />
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Bow_ElvenLong"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>5</power>
+							<cooldownTime>1.6</cooldownTime>
+							<armorPenetrationBlunt>0.6</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>		
+
+			<!-- ========== Elven Scimitar ========== -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="MeleeWeapon_ElvenScimitar"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>handle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>1.54</cooldownTime>
+							<armorPenetrationBlunt>0.55</armorPenetrationBlunt>
+							<chanceFactor>0.15</chanceFactor>
+							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>point</label>
+							<capacities>
+								<li>Stab</li>
+							</capacities>
+							<power>20</power>
+							<cooldownTime>1.54</cooldownTime>
+							<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+							<armorPenetrationSharp>0.28</armorPenetrationSharp>
+							<chanceFactor>0.33</chanceFactor>
+							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>edge</label>
+							<capacities>
+								<li>Cut</li>
+							</capacities>
+							<power>28</power>
+							<cooldownTime>1.25</cooldownTime>
+							<armorPenetrationBlunt>1.782</armorPenetrationBlunt>
+							<armorPenetrationSharp>0.8</armorPenetrationSharp>
+							<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="MeleeWeapon_ElvenScimitar"]/statBases</xpath>
+				<value>
+					<Bulk>4</Bulk>
+					<MeleeCounterParryBonus>0.38</MeleeCounterParryBonus>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="MeleeWeapon_ElvenScimitar"]</xpath>
+				<value>
+					<equippedStatOffsets>
+						<MeleeCritChance>0.24</MeleeCritChance>
+						<MeleeParryChance>0.38</MeleeParryChance>
+						<MeleeDodgeChance>0.28</MeleeDodgeChance>
+					</equippedStatOffsets>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="MeleeWeapon_ElvenScimitar"]/weaponTags</xpath>
+				<value>
+					<li>CE_OneHandedWeapon</li>
+				</value>
+			</li>
+
+			<!-- ========== Elven Chargebow ========== -->
+
+
+			<!-- ========== Elven Banebrand ========== -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="MeleeWeapon_BaneBrand"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>handle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>2</power>
+							<chanceFactor>0.1</chanceFactor>
+							<cooldownTime>1.5</cooldownTime>
+							<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>edge</label>
+							<capacities>
+								<li>Cut</li>
+							</capacities>
+							<power>33</power>
+							<cooldownTime>0.78</cooldownTime>
+							<armorPenetrationBlunt>2.84</armorPenetrationBlunt>
+							<armorPenetrationSharp>16</armorPenetrationSharp>
+							<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>point</label>
+							<capacities>
+								<li>Stab</li>
+							</capacities>
+							<power>12</power>
+							<cooldownTime>0.94</cooldownTime>
+							<armorPenetrationBlunt>1.28</armorPenetrationBlunt>
+							<armorPenetrationSharp>16</armorPenetrationSharp>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="MeleeWeapon_BaneBrand"]</xpath>
+				<value>
+					<statBases>
+						<Bulk>3</Bulk>
+						<MeleeCounterParryBonus>0.40</MeleeCounterParryBonus>
+					</statBases>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="MeleeWeapon_BaneBrand"]</xpath>
+				<value>
+					<equippedStatOffsets>
+						<MeleeCritChance>0.90</MeleeCritChance>
+						<MeleeParryChance>0.40</MeleeParryChance>
+						<MeleeDodgeChance>0.32</MeleeDodgeChance>
+					</equippedStatOffsets>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="MeleeWeapon_BaneBrand"]</xpath>
+				<value>
+					<weaponTags>
+						<li>CE_OneHandedWeapon</li>
+					</weaponTags>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -404,6 +404,7 @@ Rim-Effect: N7	|
 Rimedieval - Medieval Royalty   |
 Rimefeller	|
 RimEffect - Asari of the Rims	|
+Rim-Elves   |
 Rim-Gnoblins	| 
 Rim-Hivers!	|
 Rim Flood	|


### PR DESCRIPTION
## Additions
- Patch for Rim-Elves
  - 4 new weapons (2 medieval, 2 spacer)
  - A handful of medieval and spacer pawnkinds that need ammo.

## Reasoning
- Longbow patched as a slower, but lighter and slightly more accurate greatbow.
- Scimitar patched as a lighter longsword with inferior Stab.
- Banebrand patched as monosword with inferior Stab and AP.
- The elven charged bow fires the equivalent to a 8x35mm charge, consuming plasteel arrows with a range like an assault rifle. It trades range and overall rate-of-fire for a fairly hard-hitting round at a comparatively quite low material price.

**Note:** Elves has comparatively low weight capacity because the mod author has given them a bodySize of 0.55 (compared to 0.8 for baseline humans). This was apparently to make them more susceptible to the effects of drugs and alcohol. _For now_, I've left their bodySize as is--since it really should be on the mod author to resolve.

This lower weight cap makes it difficult for the spacer-tech elf NPCs to spawn with enough ammo. Their gigantic gene adds a decent amount of added bulk and mass capacity, but it can still be hit or miss whether or not they have enough room.

## Alternatives
- Could balance weapons some different way.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
