### PR TITLE
Update ApexRimworldLegends_Weapons_AssaultRifles.xml

### DIFF
--- a/Patches/ADE Advanced Turrets/Buildings_Security.xml
+++ b/Patches/ADE Advanced Turrets/Buildings_Security.xml
@@ -1,94 +1,111 @@
 <Patch>
 	<Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>ADE Advanced Turrets</li>
+			<li>ADE Pulse Turrets</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>
 
 				<li Class="PatchOperationRemove">
 					<xpath>Defs/ThingDef[
-						defName="ADE_Turret_HMGT" or
-						defName="ADE_Turret_HST" or
-						defName="ADE_Turret_GLT"
+						defName="ZXT_Turret_Pulsemachinegunturret" or
+						defName="ZXT_Turret_Sniperpulseturret" or
+						defName="ZXT_Turret_Armoredpowerpulseturret" or
+						defName="ZXT_Turret_Advancedrotarypulsemachinegunturret"
 						]/comps/li[@Class = "CompProperties_Refuelable"] </xpath>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[
-						defName="ADE_Turret_HMGT" or
-						defName="ADE_Turret_HST" or
-						defName="ADE_Turret_GLT"
+						defName="ZXT_Turret_Pulsemachinegunturret" or
+						defName="ZXT_Turret_Sniperpulseturret" or
+						defName="ZXT_Turret_Armoredpowerpulseturret" or
+						defName="ZXT_Turret_Advancedrotarypulsemachinegunturret"
 						]/thingClass </xpath>
 					<value>
 						<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
 					</value>
 				</li>
+				<!-- Same label??? wth? -->
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[
-						defName="ADE_Turret_HMGT" or
-						defName="ADE_Turret_HST" or
-						defName="ADE_Turret_GLT"
+						defName="ZXT_Turret_Sniperpulseturret"
+						]/label </xpath>
+					<value>
+						<label>Armored Gauss Lance</label>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+						defName="ZXT_Turret_Pulsemachinegunturret" or
+						defName="ZXT_Turret_Sniperpulseturret" or
+						defName="ZXT_Turret_Armoredpowerpulseturret" or
+						defName="ZXT_Turret_Advancedrotarypulsemachinegunturret"
 						]/fillPercent </xpath>
 					<value>
 						<fillPercent>0.85</fillPercent>
 					</value>
 				</li>
-				<!-- adding power requirement -->
-				<li Class="PatchOperationAdd">
+
+				<!-- Increasing power requirement -->
+				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[
-						defName="ADE_Turret_HMGT" or
-						defName="ADE_Turret_HST" or
-						defName="ADE_Turret_GLT"
-						]/comps </xpath>
+						defName="ZXT_Turret_Pulsemachinegunturret" or
+						defName="ZXT_Turret_Sniperpulseturret" or
+						defName="ZXT_Turret_Armoredpowerpulseturret"
+						]/comps/li[@Class = "CompProperties_Power"]/basePowerConsumption </xpath>
 					<value>
-						<li Class="CompProperties_Power">
-							<compClass>CompPowerTrader</compClass>
-							<basePowerConsumption>350</basePowerConsumption>
-						</li>
+						<basePowerConsumption>1050</basePowerConsumption>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[
-						defName="ADE_Turret_HMGT" or
-						defName="ADE_Turret_HST" or
-						defName="ADE_Turret_GLT"
+						defName="ZXT_Turret_Advancedrotarypulsemachinegunturret"
+						]/comps/li[@Class = "CompProperties_Power"]/basePowerConsumption </xpath>
+					<value>
+						<basePowerConsumption>1450</basePowerConsumption>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+						defName="ZXT_Turret_Pulsemachinegunturret" or
+						defName="ZXT_Turret_Sniperpulseturret" or
+						defName="ZXT_Turret_Armoredpowerpulseturret" or
+						defName="ZXT_Turret_Advancedrotarypulsemachinegunturret"
 						]/statBases/ShootingAccuracyTurret </xpath>
 					<value>
 						<AimingAccuracy>1</AimingAccuracy>
 						<ShootingAccuracyTurret>1</ShootingAccuracyTurret>
 					</value>
 				</li>
-				<!-- ========== HMG  Turret ========== -->
+				<!-- ========== Pulse HMG Turret ========== -->
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
-					<defName>ADE_Gun_HMGT</defName>
+					<defName>ZXT_Gun_Pulsemachinegunturret</defName>
 					<statBases>
 						<RangedWeapon_Cooldown>0.18</RangedWeapon_Cooldown>
 						<SightsEfficiency>1</SightsEfficiency>
-						<ShotSpread>0.02</ShotSpread>
-						<SwayFactor>1.13</SwayFactor>
+						<ShotSpread>0.05</ShotSpread>
+						<SwayFactor>1.03</SwayFactor>
 						<Bulk>37.08</Bulk>
 					</statBases>
 					<Properties>
-						<recoilAmount>1.09</recoilAmount>
+						<recoilAmount>0.55</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
-						<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
-						<warmupTime>1.1</warmupTime>
-						<range>54</range>
+						<defaultProjectile>Bullet_8x35mmCharged</defaultProjectile>
+						<warmupTime>1.4</warmupTime>
+						<range>72</range>
+						<minRange>6</minRange>
 						<ticksBetweenBurstShots>3</ticksBetweenBurstShots>
 						<burstShotCount>20</burstShotCount>
