### PR TITLE
Patch Warhammer 40.000 - Imperium Materials

### DIFF
--- a/Patches/Warhammer 40.000 - Imperium Materials/GrimForge_CE_Resources.xml
+++ b/Patches/Warhammer 40.000 - Imperium Materials/GrimForge_CE_Resources.xml
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Warhammer 40.000 - Imperium Materials</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- Adamantium -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="GF40K_Adamantium"]/stuffProps/categories</xpath>
+				<value>
+					<li>Metallic_Weapon</li>
+					<li>Steeled</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="GF40K_Adamantium"]/statBases</xpath>
+				<value>
+					<Bulk>0.03</Bulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GF40K_Adamantium"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+					<StuffPower_Armor_Sharp>3</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GF40K_Adamantium"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<value>
+					<StuffPower_Armor_Blunt>4.5</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GF40K_Adamantium"]/statBases/StuffPower_Armor_Heat</xpath>
+				<value>
+					<StuffPower_Armor_Heat>0.15</StuffPower_Armor_Heat>
+				</value>
+			</li>
+			
+			<!-- Auramite -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="GF40K_Auramite"]/stuffProps/categories</xpath>
+				<value>
+					<li>Metallic_Weapon</li>
+					<li>Steeled</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="GF40K_Auramite"]/statBases</xpath>
+				<value>
+					<Bulk>0.03</Bulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GF40K_Auramite"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+					<StuffPower_Armor_Sharp>2.1</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GF40K_Auramite"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<value>
+					<StuffPower_Armor_Blunt>3.15</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GF40K_Auramite"]/statBases/StuffPower_Armor_Heat</xpath>
+				<value>
+					<StuffPower_Armor_Heat>0.07</StuffPower_Armor_Heat>
+				</value>
+			</li>
+			
+			<!-- Ceramite -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="GF40K_Ceramite"]/stuffProps/categories</xpath>
+				<value>
+					<li>Steeled</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="GF40K_Ceramite"]/statBases</xpath>
+				<value>
+					<Bulk>0.06</Bulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GF40K_Ceramite"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+					<StuffPower_Armor_Sharp>2.15</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GF40K_Ceramite"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<value>
+					<StuffPower_Armor_Blunt>3.2</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GF40K_Ceramite"]/statBases/StuffPower_Armor_Heat</xpath>
+				<value>
+					<StuffPower_Armor_Heat>0.12</StuffPower_Armor_Heat>
+				</value>
+			</li>
+			
+			<!-- Diamantine -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="GF40K_Diamantine"]/stuffProps/categories</xpath>
+				<value>
+					<li>Steeled</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="GF40K_Diamantine"]/statBases</xpath>
+				<value>
+					<Bulk>0.03</Bulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GF40K_Diamantine"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+					<StuffPower_Armor_Sharp>2.35</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GF40K_Diamantine"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<value>
+					<StuffPower_Armor_Blunt>3.55</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GF40K_Diamantine"]/statBases/StuffPower_Armor_Heat</xpath>
+				<value>
+					<StuffPower_Armor_Heat>0.14</StuffPower_Armor_Heat>
+				</value>
+			</li>
+			
+			<!-- Ferrocrete -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="GF40K_Ferrocrete"]/statBases</xpath>
+				<value>
+					<Bulk>1</Bulk>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -546,6 +546,9 @@ WarCasket Expanded  |
 WarCasket Gundam Addon  |
 Warcasket Persona Weapons   |
 Warcaskets: Adeptus Astartes    |
+Warhammer"ish" - Dryad    |
+Warhammer 40.000 - Imperium Materials   |
+Warhammer 40k - Genes and Psycasts  |
 Wasters Toxic Breather  |
 Weapons+	|
 WWII German Uniforms - V's Edit |


### PR DESCRIPTION
## Additions
- Migrate patch from Warhammer 40.000 - Imperium Materials into CE's side.
  - Rebalanced some materials from their version of the patch.

## Changes
- Add some Warhammer mods to the Supported Mod List that were somehow missed, despite their patches being present.

## Reasoning
- The materials have been balanced to be fairly in-line with their scaling relative to vanilla materials (chiefly plasteel, in this case) while preserving their stated role as an extremely high-tier material as an answer to threats from intentionally OP mods like VOID.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
