### PR TITLE
EMP don't stun non-powered and manned turrets

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_StunHandler.cs
+++ b/Source/CombatExtended/Harmony/Harmony_StunHandler.cs
@@ -14,7 +14,6 @@ namespace CombatExtended.HarmonyCE
     {
         public static bool Prefix(StunHandler __instance, DamageInfo dinfo, ref int ___EMPAdaptedTicksLeft, ref int ___stunTicksLeft, ref bool ___stunFromEMP)
         {
-
             Pawn pawn = __instance.parent as Pawn;
             float bodySize = 1.0f;
             if (pawn != null)
@@ -26,42 +25,24 @@ namespace CombatExtended.HarmonyCE
                 bodySize = pawn.BodySize;
             }
 
-            if (dinfo.Def == DamageDefOf.EMP && __instance.parent is Pawn p && !(p.RaceProps?.IsFlesh ?? false))
+            if (dinfo.Def == DamageDefOf.EMP)
             {
-                if (___EMPAdaptedTicksLeft > 0)
+                if (__instance.parent.TryGetComp<CompPower>() == null && __instance.parent.TryGetComp<CompMannable>() != null)
                 {
-                    int newStunAdaptedTicks = Mathf.RoundToInt(dinfo.Amount * 45 * bodySize);
-                    int newStunTicks = Mathf.RoundToInt(dinfo.Amount * 30);
-
-                    float stunResistChance = ((float)___EMPAdaptedTicksLeft / (float)newStunAdaptedTicks) * 15;
-
-                    if (Rand.Value > stunResistChance)
+                    return false;
+                }
+                if (pawn != null && !(pawn.RaceProps?.IsFlesh ?? false))
+                {
+                    if (___EMPAdaptedTicksLeft > 0)
                     {
-                        ___EMPAdaptedTicksLeft += Mathf.RoundToInt(dinfo.Amount * 45 * bodySize);
+                        int newStunAdaptedTicks = Mathf.RoundToInt(dinfo.Amount * 45 * bodySize);
+                        int newStunTicks = Mathf.RoundToInt(dinfo.Amount * 30);
 
-                        if (___stunTicksLeft > 0 && newStunTicks > ___stunTicksLeft)
-                        {
-                            ___stunTicksLeft = newStunTicks;
-                        }
-                        else
-                        {
-                            __instance.StunFor(newStunTicks, dinfo.Instigator, true, true);
-                        }
-                    }
-                    else
-                    {
-                        MoteMakerCE.ThrowText(new Vector3((float)__instance.parent.Position.x + 1f, (float)__instance.parent.Position.y, (float)__instance.parent.Position.z + 1f), __instance.parent.Map, "Adapted".Translate(), Color.white, -1f);
-                        int adaptationReduction = Mathf.RoundToInt(Mathf.Sqrt(dinfo.Amount * 45));
+                        float stunResistChance = ((float)___EMPAdaptedTicksLeft / (float)newStunAdaptedTicks) * 15;
 
-                        if (adaptationReduction < ___EMPAdaptedTicksLeft)
+                        if (Rand.Value > stunResistChance)
                         {
-                            ___EMPAdaptedTicksLeft -= adaptationReduction;
-                        }
-                        else
-                        {
-                            float adaptationReductionRatio = (adaptationReduction - ___EMPAdaptedTicksLeft) / adaptationReduction;
-                            newStunAdaptedTicks = Mathf.RoundToInt(newStunAdaptedTicks * adaptationReductionRatio);
-                            newStunTicks = Mathf.RoundToInt(newStunTicks * adaptationReductionRatio);
+                            ___EMPAdaptedTicksLeft += Mathf.RoundToInt(dinfo.Amount * 45 * bodySize);
 
                             if (___stunTicksLeft > 0 && newStunTicks > ___stunTicksLeft)
                             {
@@ -72,15 +53,40 @@ namespace CombatExtended.HarmonyCE
                                 __instance.StunFor(newStunTicks, dinfo.Instigator, true, true);
                             }
                         }
+                        else
+                        {
+                            MoteMakerCE.ThrowText(new Vector3((float)__instance.parent.Position.x + 1f, (float)__instance.parent.Position.y, (float)__instance.parent.Position.z + 1f), __instance.parent.Map, "Adapted".Translate(), Color.white, -1f);
+                            int adaptationReduction = Mathf.RoundToInt(Mathf.Sqrt(dinfo.Amount * 45));
+
+                            if (adaptationReduction < ___EMPAdaptedTicksLeft)
+                            {
+                                ___EMPAdaptedTicksLeft -= adaptationReduction;
+                            }
+                            else
+                            {
+                                float adaptationReductionRatio = (adaptationReduction - ___EMPAdaptedTicksLeft) / adaptationReduction;
+                                newStunAdaptedTicks = Mathf.RoundToInt(newStunAdaptedTicks * adaptationReductionRatio);
+                                newStunTicks = Mathf.RoundToInt(newStunTicks * adaptationReductionRatio);
+
+                                if (___stunTicksLeft > 0 && newStunTicks > ___stunTicksLeft)
+                                {
+                                    ___stunTicksLeft = newStunTicks;
+                                }
+                                else
+                                {
+                                    __instance.StunFor(newStunTicks, dinfo.Instigator, true, true);
+                                }
+                            }
+                        }
+
                     }
+                    else
+                    {
+                        __instance.StunFor(Mathf.RoundToInt(dinfo.Amount * 30f), dinfo.Instigator, true, true);
+                        ___EMPAdaptedTicksLeft = Mathf.RoundToInt(dinfo.Amount * 45 * bodySize);
+                        ___stunFromEMP = true;
 
-                }
-                else
-                {
-                    __instance.StunFor(Mathf.RoundToInt(dinfo.Amount * 30f), dinfo.Instigator, true, true);
-                    ___EMPAdaptedTicksLeft = Mathf.RoundToInt(dinfo.Amount * 45 * bodySize);
-                    ___stunFromEMP = true;
-
+                    }
                 }
             }
             return true;


### PR DESCRIPTION
## Changes

- EMP damages nolonger stun turrets that doesn't require electricity and need to be manned.
unmanned and unpowered turrets are considered self-powered and will still be stunned.

## Reasoning

-  Why on earth should emp stun a machinegun on a tripod?

## Alternatives

- Suffer.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (a emp shotgun shell at every turret)