-						<soundCast>Shot_AssaultRifle</soundCast>
+						<soundCast>Shot_ChargeBlaster</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
-						<muzzleFlashScale>9</muzzleFlashScale>
+						<muzzleFlashScale>12</muzzleFlashScale>
 						<recoilPattern>Mounted</recoilPattern>
 					</Properties>
-					<AmmoUser>
-						<magazineSize>500</magazineSize>
-						<reloadTime>15.6</reloadTime>
-						<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
-					</AmmoUser>
 					<FireModes>
 						<aiUseBurstMode>FALSE</aiUseBurstMode>
 						<aiAimMode>AimedShot</aiAimMode>
@@ -97,40 +114,36 @@
 					</FireModes>
 				</li>
 
-				<!-- ========== Grenade Launcher Turret ========== -->
+				<!-- ========== Charged SNiper Pulse Turret ========== -->
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
-					<defName>ADE_Gun_GLT</defName>
+					<defName>ZXT_Gun_Sniperpulseturret</defName>
 					<statBases>
-						<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
+						<RangedWeapon_Cooldown>0.55</RangedWeapon_Cooldown>
 						<SightsEfficiency>1.00</SightsEfficiency>
-						<ShotSpread>0.14</ShotSpread>
-						<SwayFactor>2.02</SwayFactor>
+						<ShotSpread>0.01</ShotSpread>
+						<SwayFactor>1.02</SwayFactor>
 						<Bulk>10.66</Bulk>
 					</statBases>
 					<Properties>
-						<recoilAmount>0.34</recoilAmount>
+						<recoilAmount>2.51</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
-						<defaultProjectile>Bullet_40x53mmGrenade_HE</defaultProjectile>
-						<warmupTime>0.6</warmupTime>
-						<range>55</range>
-						<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
-						<burstShotCount>5</burstShotCount>
-						<soundCast>AGS</soundCast>
+						<defaultProjectile>Bullet_12mmRailgun_Sabot</defaultProjectile>
+						<warmupTime>1.6</warmupTime>
+						<range>102</range>
+						<minRange>10</minRange>
+						<ticksBetweenBurstShots>10</ticksBetweenBurstShots>
+						<burstShotCount>1</burstShotCount>
+						<soundCast>ChargeLance_Fire</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
-						<muzzleFlashScale>18</muzzleFlashScale>
+						<muzzleFlashScale>45</muzzleFlashScale>
 						<recoilPattern>Mounted</recoilPattern>
 						<requireLineOfSight>false</requireLineOfSight>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
 					</Properties>
-					<AmmoUser>
-						<magazineSize>40</magazineSize>
-						<reloadTime>10.9</reloadTime>
-						<ammoSet>AmmoSet_40x53mmGrenade</ammoSet>
-					</AmmoUser>
 					<FireModes>
 						<aiUseBurstMode>TRUE</aiUseBurstMode>
 						<aiAimMode>AimedShot</aiAimMode>
@@ -139,40 +152,69 @@
 					</FireModes>
 				</li>
 
-				<!-- ========== Anti Aircraft Precision ========== -->
+				<!-- ========== Armored Pulse Turrets, one caliber higher PLUS========== -->
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
-					<defName>ADE_Gun_HST</defName>
+					<defName>ZXT_Gun_Armoredpowerpulseturret</defName>
 					<statBases>
-						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
-						<SightsEfficiency>1.2</SightsEfficiency>
-						<ShotSpread>0.01</ShotSpread>
-						<SwayFactor>1.32</SwayFactor>
-						<Bulk>28.72</Bulk>
+						<RangedWeapon_Cooldown>0.25</RangedWeapon_Cooldown>
+						<SightsEfficiency>1</SightsEfficiency>
+						<ShotSpread>0.07</ShotSpread>
+						<SwayFactor>1.22</SwayFactor>
+						<Bulk>37.08</Bulk>
 					</statBases>
 					<Properties>
-						<recoilAmount>1.80</recoilAmount>
+						<recoilAmount>0.75</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
-						<defaultProjectile>Bullet_20x128mmOerlikon_AP</defaultProjectile>
+						<defaultProjectile>Bullet_8x50mmCharged</defaultProjectile>
 						<warmupTime>1.4</warmupTime>
-						<range>65</range>
-						<soundCast>autocannon_slow</soundCast>
+						<range>78</range>
+						<minRange>6</minRange>
+						<ticksBetweenBurstShots>3</ticksBetweenBurstShots>
+						<burstShotCount>20</burstShotCount>
+						<soundCast>Shot_ChargeBlaster</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
-						<targetParams>
-							<canTargetLocations>true</canTargetLocations>
-						</targetParams>
-						<muzzleFlashScale>45</muzzleFlashScale>
+						<muzzleFlashScale>22</muzzleFlashScale>
 						<recoilPattern>Mounted</recoilPattern>
 					</Properties>
-					<AmmoUser>
-						<magazineSize>150</magazineSize>
-						<reloadTime>7.8</reloadTime>
-						<ammoSet>AmmoSet_20x128mmOerlikon</ammoSet>
-					</AmmoUser>
 					<FireModes>
+						<aiUseBurstMode>FALSE</aiUseBurstMode>
 						<aiAimMode>AimedShot</aiAimMode>
 						<noSnapshot>true</noSnapshot>
