### PR TITLE
Orassans ammo fix

### DIFF
--- a/Patches/Orassans/Ammo/MissileAmmo.xml
+++ b/Patches/Orassans/Ammo/MissileAmmo.xml
@@ -54,7 +54,7 @@
 					<label>Orassan Missile shell (HEAT)</label>
 					<graphicData>
 						<texPath>Things/Ammo/Cannon/Tank/HEAT</texPath>
-						<graphicClass>Graphic_Single</graphicClass>
+						<graphicClass>Graphic_StackCount</graphicClass>
 					</graphicData>
 					<statBases>
 						<MarketValue>141.46</MarketValue>
@@ -68,7 +68,7 @@
 					<label>Orassan Missile shell (HE)</label>
 					<graphicData>
 						<texPath>Things/Ammo/Cannon/Tank/HE</texPath>
-						<graphicClass>Graphic_Single</graphicClass>
+						<graphicClass>Graphic_StackCount</graphicClass>
 					</graphicData>
 					<statBases>
 						<MarketValue>180.99</MarketValue>
@@ -82,7 +82,7 @@
 					<label>Orassan Missile shell (AP Sabot)</label>
 					<graphicData>
 						<texPath>Things/Ammo/Cannon/Tank/Sabot</texPath>
-						<graphicClass>Graphic_Single</graphicClass>
+						<graphicClass>Graphic_StackCount</graphicClass>
 					</graphicData>
 					<statBases>
 						<MarketValue>190</MarketValue>
@@ -112,7 +112,7 @@
 					<label>Orassan Missile shell (HEAT)</label>
 					<graphicData>
 						<texPath>Things/Projectile/Cannon/HEAT</texPath>
-						<graphicClass>Graphic_StackCount</graphicClass>
+						<graphicClass>Graphic_Single</graphicClass>
 					</graphicData>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
 						<damageDef>Bullet</damageDef>
@@ -142,7 +142,7 @@
 					<label>Orassan Missile shell (AP Sabot)</label>
 					<graphicData>
 						<texPath>Things/Projectile/Cannon/Sabot</texPath>
-						<graphicClass>Graphic_StackCount</graphicClass>
+						<graphicClass>Graphic_Single</graphicClass>
 					</graphicData>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
 						<damageDef>Bullet</damageDef>
@@ -173,7 +173,7 @@
 					<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 					<graphicData>
 						<texPath>Things/Projectile/Cannon/HE</texPath>
-						<graphicClass>Graphic_StackCount</graphicClass>
+						<graphicClass>Graphic_Single</graphicClass>
 					</graphicData>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
 						<damageDef>Bomb</damageDef>

--- a/Patches/Orassans/Ammo/MissileAmmo.xml
+++ b/Patches/Orassans/Ammo/MissileAmmo.xml
@@ -53,7 +53,7 @@
 					<defName>Ammo_OrassanMissileShell_HEAT</defName>
 					<label>Orassan Missile shell (HEAT)</label>
 					<graphicData>
-						<texPath>Things/Projectile/Cannon/Tank/HEAT</texPath>
+						<texPath>Things/Ammo/Cannon/Tank/HEAT</texPath>
 						<graphicClass>Graphic_Single</graphicClass>
 					</graphicData>
 					<statBases>
@@ -67,7 +67,7 @@
 					<defName>Ammo_OrassanMissileShell_HE</defName>
 					<label>Orassan Missile shell (HE)</label>
 					<graphicData>
-						<texPath>Things/Projectile/Cannon/Tank/HEAT</texPath>
+						<texPath>Things/Ammo/Cannon/Tank/HE</texPath>
 						<graphicClass>Graphic_Single</graphicClass>
 					</graphicData>
 					<statBases>
@@ -81,7 +81,7 @@
 					<defName>Ammo_OrassanMissileShell_APSabot</defName>
 					<label>Orassan Missile shell (AP Sabot)</label>
 					<graphicData>
-						<texPath>Things/Projectile/Cannon/Tank/Sabot</texPath>
+						<texPath>Things/Ammo/Cannon/Tank/Sabot</texPath>
 						<graphicClass>Graphic_Single</graphicClass>
 					</graphicData>
 					<statBases>
@@ -111,7 +111,7 @@
 					<defName>Bullet_OrassanMissileShell_HEAT</defName>
 					<label>Orassan Missile shell (HEAT)</label>
 					<graphicData>
-						<texPath>Things/Projectile/Cannon/Tank/HEAT</texPath>
+						<texPath>Things/Projectile/Cannon/HEAT</texPath>
 						<graphicClass>Graphic_StackCount</graphicClass>
 					</graphicData>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -141,7 +141,7 @@
 					<defName>Bullet_OrassanMissileShell_APSabot</defName>
 					<label>Orassan Missile shell (AP Sabot)</label>
 					<graphicData>
-						<texPath>Things/Projectile/Cannon/Tank/Sabot</texPath>
+						<texPath>Things/Projectile/Cannon/Sabot</texPath>
 						<graphicClass>Graphic_StackCount</graphicClass>
 					</graphicData>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -172,7 +172,7 @@
 					<label>Orassan Missile shell (HE)</label>
 					<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 					<graphicData>
-						<texPath>Things/Projectile/Cannon/Tank/HE</texPath>
+						<texPath>Things/Projectile/Cannon/HE</texPath>
 						<graphicClass>Graphic_StackCount</graphicClass>
 					</graphicData>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Patches/Orassans/ThingDefs_Misc/Apparel_Various.xml
+++ b/Patches/Orassans/ThingDefs_Misc/Apparel_Various.xml
@@ -192,6 +192,23 @@
 					</value>
 				</li>
 
+				<!-- ======= Clothing ======= -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Apparel_OrassanBasicTop" or defName="Apparel_OrassanBasicShorts"]/statBases</xpath>
+					<value>
+						<Bulk>0.75</Bulk>
+						<WornBulk>0</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Apparel_OrassanBasicTop" or defName="Apparel_OrassanBasicShorts"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+
 			</operations>
 		</match>
 	</Operation>


### PR DESCRIPTION
## Additions
it had ammo texture pointing to the old path,
Describe new functionality added by your code, e.g.
- Tribal smoke bombs
- New tribal smoke bomb sprite
- Tribal smoke bomb recipes at smithing bench and crafting spot using prometheum

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased regular smoke bomb radius

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
