### PR TITLE
height fuse

### DIFF
--- a/Defs/Ammo/Shell/81mmMortar.xml
+++ b/Defs/Ammo/Shell/81mmMortar.xml
@@ -80,7 +80,7 @@
       <Mass>5.27</Mass>
       <Bulk>8.17</Bulk>
     </statBases>
-    <ammoClass>GrenadeHETF</ammoClass>
+    <ammoClass>RocketFrag</ammoClass>
     <detonateProjectile>Bullet_81mmMortarShell_HE</detonateProjectile>
   </ThingDef>
 
@@ -96,7 +96,7 @@
       <Mass>5.27</Mass>
       <Bulk>8.17</Bulk>
     </statBases>
-    <ammoClass>RocketFrag</ammoClass>
+    <ammoClass>GrenadeHETF</ammoClass>
     <detonateProjectile>Bullet_81mmMortarShell_HE</detonateProjectile>
   </ThingDef>
 
@@ -281,13 +281,14 @@
       <soundExplode>MortarBomb_Explode</soundExplode>
       <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
       <ai_IsIncendiary>true</ai_IsIncendiary>
+      <detonateMoteDef>Mote_BigExplode</detonateMoteDef>
       <aimHeightOffset>0.6</aimHeightOffset>
     </projectile>
     <comps>
       <li Class="CombatExtended.CompProperties_Fragments">
         <fragments>
-          <Fragment_Large>16</Fragment_Large>
-          <Fragment_Small>25</Fragment_Small>
+          <Fragment_Large>6</Fragment_Large>
+          <Fragment_Small>45</Fragment_Small>
         </fragments>
         <fragAngleRange>-0.5~0.1</fragAngleRange>
       </li>
@@ -303,22 +304,30 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageDef>Bomb</damageDef>
-      <damageAmountBase>156</damageAmountBase>
-      <explosionRadius>2.5</explosionRadius>
+      <damageDef>Smoke</damageDef>
+      <damageAmountBase>0</damageAmountBase>
+      <explosionRadius>0.5</explosionRadius>
       <flyOverhead>true</flyOverhead>
       <soundExplode>MortarBomb_Explode</soundExplode>
       <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
       <ai_IsIncendiary>true</ai_IsIncendiary>
       <aimHeightOffset>6</aimHeightOffset>
+      <detonateMoteDef>Mote_BigExplode</detonateMoteDef>
+      <detonateEffectsScaleOverride>5</detonateEffectsScaleOverride>
     </projectile>
     <comps>
       <li Class="CombatExtended.CompProperties_Fragments">
         <fragments>
-          <Fragment_Large>16</Fragment_Large>
-          <Fragment_Small>25</Fragment_Small>
+          <Fragment_Large>11</Fragment_Large>
+          <Fragment_Small>35</Fragment_Small>
         </fragments>
-        <fragAngleRange>-80~-20</fragAngleRange>
+        <fragAngleRange>-89~-60</fragAngleRange>
+      </li>
+      <li Class="CombatExtended.CompProperties_Fragments">
+        <fragments>
+          <Fragment_Small>15</Fragment_Small>
+        </fragments>
+        <fragAngleRange>-60~-30</fragAngleRange>
       </li>
     </comps>
   </ThingDef>

--- a/Defs/Ammo/Shell/81mmMortar.xml
+++ b/Defs/Ammo/Shell/81mmMortar.xml
@@ -1,642 +1,734 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Defs>
 
-	<ThingCategoryDef>
-		<defName>Ammo81mmMortarShells</defName>
-		<label>81mm mortar shell</label>
-		<parent>AmmoShells</parent>
-		<iconPath>UI/Icons/ThingCategories/CaliberMortar</iconPath>
-	</ThingCategoryDef>
+  <ThingCategoryDef>
+    <defName>Ammo81mmMortarShells</defName>
+    <label>81mm mortar shell</label>
+    <parent>AmmoShells</parent>
+    <iconPath>UI/Icons/ThingCategories/CaliberMortar</iconPath>
+  </ThingCategoryDef>
 
-	<!-- ==================== AmmoSet ========================== -->
+  <!-- ==================== AmmoSet ========================== -->
 
-	<CombatExtended.AmmoSetDef>
-		<defName>AmmoSet_81mmMortarShell</defName>
-		<label>81mm mortar shells</label>
-		<ammoTypes>
-			<!-- Overrides vanilla artillery shell -->
-			<Shell_HighExplosive>Bullet_81mmMortarShell_HE</Shell_HighExplosive>
-			<Shell_Incendiary>Bullet_81mmMortarShell_Incendiary</Shell_Incendiary>
-			<Shell_EMP>Bullet_81mmMortarShell_EMP</Shell_EMP>
-			<Shell_Firefoam>Bullet_81mmMortarShell_Firefoam</Shell_Firefoam>
-			<Shell_Smoke>Bullet_81mmMortarShell_Smoke</Shell_Smoke>
-			<Shell_AntigrainWarhead>Bullet_81mmMortarShell_Antigrain</Shell_AntigrainWarhead>
-			<Shell_Toxic MayRequire="Ludeon.RimWorld.Biotech">Bullet_81mmMortarShell_Tox</Shell_Toxic>
-		</ammoTypes>
-		<isMortarAmmoSet>true</isMortarAmmoSet>
-	</CombatExtended.AmmoSetDef>
+  <CombatExtended.AmmoSetDef>
+    <defName>AmmoSet_81mmMortarShell</defName>
+    <label>81mm mortar shells</label>
+    <ammoTypes>
+      <!-- Overrides vanilla artillery shell -->
+      <Shell_HighExplosive>Bullet_81mmMortarShell_HE</Shell_HighExplosive>
+      <Shell_HighExplosive_HF>Bullet_81mmMortarShell_HE_HF</Shell_HighExplosive_HF>
+      <Shell_HighExplosive_HiF>Bullet_81mmMortarShell_HE_HiF</Shell_HighExplosive_HiF>
+      <Shell_Incendiary>Bullet_81mmMortarShell_Incendiary</Shell_Incendiary>
+      <Shell_EMP>Bullet_81mmMortarShell_EMP</Shell_EMP>
+      <Shell_Firefoam>Bullet_81mmMortarShell_Firefoam</Shell_Firefoam>
+      <Shell_Smoke>Bullet_81mmMortarShell_Smoke</Shell_Smoke>
+      <Shell_AntigrainWarhead>Bullet_81mmMortarShell_Antigrain</Shell_AntigrainWarhead>
+      <Shell_Toxic MayRequire="Ludeon.RimWorld.Biotech">Bullet_81mmMortarShell_Tox</Shell_Toxic>
+    </ammoTypes>
+    <isMortarAmmoSet>true</isMortarAmmoSet>
+  </CombatExtended.AmmoSetDef>
 
-	<!-- ==================== Ammo ========================== -->
+  <!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="81mmMortarShellBase" ParentName="HeavyAmmoBase" Abstract="True">
-		<description>Low-velocity shell designed to be fired from a mortar.</description>
-		<statBases>
-			<MaxHitPoints>200</MaxHitPoints>
-		</statBases>
-		<thingCategories>
-			<li>Ammo81mmMortarShells</li>
-		</thingCategories>
-		<stackLimit>25</stackLimit>
-		<cookOffFlashScale>30</cookOffFlashScale>
-		<cookOffSound>MortarBomb_Explode</cookOffSound>
-		<isMortarAmmo>true</isMortarAmmo>
-	</ThingDef>
+  <ThingDef Class="CombatExtended.AmmoDef" Name="81mmMortarShellBase" ParentName="HeavyAmmoBase" Abstract="True">
+    <description>Low-velocity shell designed to be fired from a mortar.</description>
+    <statBases>
+      <MaxHitPoints>200</MaxHitPoints>
+    </statBases>
+    <thingCategories>
+      <li>Ammo81mmMortarShells</li>
+    </thingCategories>
+    <stackLimit>25</stackLimit>
+    <cookOffFlashScale>30</cookOffFlashScale>
+    <cookOffSound>MortarBomb_Explode</cookOffSound>
+    <isMortarAmmo>true</isMortarAmmo>
+  </ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="81mmMortarShellBaseCraftableBase" ParentName="81mmMortarShellBase" Abstract="True">
-		<tradeTags>
-			<li>CE_AutoEnableTrade</li>
-			<li>CE_AutoEnableCrafting_TableMachining</li>
-		</tradeTags>
-	</ThingDef>
+  <ThingDef Class="CombatExtended.AmmoDef" Name="81mmMortarShellBaseCraftableBase" ParentName="81mmMortarShellBase" Abstract="True">
+    <tradeTags>
+      <li>CE_AutoEnableTrade</li>
+      <li>CE_AutoEnableCrafting_TableMachining</li>
+    </tradeTags>
+  </ThingDef>
 