+						<noSingleShot>true</noSingleShot>
+					</FireModes>
+				</li>
+				<!-- ========== Armored Gatling Gun, ========= -->
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>ZXT_Gun_Advancedrotarypulsemachinegunturret</defName>
+					<statBases>
+						<RangedWeapon_Cooldown>0.25</RangedWeapon_Cooldown>
+						<SightsEfficiency>1</SightsEfficiency>
+						<ShotSpread>0.11</ShotSpread>
+						<SwayFactor>1.25</SwayFactor>
+						<Bulk>37.08</Bulk>
+					</statBases>
+					<Properties>
+						<recoilAmount>0.725</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_12x64mmCharged</defaultProjectile>
+						<warmupTime>1.25</warmupTime>
+						<range>77</range>
+						<minRange>10</minRange>
+						<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+						<burstShotCount>30</burstShotCount>
+						<soundCast>Shot_ChargeBlaster</soundCast>
+						<soundCastTail>GunTail_Medium</soundCastTail>
+						<muzzleFlashScale>22</muzzleFlashScale>
+						<recoilPattern>Mounted</recoilPattern>
+					</Properties>
+					<FireModes>
+						<aiUseBurstMode>FALSE</aiUseBurstMode>
+						<aiAimMode>AimedShot</aiAimMode>
+						<noSnapshot>true</noSnapshot>
+						<noSingleShot>true</noSingleShot>
 					</FireModes>
 				</li>
 

--- a/Patches/ADE Advanced Turrets/Buildings_Security.xml
+++ b/Patches/ADE Advanced Turrets/Buildings_Security.xml
@@ -1,111 +1,95 @@
 <Patch>
 	<Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>ADE Pulse Turrets</li>
+			<li>ADE Advanced Turrets</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>
 
 				<li Class="PatchOperationRemove">
 					<xpath>Defs/ThingDef[
-						defName="ZXT_Turret_Pulsemachinegunturret" or
-						defName="ZXT_Turret_Sniperpulseturret" or
-						defName="ZXT_Turret_Armoredpowerpulseturret" or
-						defName="ZXT_Turret_Advancedrotarypulsemachinegunturret"
+						defName="ADE_Turret_HMGT" or
+						defName="ADE_Turret_HST" or
+						defName="ADE_Turret_GLT"
 						]/comps/li[@Class = "CompProperties_Refuelable"] </xpath>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[
-						defName="ZXT_Turret_Pulsemachinegunturret" or
-						defName="ZXT_Turret_Sniperpulseturret" or
-						defName="ZXT_Turret_Armoredpowerpulseturret" or
-						defName="ZXT_Turret_Advancedrotarypulsemachinegunturret"
+						defName="ADE_Turret_HMGT" or
+						defName="ADE_Turret_HST" or
+						defName="ADE_Turret_GLT"
 						]/thingClass </xpath>
 					<value>
 						<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
 					</value>
 				</li>
-				<!-- Same label??? wth? -->
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[
-						defName="ZXT_Turret_Sniperpulseturret"
-						]/label </xpath>
-					<value>
-						<label>Armored Gauss Lance</label>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[
-						defName="ZXT_Turret_Pulsemachinegunturret" or
-						defName="ZXT_Turret_Sniperpulseturret" or
-						defName="ZXT_Turret_Armoredpowerpulseturret" or
-						defName="ZXT_Turret_Advancedrotarypulsemachinegunturret"
+						defName="ADE_Turret_HMGT" or
+						defName="ADE_Turret_HST" or
+						defName="ADE_Turret_GLT"
 						]/fillPercent </xpath>
 					<value>
 						<fillPercent>0.85</fillPercent>
 					</value>
 				</li>
-
-				<!-- Increasing power requirement -->
-				<li Class="PatchOperationReplace">
+				<!-- adding power requirement -->
+				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[
-						defName="ZXT_Turret_Pulsemachinegunturret" or
-						defName="ZXT_Turret_Sniperpulseturret" or
-						defName="ZXT_Turret_Armoredpowerpulseturret"
-						]/comps/li[@Class = "CompProperties_Power"]/basePowerConsumption </xpath>
+						defName="ADE_Turret_HMGT" or
+						defName="ADE_Turret_HST" or
+						defName="ADE_Turret_GLT"
+						]/comps </xpath>
 					<value>
-						<basePowerConsumption>1050</basePowerConsumption>
+						<li Class="CompProperties_Power">
+							<compClass>CompPowerTrader</compClass>
+							<basePowerConsumption>350</basePowerConsumption>
+						</li>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[
-						defName="ZXT_Turret_Advancedrotarypulsemachinegunturret"
-						]/comps/li[@Class = "CompProperties_Power"]/basePowerConsumption </xpath>
-					<value>
-						<basePowerConsumption>1450</basePowerConsumption>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[
-						defName="ZXT_Turret_Pulsemachinegunturret" or
-						defName="ZXT_Turret_Sniperpulseturret" or
-						defName="ZXT_Turret_Armoredpowerpulseturret" or
-						defName="ZXT_Turret_Advancedrotarypulsemachinegunturret"
+						defName="ADE_Turret_HMGT" or
+						defName="ADE_Turret_HST" or
+						defName="ADE_Turret_GLT"
 						]/statBases/ShootingAccuracyTurret </xpath>
 					<value>
 						<AimingAccuracy>1</AimingAccuracy>
 						<ShootingAccuracyTurret>1</ShootingAccuracyTurret>
 					</value>
 				</li>
