### PR TITLE
No stuff4 unfinished arrow

### DIFF
--- a/Defs/ThingDefs_Items/Items_Unfinished.xml
+++ b/Defs/ThingDefs_Items/Items_Unfinished.xml
@@ -1,95 +1,95 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
 
-  <ThingDef ParentName="UnfinishedBase">
-    <defName>UnfinishedAmmo</defName>
-    <label>Unfinished ammo batch</label>
-    <graphicData>
-      <texPath>Things/Item/Unfinished/UnfinishedComponent</texPath>
-      <graphicClass>Graphic_Single</graphicClass>
-    </graphicData>
-    <stuffCategories Inherit="False" />
-  </ThingDef>
+	<ThingDef ParentName="UnfinishedBase">
+	<defName>UnfinishedAmmo</defName>
+	<label>Unfinished ammo batch</label>
+	<graphicData>
+		<texPath>Things/Item/Unfinished/UnfinishedComponent</texPath>
+		<graphicClass>Graphic_Single</graphicClass>
+	</graphicData>
+	<stuffCategories Inherit="False" />
+	</ThingDef>
 
-  <ThingDef ParentName="UnfinishedBase">
-    <defName>UnfinishedArrows</defName>
-    <label>Unfinished arrow batch</label>
-    <graphicData>
-      <texPath>Things/Item/Unfinished/UnfinishedGun</texPath>
-      <graphicClass>Graphic_Single</graphicClass>
-      <color>(133,97,67)</color>
-    </graphicData>
-    <stuffCategories Inherit="False" />
-  </ThingDef>
+	<ThingDef ParentName="UnfinishedBase">
+	<defName>UnfinishedArrows</defName>
+	<label>Unfinished arrow batch</label>
+	<graphicData>
+		<texPath>Things/Item/Unfinished/UnfinishedGun</texPath>
+		<graphicClass>Graphic_Single</graphicClass>
+		<color>(133,97,67)</color>
+	</graphicData>
+	<stuffCategories Inherit="False" />
+	</ThingDef>
 
-  <ThingDef ParentName="UnfinishedBase">
-    <defName>UnfinishedTurretGun</defName>
-    <label>Unfinished turret gun</label>
-    <graphicData>
-      <texPath>Things/Item/Unfinished/UnfinishedGun</texPath>
-      <graphicClass>Graphic_Single</graphicClass>
-    </graphicData>
-    <stuffCategories Inherit="False">
-      <li>Metallic</li>
-    </stuffCategories>
-  </ThingDef>
+	<ThingDef ParentName="UnfinishedBase">
+	<defName>UnfinishedTurretGun</defName>
+	<label>Unfinished turret gun</label>
+	<graphicData>
+		<texPath>Things/Item/Unfinished/UnfinishedGun</texPath>
+		<graphicClass>Graphic_Single</graphicClass>
+	</graphicData>
+	<stuffCategories Inherit="False">
+		<li>Metallic</li>
+	</stuffCategories>
+	</ThingDef>
 
-  <ThingDef ParentName="UnfinishedBase">
-    <defName>UnfinishedShield</defName>
-    <label>Unfinished shield</label>
-    <graphicData>
-      <texPath>Things/Item/Unfinished/UnfinishedTechArmor</texPath>
-      <graphicClass>Graphic_Single</graphicClass>
-    </graphicData>
-    <stuffCategories>
-      <li>Metallic</li>
-      <li>Woody</li>
-      <li>Stony</li>
-      <li>Fabric</li>
-      <li>Leathery</li>
-    </stuffCategories>
-  </ThingDef>
+	<ThingDef ParentName="UnfinishedBase">
+	<defName>UnfinishedShield</defName>
+	<label>Unfinished shield</label>
+	<graphicData>
+		<texPath>Things/Item/Unfinished/UnfinishedTechArmor</texPath>
+		<graphicClass>Graphic_Single</graphicClass>
+	</graphicData>
+	<stuffCategories>
+		<li>Metallic</li>
+		<li>Woody</li>
+		<li>Stony</li>
+		<li>Fabric</li>
+		<li>Leathery</li>
+	</stuffCategories>
+	</ThingDef>
 