-	<!-- Need to override mortar shell because of hardcoded vanilla references -->
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="81mmMortarShellBaseCraftableBase">
-		<defName>Shell_HighExplosive</defName>
-		<label>81mm mortar shell (HE)</label>
-		<graphicData>
-			<texPath>Things/Ammo/Mortar/HE</texPath>
-			<graphicClass>Graphic_StackCount</graphicClass>
-		</graphicData>
-		<statBases>
-			<MarketValue>50.09</MarketValue>
-			<Mass>5.27</Mass>
-			<Bulk>8.17</Bulk>
-		</statBases>
-		<ammoClass>GrenadeHE</ammoClass>
-		<detonateProjectile>Bullet_81mmMortarShell_HE</detonateProjectile>
-	</ThingDef>
+  <!-- Need to override mortar shell because of hardcoded vanilla references -->
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="81mmMortarShellBaseCraftableBase">
+    <defName>Shell_HighExplosive</defName>
+    <label>81mm mortar shell (HE)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Mortar/HE</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>50.09</MarketValue>
+      <Mass>5.27</Mass>
+      <Bulk>8.17</Bulk>
+    </statBases>
+    <ammoClass>GrenadeHE</ammoClass>
+    <detonateProjectile>Bullet_81mmMortarShell_HE</detonateProjectile>
+  </ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="81mmMortarShellBaseCraftableBase">
-		<defName>Shell_Incendiary</defName>
-		<label>81mm mortar shell (Incendiary)</label>
-		<graphicData>
-			<texPath>Things/Ammo/Mortar/Incendiary</texPath>
-			<graphicClass>Graphic_StackCount</graphicClass>
-		</graphicData>
-		<statBases>
-			<MarketValue>42.34</MarketValue>
-			<Mass>5.65</Mass>
-			<Bulk>9.0</Bulk>
-		</statBases>
-		<ammoClass>GrenadeIncendiary</ammoClass>
-		<detonateProjectile>Bullet_81mmMortarShell_Incendiary</detonateProjectile>
-	</ThingDef>
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="81mmMortarShellBaseCraftableBase">
+    <defName>Shell_HighExplosive_HF</defName>
+    <label>81mm mortar shell (HE-HF)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Mortar/HE</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>50.09</MarketValue>
+      <Mass>5.27</Mass>
+      <Bulk>8.17</Bulk>
+    </statBases>
+    <ammoClass>GrenadeHETF</ammoClass>
+    <detonateProjectile>Bullet_81mmMortarShell_HE</detonateProjectile>
+  </ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="81mmMortarShellBaseCraftableBase">
-		<defName>Shell_EMP</defName>
-		<label>81mm mortar shell (EMP)</label>
-		<graphicData>
-			<texPath>Things/Ammo/Mortar/EMP</texPath>
-			<graphicClass>Graphic_StackCount</graphicClass>
-		</graphicData>
-		<statBases>
-			<MarketValue>112.42</MarketValue>
-			<Mass>5.27</Mass>
-			<Bulk>8.17</Bulk>
-		</statBases>
-		<ammoClass>GrenadeEMP</ammoClass>
-		<detonateProjectile>Bullet_81mmMortarShell_EMP</detonateProjectile>
-	</ThingDef>
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="81mmMortarShellBaseCraftableBase">
+    <defName>Shell_HighExplosive_HiF</defName>
+    <label>81mm mortar shell (HE-HiF)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Mortar/HE</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>50.09</MarketValue>
+      <Mass>5.27</Mass>
+      <Bulk>8.17</Bulk>
+    </statBases>
+    <ammoClass>RocketFrag</ammoClass>
+    <detonateProjectile>Bullet_81mmMortarShell_HE</detonateProjectile>
+  </ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="81mmMortarShellBaseCraftableBase">
-		<defName>Shell_Firefoam</defName>
-		<label>81mm mortar shell (Foam)</label>
-		<graphicData>
-			<texPath>Things/Ammo/Mortar/Firefoam</texPath>
-			<graphicClass>Graphic_StackCount</graphicClass>
-		</graphicData>
-		<statBases>
-			<MarketValue>37.03</MarketValue>
-			<Mass>4.1</Mass>
-			<Bulk>10.01</Bulk>
-		</statBases>
-		<ammoClass>FoamFuel</ammoClass>
-		<detonateProjectile>Bullet_81mmMortarShell_Firefoam</detonateProjectile>
-	</ThingDef>
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="81mmMortarShellBaseCraftableBase">
+    <defName>Shell_Incendiary</defName>
+    <label>81mm mortar shell (Incendiary)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Mortar/Incendiary</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>42.34</MarketValue>
+      <Mass>5.65</Mass>
+      <Bulk>9.0</Bulk>
+    </statBases>
+    <ammoClass>GrenadeIncendiary</ammoClass>
+    <detonateProjectile>Bullet_81mmMortarShell_Incendiary</detonateProjectile>
+  </ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="81mmMortarShellBaseCraftableBase">
-		<defName>Shell_Smoke</defName>
-		<label>81mm mortar shell (Smoke)</label>
-		<graphicData>
-			<texPath>Things/Ammo/Mortar/Smoke</texPath>
-			<graphicClass>Graphic_StackCount</graphicClass>
-		</graphicData>
-		<statBases>
-			<MarketValue>37.03</MarketValue>
-			<Mass>4.1</Mass>
-			<Bulk>10.01</Bulk>
-		</statBases>
-		<ammoClass>Smoke</ammoClass>
-		<detonateProjectile>Bullet_81mmMortarShell_Smoke</detonateProjectile>
-	</ThingDef>
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="81mmMortarShellBaseCraftableBase">
+    <defName>Shell_EMP</defName>
+    <label>81mm mortar shell (EMP)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Mortar/EMP</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>112.42</MarketValue>
+      <Mass>5.27</Mass>
+      <Bulk>8.17</Bulk>
+    </statBases>
+    <ammoClass>GrenadeEMP</ammoClass>
+    <detonateProjectile>Bullet_81mmMortarShell_EMP</detonateProjectile>
+  </ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="81mmMortarShellBase">
-		<defName>Shell_AntigrainWarhead</defName>
-		<label>81mm mortar shell (Anti)</label>
-		<graphicData>
-			<texPath>Things/Ammo/Mortar/Antigrain</texPath>
-			<graphicClass>Graphic_StackCount</graphicClass>
-		</graphicData>
-		<statBases>
-			<MarketValue>1500</MarketValue>
-			<Mass>6.5</Mass>
-			<Bulk>6</Bulk>
-		</statBases>
-		<thingSetMakerTags>
-			<li>RewardStandardCore</li>
-		</thingSetMakerTags>
-		<tradeTags>
-			<li>CE_AutoEnableTrade_Sellable</li>
-		</tradeTags>
-		<ammoClass>Antigrain</ammoClass>
-		<comps>
-			<!-- Vanilla values -->
-			<li Class="CompProperties_Explosive">
-				<explosiveRadius>14.9</explosiveRadius>
-				<explosiveDamageType>BombSuper</explosiveDamageType>
-				<startWickHitPointsPercent>0.7</startWickHitPointsPercent>
-				<chanceToStartFire>0.22</chanceToStartFire>
-				<damageFalloff>true</damageFalloff>
-				<explosionEffect>GiantExplosion</explosionEffect>
-				<explosionSound>Explosion_GiantBomb</explosionSound>
-				<wickTicks>60~120</wickTicks>
-				<explodeOnKilled>True</explodeOnKilled>
-				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-			</li>
-		</comps>
-	</ThingDef>
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="81mmMortarShellBaseCraftableBase">
+    <defName>Shell_Firefoam</defName>
+    <label>81mm mortar shell (Foam)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Mortar/Firefoam</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>37.03</MarketValue>
+      <Mass>4.1</Mass>
+      <Bulk>10.01</Bulk>
+    </statBases>
+    <ammoClass>FoamFuel</ammoClass>
+    <detonateProjectile>Bullet_81mmMortarShell_Firefoam</detonateProjectile>
+  </ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="81mmMortarShellBaseCraftableBase" MayRequire="Ludeon.RimWorld.Biotech">
-		<defName>Shell_Toxic</defName>
-		<label>81mm mortar shell (Toxic)</label>
-		<graphicData>
-			<texPath>Things/Ammo/Mortar/Toxic</texPath>
-			<graphicClass>Graphic_StackCount</graphicClass>
-		</graphicData>
-		<statBases>
-			<MarketValue>37.03</MarketValue>
-			<Mass>4.1</Mass>
-			<Bulk>10.01</Bulk>
-		</statBases>
-		<ammoClass>Toxic</ammoClass>
-		<detonateProjectile>Bullet_81mmMortarShell_Tox</detonateProjectile>
-	</ThingDef>
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="81mmMortarShellBaseCraftableBase">
+    <defName>Shell_Smoke</defName>
+    <label>81mm mortar shell (Smoke)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Mortar/Smoke</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>37.03</MarketValue>
+      <Mass>4.1</Mass>
+      <Bulk>10.01</Bulk>
+    </statBases>
+    <ammoClass>Smoke</ammoClass>
+    <detonateProjectile>Bullet_81mmMortarShell_Smoke</detonateProjectile>
+  </ThingDef>
 