-				<!-- ========== Pulse HMG Turret ========== -->
+				<!-- ========== HMG  Turret ========== -->
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
-					<defName>ZXT_Gun_Pulsemachinegunturret</defName>
+					<defName>ADE_Gun_HMGT</defName>
 					<statBases>
 						<RangedWeapon_Cooldown>0.18</RangedWeapon_Cooldown>
 						<SightsEfficiency>1</SightsEfficiency>
-						<ShotSpread>0.05</ShotSpread>
-						<SwayFactor>1.03</SwayFactor>
+						<ShotSpread>0.02</ShotSpread>
+						<SwayFactor>1.13</SwayFactor>
 						<Bulk>37.08</Bulk>
 					</statBases>
 					<Properties>
-						<recoilAmount>0.55</recoilAmount>
+						<recoilAmount>1.09</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
-						<defaultProjectile>Bullet_8x35mmCharged</defaultProjectile>
-						<warmupTime>1.4</warmupTime>
-						<range>72</range>
-						<minRange>6</minRange>
+						<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
+						<warmupTime>1.1</warmupTime>
+						<range>54</range>
+						<minRange>4</minRange>
 						<ticksBetweenBurstShots>3</ticksBetweenBurstShots>
 						<burstShotCount>20</burstShotCount>
-						<soundCast>Shot_ChargeBlaster</soundCast>
+						<soundCast>Shot_AssaultRifle</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
-						<muzzleFlashScale>12</muzzleFlashScale>
+						<muzzleFlashScale>9</muzzleFlashScale>
 						<recoilPattern>Mounted</recoilPattern>
 					</Properties>
+					<AmmoUser>
+						<magazineSize>500</magazineSize>
+						<reloadTime>15.6</reloadTime>
+						<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
+					</AmmoUser>
 					<FireModes>
 						<aiUseBurstMode>FALSE</aiUseBurstMode>
 						<aiAimMode>AimedShot</aiAimMode>
@@ -114,36 +98,41 @@
 					</FireModes>
 				</li>
 
-				<!-- ========== Charged SNiper Pulse Turret ========== -->
+				<!-- ========== Grenade Launcher Turret ========== -->
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
-					<defName>ZXT_Gun_Sniperpulseturret</defName>
+					<defName>ADE_Gun_GLT</defName>
 					<statBases>
-						<RangedWeapon_Cooldown>0.55</RangedWeapon_Cooldown>
+						<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
 						<SightsEfficiency>1.00</SightsEfficiency>
-						<ShotSpread>0.01</ShotSpread>
-						<SwayFactor>1.02</SwayFactor>
+						<ShotSpread>0.14</ShotSpread>
+						<SwayFactor>2.02</SwayFactor>
 						<Bulk>10.66</Bulk>
 					</statBases>
 					<Properties>
-						<recoilAmount>2.51</recoilAmount>
+						<recoilAmount>0.34</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
-						<defaultProjectile>Bullet_12mmRailgun_Sabot</defaultProjectile>
-						<warmupTime>1.6</warmupTime>
-						<range>102</range>
-						<minRange>10</minRange>
-						<ticksBetweenBurstShots>10</ticksBetweenBurstShots>
-						<burstShotCount>1</burstShotCount>
-						<soundCast>ChargeLance_Fire</soundCast>
+						<defaultProjectile>Bullet_40x53mmGrenade_HE</defaultProjectile>
+						<warmupTime>0.6</warmupTime>
+						<range>55</range>
+						<minRange>4</minRange>
+						<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+						<burstShotCount>5</burstShotCount>
+						<soundCast>AGS</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
-						<muzzleFlashScale>45</muzzleFlashScale>
+						<muzzleFlashScale>18</muzzleFlashScale>
 						<recoilPattern>Mounted</recoilPattern>
 						<requireLineOfSight>false</requireLineOfSight>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
 					</Properties>
+					<AmmoUser>
+						<magazineSize>40</magazineSize>
+						<reloadTime>10.9</reloadTime>
+						<ammoSet>AmmoSet_40x53mmGrenade</ammoSet>
+					</AmmoUser>
 					<FireModes>
 						<aiUseBurstMode>TRUE</aiUseBurstMode>
 						<aiAimMode>AimedShot</aiAimMode>
@@ -152,69 +141,41 @@
 					</FireModes>
 				</li>
 
-				<!-- ========== Armored Pulse Turrets, one caliber higher PLUS========== -->
+				<!-- ========== Anti Aircraft Precision ========== -->
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
-					<defName>ZXT_Gun_Armoredpowerpulseturret</defName>
+					<defName>ADE_Gun_HST</defName>
 					<statBases>
-						<RangedWeapon_Cooldown>0.25</RangedWeapon_Cooldown>
-						<SightsEfficiency>1</SightsEfficiency>
-						<ShotSpread>0.07</ShotSpread>
-						<SwayFactor>1.22</SwayFactor>
-						<Bulk>37.08</Bulk>
+						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+						<SightsEfficiency>1.2</SightsEfficiency>
+						<ShotSpread>0.01</ShotSpread>
+						<SwayFactor>1.32</SwayFactor>
+						<Bulk>28.72</Bulk>
 					</statBases>
 					<Properties>
-						<recoilAmount>0.75</recoilAmount>
+						<recoilAmount>1.80</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
-						<defaultProjectile>Bullet_8x50mmCharged</defaultProjectile>
+						<defaultProjectile>Bullet_20x128mmOerlikon_AP</defaultProjectile>
 						<warmupTime>1.4</warmupTime>