-  <ThingDef ParentName="UnfinishedTechArmor">
-    <defName>UnfinishedSteeledTechArmor</defName>
-    <label>unfinished hard metal armor</label>
-    <description>An unfinished piece of hard metal armor.</description>
-    <stuffCategories>
-      <li>Steeled</li>
-    </stuffCategories>
-  </ThingDef>
+	<ThingDef ParentName="UnfinishedTechArmor">
+	<defName>UnfinishedSteeledTechArmor</defName>
+	<label>unfinished hard metal armor</label>
+	<description>An unfinished piece of hard metal armor.</description>
+	<stuffCategories>
+		<li>Steeled</li>
+	</stuffCategories>
+	</ThingDef>
 
-  <ThingDef ParentName="UnfinishedBase">
-    <defName>UnfinishedArmoredApparel</defName>
-    <label>unfinished armored apparel</label>
-    <description>An unfinished piece of an armored apparel.</description>
-    <graphicData>
-      <texPath>Things/Item/Unfinished/UnfinishedApparel</texPath>
-      <graphicClass>Graphic_Single</graphicClass>
-    </graphicData>
-    <stuffCategories>
-      <li>Fabric</li>
-      <li>SoftArmor</li>
-    </stuffCategories>
-    <comps>
-      <li>
-        <compClass>CompColorable</compClass>
-      </li>
-    </comps>
-  </ThingDef>
+	<ThingDef ParentName="UnfinishedBase">
+	<defName>UnfinishedArmoredApparel</defName>
+	<label>unfinished armored apparel</label>
+	<description>An unfinished piece of an armored apparel.</description>
+	<graphicData>
+		<texPath>Things/Item/Unfinished/UnfinishedApparel</texPath>
+		<graphicClass>Graphic_Single</graphicClass>
+	</graphicData>
+	<stuffCategories>
+		<li>Fabric</li>
+		<li>SoftArmor</li>
+	</stuffCategories>
+	<comps>
+		<li>
+		<compClass>CompColorable</compClass>
+		</li>
+	</comps>
+	</ThingDef>
 
-  <!-- ======================= Minified things ========================= -->
+	<!-- ======================= Minified things ========================= -->
 
-  <ThingDef ParentName="MinifiedThing">
-    <defName>MinifiedTurretGun</defName>
-    <label>improvised turret</label>
-    <thingCategories>
-      <li>WeaponsTurrets</li>
-    </thingCategories>
-    <statBases>
-      <Mass>16</Mass>
-      <Bulk>20</Bulk>
-    </statBases>
-  </ThingDef>
+	<ThingDef ParentName="MinifiedThing">
+	<defName>MinifiedTurretGun</defName>
+	<label>improvised turret</label>
+	<thingCategories>
+		<li>WeaponsTurrets</li>
+	</thingCategories>
+	<statBases>
+		<Mass>16</Mass>
+		<Bulk>20</Bulk>
+	</statBases>
+	</ThingDef>
 
 </Defs>

--- a/Defs/ThingDefs_Items/Items_Unfinished.xml
+++ b/Defs/ThingDefs_Items/Items_Unfinished.xml
@@ -17,8 +17,9 @@
     <graphicData>
       <texPath>Things/Item/Unfinished/UnfinishedGun</texPath>
       <graphicClass>Graphic_Single</graphicClass>
+      <color>(133,97,67)</color>
     </graphicData>
-    <stuffCategories Inherit="False"/>
+    <stuffCategories Inherit="False" />
   </ThingDef>
 
   <ThingDef ParentName="UnfinishedBase">

--- a/Defs/ThingDefs_Items/Items_Unfinished.xml
+++ b/Defs/ThingDefs_Items/Items_Unfinished.xml
@@ -73,7 +73,7 @@
 		</stuffCategories>
 		<comps>
 			<li>
-			<compClass>CompColorable</compClass>
+				<compClass>CompColorable</compClass>
 			</li>
 		</comps>
 	</ThingDef>