-	<!-- ================== Projectiles ================== -->
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="81mmMortarShellBase">
+    <defName>Shell_AntigrainWarhead</defName>
+    <label>81mm mortar shell (Anti)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Mortar/Antigrain</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>1500</MarketValue>
+      <Mass>6.5</Mass>
+      <Bulk>6</Bulk>
+    </statBases>
+    <thingSetMakerTags>
+      <li>RewardStandardCore</li>
+    </thingSetMakerTags>
+    <tradeTags>
+      <li>CE_AutoEnableTrade_Sellable</li>
+    </tradeTags>
+    <ammoClass>Antigrain</ammoClass>
+    <comps>
+      <!-- Vanilla values -->
+      <li Class="CompProperties_Explosive">
+        <explosiveRadius>14.9</explosiveRadius>
+        <explosiveDamageType>BombSuper</explosiveDamageType>
+        <startWickHitPointsPercent>0.7</startWickHitPointsPercent>
+        <chanceToStartFire>0.22</chanceToStartFire>
+        <damageFalloff>true</damageFalloff>
+        <explosionEffect>GiantExplosion</explosionEffect>
+        <explosionSound>Explosion_GiantBomb</explosionSound>
+        <wickTicks>60~120</wickTicks>
+        <explodeOnKilled>True</explodeOnKilled>
+        <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+      </li>
+    </comps>
+  </ThingDef>
 
-	<ThingDef Name="Base81mmMortarShell" ParentName="BaseExplosiveBullet" Abstract="true">
-		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
-		<graphicData>
-			<shaderType>TransparentPostLight</shaderType>
-		</graphicData>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>0</speed>
-			<soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
-			<soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
-			<soundAmbient>MortarRound_Ambient</soundAmbient>
-			<flyOverhead>true</flyOverhead>
-			<dropsCasings>false</dropsCasings>
-			<gravityFactor>5</gravityFactor>
-			<shellingProps>
-				<iconPath>Things/WorldObjects/Munitions/Mortar</iconPath>
-				<tilesPerTick>0.06</tilesPerTick>
-				<range>10</range>
-			</shellingProps>
-		</projectile>
-	</ThingDef>
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="81mmMortarShellBaseCraftableBase" MayRequire="Ludeon.RimWorld.Biotech">
+    <defName>Shell_Toxic</defName>
+    <label>81mm mortar shell (Toxic)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Mortar/Toxic</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>37.03</MarketValue>
+      <Mass>4.1</Mass>
+      <Bulk>10.01</Bulk>
+    </statBases>
+    <ammoClass>Toxic</ammoClass>
+    <detonateProjectile>Bullet_81mmMortarShell_Tox</detonateProjectile>
+  </ThingDef>
 
-	<ThingDef ParentName="Base81mmMortarShell">
-		<defName>Bullet_81mmMortarShell_HE</defName>
-		<label>81mm mortar shell (HE)</label>
-		<graphicData>
-			<texPath>Things/Projectile/Mortar/HE</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>Bomb</damageDef>
-			<damageAmountBase>156</damageAmountBase>
-			<explosionRadius>2.5</explosionRadius>
-			<flyOverhead>true</flyOverhead>
-			<soundExplode>MortarBomb_Explode</soundExplode>
-			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-			<ai_IsIncendiary>true</ai_IsIncendiary>
-		</projectile>
-		<comps>
-			<li Class="CombatExtended.CompProperties_Fragments">
-				<fragments>
-					<Fragment_Large>16</Fragment_Large>
-					<Fragment_Small>25</Fragment_Small>
-				</fragments>
-			</li>
-		</comps>
-	</ThingDef>
+  <!-- ================== Projectiles ================== -->
 
-	<ThingDef ParentName="Base81mmMortarShell">
-		<defName>Bullet_81mmMortarShell_Incendiary</defName>
-		<label>81mm mortar shell (Incendiary)</label>
-		<graphicData>
-			<texPath>Things/Projectile/Mortar/Incendiary</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>PrometheumFlame</damageDef>
-			<damageAmountBase>11</damageAmountBase>
-			<explosionRadius>6.5</explosionRadius>
-			<flyOverhead>true</flyOverhead>
-			<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
-			<preExplosionSpawnChance>0.15</preExplosionSpawnChance>
-			<soundExplode>MortarIncendiary_Explode</soundExplode>
-		</projectile>
-	</ThingDef>
+  <ThingDef Name="Base81mmMortarShell" ParentName="BaseExplosiveBullet" Abstract="true">
+    <thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+    <graphicData>
+      <shaderType>TransparentPostLight</shaderType>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <speed>0</speed>
+      <soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
+      <soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
+      <soundAmbient>MortarRound_Ambient</soundAmbient>
+      <flyOverhead>true</flyOverhead>
+      <dropsCasings>false</dropsCasings>
+      <gravityFactor>5</gravityFactor>
+      <shellingProps>
+        <iconPath>Things/WorldObjects/Munitions/Mortar</iconPath>
+        <tilesPerTick>0.06</tilesPerTick>
+        <range>10</range>
+      </shellingProps>
+    </projectile>
+  </ThingDef>
 