-						<range>78</range>
+						<range>65</range>
 						<minRange>6</minRange>
-						<ticksBetweenBurstShots>3</ticksBetweenBurstShots>
-						<burstShotCount>20</burstShotCount>
-						<soundCast>Shot_ChargeBlaster</soundCast>
+						<soundCast>autocannon_slow</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
-						<muzzleFlashScale>22</muzzleFlashScale>
+						<targetParams>
+							<canTargetLocations>true</canTargetLocations>
+						</targetParams>
+						<muzzleFlashScale>45</muzzleFlashScale>
 						<recoilPattern>Mounted</recoilPattern>
 					</Properties>
+					<AmmoUser>
+						<magazineSize>150</magazineSize>
+						<reloadTime>7.8</reloadTime>
+						<ammoSet>AmmoSet_20x128mmOerlikon</ammoSet>
+					</AmmoUser>
 					<FireModes>
-						<aiUseBurstMode>FALSE</aiUseBurstMode>
 						<aiAimMode>AimedShot</aiAimMode>
 						<noSnapshot>true</noSnapshot>
-						<noSingleShot>true</noSingleShot>
-					</FireModes>
-				</li>
-				<!-- ========== Armored Gatling Gun, ========= -->
-				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
-					<defName>ZXT_Gun_Advancedrotarypulsemachinegunturret</defName>
-					<statBases>
-						<RangedWeapon_Cooldown>0.25</RangedWeapon_Cooldown>
-						<SightsEfficiency>1</SightsEfficiency>
-						<ShotSpread>0.11</ShotSpread>
-						<SwayFactor>1.25</SwayFactor>
-						<Bulk>37.08</Bulk>
-					</statBases>
-					<Properties>
-						<recoilAmount>0.725</recoilAmount>
-						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-						<hasStandardCommand>true</hasStandardCommand>
-						<defaultProjectile>Bullet_12x64mmCharged</defaultProjectile>
-						<warmupTime>1.25</warmupTime>
-						<range>77</range>
-						<minRange>10</minRange>
-						<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
-						<burstShotCount>30</burstShotCount>
-						<soundCast>Shot_ChargeBlaster</soundCast>
-						<soundCastTail>GunTail_Medium</soundCastTail>
-						<muzzleFlashScale>22</muzzleFlashScale>
-						<recoilPattern>Mounted</recoilPattern>
-					</Properties>
-					<FireModes>
-						<aiUseBurstMode>FALSE</aiUseBurstMode>
-						<aiAimMode>AimedShot</aiAimMode>
-						<noSnapshot>true</noSnapshot>
-						<noSingleShot>true</noSingleShot>
 					</FireModes>
 				</li>
 

--- a/Patches/ADE Advanced turrets PLUS/Buildings_Security.xml
+++ b/Patches/ADE Advanced turrets PLUS/Buildings_Security.xml
@@ -77,6 +77,7 @@
 						<defaultProjectile>Bullet_145x114mm_FMJ</defaultProjectile>
 						<warmupTime>1.1</warmupTime>
 						<range>68</range>
+						<minRange>4</minRange>
 						<ticksBetweenBurstShots>3</ticksBetweenBurstShots>
 						<burstShotCount>20</burstShotCount>
 						<soundCast>Shot_Autocannon</soundCast>
@@ -115,6 +116,8 @@
 						<defaultProjectile>Bullet_20x102mmNATO_AP</defaultProjectile>
 						<warmupTime>0.6</warmupTime>
 						<range>62</range>
+						<minRange>6</minRange>
+						<minRange>10</minRange>
 						<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
 						<burstShotCount>20</burstShotCount>
 						<soundCast>Shot_Autocannon</soundCast>
@@ -157,6 +160,7 @@
 						<defaultProjectile>Bullet_57x483mmBofors_HE</defaultProjectile>
 						<warmupTime>2.5</warmupTime>
 						<range>80</range>
+						<minRange>8</minRange>
 						<soundCast>autocannon_slow</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<targetParams>

--- a/Patches/ADE Pulse Turrets PLUS/Buildings_Security.xml
+++ b/Patches/ADE Pulse Turrets PLUS/Buildings_Security.xml
@@ -98,6 +98,7 @@
 						<defaultProjectile>Bullet_8x35mmCharged</defaultProjectile>
 						<warmupTime>1.4</warmupTime>
 						<range>72</range>
+						<minRange>6</minRange>
 						<ticksBetweenBurstShots>3</ticksBetweenBurstShots>
 						<burstShotCount>20</burstShotCount>
 						<soundCast>Shot_ChargeBlaster</soundCast>
@@ -105,11 +106,6 @@
 						<muzzleFlashScale>12</muzzleFlashScale>
 						<recoilPattern>Mounted</recoilPattern>
 					</Properties>
-					<AmmoUser>
-						<magazineSize>200</magazineSize>
-						<reloadTime>15.8</reloadTime>
-						<ammoSet>AmmoSet_8x35mmCharged</ammoSet>
-					</AmmoUser>
 					<FireModes>
 						<aiUseBurstMode>FALSE</aiUseBurstMode>
 						<aiAimMode>AimedShot</aiAimMode>
@@ -136,6 +132,7 @@
 						<defaultProjectile>Bullet_12mmRailgun_Sabot</defaultProjectile>
 						<warmupTime>1.6</warmupTime>
 						<range>102</range>