--- a/Defs/ThingDefs_Items/Items_Unfinished.xml
+++ b/Defs/ThingDefs_Items/Items_Unfinished.xml
@@ -2,94 +2,94 @@
 <Defs>
 
 	<ThingDef ParentName="UnfinishedBase">
-	<defName>UnfinishedAmmo</defName>
-	<label>Unfinished ammo batch</label>
-	<graphicData>
-		<texPath>Things/Item/Unfinished/UnfinishedComponent</texPath>
-		<graphicClass>Graphic_Single</graphicClass>
-	</graphicData>
-	<stuffCategories Inherit="False" />
+		<defName>UnfinishedAmmo</defName>
+		<label>Unfinished ammo batch</label>
+		<graphicData>
+			<texPath>Things/Item/Unfinished/UnfinishedComponent</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<stuffCategories Inherit="False" />
 	</ThingDef>
 
 	<ThingDef ParentName="UnfinishedBase">
-	<defName>UnfinishedArrows</defName>
-	<label>Unfinished arrow batch</label>
-	<graphicData>
-		<texPath>Things/Item/Unfinished/UnfinishedGun</texPath>
-		<graphicClass>Graphic_Single</graphicClass>
-		<color>(133,97,67)</color>
-	</graphicData>
-	<stuffCategories Inherit="False" />
+		<defName>UnfinishedArrows</defName>
+		<label>Unfinished arrow batch</label>
+		<graphicData>
+			<texPath>Things/Item/Unfinished/UnfinishedGun</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<color>(133,97,67)</color>
+		</graphicData>
+		<stuffCategories Inherit="False" />
 	</ThingDef>
 
 	<ThingDef ParentName="UnfinishedBase">
-	<defName>UnfinishedTurretGun</defName>
-	<label>Unfinished turret gun</label>
-	<graphicData>
-		<texPath>Things/Item/Unfinished/UnfinishedGun</texPath>
-		<graphicClass>Graphic_Single</graphicClass>
-	</graphicData>
-	<stuffCategories Inherit="False">
-		<li>Metallic</li>
-	</stuffCategories>
+		<defName>UnfinishedTurretGun</defName>
+		<label>Unfinished turret gun</label>
+		<graphicData>
+			<texPath>Things/Item/Unfinished/UnfinishedGun</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<stuffCategories Inherit="False">
+			<li>Metallic</li>
+		</stuffCategories>
 	</ThingDef>
 
 	<ThingDef ParentName="UnfinishedBase">
-	<defName>UnfinishedShield</defName>
-	<label>Unfinished shield</label>
-	<graphicData>
-		<texPath>Things/Item/Unfinished/UnfinishedTechArmor</texPath>
-		<graphicClass>Graphic_Single</graphicClass>
-	</graphicData>
-	<stuffCategories>
-		<li>Metallic</li>
-		<li>Woody</li>
-		<li>Stony</li>
-		<li>Fabric</li>
-		<li>Leathery</li>
-	</stuffCategories>
+		<defName>UnfinishedShield</defName>
+		<label>Unfinished shield</label>
+		<graphicData>
+			<texPath>Things/Item/Unfinished/UnfinishedTechArmor</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<stuffCategories>
+			<li>Metallic</li>
+			<li>Woody</li>
+			<li>Stony</li>
+			<li>Fabric</li>
+			<li>Leathery</li>
+		</stuffCategories>
 	</ThingDef>
 
 	<ThingDef ParentName="UnfinishedTechArmor">
-	<defName>UnfinishedSteeledTechArmor</defName>
-	<label>unfinished hard metal armor</label>
-	<description>An unfinished piece of hard metal armor.</description>
-	<stuffCategories>
-		<li>Steeled</li>
-	</stuffCategories>
+		<defName>UnfinishedSteeledTechArmor</defName>
+		<label>unfinished hard metal armor</label>
+		<description>An unfinished piece of hard metal armor.</description>
+		<stuffCategories>
+			<li>Steeled</li>
+		</stuffCategories>
 	</ThingDef>
 
 	<ThingDef ParentName="UnfinishedBase">