-	<ThingDef ParentName="Base81mmMortarShell">
-		<defName>Bullet_81mmMortarShell_EMP</defName>
-		<label>81mm mortar shell (EMP)</label>
-		<graphicData>
-			<texPath>Things/Projectile/Mortar/EMP</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>EMP</damageDef>
-			<damageAmountBase>156</damageAmountBase>
-			<flyOverhead>true</flyOverhead>
-			<explosionRadius>5.5</explosionRadius>
-		</projectile>
-	</ThingDef>
+  <ThingDef ParentName="Base81mmMortarShell">
+    <defName>Bullet_81mmMortarShell_HE</defName>
+    <label>81mm mortar shell (HE)</label>
+    <graphicData>
+      <texPath>Things/Projectile/Mortar/HE</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageDef>Bomb</damageDef>
+      <damageAmountBase>156</damageAmountBase>
+      <explosionRadius>2.5</explosionRadius>
+      <flyOverhead>true</flyOverhead>
+      <soundExplode>MortarBomb_Explode</soundExplode>
+      <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+      <ai_IsIncendiary>true</ai_IsIncendiary>
+    </projectile>
+    <comps>
+      <li Class="CombatExtended.CompProperties_Fragments">
+        <fragments>
+          <Fragment_Large>16</Fragment_Large>
+          <Fragment_Small>25</Fragment_Small>
+        </fragments>
+      </li>
+    </comps>
+  </ThingDef>
 
-	<ThingDef ParentName="Base81mmMortarShell">
-		<defName>Bullet_81mmMortarShell_Firefoam</defName>
-		<label>81mm mortar shell (Foam)</label>
-		<graphicData>
-			<texPath>Things/Projectile/Mortar/Firefoam</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>Extinguish</damageDef>
-			<suppressionFactor>0.0</suppressionFactor>
-			<dangerFactor>0.0</dangerFactor>
-			<explosionRadius>5</explosionRadius>
-			<flyOverhead>true</flyOverhead>
-			<soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
-			<soundExplode>Explosion_EMP</soundExplode>
-			<soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
-			<soundAmbient>MortarRound_Ambient</soundAmbient>
-			<postExplosionSpawnThingDef>Filth_FireFoam</postExplosionSpawnThingDef>
-			<postExplosionSpawnChance>1</postExplosionSpawnChance>
-			<postExplosionSpawnThingCount>3</postExplosionSpawnThingCount>
-			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-			<explosionEffect>ExtinguisherExplosion</explosionEffect>
-		</projectile>
-	</ThingDef>
+  <ThingDef ParentName="Base81mmMortarShell">
+    <defName>Bullet_81mmMortarShell_HE_HF</defName>
+    <label>81mm mortar shell (HE-HF)</label>
+    <thingClass>CombatExtended.ProjectileCE_HeightFuse</thingClass>
+    <graphicData>
+      <texPath>Things/Projectile/Mortar/HE</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageDef>Bomb</damageDef>
+      <damageAmountBase>156</damageAmountBase>
+      <explosionRadius>2.5</explosionRadius>
+      <flyOverhead>true</flyOverhead>
+      <soundExplode>MortarBomb_Explode</soundExplode>
+      <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+      <ai_IsIncendiary>true</ai_IsIncendiary>
+      <aimHeightOffset>0.6</aimHeightOffset>
+    </projectile>
+    <comps>
+      <li Class="CombatExtended.CompProperties_Fragments">
+        <fragments>
+          <Fragment_Large>16</Fragment_Large>
+          <Fragment_Small>25</Fragment_Small>
+        </fragments>
+        <fragAngleRange>-0.5~0.1</fragAngleRange>
+      </li>
+    </comps>
+  </ThingDef>
 
-	<ThingDef ParentName="Base81mmMortarShell">
-		<defName>Bullet_81mmMortarShell_Smoke</defName>
-		<label>81mm mortar shell (Smoke)</label>
-		<graphicData>
-			<texPath>Things/Projectile/Mortar/Smoke</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>Smoke</damageDef>
-			<suppressionFactor>0.0</suppressionFactor>
-			<dangerFactor>0.0</dangerFactor>
-			<explosionRadius>6</explosionRadius>
-			<flyOverhead>true</flyOverhead>
-			<soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
-			<soundExplode>Explosion_EMP</soundExplode>
-			<soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
-			<soundAmbient>MortarRound_Ambient</soundAmbient>
-			<postExplosionGasType>BlindSmoke</postExplosionGasType>
-			<preExplosionSpawnChance>1</preExplosionSpawnChance>
-			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-			<explosionEffect>ExtinguisherExplosion</explosionEffect>
-		</projectile>
-	</ThingDef>
+  <ThingDef ParentName="Base81mmMortarShell">
+    <defName>Bullet_81mmMortarShell_HE_HiF</defName>
+    <label>81mm mortar shell (HE-HiF)</label>
+    <thingClass>CombatExtended.ProjectileCE_HeightFuse</thingClass>
+    <graphicData>
+      <texPath>Things/Projectile/Mortar/HE</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageDef>Bomb</damageDef>
+      <damageAmountBase>156</damageAmountBase>
+      <explosionRadius>2.5</explosionRadius>
+      <flyOverhead>true</flyOverhead>
+      <soundExplode>MortarBomb_Explode</soundExplode>
+      <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+      <ai_IsIncendiary>true</ai_IsIncendiary>
+      <aimHeightOffset>6</aimHeightOffset>
+    </projectile>
+    <comps>
+      <li Class="CombatExtended.CompProperties_Fragments">
+        <fragments>
+          <Fragment_Large>16</Fragment_Large>
+          <Fragment_Small>25</Fragment_Small>
+        </fragments>
+        <fragAngleRange>-80~-20</fragAngleRange>
+      </li>
+    </comps>
+  </ThingDef>
 
-	<ThingDef ParentName="Base81mmMortarShell">
-		<defName>Bullet_81mmMortarShell_Antigrain</defName>
-		<label>81mm mortar shell (Anti)</label>
-		<graphicData>
-			<texPath>Things/Projectile/Mortar/Antigrain</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>BombSuper</damageDef>
-			<explosionRadius>50</explosionRadius>
-			<explosionChanceToStartFire>0.22</explosionChanceToStartFire>
-			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-			<flyOverhead>true</flyOverhead>
-			<explosionEffect>GiantExplosion</explosionEffect>
-			<soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
-			<soundExplode>Explosion_GiantBomb</soundExplode>
-			<soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
-			<soundAmbient>MortarRound_Ambient</soundAmbient>
-			<shellingProps>
-				<damage>0.85</damage>
-			</shellingProps>
-		</projectile>
-	</ThingDef>
+  <ThingDef ParentName="Base81mmMortarShell">
+    <defName>Bullet_81mmMortarShell_Incendiary</defName>
+    <label>81mm mortar shell (Incendiary)</label>
+    <graphicData>
+      <texPath>Things/Projectile/Mortar/Incendiary</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageDef>PrometheumFlame</damageDef>
+      <damageAmountBase>11</damageAmountBase>
+      <explosionRadius>6.5</explosionRadius>
+      <flyOverhead>true</flyOverhead>
+      <preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
+      <preExplosionSpawnChance>0.15</preExplosionSpawnChance>
+      <soundExplode>MortarIncendiary_Explode</soundExplode>
+    </projectile>
+  </ThingDef>
 
-	<ThingDef ParentName="Base81mmMortarShell" MayRequire="Ludeon.RimWorld.Biotech">
-		<defName>Bullet_81mmMortarShell_Tox</defName>
-		<label>81mm mortar shell (Toxic)</label>
-		<graphicData>
-			<texPath>Things/Projectile/Mortar/Toxic</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>ToxGas</damageDef>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
-			<explosionRadius>0.1</explosionRadius>
-			<flyOverhead>true</flyOverhead>
-			<soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
-			<soundExplode>ToxicShellLanded</soundExplode>
-			<soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
-			<soundAmbient>MortarRound_Ambient</soundAmbient>
-			<postExplosionSpawnThingDef>Shell_Toxic_Releasing</postExplosionSpawnThingDef>
-			<postExplosionSpawnThingDefWater>Shell_Toxic_Releasing_Water</postExplosionSpawnThingDefWater>
-		</projectile>
-	</ThingDef>
+  <ThingDef ParentName="Base81mmMortarShell">
+    <defName>Bullet_81mmMortarShell_EMP</defName>
+    <label>81mm mortar shell (EMP)</label>
+    <graphicData>
+      <texPath>Things/Projectile/Mortar/EMP</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageDef>EMP</damageDef>
+      <damageAmountBase>156</damageAmountBase>
+      <flyOverhead>true</flyOverhead>
+      <explosionRadius>5.5</explosionRadius>
+    </projectile>
+  </ThingDef>
 