+						<minRange>10</minRange>
 						<ticksBetweenBurstShots>10</ticksBetweenBurstShots>
 						<burstShotCount>1</burstShotCount>
 						<soundCast>ChargeLance_Fire</soundCast>
@@ -147,11 +144,6 @@
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
 					</Properties>
-					<AmmoUser>
-						<magazineSize>100</magazineSize>
-						<reloadTime>15.8</reloadTime>
-						<ammoSet>AmmoSet_12mmRailgun</ammoSet>
-					</AmmoUser>
 					<FireModes>
 						<aiUseBurstMode>TRUE</aiUseBurstMode>
 						<aiAimMode>AimedShot</aiAimMode>
@@ -178,6 +170,7 @@
 						<defaultProjectile>Bullet_8x50mmCharged</defaultProjectile>
 						<warmupTime>1.4</warmupTime>
 						<range>78</range>
+						<minRange>6</minRange>
 						<ticksBetweenBurstShots>3</ticksBetweenBurstShots>
 						<burstShotCount>20</burstShotCount>
 						<soundCast>Shot_ChargeBlaster</soundCast>
@@ -185,11 +178,6 @@
 						<muzzleFlashScale>22</muzzleFlashScale>
 						<recoilPattern>Mounted</recoilPattern>
 					</Properties>
-					<AmmoUser>
-						<magazineSize>250</magazineSize>
-						<reloadTime>16.5</reloadTime>
-						<ammoSet>AmmoSet_8x50mmCharged</ammoSet>
-					</AmmoUser>
 					<FireModes>
 						<aiUseBurstMode>FALSE</aiUseBurstMode>
 						<aiAimMode>AimedShot</aiAimMode>
@@ -214,6 +202,7 @@
 						<defaultProjectile>Bullet_12x64mmCharged</defaultProjectile>
 						<warmupTime>1.25</warmupTime>
 						<range>77</range>
+						<minRange>10</minRange>
 						<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
 						<burstShotCount>30</burstShotCount>
 						<soundCast>Shot_ChargeBlaster</soundCast>
@@ -221,11 +210,6 @@
 						<muzzleFlashScale>22</muzzleFlashScale>
 						<recoilPattern>Mounted</recoilPattern>
 					</Properties>
-					<AmmoUser>
-						<magazineSize>300</magazineSize>
-						<reloadTime>18.5</reloadTime>
-						<ammoSet>AmmoSet_MechCharged</ammoSet>
-					</AmmoUser>
 					<FireModes>
 						<aiUseBurstMode>FALSE</aiUseBurstMode>
 						<aiAimMode>AimedShot</aiAimMode>

--- a/Patches/Apex - Rimworld Legends/ApexRimworldLegends_Weapons_AssaultRifles.xml
+++ b/Patches/Apex - Rimworld Legends/ApexRimworldLegends_Weapons_AssaultRifles.xml
@@ -271,7 +271,7 @@
 						<recoilAmount>1.96</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
-						<defaultProjectile>Bullet_5x35mmCharged</defaultProjectile>
+						<defaultProjectile>Bullet_8x40mmCharged</defaultProjectile>
 						<burstShotCount>6</burstShotCount>
 						<ticksBetweenBurstShots>5.2</ticksBetweenBurstShots>
 						<warmupTime>1</warmupTime>
@@ -283,7 +283,7 @@
 					<AmmoUser>
 						<magazineSize>36</magazineSize>
 						<reloadTime>4</reloadTime>
-						<ammoSet>AmmoSet_5x35mmCharged</ammoSet>
+						<ammoSet>AmmoSet_8x40mmCharged</ammoSet>
 					</AmmoUser>
 					<FireModes />
 					<weaponTags>

--- a/Patches/Apex - Rimworld Legends/ApexRimworldLegends_Weapons_AssaultRifles.xml
+++ b/Patches/Apex - Rimworld Legends/ApexRimworldLegends_Weapons_AssaultRifles.xml
@@ -254,7 +254,7 @@
 						</tools>
 					</value>
 				</li>
-		<!-- Havoc High velocity 6x22 -->
+		<!-- Havoc low velocity 5x35 -->
 				<li Class="PatchOperationAdd">
 				   <xpath>Defs</xpath>
 				   <value>
@@ -263,7 +263,7 @@
 						 <defName>AmmoSet_6x22mmCharged_HighVelocity</defName>
 						 <label>6x22 Charged (High Velocity)</label>
 						 <ammoTypes>
-							<Ammo_5x35mmCharged>Bullet_6x22mmCharged_HighVelocity</Ammo_5x35mmCharged>
+							<Ammo_6x22mmCharged>Bullet_6x22mmCharged_HighVelocity</Ammo_6x22mmCharged>
 						 </ammoTypes>
 					  </CombatExtended.AmmoSetDef>
 					  <!-- ================== Projectiles ================== -->
@@ -280,7 +280,7 @@
 							</secondaryDamage>
 							<speed>201</speed>
 							<armorPenetrationSharp>20</armorPenetrationSharp>
-							<armorPenetrationBlunt>22.5</armorPenetrationBlunt>
+							<armorPenetrationBlunt>18.5</armorPenetrationBlunt>
 						 </projectile>
 					  </ThingDef>
 				   </value>