-	<defName>UnfinishedArmoredApparel</defName>
-	<label>unfinished armored apparel</label>
-	<description>An unfinished piece of an armored apparel.</description>
-	<graphicData>
-		<texPath>Things/Item/Unfinished/UnfinishedApparel</texPath>
-		<graphicClass>Graphic_Single</graphicClass>
-	</graphicData>
-	<stuffCategories>
-		<li>Fabric</li>
-		<li>SoftArmor</li>
-	</stuffCategories>
-	<comps>
-		<li>
-		<compClass>CompColorable</compClass>
-		</li>
-	</comps>
+		<defName>UnfinishedArmoredApparel</defName>
+		<label>unfinished armored apparel</label>
+		<description>An unfinished piece of an armored apparel.</description>
+		<graphicData>
+			<texPath>Things/Item/Unfinished/UnfinishedApparel</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<stuffCategories>
+			<li>Fabric</li>
+			<li>SoftArmor</li>
+		</stuffCategories>
+		<comps>
+			<li>
+			<compClass>CompColorable</compClass>
+			</li>
+		</comps>
 	</ThingDef>
 
 	<!-- ======================= Minified things ========================= -->
 
 	<ThingDef ParentName="MinifiedThing">
-	<defName>MinifiedTurretGun</defName>
-	<label>improvised turret</label>
-	<thingCategories>
-		<li>WeaponsTurrets</li>
-	</thingCategories>
-	<statBases>
-		<Mass>16</Mass>
-		<Bulk>20</Bulk>
-	</statBases>
+		<defName>MinifiedTurretGun</defName>
+		<label>improvised turret</label>
+		<thingCategories>
+			<li>WeaponsTurrets</li>
+		</thingCategories>
+		<statBases>
+			<Mass>16</Mass>
+			<Bulk>20</Bulk>
+		</statBases>
 	</ThingDef>
 
 </Defs>

--- a/Defs/ThingDefs_Items/Items_Unfinished.xml
+++ b/Defs/ThingDefs_Items/Items_Unfinished.xml
@@ -1,93 +1,94 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
 
-	<ThingDef ParentName="UnfinishedBase">
-		<defName>UnfinishedAmmo</defName>
-		<label>Unfinished ammo batch</label>
-		<graphicData>
-			<texPath>Things/Item/Unfinished/UnfinishedComponent</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<stuffCategories Inherit="False" />
-	</ThingDef>
+  <ThingDef ParentName="UnfinishedBase">
+    <defName>UnfinishedAmmo</defName>
+    <label>Unfinished ammo batch</label>
+    <graphicData>
+      <texPath>Things/Item/Unfinished/UnfinishedComponent</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <stuffCategories Inherit="False" />
+  </ThingDef>
 
-	<ThingDef ParentName="UnfinishedBase">
-		<defName>UnfinishedArrows</defName>
-		<label>Unfinished arrow batch</label>
-		<graphicData>
-			<texPath>Things/Item/Unfinished/UnfinishedGun</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-	</ThingDef>
+  <ThingDef ParentName="UnfinishedBase">
+    <defName>UnfinishedArrows</defName>
+    <label>Unfinished arrow batch</label>
+    <graphicData>
+      <texPath>Things/Item/Unfinished/UnfinishedGun</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <stuffCategories Inherit="False"/>
+  </ThingDef>
 
-	<ThingDef ParentName="UnfinishedBase">
-		<defName>UnfinishedTurretGun</defName>
-		<label>Unfinished turret gun</label>
-		<graphicData>
-			<texPath>Things/Item/Unfinished/UnfinishedGun</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<stuffCategories Inherit="False">
-			<li>Metallic</li>
-		</stuffCategories>
-	</ThingDef>
+  <ThingDef ParentName="UnfinishedBase">
+    <defName>UnfinishedTurretGun</defName>
+    <label>Unfinished turret gun</label>
+    <graphicData>
+      <texPath>Things/Item/Unfinished/UnfinishedGun</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <stuffCategories Inherit="False">
+      <li>Metallic</li>
+    </stuffCategories>
+  </ThingDef>
 