-	<!-- ==================== Recipes ========================== -->
+  <ThingDef ParentName="Base81mmMortarShell">
+    <defName>Bullet_81mmMortarShell_Firefoam</defName>
+    <label>81mm mortar shell (Foam)</label>
+    <graphicData>
+      <texPath>Things/Projectile/Mortar/Firefoam</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageDef>Extinguish</damageDef>
+      <suppressionFactor>0.0</suppressionFactor>
+      <dangerFactor>0.0</dangerFactor>
+      <explosionRadius>5</explosionRadius>
+      <flyOverhead>true</flyOverhead>
+      <soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
+      <soundExplode>Explosion_EMP</soundExplode>
+      <soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
+      <soundAmbient>MortarRound_Ambient</soundAmbient>
+      <postExplosionSpawnThingDef>Filth_FireFoam</postExplosionSpawnThingDef>
+      <postExplosionSpawnChance>1</postExplosionSpawnChance>
+      <postExplosionSpawnThingCount>3</postExplosionSpawnThingCount>
+      <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+      <explosionEffect>ExtinguisherExplosion</explosionEffect>
+    </projectile>
+  </ThingDef>
 
-	<RecipeDef ParentName="AmmoRecipeBase">
-		<defName>MakeShell_HighExplosive</defName>
-		<label>make 81mm HE mortar shells x5</label>
-		<description>Craft 5 81mm HE mortar shells.</description>
-		<jobString>Making 81mm HE mortar shells.</jobString>
-		<ingredients>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>Steel</li>
-					</thingDefs>
-				</filter>
-				<count>54</count>
-			</li>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>FSX</li>
-					</thingDefs>
-				</filter>
-				<count>10</count>
-			</li>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>ComponentIndustrial</li>
-					</thingDefs>
-				</filter>
-				<count>2</count>
-			</li>
-		</ingredients>
-		<fixedIngredientFilter>
-			<thingDefs>
-				<li>Steel</li>
-				<li>FSX</li>
-				<li>ComponentIndustrial</li>
-			</thingDefs>
-		</fixedIngredientFilter>
-		<products>
-			<Shell_HighExplosive>5</Shell_HighExplosive>
-		</products>
-		<skillRequirements>
-			<Crafting>4</Crafting>
-		</skillRequirements>
-		<workAmount>10600</workAmount>
-	</RecipeDef>
+  <ThingDef ParentName="Base81mmMortarShell">
+    <defName>Bullet_81mmMortarShell_Smoke</defName>
+    <label>81mm mortar shell (Smoke)</label>
+    <graphicData>
+      <texPath>Things/Projectile/Mortar/Smoke</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageDef>Smoke</damageDef>
+      <suppressionFactor>0.0</suppressionFactor>
+      <dangerFactor>0.0</dangerFactor>
+      <explosionRadius>6</explosionRadius>
+      <flyOverhead>true</flyOverhead>
+      <soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
+      <soundExplode>Explosion_EMP</soundExplode>
+      <soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
+      <soundAmbient>MortarRound_Ambient</soundAmbient>
+      <postExplosionGasType>BlindSmoke</postExplosionGasType>
+      <preExplosionSpawnChance>1</preExplosionSpawnChance>
+      <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+      <explosionEffect>ExtinguisherExplosion</explosionEffect>
+    </projectile>
+  </ThingDef>
 
-	<RecipeDef ParentName="AmmoRecipeBase">
-		<defName>MakeShell_Incendiary</defName>
-		<label>make 81mm incendiary mortar shells x5</label>
-		<description>Craft 5 81mm incendiary mortar shells.</description>
-		<jobString>Making 81mm incendiary mortar shells.</jobString>
-		<ingredients>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>Steel</li>
-					</thingDefs>
-				</filter>
-				<count>58</count>
-			</li>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>Prometheum</li>
-					</thingDefs>
-				</filter>
-				<count>5</count>
-			</li>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>ComponentIndustrial</li>
-					</thingDefs>
-				</filter>
-				<count>2</count>
-			</li>
-		</ingredients>
-		<fixedIngredientFilter>
-			<thingDefs>
-				<li>Steel</li>
-				<li>Prometheum</li>
-				<li>ComponentIndustrial</li>
-			</thingDefs>
-		</fixedIngredientFilter>
-		<products>
-			<Shell_Incendiary>5</Shell_Incendiary>
-		</products>
-		<skillRequirements>
-			<Crafting>4</Crafting>
-		</skillRequirements>
-		<workAmount>9000</workAmount>
-	</RecipeDef>
+  <ThingDef ParentName="Base81mmMortarShell">
+    <defName>Bullet_81mmMortarShell_Antigrain</defName>
+    <label>81mm mortar shell (Anti)</label>
+    <graphicData>
+      <texPath>Things/Projectile/Mortar/Antigrain</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageDef>BombSuper</damageDef>
+      <explosionRadius>50</explosionRadius>
+      <explosionChanceToStartFire>0.22</explosionChanceToStartFire>
+      <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+      <flyOverhead>true</flyOverhead>
+      <explosionEffect>GiantExplosion</explosionEffect>
+      <soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
+      <soundExplode>Explosion_GiantBomb</soundExplode>
+      <soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
+      <soundAmbient>MortarRound_Ambient</soundAmbient>
+      <shellingProps>
+        <damage>0.85</damage>
+      </shellingProps>
+    </projectile>
+  </ThingDef>
 
-	<RecipeDef ParentName="AmmoRecipeBase">
-		<defName>MakeShell_EMP</defName>
-		<label>make 81mm EMP mortar shells x5</label>
-		<description>Craft 5 81mm EMP mortar shells.</description>
-		<jobString>Making 81mm EMP mortar shells.</jobString>
-		<researchPrerequisite>MicroelectronicsBasics</researchPrerequisite>
-		<ingredients>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>Steel</li>
-					</thingDefs>
-				</filter>
-				<count>54</count>
-			</li>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>ComponentIndustrial</li>
-					</thingDefs>
-				</filter>
-				<count>14</count>
-			</li>
-		</ingredients>
-		<fixedIngredientFilter>
-			<thingDefs>
-				<li>Steel</li>
-				<li>ComponentIndustrial</li>
-			</thingDefs>
-		</fixedIngredientFilter>
-		<products>
-			<Shell_EMP>5</Shell_EMP>
-		</products>
-		<skillRequirements>
-			<Crafting>4</Crafting>
-		</skillRequirements>
-		<workAmount>13800</workAmount>
-	</RecipeDef>
+  <ThingDef ParentName="Base81mmMortarShell" MayRequire="Ludeon.RimWorld.Biotech">
+    <defName>Bullet_81mmMortarShell_Tox</defName>
+    <label>81mm mortar shell (Toxic)</label>
+    <graphicData>
+      <texPath>Things/Projectile/Mortar/Toxic</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageDef>ToxGas</damageDef>
+      <armorPenetrationSharp>0</armorPenetrationSharp>
+      <armorPenetrationBlunt>0</armorPenetrationBlunt>
+      <explosionRadius>0.1</explosionRadius>
+      <flyOverhead>true</flyOverhead>
+      <soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
+      <soundExplode>ToxicShellLanded</soundExplode>
+      <soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
+      <soundAmbient>MortarRound_Ambient</soundAmbient>
+      <postExplosionSpawnThingDef>Shell_Toxic_Releasing</postExplosionSpawnThingDef>
+      <postExplosionSpawnThingDefWater>Shell_Toxic_Releasing_Water</postExplosionSpawnThingDefWater>
+    </projectile>
+  </ThingDef>
 