--- a/Patches/Apex - Rimworld Legends/ApexRimworldLegends_Weapons_AssaultRifles.xml
+++ b/Patches/Apex - Rimworld Legends/ApexRimworldLegends_Weapons_AssaultRifles.xml
@@ -258,29 +258,29 @@
 				<li Class="PatchOperationAdd">
 				   <xpath>Defs</xpath>
 				   <value>
-					  <!-- ============== 5x35 low velocity ammoset ============ -->
+					  <!-- ============== 6x22 High velocity ammoset ============ -->
 					  <CombatExtended.AmmoSetDef>
-						 <defName>AmmoSet_5x35mmCharged_LowVelocity</defName>
-						 <label>5x35 Charged (Low Velocity)</label>
+						 <defName>AmmoSet_6x22mmCharged_HighVelocity</defName>
+						 <label>6x22 Charged (Low Velocity)</label>
 						 <ammoTypes>
-							<Ammo_5x35mmCharged>Bullet_5x35mmCharged_LowVelocity</Ammo_5x35mmCharged>
+							<Ammo_5x35mmCharged>Bullet_6x22mmCharged_HighVelocity</Ammo_5x35mmCharged>
 						 </ammoTypes>
 					  </CombatExtended.AmmoSetDef>
 					  <!-- ================== Projectiles ================== -->
-					  <ThingDef ParentName="Base5x35mmChargedBullet">
-						 <defName>Bullet_5x35mmCharged_LowVelocity</defName>
-						 <label>5x35mm Charged Bullet (Low Velocity)</label>
+					  <ThingDef ParentName="6x22mmChargedBase">
+						 <defName>Bullet_6x22mmCharged_HighVelocity</defName>
+						 <label>6x22 Charged Bullet (High Velocity)</label>
 						 <projectile Class="CombatExtended.ProjectilePropertiesCE">
-							<damageAmountBase>10</damageAmountBase>
+							<damageAmountBase>11</damageAmountBase>
 							<secondaryDamage>
 							   <li>
 								  <def>Bomb_Secondary</def>
 								  <amount>2</amount>
 							   </li>
 							</secondaryDamage>
-							<speed>100</speed>
+							<speed>201</speed>
 							<armorPenetrationSharp>20</armorPenetrationSharp>
-							<armorPenetrationBlunt>25</armorPenetrationBlunt>
+							<armorPenetrationBlunt>18.5</armorPenetrationBlunt>
 						 </projectile>
 					  </ThingDef>
 				   </value>
@@ -301,7 +301,7 @@
 						<recoilAmount>1.96</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
-						<defaultProjectile>Bullet_5x35mmCharged_LowVelocity</defaultProjectile>
+						<defaultProjectile>Bullet_6x22mmCharged_HighVelocity</defaultProjectile>
 						<burstShotCount>6</burstShotCount>
 						<ticksBetweenBurstShots>5.2</ticksBetweenBurstShots>
 						<warmupTime>1</warmupTime>
@@ -313,7 +313,7 @@
 					<AmmoUser>
 						<magazineSize>36</magazineSize>
 						<reloadTime>4</reloadTime>
-						<ammoSet>AmmoSet_5x35mmCharged_LowVelocity</ammoSet>
+						<ammoSet>AmmoSet_6x22mmCharged_HighVelocity</ammoSet>
 					</AmmoUser>
 					<FireModes />
 					<weaponTags>

--- a/Patches/Apex - Rimworld Legends/ApexRimworldLegends_Weapons_AssaultRifles.xml
+++ b/Patches/Apex - Rimworld Legends/ApexRimworldLegends_Weapons_AssaultRifles.xml
@@ -254,14 +254,14 @@
 						</tools>
 					</value>
 				</li>
-		<!-- Havoc low velocity 5x35 -->
+		<!-- Havoc High velocity 6x22 -->
 				<li Class="PatchOperationAdd">
 				   <xpath>Defs</xpath>
 				   <value>
 					  <!-- ============== 6x22 High velocity ammoset ============ -->
 					  <CombatExtended.AmmoSetDef>
 						 <defName>AmmoSet_6x22mmCharged_HighVelocity</defName>
-						 <label>6x22 Charged (Low Velocity)</label>
+						 <label>6x22 Charged (High Velocity)</label>
 						 <ammoTypes>
 							<Ammo_5x35mmCharged>Bullet_6x22mmCharged_HighVelocity</Ammo_5x35mmCharged>
 						 </ammoTypes>
@@ -280,7 +280,7 @@
 							</secondaryDamage>
 							<speed>201</speed>
 							<armorPenetrationSharp>20</armorPenetrationSharp>
-							<armorPenetrationBlunt>18.5</armorPenetrationBlunt>
+							<armorPenetrationBlunt>22.5</armorPenetrationBlunt>
 						 </projectile>
 					  </ThingDef>
 				   </value>

--- a/Patches/Apex - Rimworld Legends/ApexRimworldLegends_Weapons_AssaultRifles.xml
+++ b/Patches/Apex - Rimworld Legends/ApexRimworldLegends_Weapons_AssaultRifles.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <Patch>
 	<Operation Class="PatchOperationFindMod">
 		<mods>
@@ -6,7 +6,6 @@
 		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>
-
 				<!-- VK-47 Flatline -->
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>ARL_BullpupRifle</defName>
@@ -254,7 +253,7 @@
 						</tools>
 					</value>
 				</li>
-		<!-- Havoc low velocity 5x35 -->
+		<!-- Havoc high velocity 6x22mm charged rounds-->
 				<li Class="PatchOperationAdd">
 				   <xpath>Defs</xpath>
 				   <value>
