### PR TITLE
Loadouts meal fix

### DIFF
--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_UpdateLoadout.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_UpdateLoadout.cs
@@ -280,7 +280,7 @@ namespace CombatExtended
 
         private static bool AllowedByFoodRestriction(Thing thing, Pawn pawn)
         {
-            if (thing != null && thing.def.IsIngestible)
+            if (thing != null && thing.def.IsNutritionGivingIngestible)
             {
                 return pawn.foodRestriction.GetCurrentRespectedRestriction(pawn).Allows(thing);
             }

--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_UpdateLoadout.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_UpdateLoadout.cs
@@ -215,7 +215,7 @@ namespace CombatExtended
             {
                 findItem = t => t.GetInnerIfMinified().def == curSlot.thingDef;
             }
-            Predicate<Thing> search = t => findItem(t) && !t.IsForbidden(pawn) && pawn.CanReserve(t, 10, 1) && !isFoodInPrison(t) && AllowedByBiocode(t, pawn);
+            Predicate<Thing> search = t => findItem(t) && !t.IsForbidden(pawn) && pawn.CanReserve(t, 10, 1) && !isFoodInPrison(t) && AllowedByBiocode(t, pawn) && AllowedByFoodRestriction(t, pawn);
 
             // look for a thing near the pawn.
             curThing = GenClosest.ClosestThingReachable(
@@ -276,6 +276,18 @@ namespace CombatExtended
         {
             CompBiocodable compBiocoded = thing.TryGetComp<CompBiocodable>();
             return (compBiocoded == null || !compBiocoded.Biocoded || compBiocoded.CodedPawn == pawn);
+        }
+
+        private static bool AllowedByFoodRestriction(Thing thing, Pawn pawn)
+        {
+            if (thing != null && thing.def.IsIngestible)
+            {
+                return pawn.foodRestriction.GetCurrentRespectedRestriction(pawn).Allows(thing);
+            }
+            else
+            {
+                return true;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Changes

- Updated loadouts to respect the pawn's current food restrictions

## Reasoning

- Should prevent pawns from picking up food that they cannot eat

## Alternatives

- Use `pawn.WillEat` instead, this also checks for venerated animal meat or royal restrictions
- Not check for restrictions at all

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] Playtested a colony (specify how long)