-	<RecipeDef ParentName="AmmoRecipeBase">
-		<defName>MakeShell_Firefoam</defName>
-		<label>make 81mm firefoam mortar shells x5</label>
-		<description>Craft 5 81mm firefoam mortar shells.</description>
-		<jobString>Making 81mm firefoam mortar shells.</jobString>
-		<researchPrerequisite>Firefoam</researchPrerequisite>
-		<ingredients>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>Steel</li>
-					</thingDefs>
-				</filter>
-				<count>42</count>
-			</li>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>ComponentIndustrial</li>
-					</thingDefs>
-				</filter>
-				<count>2</count>
-			</li>
-			<li>
-				<filter>
-					<categories>
-						<li>MeatRaw</li>
-					</categories>
-				</filter>
-				<count>17</count>
-			</li>
-		</ingredients>
-		<fixedIngredientFilter>
-			<thingDefs>
-				<li>Steel</li>
-				<li>ComponentIndustrial</li>
-			</thingDefs>
-			<categories>
-				<li>MeatRaw</li>
-			</categories>
-		</fixedIngredientFilter>
-		<products>
-			<Shell_Firefoam>5</Shell_Firefoam>
-		</products>
-		<skillRequirements>
-			<Crafting>4</Crafting>
-		</skillRequirements>
-		<workAmount>8800</workAmount>
-	</RecipeDef>
+  <!-- ==================== Recipes ========================== -->
 
-	<RecipeDef ParentName="AmmoRecipeBase">
-		<defName>MakeShell_Smoke</defName>
-		<label>make 81mm smoke mortar shells x5</label>
-		<description>Craft 5 81mm smoke mortar shells.</description>
-		<jobString>Making 81mm smoke mortar shells.</jobString>
-		<ingredients>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>Steel</li>
-					</thingDefs>
-				</filter>
-				<count>42</count>
-			</li>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>ComponentIndustrial</li>
-					</thingDefs>
-				</filter>
-				<count>2</count>
-			</li>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>Prometheum</li>
-					</thingDefs>
-				</filter>
-				<count>2</count>
-			</li>
-		</ingredients>
-		<fixedIngredientFilter>
-			<thingDefs>
-				<li>Steel</li>
-				<li>Prometheum</li>
-				<li>ComponentIndustrial</li>
-			</thingDefs>
-		</fixedIngredientFilter>
-		<products>
-			<Shell_Smoke>5</Shell_Smoke>
-		</products>
-		<skillRequirements>
-			<Crafting>4</Crafting>
-		</skillRequirements>
-		<workAmount>6600</workAmount>
-	</RecipeDef>
+  <RecipeDef ParentName="AmmoRecipeBase">
+    <defName>MakeShell_HighExplosive</defName>
+    <label>make 81mm HE mortar shells x5</label>
+    <description>Craft 5 81mm HE mortar shells.</description>
+    <jobString>Making 81mm HE mortar shells.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>54</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>FSX</li>
+          </thingDefs>
+        </filter>
+        <count>10</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>2</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>FSX</li>
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Shell_HighExplosive>5</Shell_HighExplosive>
+    </products>
+    <skillRequirements>
+      <Crafting>4</Crafting>
+    </skillRequirements>
+    <workAmount>10600</workAmount>
+  </RecipeDef>
 
-	<RecipeDef ParentName="AmmoRecipeBase" MayRequire="Ludeon.RimWorld.Biotech">
-		<defName>MakeShell_Toxic</defName>
-		<label>make 81mm tox mortar shells x5</label>
-		<description>Craft 5 81mm tox mortar shells.</description>
-		<jobString>Making 81mm tox mortar shells.</jobString>
-		<researchPrerequisite>ToxGas</researchPrerequisite>
-		<ingredients>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>Steel</li>
-					</thingDefs>
-				</filter>
-				<count>42</count>
-			</li>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>ComponentIndustrial</li>
-					</thingDefs>
-				</filter>
-				<count>2</count>
-			</li>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>Prometheum</li>
-					</thingDefs>
-				</filter>
-				<count>2</count>
-			</li>
-		</ingredients>
-		<fixedIngredientFilter>
-			<thingDefs>
-				<li>Steel</li>
-				<li>Prometheum</li>
-				<li>ComponentIndustrial</li>
-			</thingDefs>
-		</fixedIngredientFilter>
-		<products>
-			<Shell_Toxic>5</Shell_Toxic>
-		</products>
-		<skillRequirements>
-			<Crafting>4</Crafting>
-		</skillRequirements>
-		<workAmount>6600</workAmount>
-	</RecipeDef>
+  <RecipeDef ParentName="AmmoRecipeBase">
+    <defName>MakeShell_Incendiary</defName>
+    <label>make 81mm incendiary mortar shells x5</label>
+    <description>Craft 5 81mm incendiary mortar shells.</description>
+    <jobString>Making 81mm incendiary mortar shells.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>58</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Prometheum</li>
+          </thingDefs>
+        </filter>
+        <count>5</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>2</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>Prometheum</li>
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Shell_Incendiary>5</Shell_Incendiary>
+    </products>
+    <skillRequirements>
+      <Crafting>4</Crafting>
+    </skillRequirements>
+    <workAmount>9000</workAmount>
+  </RecipeDef>
+
+  <RecipeDef ParentName="AmmoRecipeBase">
+    <defName>MakeShell_EMP</defName>
+    <label>make 81mm EMP mortar shells x5</label>
+    <description>Craft 5 81mm EMP mortar shells.</description>
+    <jobString>Making 81mm EMP mortar shells.</jobString>
+    <researchPrerequisite>MicroelectronicsBasics</researchPrerequisite>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>54</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>14</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Shell_EMP>5</Shell_EMP>
+    </products>
+    <skillRequirements>
+      <Crafting>4</Crafting>
+    </skillRequirements>
+    <workAmount>13800</workAmount>
+  </RecipeDef>
+
+  <RecipeDef ParentName="AmmoRecipeBase">
+    <defName>MakeShell_Firefoam</defName>
+    <label>make 81mm firefoam mortar shells x5</label>
+    <description>Craft 5 81mm firefoam mortar shells.</description>
+    <jobString>Making 81mm firefoam mortar shells.</jobString>
+    <researchPrerequisite>Firefoam</researchPrerequisite>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>42</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>2</count>
+      </li>
+      <li>
+        <filter>
+          <categories>
+            <li>MeatRaw</li>
+          </categories>
+        </filter>
+        <count>17</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+      <categories>
+        <li>MeatRaw</li>
+      </categories>
+    </fixedIngredientFilter>
+    <products>
+      <Shell_Firefoam>5</Shell_Firefoam>
+    </products>
+    <skillRequirements>
+      <Crafting>4</Crafting>
+    </skillRequirements>
+    <workAmount>8800</workAmount>
+  </RecipeDef>
+
+  <RecipeDef ParentName="AmmoRecipeBase">
+    <defName>MakeShell_Smoke</defName>
+    <label>make 81mm smoke mortar shells x5</label>
+    <description>Craft 5 81mm smoke mortar shells.</description>
+    <jobString>Making 81mm smoke mortar shells.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>42</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>2</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Prometheum</li>
+          </thingDefs>
+        </filter>
+        <count>2</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>Prometheum</li>
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Shell_Smoke>5</Shell_Smoke>
+    </products>
+    <skillRequirements>
+      <Crafting>4</Crafting>
+    </skillRequirements>
+    <workAmount>6600</workAmount>
+  </RecipeDef>
+
+  <RecipeDef ParentName="AmmoRecipeBase" MayRequire="Ludeon.RimWorld.Biotech">
+    <defName>MakeShell_Toxic</defName>
+    <label>make 81mm tox mortar shells x5</label>
+    <description>Craft 5 81mm tox mortar shells.</description>
+    <jobString>Making 81mm tox mortar shells.</jobString>
+    <researchPrerequisite>ToxGas</researchPrerequisite>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>42</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>2</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Prometheum</li>
+          </thingDefs>
+        </filter>
+        <count>2</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>Prometheum</li>
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Shell_Toxic>5</Shell_Toxic>
+    </products>
+    <skillRequirements>
+      <Crafting>4</Crafting>
+    </skillRequirements>
+    <workAmount>6600</workAmount>
+  </RecipeDef>
 
 </Defs>