@@ -267,7 +266,7 @@
 						 </ammoTypes>
 					  </CombatExtended.AmmoSetDef>
 					  <!-- ================== Projectiles ================== -->
-					  <ThingDef ParentName="6x22mmChargedBase">
+					  <ThingDef ParentName="Base6x22mmChargedBullet">
 						 <defName>Bullet_6x22mmCharged_HighVelocity</defName>
 						 <label>6x22 Charged Bullet (High Velocity)</label>
 						 <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -364,7 +363,6 @@
 						</tools>
 					</value>
 				</li>
-
 			</operations>
 		</match>
 	</Operation>

--- a/Patches/Apex - Rimworld Legends/ApexRimworldLegends_Weapons_AssaultRifles.xml
+++ b/Patches/Apex - Rimworld Legends/ApexRimworldLegends_Weapons_AssaultRifles.xml
@@ -254,8 +254,38 @@
 						</tools>
 					</value>
 				</li>
-
-				<!-- Havoc -->
+		<!-- Havoc low velocity 5x35 -->
+				<li Class="PatchOperationAdd">
+				   <xpath>Defs</xpath>
+				   <value>
+					  <!-- ============== 5x35 low velocity ammoset ============ -->
+					  <CombatExtended.AmmoSetDef>
+						 <defName>AmmoSet_5x35mmCharged_LowVelocity</defName>
+						 <label>5x35 Charged (Low Velocity)</label>
+						 <ammoTypes>
+							<Ammo_5x35mmCharged>Bullet_5x35mmCharged_LowVelocity</Ammo_5x35mmCharged>
+						 </ammoTypes>
+					  </CombatExtended.AmmoSetDef>
+					  <!-- ================== Projectiles ================== -->
+					  <ThingDef ParentName="Base5x35mmChargedBullet">
+						 <defName>Bullet_5x35mmCharged_LowVelocity</defName>
+						 <label>5x35mm Charged Bullet (Low Velocity)</label>
+						 <projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<damageAmountBase>10</damageAmountBase>
+							<secondaryDamage>
+							   <li>
+								  <def>Bomb_Secondary</def>
+								  <amount>2</amount>
+							   </li>
+							</secondaryDamage>
+							<speed>100</speed>
+							<armorPenetrationSharp>20</armorPenetrationSharp>
+							<armorPenetrationBlunt>25</armorPenetrationBlunt>
+						 </projectile>
+					  </ThingDef>
+				   </value>
+				</li>
+		<!-- Havoc -->
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>ARL_MechanoidRifle</defName>
 					<statBases>
@@ -271,7 +301,7 @@
 						<recoilAmount>1.96</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
-						<defaultProjectile>Bullet_8x40mmCharged</defaultProjectile>
+						<defaultProjectile>Bullet_5x35mmCharged_LowVelocity</defaultProjectile>
 						<burstShotCount>6</burstShotCount>
 						<ticksBetweenBurstShots>5.2</ticksBetweenBurstShots>
 						<warmupTime>1</warmupTime>
@@ -283,21 +313,19 @@
 					<AmmoUser>
 						<magazineSize>36</magazineSize>
 						<reloadTime>4</reloadTime>
-						<ammoSet>AmmoSet_8x40mmCharged</ammoSet>
+						<ammoSet>AmmoSet_5x35mmCharged_LowVelocity</ammoSet>
 					</AmmoUser>
 					<FireModes />
 					<weaponTags>
 						<li>CE_AI_AssaultWeapon</li>
 					</weaponTags>
 				</li>
-
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="ARL_MechanoidRifle"]/label</xpath>
 					<value>
 						<label>Havoc</label>
 					</value>
 				</li>
-
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="ARL_MechanoidRifle"]/tools</xpath>
 					<value>

--- a/Patches/Apex - Rimworld Legends/ApexRimworldLegends_Weapons_AssaultRifles.xml
+++ b/Patches/Apex - Rimworld Legends/ApexRimworldLegends_Weapons_AssaultRifles.xml
@@ -270,16 +270,16 @@
 						 <defName>Bullet_6x22mmCharged_HighVelocity</defName>
 						 <label>6x22 Charged Bullet (High Velocity)</label>
 						 <projectile Class="CombatExtended.ProjectilePropertiesCE">
-							<damageAmountBase>11</damageAmountBase>
+							<damageAmountBase>15</damageAmountBase>
 							<secondaryDamage>
 							   <li>
 								  <def>Bomb_Secondary</def>
-								  <amount>2</amount>
+								  <amount>5</amount>
 							   </li>
 							</secondaryDamage>
-							<speed>201</speed>
+							<speed>205</speed>
 							<armorPenetrationSharp>20</armorPenetrationSharp>
-							<armorPenetrationBlunt>18.5</armorPenetrationBlunt>
+							<armorPenetrationBlunt>44.1</armorPenetrationBlunt>
 						 </projectile>
 					  </ThingDef>
 				   </value>
@@ -363,6 +363,7 @@
 						</tools>
 					</value>
 				</li>
+
 			</operations>
 		</match>
 	</Operation>


### PR DESCRIPTION
Nerfed Havoc Performance back down to assault rifle levels, Prior ammo had 30mm RHA which was charge lance/blaster levels of penetration, nerfed it to 8x40 Mechanoid Ammo with 16mm RHA penetration