### PR TITLE
Remove 81mm shells from most IED costs.

### DIFF
--- a/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
@@ -544,6 +544,38 @@
 		</value>
 	</Operation>
 
+  	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="TrapIED_Smoke"]/costList</xpath>
+		<value>
+			<costList>
+				<Steel>10</Steel>
+				<Prometheum>1</Prometheum>
+				<ComponentIndustrial>1</ComponentIndustrial>
+			</costList>
+		</value>
+	</Operation>
+
+  	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="TrapIED_EMP"]/costList</xpath>
+		<value>
+			<costList>
+				<Steel>10</Steel>
+				<ComponentIndustrial>6</ComponentIndustrial>
+			</costList>
+		</value>
+	</Operation>
+
+  	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="TrapIED_Firefoam"]/costList</xpath>
+		<value>
+			<costList>
+				<Steel>10</Steel>
+        <MeatRaw>7</MeatRaw>
+				<ComponentIndustrial>1</ComponentIndustrial>
+			</costList>
+		</value>
+	</Operation>
+  
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="TrapIED_HighExplosive"]/comps/li[@Class="CompProperties_Explosive"]</xpath>
 		<value>

--- a/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
@@ -575,6 +575,41 @@
 			</costList>
 		</value>
 	</Operation>
+
+  <Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="TrapIED_HighExplosive"]/description</xpath>
+		<value>
+		  <description>A simple high-explosive bomb connected to a trigger which detonates on touch or bullet impact. Since it is hidden in the surrounding terrain, it cannot be placed adjacent to other traps. Animals can sense these when calm.</description>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="TrapIED_Incendiary"]/description</xpath>
+		<value>
+      <description>A simple incendiary bomb connected to a trigger which detonates on touch or bullet impact. Since it is hidden in the surrounding terrain, it cannot be placed adjacent to other traps. Animals can sense these when calm.</description>
+		</value>
+	</Operation>
+
+  	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="TrapIED_Smoke"]/description</xpath>
+		<value>
+		  <description>A simple smoke bomb connected to a trigger which detonates on touch or bullet impact. Since it is hidden in the surrounding terrain, it cannot be placed adjacent to other traps. Animals can sense these when calm.</description>
+		</value>
+	</Operation>
+
+  	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="TrapIED_EMP"]/description</xpath>
+		<value>
+		  <description>A simple EMP bomb connected to a trigger which detonates on touch or bullet impact. Since it is hidden in the surrounding terrain, it cannot be placed adjacent to other traps. Animals can sense these when calm.</description>
+		</value>
+	</Operation>
+
+  	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="TrapIED_Firefoam"]/description</xpath>
+		<value>
+		  <description>A simple firefoam bomb connected to a trigger which detonates on touch or bullet impact. Since it is hidden in the surrounding terrain, it cannot be placed adjacent to other traps. Animals can sense these when calm.</description>
+		</value>
+	</Operation>
   
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="TrapIED_HighExplosive"]/comps/li[@Class="CompProperties_Explosive"]</xpath>


### PR DESCRIPTION
## Changes

- replaced 81mm shells from the cost lists of the EMP, Firefoam, and Smoke IEDs with an equivalent payload material (1 prometheum for smoke, 7 raw meat for firefoam, 5 components for EMP), 10 steel and 1 component.

## Reasoning

- more consistency
- no antimatter material exists so it can't be done for antigrain IEDs, but I see no reason why it shouldn't be done for all the other kinds.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