--- a/Defs/Effects/Motes.xml
+++ b/Defs/Effects/Motes.xml
@@ -1,97 +1,97 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Defs>
-	<!-- Suppression Mote -->
+  <!-- Suppression Mote -->
 
-	<ThingDef ParentName="MoteBase">
-		<defName>Mote_SuppressIcon</defName>
-		<graphicData>
-			<texPath>Things/Mote/Mote_SuppressIcon</texPath>
-		</graphicData>
-		<thingClass>MoteThrownAttached</thingClass>
-		<altitudeLayer>MetaOverlays</altitudeLayer>
-		<mote>
-			<fadeInTime>0.25</fadeInTime>
-			<solidTime>1</solidTime>
-			<fadeOutTime>1.4</fadeOutTime>
-			<attachedDrawOffset>(0.45, 0, 0.45)</attachedDrawOffset>
-		</mote>
-	</ThingDef>
+  <ThingDef ParentName="MoteBase">
+    <defName>Mote_SuppressIcon</defName>
+    <graphicData>
+      <texPath>Things/Mote/Mote_SuppressIcon</texPath>
+    </graphicData>
+    <thingClass>MoteThrownAttached</thingClass>
+    <altitudeLayer>MetaOverlays</altitudeLayer>
+    <mote>
+      <fadeInTime>0.25</fadeInTime>
+      <solidTime>1</solidTime>
+      <fadeOutTime>1.4</fadeOutTime>
+      <attachedDrawOffset>(0.45, 0, 0.45)</attachedDrawOffset>
+    </mote>
+  </ThingDef>
 
-	<ThingDef ParentName="MoteBase">
-		<defName>Mote_HunkerIcon</defName>
-		<graphicData>
-			<texPath>Things/Mote/Mote_HunkerDownIcon</texPath>
-		</graphicData>
-		<thingClass>MoteThrownAttached</thingClass>
-		<altitudeLayer>MetaOverlays</altitudeLayer>
-		<mote>
-			<fadeInTime>0.25</fadeInTime>
-			<solidTime>1</solidTime>
-			<fadeOutTime>1.4</fadeOutTime>
-			<attachedDrawOffset>(0.45, 0, 0.45)</attachedDrawOffset>
-		</mote>
-	</ThingDef>
+  <ThingDef ParentName="MoteBase">
+    <defName>Mote_HunkerIcon</defName>
+    <graphicData>
+      <texPath>Things/Mote/Mote_HunkerDownIcon</texPath>
+    </graphicData>
+    <thingClass>MoteThrownAttached</thingClass>
+    <altitudeLayer>MetaOverlays</altitudeLayer>
+    <mote>
+      <fadeInTime>0.25</fadeInTime>
+      <solidTime>1</solidTime>
+      <fadeOutTime>1.4</fadeOutTime>
+      <attachedDrawOffset>(0.45, 0, 0.45)</attachedDrawOffset>
+    </mote>
+  </ThingDef>
 
-	<!-- Legacy Motes -->
+  <!-- Legacy Motes -->
 
-	<ThingDef ParentName="MoteBase">
-		<defName>Mote_BigExplode</defName>
-		<graphicData>
-			<texPath>Things/Mote/BigExplode</texPath>
-		</graphicData>
-		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<mote>
-			<fadeInTime>0.05</fadeInTime>
-			<solidTime>0.4</solidTime>
-			<fadeOutTime>0.45</fadeOutTime>
-			<growthRate>15</growthRate>
-		</mote>
-	</ThingDef>
+  <ThingDef ParentName="MoteBase">
+    <defName>Mote_BigExplode</defName>
+    <graphicData>
+      <texPath>Things/Mote/BigExplode</texPath>
+    </graphicData>
+    <altitudeLayer>MoteOverhead</altitudeLayer>
+    <mote>
+      <fadeInTime>0</fadeInTime>
+      <solidTime>0.4</solidTime>
+      <fadeOutTime>0.45</fadeOutTime>
+      <growthRate>0</growthRate>
+    </mote>
+  </ThingDef>
 
-	<ThingDef ParentName="MoteBase">
-		<defName>Mote_Firetrail</defName>
-		<graphicData>
-			<texPath>Things/Mote/Mote_FireSmoked</texPath>
-		</graphicData>
-		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<mote>
-			<fadeInTime>0.083</fadeInTime>
-			<solidTime>0.083</solidTime>
-			<fadeOutTime>1</fadeOutTime>
-			<growthRate>0.035</growthRate>
-		</mote>
-	</ThingDef>
+  <ThingDef ParentName="MoteBase">
+    <defName>Mote_Firetrail</defName>
+    <graphicData>
+      <texPath>Things/Mote/Mote_FireSmoked</texPath>
+    </graphicData>
+    <altitudeLayer>MoteOverhead</altitudeLayer>
+    <mote>
+      <fadeInTime>0.083</fadeInTime>
+      <solidTime>0.083</solidTime>
+      <fadeOutTime>1</fadeOutTime>
+      <growthRate>0.035</growthRate>
+    </mote>
+  </ThingDef>
 
-	<!-- Flare Motes -->
+  <!-- Flare Motes -->
 
-	<ThingDef ParentName="MoteBase">
-		<defName>Mote_FlareGlow</defName>
-		<thingClass>CombatExtended.MoteThrownCE</thingClass>
-		<graphicData>
-			<texPath>Things/Mote/FireGlow</texPath>
-			<shaderType>MoteGlow</shaderType>
-		</graphicData>
-		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<mote>
-			<fadeInTime>0.75</fadeInTime>
-			<solidTime>1.08</solidTime>
-			<fadeOutTime>0.8</fadeOutTime>
-		</mote>
-	</ThingDef>
+  <ThingDef ParentName="MoteBase">
+    <defName>Mote_FlareGlow</defName>
+    <thingClass>CombatExtended.MoteThrownCE</thingClass>
+    <graphicData>
+      <texPath>Things/Mote/FireGlow</texPath>
+      <shaderType>MoteGlow</shaderType>
+    </graphicData>
+    <altitudeLayer>MoteOverhead</altitudeLayer>
+    <mote>
+      <fadeInTime>0.75</fadeInTime>
+      <solidTime>1.08</solidTime>
+      <fadeOutTime>0.8</fadeOutTime>
+    </mote>
+  </ThingDef>
 