-	<ThingDef ParentName="UnfinishedBase">
-		<defName>UnfinishedShield</defName>
-		<label>Unfinished shield</label>
-		<graphicData>
-			<texPath>Things/Item/Unfinished/UnfinishedTechArmor</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<stuffCategories>
-			<li>Metallic</li>
-			<li>Woody</li>
-			<li>Stony</li>
-			<li>Fabric</li>
-			<li>Leathery</li>
-		</stuffCategories>
-	</ThingDef>
+  <ThingDef ParentName="UnfinishedBase">
+    <defName>UnfinishedShield</defName>
+    <label>Unfinished shield</label>
+    <graphicData>
+      <texPath>Things/Item/Unfinished/UnfinishedTechArmor</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <stuffCategories>
+      <li>Metallic</li>
+      <li>Woody</li>
+      <li>Stony</li>
+      <li>Fabric</li>
+      <li>Leathery</li>
+    </stuffCategories>
+  </ThingDef>
 
-	<ThingDef ParentName="UnfinishedTechArmor">
-		<defName>UnfinishedSteeledTechArmor</defName>
-		<label>unfinished hard metal armor</label>
-		<description>An unfinished piece of hard metal armor.</description>
-		<stuffCategories>
-			<li>Steeled</li>
-		</stuffCategories>
-	</ThingDef>
+  <ThingDef ParentName="UnfinishedTechArmor">
+    <defName>UnfinishedSteeledTechArmor</defName>
+    <label>unfinished hard metal armor</label>
+    <description>An unfinished piece of hard metal armor.</description>
+    <stuffCategories>
+      <li>Steeled</li>
+    </stuffCategories>
+  </ThingDef>
 
-	<ThingDef ParentName="UnfinishedBase">
-		<defName>UnfinishedArmoredApparel</defName>
-		<label>unfinished armored apparel</label>
-		<description>An unfinished piece of an armored apparel.</description>
-		<graphicData>
-			<texPath>Things/Item/Unfinished/UnfinishedApparel</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<stuffCategories>
-			<li>Fabric</li>
-			<li>SoftArmor</li>
-		</stuffCategories>
-		<comps>
-			<li>
-				<compClass>CompColorable</compClass>
-			</li>
-		</comps>
-	</ThingDef>
+  <ThingDef ParentName="UnfinishedBase">
+    <defName>UnfinishedArmoredApparel</defName>
+    <label>unfinished armored apparel</label>
+    <description>An unfinished piece of an armored apparel.</description>
+    <graphicData>
+      <texPath>Things/Item/Unfinished/UnfinishedApparel</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <stuffCategories>
+      <li>Fabric</li>
+      <li>SoftArmor</li>
+    </stuffCategories>
+    <comps>
+      <li>
+        <compClass>CompColorable</compClass>
+      </li>
+    </comps>
+  </ThingDef>
 
-	<!-- ======================= Minified things ========================= -->
+  <!-- ======================= Minified things ========================= -->
 
-	<ThingDef ParentName="MinifiedThing">
-		<defName>MinifiedTurretGun</defName>
-		<label>improvised turret</label>
-		<thingCategories>
-			<li>WeaponsTurrets</li>
-		</thingCategories>
-		<statBases>
-			<Mass>16</Mass>
-			<Bulk>20</Bulk>
-		</statBases>
-	</ThingDef>
+  <ThingDef ParentName="MinifiedThing">
+    <defName>MinifiedTurretGun</defName>
+    <label>improvised turret</label>
+    <thingCategories>
+      <li>WeaponsTurrets</li>
+    </thingCategories>
+    <statBases>
+      <Mass>16</Mass>
+      <Bulk>20</Bulk>
+    </statBases>
+  </ThingDef>
 
 </Defs>


### PR DESCRIPTION
## Changes

Remove stuff in unfinished arrow

## Reasoning

So I was told that while making poison arrow (or whatever neolithic ammo with a non-stuff in its ingredients) sometimes an error pops out when that non-stuff was used for the stuff of unfinished ammo. So I got rid of it

## Alternatives

Suffer.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (15x poison arrow recipe)