-	<ThingDef ParentName="MoteBase">
-		<defName>Mote_FlareSmoke</defName>
-		<thingClass>CombatExtended.MoteThrownCE</thingClass>
-		<graphicData>
-			<texPath>Things/Mote/Smoke</texPath>
-		</graphicData>
-		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<mote>
-			<fadeInTime>0.50</fadeInTime>
-			<solidTime>6</solidTime>
-			<fadeOutTime>3.2</fadeOutTime>
-			<growthRate>0.005</growthRate>
-		</mote>
-	</ThingDef>
+  <ThingDef ParentName="MoteBase">
+    <defName>Mote_FlareSmoke</defName>
+    <thingClass>CombatExtended.MoteThrownCE</thingClass>
+    <graphicData>
+      <texPath>Things/Mote/Smoke</texPath>
+    </graphicData>
+    <altitudeLayer>MoteOverhead</altitudeLayer>
+    <mote>
+      <fadeInTime>0.50</fadeInTime>
+      <solidTime>6</solidTime>
+      <fadeOutTime>3.2</fadeOutTime>
+      <growthRate>0.005</growthRate>
+    </mote>
+  </ThingDef>
 
 </Defs>

--- a/Source/CombatExtended/CombatExtended/Comps/CompExplosiveCE.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompExplosiveCE.cs
@@ -32,7 +32,10 @@ namespace CombatExtended
             }
 
             //Try to throw fragments -- increase count by scaleFactor
-            parent.TryGetComp<CompFragments>()?.Throw(pos, map, instigator);//scaleFactor);
+            foreach (var comp in parent.GetComps<CompFragments>())
+            {
+                comp.Throw(pos, map, instigator);
+            }
 
             if (Props.explosiveRadius > 0 //&& Props.damageAmountBase > 0 Disabled to allow flame explosions etc
                     && parent.def != null)

--- a/Source/CombatExtended/CombatExtended/DefOfs/CE_ThingDefOf.cs
+++ b/Source/CombatExtended/CombatExtended/DefOfs/CE_ThingDefOf.cs
@@ -10,6 +10,8 @@ namespace CombatExtended
     [DefOf]
     public static class CE_ThingDefOf
     {
+        public static ThingDef Mote_BigExplode;
+
         public static ThingDef Mote_FlareSmoke;
 
         public static ThingDef Mote_FlareGlow;

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -1341,14 +1341,27 @@ namespace CombatExtended
                 effecter.Trigger(new TargetInfo(explodePos.ToIntVec3(), Map, false), new TargetInfo(explodePos.ToIntVec3(), Map, false));
                 effecter.Cleanup();
             }
-
+            ProjectilePropertiesCE projectileCE = def.projectile as ProjectilePropertiesCE;
+            float effectScale = projectileCE.detonateEffectsScaleOverride > 0 ? projectileCE.detonateEffectsScaleOverride : projectileCE.explosionRadius * 2;
+            if (projectileCE.detonateMoteDef != null)
+            {
+                MoteMaker.MakeStaticMote(DrawPos, Map, CE_ThingDefOf.Mote_BigExplode, effectScale);
+            }
+            if (projectileCE.detonateFleckDef != null)
+            {
+                FleckCreationData dataStatic = FleckMaker.GetDataStatic(DrawPos, MapHeld, projectileCE.detonateFleckDef, effectScale);
+                MapHeld.flecks.CreateFleck(dataStatic);
+            }
             var projectilePropsCE = (def.projectile as ProjectilePropertiesCE);
 
             var explodingComp = this.TryGetComp<CompExplosiveCE>();
 
             if (explodingComp == null)
             {
-                this.TryGetComp<CompFragments>()?.Throw(explodePos, Map, launcher);
+                foreach (var comp in GetComps<CompFragments>())
+                {
+                    comp.Throw(explodePos, Map, launcher);
+                }
             }
 
             //If the comp exists, it'll already call CompFragments

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_BunkerBuster.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_BunkerBuster.cs
@@ -43,9 +43,9 @@ namespace CombatExtended
                                            postExplosionGasType: props.postExplosionGasType
                                           );
 
-                if (this.TryGetComp<CompFragments>() != null)
+                foreach (var comp in GetComps<CompFragments>())
                 {
-                    this.TryGetComp<CompFragments>().Throw(finalPos.ToVector3(), this.Map, this);
+                    comp.Throw(finalPos.ToVector3(), this.Map, this);
                 }
 
                 this.Destroy();

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_HeightFuse.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_HeightFuse.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using RimWorld;
+using UnityEngine;
+using Verse;
+using Verse.Sound;
+using CombatExtended.Compatibility;
+using CombatExtended.Lasers;
+using ProjectileImpactFX;
+using CombatExtended.Utilities;
+
+namespace CombatExtended
+{
+    class ProjectileCE_HeightFuse : ProjectileCE
+    {
+        float detonationHeight => (def.projectile as ProjectilePropertiesCE).aimHeightOffset;
+
+        bool armed;
+
+        public override void ExposeData()
+        {
+            base.ExposeData();
+            Scribe_Values.Look(ref armed, "armed", false);
+        }
+
+        public override void Tick()
+        {
+            base.Tick();
+            if (!armed && LastPos.y > detonationHeight)
+            {
+                armed = true;
+            }
+            if (armed && Height <= detonationHeight)
+            {
+                HeightFuseAirBurst();
+            }
+        }
+
+        public override void Impact(Thing hitThing)
+        {
+            //intercept impact if it hit something after where height fuse should have triggered
+            if (armed && Height <= detonationHeight)
+            {
+                HeightFuseAirBurst();
+            }
+            else
+            {
+                base.Impact(hitThing);
+            }
+        }
+
+        void HeightFuseAirBurst()
+        {
+            Mote mote = MoteMaker.MakeStaticMote(DrawPos, Map, CE_ThingDefOf.Mote_BigExplode, (def.projectile as ProjectilePropertiesCE).explosionRadius * 2);
+            float f = (LastPos.y - detonationHeight) / (LastPos.y - Height);
+            ExactPosition = f * (LastPos - ExactPosition);
+            base.Impact(null);
+        }
+    }
+}

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_HeightFuse.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_HeightFuse.cs
@@ -53,9 +53,13 @@ namespace CombatExtended
 
         void HeightFuseAirBurst()
         {
-            Mote mote = MoteMaker.MakeStaticMote(DrawPos, Map, CE_ThingDefOf.Mote_BigExplode, (def.projectile as ProjectilePropertiesCE).explosionRadius * 2);
             float f = (LastPos.y - detonationHeight) / (LastPos.y - Height);
             ExactPosition = f * (LastPos - ExactPosition);
+            if (!ExactPosition.ToIntVec3().IsValid)
+            {
+                Destroy();
+                return;
+            }
             base.Impact(null);
         }
     }

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectilePropertiesCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectilePropertiesCE.cs
@@ -31,6 +31,10 @@ namespace CombatExtended
         public float airborneSuppressionFactor = 1;
         public float dangerFactor = 1;
 
+        public ThingDef detonateMoteDef;
+        public FleckDef detonateFleckDef;
+        public float detonateEffectsScaleOverride = -1;
+
         #region Bunker Buster fields
         /// <summary>
         /// Amount of tiles ProjectileCE_BunkerBuster will detonate after after penetrating an obstacle


### PR DESCRIPTION
## Additions

Height-fused projectile that uses aimHeightOffset as which height it should detonate. Intended for fly overhead projectiles. Flying above aimHeightOffset will arm the shell, after which flying below aimHeightOffset will detonate the shell.

Includes two air burst mortar shells for demonstration and testing purposes, may be removed later.
HF shell detonate at 0.6 height (somewhere near human body I think?) and spread frags horizontally.
HiF shell detonate at 6 height and spread frags in a downward facing cone.

## Changes

Added detonateMoteDef detonateFleckDef detonateEffectsScaleOverride in ProjectilePropertiesCE, which will be played at projectile's drawpos when hit. Scale will be projectile's explosion diameter, with optional override.
Changed some occurances of compfragments to accept multiple of compfragment, for when someone wants some frag to be directional but not every frag.
(for example, stray frags for shrapnel shell, air burst shell, or top-attack ATGM where you want a high penetration jet frag pointed downward, but not the rest.

## Reasoning

- Time-fused shells, when used as mortar shell, often stuck ground before fuse set off.

## Alternatives

Suffer.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
