### PR TITLE
Rimsenal Spacer Patch

### DIFF
--- a/Defs/Ammo/Rifle/5x100mmCaseless.xml
+++ b/Defs/Ammo/Rifle/5x100mmCaseless.xml
@@ -27,6 +27,15 @@
 		</ammoTypes>
 		<similarTo>AmmoSet_Rifle</similarTo>
 	</CombatExtended.AmmoSetDef>
+	
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_5x100mmCaseless_LV</defName>
+		<label>5x100mm Caseless</label>
+		<ammoTypes>
+			<Ammo_5x100mmCaseless_Sabot>Bullet_5x100mmCaseless_Sabot_LV</Ammo_5x100mmCaseless_Sabot>
+		</ammoTypes>
+		<similarTo>AmmoSet_Rifle</similarTo>
+	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->
 
@@ -93,6 +102,18 @@
 			<armorPenetrationSharp>20</armorPenetrationSharp>
 			<armorPenetrationBlunt>108</armorPenetrationBlunt>
 			<speed>204</speed>
+		</projectile>
+	</ThingDef>
+	
+	<ThingDef ParentName="Base5x100mmCaselessBullet">
+		<defName>Bullet_5x100mmCaseless_Sabot_LV</defName>
+		<label>5x100 Caseless bullet (Sabot)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<damageAmountBase>6</damageAmountBase>
+			<armorPenetrationSharp>12</armorPenetrationSharp>
+			<armorPenetrationBlunt>18.76</armorPenetrationBlunt>
+			<speed>100</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Patches/Rimsenal - Spacer Faction Pack/Apparel_Spacer_CE.xml
+++ b/Patches/Rimsenal - Spacer Faction Pack/Apparel_Spacer_CE.xml
@@ -1,0 +1,110 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Rimsenal - Spacer Faction Pack</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+			
+				<!-- ==========  Unisuit =========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Apparel_Unisuit"]/statBases</xpath>
+					<value>
+						<Bulk>0</Bulk>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Apparel_Unisuit"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Apparel_Unisuit"]/apparel/bodyPartGroups</xpath>
+					<value>
+						<li>Hands</li>
+						<li>Feet</li>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/ThingDef[defName="Apparel_Unisuit"]</xpath>
+					<value>
+						<li Class="CombatExtended.PartialArmorExt">
+							<stats>
+								<li>
+									<ArmorRating_Sharp>0.625</ArmorRating_Sharp>
+									<parts>
+										<li>Hand</li>
+									</parts>
+								</li>
+								<li>
+									<ArmorRating_Blunt>0.625</ArmorRating_Blunt>
+									<parts>
+										<li>Hand</li>
+									</parts>
+								</li>
+							</stats>
+						</li>
+					</value>
+				</li>
+				
+				<!-- ==========  Smart Visor =========== -->
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Apparel_SmartVisor"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>0.01</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Apparel_SmartVisor"]/statBases</xpath>
+					<value>
+						<NightVisionEfficiency_Apparel>0.80</NightVisionEfficiency_Apparel>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Apparel_SmartVisor"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>0.01</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAttributeAdd">
+					<xpath>Defs/ThingDef[defName="Apparel_SmartVisor"]/costList</xpath>
+					<attribute>Inherit</attribute>
+					<value>false</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Apparel_SmartVisor"]/equippedStatOffsets</xpath>
+					<value>
+						<equippedStatOffsets Inherit="False">
+							<AimingAccuracy>0.3</AimingAccuracy>
+							<AimingDelayFactor>-0.25</AimingDelayFactor>
+						</equippedStatOffsets>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Apparel_SmartVisor"]/apparel</xpath>
+					<value>
+						<layers Inherit="False">
+							<li>StrappedHead</li>
+						</layers>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>
+			
+			

--- a/Patches/Rimsenal - Spacer Faction Pack/Explosives_Smart_CE.xml
+++ b/Patches/Rimsenal - Spacer Faction Pack/Explosives_Smart_CE.xml
@@ -9,20 +9,29 @@
 			<operations>
 
 				<!-- ========== Remove Recipe Maker & Verbs ========== -->
+				<li Class="PatchOperationAttributeSet">
+					<xpath>Defs/ThingDef[defName="Weapon_GrenadeSmart"]</xpath>
+					<attribute>ParentName</attribute>
+					<value>BaseWeapon</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Weapon_GrenadeSmart"]/smeltable</xpath>
+					<value>
+						<smeltable>false</smeltable>
+					</value>
+				</li>
+
 				<li Class="PatchOperationRemove">
 					<xpath>Defs/ThingDef[defName="Weapon_GrenadeSmart"]/recipeMaker </xpath>
 				</li>
+				
 				<li Class="PatchOperationRemove">
 					<xpath>Defs/ThingDef[defName="Weapon_GrenadeSmart"]/costList </xpath>
 				</li>
+
 				<li Class="PatchOperationRemove">
 					<xpath>Defs/ThingDef[defName="Weapon_GrenadeSmart"]/verbs </xpath>
-				</li>
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="Weapon_GrenadeSmart"] </xpath>
-					<value>
-						<tickerType>Normal</tickerType>
-					</value>
 				</li>
 
 				<!-- ========== Projectile ========== -->
@@ -155,7 +164,18 @@
 						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
-				
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Weapon_GrenadeSmart"]/graphicData</xpath>
+					<value>
+						<graphicData>
+							<texPath>Things/Projectile/SmartGrenade</texPath>
+							<graphicClass>Graphic_Single</graphicClass>
+							<onGroundRandomRotateAngle>0</onGroundRandomRotateAngle>
+						</graphicData>
+					</value>
+				</li>
+
 				<li Class="PatchOperationAdd">
 					<xpath>Defs</xpath>
 					<value>

--- a/Patches/Rimsenal - Spacer Faction Pack/Explosives_Smart_CE.xml
+++ b/Patches/Rimsenal - Spacer Faction Pack/Explosives_Smart_CE.xml
@@ -24,6 +24,7 @@
 						<tickerType>Normal</tickerType>
 					</value>
 				</li>
+
 				<!-- ========== Projectile ========== -->
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="Proj_GrenadeSmart"]/projectile</xpath>
@@ -68,6 +69,7 @@
 						</li>
 					</value>
 				</li>
+
 				<!-- Weapon Stack and Appearance -->
 
 				<li Class="PatchOperationAdd">
@@ -102,8 +104,8 @@
 						</value>
 					</nomatch>
 				</li>
-				<!-- Weapon Values -->
 
+				<!-- Weapon Values -->
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="Weapon_GrenadeSmart"]/comps</xpath>
 					<value>
@@ -119,6 +121,7 @@
 						</li>
 					</value>
 				</li>
+
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>Weapon_GrenadeSmart</defName>
 					<statBases>
@@ -152,6 +155,7 @@
 						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
+				
 				<li Class="PatchOperationAdd">
 					<xpath>Defs</xpath>
 					<value>

--- a/Patches/Rimsenal - Spacer Faction Pack/Explosives_Smart_CE.xml
+++ b/Patches/Rimsenal - Spacer Faction Pack/Explosives_Smart_CE.xml
@@ -1,0 +1,238 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Rimsenal - Spacer Faction Pack</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<!-- ========== Remove Recipe Maker & Verbs ========== -->
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/ThingDef[defName="Weapon_GrenadeSmart"]/recipeMaker </xpath>
+				</li>
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/ThingDef[defName="Weapon_GrenadeSmart"]/costList </xpath>
+				</li>
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/ThingDef[defName="Weapon_GrenadeSmart"]/verbs </xpath>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Weapon_GrenadeSmart"] </xpath>
+					<value>
+						<tickerType>Normal</tickerType>
+					</value>
+				</li>
+				<!-- ========== Projectile ========== -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Proj_GrenadeSmart"]/projectile</xpath>
+					<value>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<explosionRadius>1.5</explosionRadius>
+							<damageDef>Bomb</damageDef>
+							<damageAmountBase>56</damageAmountBase>
+							<explosionDelay>60</explosionDelay>
+							<dropsCasings>true</dropsCasings>
+							<casingMoteDefname>Fleck_GrenadePin</casingMoteDefname>
+							<casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
+							<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+							<speed>12</speed>
+							<suppressionFactor>3.0</suppressionFactor>
+							<dangerFactor>2.0</dangerFactor>
+							<airborneSuppressionFactor>0.25</airborneSuppressionFactor>
+						</projectile>
+					</value>
+				</li>
+
+				<!-- ========== Check Comp ========== -->
+
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[defName="Proj_GrenadeSmart"]/comps</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="Proj_GrenadeSmart"]</xpath>
+						<value>
+							<comps />
+						</value>
+					</nomatch>
+				</li>
+
+				<!-- ========== Add Fragmentation ========== -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Proj_GrenadeSmart"]/comps</xpath>
+					<value>
+						<li Class="CombatExtended.CompProperties_Fragments">
+							<fragments>
+								<Fragment_Small>40</Fragment_Small>
+							</fragments>
+						</li>
+					</value>
+				</li>
+				<!-- Weapon Stack and Appearance -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Weapon_GrenadeSmart"]/graphicData </xpath>
+					<value>
+						<onGroundRandomRotateAngle>0</onGroundRandomRotateAngle>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Weapon_GrenadeSmart"] </xpath>
+					<value>
+						<thingClass>CombatExtended.AmmoThing</thingClass>
+						<stackLimit>75</stackLimit>
+						<resourceReadoutPriority>First</resourceReadoutPriority>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAttributeSet">
+					<xpath>Defs/ThingDef[defName="Weapon_GrenadeSmart"] </xpath>
+					<attribute>Class</attribute>
+					<value>CombatExtended.AmmoDef</value>
+				</li>
+
+				<!-- Weapon Check Comps -->
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[defName="Weapon_GrenadeSmart"]/comps</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="Weapon_GrenadeSmart"]</xpath>
+						<value>
+							<comps />
+						</value>
+					</nomatch>
+				</li>
+				<!-- Weapon Values -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Weapon_GrenadeSmart"]/comps</xpath>
+					<value>
+						<li Class="CombatExtended.CompProperties_ExplosiveCE">
+							<damageAmountBase>40</damageAmountBase>
+							<explosiveDamageType>Bomb</explosiveDamageType>
+							<explosiveRadius>1.5</explosiveRadius>
+						</li>
+						<li Class="CombatExtended.CompProperties_Fragments">
+							<fragments>
+								<Fragment_Small>20</Fragment_Small>
+							</fragments>
+						</li>
+					</value>
+				</li>
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>Weapon_GrenadeSmart</defName>
+					<statBases>
+						<Mass>0.4</Mass>
+						<Bulk>0.87</Bulk>
+						<MarketValue>15.22</MarketValue>
+						<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+						<SightsEfficiency>10</SightsEfficiency>
+					</statBases>
+					<Properties>
+						<label>throw frag grenade</label>
+						<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<range>14.0</range>
+						<minRange>4</minRange>
+						<warmupTime>0.8</warmupTime>
+						<noiseRadius>4</noiseRadius>
+						<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
+						<soundCast>ThrowGrenade</soundCast>
+						<targetParams>
+							<canTargetLocations>true</canTargetLocations>
+						</targetParams>
+						<defaultProjectile>Proj_GrenadeSmart</defaultProjectile>
+						<onlyManualCast>true</onlyManualCast>
+						<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
+						<ai_AvoidFriendlyFireRadius>7</ai_AvoidFriendlyFireRadius>
+					</Properties>
+					<weaponTags>
+						<li>CE_AI_Grenade</li>
+						<li>CE_AI_AOE</li>
+						<li>CE_OneHandedWeapon</li>
+					</weaponTags>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs</xpath>
+					<value>
+
+						<RecipeDef Name="RSExplosive_RecipeBase" Abstract="true">
+							<workSpeedStat>GeneralLaborSpeed</workSpeedStat>
+							<effectWorking>Cook</effectWorking>
+							<soundWorking>Recipe_Smith</soundWorking>
+							<workSkill>Crafting</workSkill>
+							<unfinishedThingDef>UnfinishedGun</unfinishedThingDef>
+							<fixedIngredientFilter>
+								<thingDefs>
+									<li>Plasteel</li>
+									<li>ComponentIndustrial</li>
+									<li>FSX</li>
+								</thingDefs>
+							</fixedIngredientFilter>
+						</RecipeDef>
+
+						<!-- YP BaegYa Microwave Grenades -->
+						<RecipeDef ParentName="RSExplosive_RecipeBase">
+						
+							<defName>Craft_10_Smartgrenade</defName>
+							<label>Craft 10 smart grenades</label>
+							<description>Craft 10 smart grenades.</description>
+							<jobString>Crafting smart grenades</jobString>
+							<workSpeedStat>GeneralLaborSpeed</workSpeedStat>
+							<effectWorking>Cook</effectWorking>
+							<soundWorking>Recipe_Smith</soundWorking>
+							<workSkill>Crafting</workSkill>
+							<unfinishedThingDef>UnfinishedGun</unfinishedThingDef>
+							<fixedIngredientFilter>
+								<thingDefs>
+									<li>Plasteel</li>
+									<li>SubcoreBasic</li>
+									<li>FSX</li>
+								</thingDefs>
+							</fixedIngredientFilter>
+							<ingredients>
+								<li>
+									<filter>
+										<thingDefs>
+											<li>SubcoreBasic</li>
+										</thingDefs>
+									</filter>
+									<count>1</count>
+								</li>
+								<li>
+									<filter>
+										<thingDefs>
+											<li>Plasteel</li>
+										</thingDefs>
+									</filter>
+									<count>5</count>
+								</li>
+								<li>
+									<filter>
+										<thingDefs>
+											<li>FSX</li>
+										</thingDefs>
+									</filter>
+									<count>2</count>
+								</li>
+							</ingredients>
+							<researchPrerequisite>SmartWeapons</researchPrerequisite>
+							<skillRequirements>
+								<Crafting>7</Crafting>
+							</skillRequirements>
+							<products>
+								<Weapon_GrenadeSmart>10</Weapon_GrenadeSmart>
+							</products>
+							<workAmount>20000</workAmount>
+							<recipeUsers>
+								<li>FabricationBench</li>
+							</recipeUsers>
+						</RecipeDef>
+
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Rimsenal - Spacer Faction Pack/Mechs_Body_CE.xml
+++ b/Patches/Rimsenal - Spacer Faction Pack/Mechs_Body_CE.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Rimsenal - Spacer Faction Pack</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!--Natural Armor-->
+				<li Class="PatchOperationAdd">
+					<xpath>
+						Defs/BodyDef[defName="Tagmaton" or defName="Omniservant"]//*[
+						def="MechanicalThorax" or
+						def="MechanicalNeck" or
+						def="MechanicalShoulder" or
+						def="MechanicalArm" or
+						def="MechanicalHand" or
+						def="MechanicalLeg" or
+						def="MechanicalFoot"
+						]
+					</xpath>
+					<value>
+						<groups>
+							<li>CoveredByNaturalArmor</li>
+						</groups>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>
+						Defs/BodyDef[defName="Tagmaton" or defName="Omniservant"]//*[
+						def="MechanicalFinger" or
+						def="MechanicalHead"
+						]/groups
+					</xpath>
+					<value>
+						<li>CoveredByNaturalArmor</li>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Rimsenal - Spacer Faction Pack/Mechs_Body_CE.xml
+++ b/Patches/Rimsenal - Spacer Faction Pack/Mechs_Body_CE.xml
@@ -27,6 +27,7 @@
 						</groups>
 					</value>
 				</li>
+
 				<li Class="PatchOperationAdd">
 					<xpath>
 						Defs/BodyDef[defName="Tagmaton" or defName="Omniservant"]//*[
@@ -38,6 +39,7 @@
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
+				
 			</operations>
 		</match>
 	</Operation>

--- a/Patches/Rimsenal - Spacer Faction Pack/Mechs_Smart_CE.xml
+++ b/Patches/Rimsenal - Spacer Faction Pack/Mechs_Smart_CE.xml
@@ -15,6 +15,7 @@
 						<ArmorRating_Sharp>7</ArmorRating_Sharp>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[@Name="BaseMechanoidTagma"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
@@ -62,6 +63,7 @@
 						</tools>
 					</value>
 				</li>
+
 				<!-- ========== Omniservant =========== -->
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[@Name="RSMechanoid"]/statBases/ArmorRating_Sharp</xpath>
@@ -69,12 +71,14 @@
 						<ArmorRating_Sharp>2</ArmorRating_Sharp>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[@Name="RSMechanoid"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>4</ArmorRating_Blunt>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[@Name="RSMechanoid"]/tools</xpath>
 					<value>
@@ -113,6 +117,7 @@
 						</tools>
 					</value>
 				</li>
+
 				<!-- ========== Borer =========== -->
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="Mech_Borer"]/tools</xpath>
@@ -132,6 +137,7 @@
 						</tools>
 					</value>
 				</li>
+
 				<!-- ========== Psiloid =========== -->
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="Mech_Psiloid"]/statBases/ArmorRating_Sharp</xpath>
@@ -139,12 +145,14 @@
 						<ArmorRating_Sharp>3.5</ArmorRating_Sharp>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="Mech_Psiloid"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>6</ArmorRating_Blunt>
 					</value>
 				</li>
+				
 			</operations>
 		</match>
 	</Operation>

--- a/Patches/Rimsenal - Spacer Faction Pack/Mechs_Smart_CE.xml
+++ b/Patches/Rimsenal - Spacer Faction Pack/Mechs_Smart_CE.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Rimsenal - Spacer Faction Pack</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- ========== Tagma =========== -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="BaseMechanoidTagma"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>7</ArmorRating_Sharp>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="BaseMechanoidTagma"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>15</ArmorRating_Blunt>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Mech_Tagmaton"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>left fist</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>7</power>
+								<cooldownTime>1.11</cooldownTime>
+								<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>1.75</armorPenetrationBlunt>
+								<chanceFactor>0.1</chanceFactor>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>right fist</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>7</power>
+								<cooldownTime>1.11</cooldownTime>
+								<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>1.75</armorPenetrationBlunt>
+								<chanceFactor>0.1</chanceFactor>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>6</power>
+								<cooldownTime>1.85</cooldownTime>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<chanceFactor>0.1</chanceFactor>
+								<armorPenetrationBlunt>0.7</armorPenetrationBlunt>
+							</li>
+						</tools>
+					</value>
+				</li>
+				<!-- ========== Omniservant =========== -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="RSMechanoid"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>2</ArmorRating_Sharp>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="RSMechanoid"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>4</ArmorRating_Blunt>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="RSMechanoid"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>left fist</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>4</power>
+								<cooldownTime>1.11</cooldownTime>
+								<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>1.25</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>right fist</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>4</power>
+								<cooldownTime>1.11</cooldownTime>
+								<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>1.25</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>3</power>
+								<cooldownTime>1.85</cooldownTime>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<chanceFactor>0.1</chanceFactor>
+								<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+							</li>
+						</tools>
+					</value>
+				</li>
+				<!-- ========== Borer =========== -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Mech_Borer"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>drill</label>
+								<capacities>
+									<li>Blunt</li>
+									<li>Stab</li>
+								</capacities>
+								<power>12</power>
+								<cooldownTime>2.5</cooldownTime>
+								<armorPenetrationSharp>0.85</armorPenetrationSharp>
+								<armorPenetrationBlunt>2.25</armorPenetrationBlunt>
+							</li>
+						</tools>
+					</value>
+				</li>
+				<!-- ========== Psiloid =========== -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Mech_Psiloid"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>3.5</ArmorRating_Sharp>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Mech_Psiloid"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>6</ArmorRating_Blunt>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Rimsenal - Spacer Faction Pack/Weapons_Smart_CE.xml
+++ b/Patches/Rimsenal - Spacer Faction Pack/Weapons_Smart_CE.xml
@@ -8,6 +8,7 @@
 		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>
+
 				<!-- ========== Melee Tools =========== -->
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[
@@ -40,6 +41,7 @@
 						</tools>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[
 					defName="Gun_SmartBoltActionRifle" or 
@@ -87,6 +89,7 @@
 						</tools>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="Gun_SmartMinigun"]/tools</xpath>
 					<value>
@@ -104,6 +107,7 @@
 						</tools>
 					</value>
 				</li>
+
 				<!-- ========== Stats =========== -->
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[
@@ -146,6 +150,7 @@
 						<AimingAccuracy>0.5</AimingAccuracy>
 					</value>
 				</li>
+
 				<!-- ========== Smart Revolver =========== -->
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>Gun_SmartRevolver</defName>
@@ -183,6 +188,7 @@
 						<li>AdvancedGun</li>
 					</weaponTags>
 				</li>
+
 				<!-- ========== Smart Pistol =========== -->
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>Gun_SmartAutoPistol</defName>
@@ -220,6 +226,7 @@
 						<li>AdvancedGun</li>
 					</weaponTags>
 				</li>
+
 				<!-- ========== Smart Bolt Action =========== -->
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>Gun_SmartBoltActionRifle</defName>
@@ -257,6 +264,7 @@
 						<li>AdvancedGun</li>
 					</weaponTags>
 				</li>
+
 				<!-- ========== Smart MP =========== -->
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>Gun_SmartMachinePistol</defName>
@@ -297,6 +305,7 @@
 						<li>AdvancedGun</li>
 					</weaponTags>
 				</li>
+
 				<!-- ========== Smart Pump =========== -->
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>Gun_SmartPumpShotgun</defName>
@@ -333,6 +342,7 @@
 					  <li>CE_AI_BROOM</li>
 					</weaponTags>
 				</li>
+
 				<!-- ========== Smart Chain =========== -->
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>Gun_SmartChainShotgun</defName>
@@ -371,6 +381,7 @@
 					  <li>CE_AI_BROOM</li>
 					</weaponTags>
 				</li>
+
 				<!-- ========== Smart SMG =========== -->
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>Gun_SmartHeavySMG</defName>
@@ -455,6 +466,7 @@
 						<li>Bipod_LMG</li>
 					</weaponTags>
 				</li>
+
 				<!-- ========== Smart Rifle =========== -->
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>Gun_SmartAssaultRifle</defName>
@@ -496,6 +508,7 @@
 						<li>AdvancedGun</li>
 					</weaponTags>
 				</li>
+
 				<!-- ========== Smart Sniper Rifle =========== -->
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>Gun_SniperRifleSmart</defName>
@@ -531,6 +544,7 @@
 						<li>Bipod_DMR</li>
 					</weaponTags>
 				</li>
+
 				<!-- ========== Minigun =========== -->
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>Gun_SmartMinigun</defName>
@@ -569,6 +583,7 @@
 						<li>AdvancedGun</li>
 					</weaponTags>
 				</li>
+
 				<!-- ========== Smart Rifle (Charge) =========== -->
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>Gun_SmartChargeRifle</defName>
@@ -610,6 +625,7 @@
 						<li>AdvancedGun</li>
 					</weaponTags>
 				</li>
+
 				<!-- ========== Smart Lance (Charge Sniper) =========== -->
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>Gun_SmartChargeLance</defName>
@@ -645,6 +661,7 @@
 						<li>AdvancedGun</li>
 					</weaponTags>
 				</li>
+
 				<!-- ========== Slug Spitter =========== -->
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>Gun_SlugSpitter</defName>
@@ -684,6 +701,7 @@
 						<li>NoSwitch</li>
 					</weaponTags>
 				</li>
+
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[@Name="Gun_SlugSpitterBase"]/tools</xpath>
 					<value>
@@ -702,6 +720,7 @@
 						</tools>
 					</value>
 				</li>
+
 				<!-- ========== Smart Sword =========== -->
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="MeleeWeapon_SmartSword"]/tools</xpath>
@@ -742,6 +761,7 @@
 						</tools>
 					</value>
 				</li>
+
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="MeleeWeapon_SmartSword"]/statBases</xpath>
 					<value>
@@ -749,6 +769,7 @@
 						<Bulk>8.5</Bulk>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="MeleeWeapon_SmartSword"]/equippedStatOffsets/MeleeDodgeChance</xpath>
 					<value>
@@ -757,6 +778,7 @@
 						<MeleeDodgeChance>0.6</MeleeDodgeChance>
 					</value>
 				</li>
+
 				<!-- ========== Stun Prod =========== -->
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="MeleeWeapon_StunProd"]/tools</xpath>
@@ -793,6 +815,7 @@
 						</tools>
 					</value>
 				</li>
+
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="MeleeWeapon_StunProd"]/statBases</xpath>
 					<value>
@@ -800,6 +823,7 @@
 						<Bulk>5</Bulk>
 					</value>
 				</li>
+				
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="MeleeWeapon_StunProd"]</xpath>
 					<value>
@@ -810,6 +834,7 @@
 						</equippedStatOffsets>
 					</value>
 				</li>
+
 			</operations>
 		</match>
 	</Operation>

--- a/Patches/Rimsenal - Spacer Faction Pack/Weapons_Smart_CE.xml
+++ b/Patches/Rimsenal - Spacer Faction Pack/Weapons_Smart_CE.xml
@@ -1,0 +1,817 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Rimsenal - Spacer Faction Pack</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- ========== Melee Tools =========== -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+					defName="Gun_SmartRevolver" or 
+					defName="Gun_SmartAutoPistol" or 
+					defName="Gun_SmartMachinePistol"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>grip</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>2</power>
+								<cooldownTime>1.54</cooldownTime>
+								<chanceFactor>1.5</chanceFactor>
+								<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>muzzle</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>2</power>
+								<cooldownTime>1.54</cooldownTime>
+								<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+							</li>
+						</tools>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+					defName="Gun_SmartBoltActionRifle" or 
+					defName="Gun_SmartPumpShotgun" or 
+					defName="Gun_SmartChainShotgun" or 
+					defName="Gun_SmartHeavySMG" or 
+					defName="Gun_SmartLMG" or 
+					defName="Gun_SmartAssaultRifle" or 
+					defName="Gun_SniperRifleSmart" or 
+					defName="Gun_SmartChargeRifle" or 
+					defName="Gun_SmartChargeLance"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>stock</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>8</power>
+								<cooldownTime>1.55</cooldownTime>
+								<chanceFactor>1.5</chanceFactor>
+								<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>barrel</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>5</power>
+								<cooldownTime>2.02</cooldownTime>
+								<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>muzzle</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>8</power>
+								<cooldownTime>1.55</cooldownTime>
+								<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+							</li>
+						</tools>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Gun_SmartMinigun"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+							  <label>barrels</label>
+							  <capacities>
+								<li>Blunt</li>
+							  </capacities>
+							  <power>10</power>
+							  <cooldownTime>2.44</cooldownTime>
+							  <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+							  <linkedBodyPartsGroup>Barrels</linkedBodyPartsGroup>
+							</li>
+						</tools>
+					</value>
+				</li>
+				<!-- ========== Stats =========== -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[
+						defName="Gun_SmartRevolver" or 
+						defName="Gun_SmartAutoPistol" or 
+						defName="Gun_SmartMachinePistol" or 
+						defName="Gun_SmartBoltActionRifle" or 
+						defName="Gun_SmartPumpShotgun" or 
+						defName="Gun_SmartChainShotgun" or 
+						defName="Gun_SmartHeavySMG" or 
+						defName="Gun_SmartLMG" or 
+						defName="Gun_SmartAssaultRifle" or 
+						defName="Gun_SniperRifleSmart" or 
+						defName="Gun_SmartChargeRifle" or 
+						defName="Gun_SmartChargeLance" or 
+						defName="Gun_SmartMinigun" 
+						]/statBases </xpath>
+					<value>
+						<NightVisionEfficiency_Weapon>0.50</NightVisionEfficiency_Weapon>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[
+						defName="Gun_SmartRevolver" or 
+						defName="Gun_SmartAutoPistol" or 
+						defName="Gun_SmartMachinePistol" or 
+						defName="Gun_SmartBoltActionRifle" or 
+						defName="Gun_SmartPumpShotgun" or 
+						defName="Gun_SmartChainShotgun" or 
+						defName="Gun_SmartHeavySMG" or 
+						defName="Gun_SmartLMG" or 
+						defName="Gun_SmartAssaultRifle" or 
+						defName="Gun_SniperRifleSmart" or 
+						defName="Gun_SmartChargeRifle" or 
+						defName="Gun_SmartChargeLance" or 
+						defName="Gun_SmartMinigun" 
+						]/equippedStatOffsets </xpath>
+					<value>
+						<AimingAccuracy>0.5</AimingAccuracy>
+					</value>
+				</li>
+				<!-- ========== Smart Revolver =========== -->
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>Gun_SmartRevolver</defName>
+					<statBases>
+						<SightsEfficiency>0.9</SightsEfficiency>
+						<ShotSpread>0.135</ShotSpread><!--25% reduction-->
+						<SwayFactor>0.635</SwayFactor><!--25% reduction-->
+						<Bulk>2.41</Bulk>
+						<Mass>1.39</Mass>
+						<RangedWeapon_Cooldown>0.51</RangedWeapon_Cooldown>
+					</statBases>
+					<Properties>
+						<recoilAmount>1.76</recoilAmount><!--50% reduction-->
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_44Magnum_HV_FMJ</defaultProjectile>
+						<warmupTime>0.4</warmupTime>
+						<range>23</range>
+						<soundCast>Shot_Revolver</soundCast>
+						<soundCastTail>GunTail_Light</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+					<AmmoUser>
+						<magazineSize>6</magazineSize>
+						<reloadTime>3.6</reloadTime>
+						<ammoSet>AmmoSet_44Magnum_HV</ammoSet>
+					</AmmoUser>
+					<FireModes>
+						<aiAimMode>Snapshot</aiAimMode>
+					</FireModes>
+					<weaponTags>
+						<li>CE_Sidearm</li>
+						<li>CE_AI_Pistol</li>
+						<li>CE_OneHandedWeapon</li>
+						<li>AdvancedGun</li>
+					</weaponTags>
+				</li>
+				<!-- ========== Smart Pistol =========== -->
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>Gun_SmartAutoPistol</defName>
+					<statBases>
+						<SightsEfficiency>0.9</SightsEfficiency>
+						<ShotSpread>0.13</ShotSpread>
+						<SwayFactor>0.80</SwayFactor>
+						<Bulk>2.10</Bulk>
+						<Mass>1.11</Mass>
+						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+					</statBases>
+					<Properties>
+						<recoilAmount>0.89</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_FN57x28mm_FMJ</defaultProjectile>
+						<warmupTime>0.4</warmupTime>
+						<range>23</range>
+						<soundCast>Shot_Autopistol</soundCast>
+						<soundCastTail>GunTail_Light</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+					<AmmoUser>
+						<magazineSize>14</magazineSize>
+						<reloadTime>3.0</reloadTime>
+						<ammoSet>AmmoSet_FN57x28mm</ammoSet>
+					</AmmoUser>
+					<FireModes>
+						<aiAimMode>Snapshot</aiAimMode>
+					</FireModes>
+					<weaponTags>
+						<li>CE_Sidearm</li>
+						<li>CE_AI_Pistol</li>
+						<li>CE_OneHandedWeapon</li>
+						<li>AdvancedGun</li>
+					</weaponTags>
+				</li>
+				<!-- ========== Smart Bolt Action =========== -->
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>Gun_SmartBoltActionRifle</defName>
+					<statBases>
+						<SightsEfficiency>1.2</SightsEfficiency>
+						<ShotSpread>0.02</ShotSpread>
+						<SwayFactor>1.26</SwayFactor>
+						<Bulk>9.50</Bulk>
+						<Mass>4.19</Mass>
+						<RangedWeapon_Cooldown>1.17</RangedWeapon_Cooldown>
+					</statBases>
+					<Properties>
+						<recoilAmount>0.97</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_277Fury_FMJ</defaultProjectile>
+						<warmupTime>0.9</warmupTime>
+						<range>68</range>
+						<soundCast>Shot_BoltActionRifle</soundCast>
+						<soundCastTail>GunTail_Heavy</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+					<AmmoUser>
+						<magazineSize>10</magazineSize>
+						<reloadTime>3.0</reloadTime>
+						<ammoSet>AmmoSet_277Fury</ammoSet>
+					</AmmoUser>
+					<FireModes>
+						<aiAimMode>AimedShot</aiAimMode>
+					</FireModes>
+					<weaponTags>
+						<li>CE_Sidearm</li>
+						<li>CE_AI_Pistol</li>
+						<li>CE_OneHandedWeapon</li>
+						<li>AdvancedGun</li>
+					</weaponTags>
+				</li>
+				<!-- ========== Smart MP =========== -->
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>Gun_SmartMachinePistol</defName>
+					<statBases>
+						<SightsEfficiency>0.9</SightsEfficiency>
+						<ShotSpread>0.11</ShotSpread>
+						<SwayFactor>1.45</SwayFactor>
+						<Bulk>2.95</Bulk>
+						<Mass>2.84</Mass>
+						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					</statBases>
+					<Properties>
+						<recoilAmount>0.57</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_FN57x28mm_FMJ</defaultProjectile>
+						<warmupTime>0.4</warmupTime>
+						<range>21</range>
+						<burstShotCount>6</burstShotCount>
+						<ticksBetweenBurstShots>3</ticksBetweenBurstShots>
+						<soundCast>Shot_MachinePistol</soundCast>
+						<soundCastTail>GunTail_Light</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+					<AmmoUser>
+						<magazineSize>30</magazineSize>
+						<reloadTime>3.0</reloadTime>
+						<ammoSet>AmmoSet_FN57x28mm</ammoSet>
+					</AmmoUser>
+					<FireModes>
+						<aimedBurstShotCount>3</aimedBurstShotCount>
+						<aiAimMode>Snapshot</aiAimMode>
+					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_Pistol</li>
+						<li>CE_OneHandedWeapon</li>
+						<li>AdvancedGun</li>
+					</weaponTags>
+				</li>
+				<!-- ========== Smart Pump =========== -->
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>Gun_SmartPumpShotgun</defName>
+					<statBases>
+						<SightsEfficiency>1.2</SightsEfficiency>
+						<ShotSpread>0.11</ShotSpread>
+						<SwayFactor>0.90</SwayFactor>
+						<Bulk>9.00</Bulk>
+						<Mass>3.00</Mass>
+						<RangedWeapon_Cooldown>1.00</RangedWeapon_Cooldown>
+					</statBases>
+					<Properties>
+						<recoilAmount>1.58</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
+						<warmupTime>0.4</warmupTime>
+						<range>18</range>
+						<soundCast>Shot_Shotgun</soundCast>
+						<soundCastTail>GunTail_Heavy</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+					<AmmoUser>
+					  <magazineSize>6</magazineSize>
+					  <reloadOneAtATime>true</reloadOneAtATime>
+					  <reloadTime>0.45</reloadTime>
+					  <ammoSet>AmmoSet_12Gauge</ammoSet>
+					</AmmoUser>
+					<FireModes>
+					  <aiAimMode>Snapshot</aiAimMode>
+					</FireModes>
+					<weaponTags>
+					  <li>AdvancedGun</li>
+					  <li>CE_AI_BROOM</li>
+					</weaponTags>
+				</li>
+				<!-- ========== Smart Chain =========== -->
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>Gun_SmartChainShotgun</defName>
+					<statBases>
+						<SightsEfficiency>1.2</SightsEfficiency>
+						<ShotSpread>0.11</ShotSpread>
+						<SwayFactor>0.95</SwayFactor>
+						<Bulk>6.70</Bulk>
+						<Mass>3.50</Mass>
+						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
+					</statBases>
+					<Properties>
+						<recoilAmount>1.46</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
+						<warmupTime>0.4</warmupTime>
+						<range>18</range>
+						<burstShotCount>3</burstShotCount>
+						<ticksBetweenBurstShots>12</ticksBetweenBurstShots>
+						<soundCast>Shot_Shotgun</soundCast>
+						<soundCastTail>GunTail_Heavy</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+					<AmmoUser>
+					  <magazineSize>9</magazineSize>
+					  <reloadTime>3</reloadTime>
+					  <ammoSet>AmmoSet_12Gauge</ammoSet>
+					</AmmoUser>
+					<FireModes>
+					  <aimedBurstShotCount>2</aimedBurstShotCount>
+					  <aiAimMode>Snapshot</aiAimMode>
+					</FireModes>
+					<weaponTags>
+					  <li>AdvancedGun</li>
+					  <li>CE_AI_BROOM</li>
+					</weaponTags>
+				</li>
+				<!-- ========== Smart SMG =========== -->
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>Gun_SmartHeavySMG</defName>
+					<statBases>
+						<SightsEfficiency>1.2</SightsEfficiency>
+						<ShotSpread>0.11</ShotSpread>
+						<SwayFactor>0.71</SwayFactor>
+						<Bulk>4.50</Bulk>
+						<Mass>2.5</Mass>
+						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					</statBases>
+					<Properties>
+						<recoilAmount>0.58</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_FN57x28mm_FMJ</defaultProjectile>
+						<warmupTime>0.4</warmupTime>
+						<range>31</range>
+						<burstShotCount>6</burstShotCount>
+						<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+						<soundCast>Shot_Minigun</soundCast>
+						<soundCastTail>GunTail_Heavy</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+					<AmmoUser>
+						<magazineSize>50</magazineSize>
+						<reloadTime>3.0</reloadTime>
+						<ammoSet>AmmoSet_FN57x28mm</ammoSet>
+					</AmmoUser>
+					<FireModes>
+						<aimedBurstShotCount>3</aimedBurstShotCount>
+						<aiAimMode>Snapshot</aiAimMode>
+					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+						<li>AdvancedGun</li>
+					</weaponTags>
+				</li>
+
+				<!-- ========== Smart MG =========== -->
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>Gun_SmartLMG</defName>
+					<statBases>
+						<SightsEfficiency>1.2</SightsEfficiency>
+						<ShotSpread>0.04</ShotSpread>
+						<SwayFactor>1.60</SwayFactor>
+						<Bulk>12.90</Bulk>
+						<Mass>8.70</Mass>
+						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
+					</statBases>
+					<Properties>
+						<recoilAmount>0.66</recoilAmount><!--Halved from 1.33-->
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_277Fury_FMJ</defaultProjectile>
+						<warmupTime>1.1</warmupTime>
+						<range>68</range>
+						<burstShotCount>10</burstShotCount>
+						<ticksBetweenBurstShots>7</ticksBetweenBurstShots>
+						<targetParams>
+							<canTargetLocations>true</canTargetLocations>
+						</targetParams>
+						<recoilPattern>Mounted</recoilPattern>
+						<soundCast>Shot_Minigun</soundCast>
+						<soundCastTail>GunTail_Medium</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+					<AmmoUser>
+						<magazineSize>100</magazineSize>
+						<reloadTime>5.1</reloadTime>
+						<ammoSet>AmmoSet_277Fury</ammoSet>
+					</AmmoUser>
+					<FireModes>
+						<aimedBurstShotCount>5</aimedBurstShotCount>
+						<aiAimMode>SuppressFire</aiAimMode>
+					</FireModes>
+					<weaponTags>
+						<li>CE_MachineGun</li>
+						<li>CE_AI_Suppressive</li>
+						<li>AdvancedGun</li>
+						<li>Bipod_LMG</li>
+					</weaponTags>
+				</li>
+				<!-- ========== Smart Rifle =========== -->
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>Gun_SmartAssaultRifle</defName>
+					<statBases>
+						<WorkToMake>39500</WorkToMake>
+						<SightsEfficiency>1.20</SightsEfficiency>
+						<ShotSpread>0.05</ShotSpread>
+						<SwayFactor>1.00</SwayFactor>
+						<Bulk>9.00</Bulk>
+						<Mass>3.40</Mass>
+						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					</statBases>
+					<Properties>
+						<recoilAmount>1.11</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_277Fury_FMJ</defaultProjectile>
+						<warmupTime>0.9</warmupTime>
+						<range>62</range>
+						<burstShotCount>6</burstShotCount>
+						<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+						<soundCast>Shot_AssaultRifle</soundCast>
+						<soundCastTail>GunTail_Medium</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+					<AmmoUser>
+						<magazineSize>30</magazineSize>
+						<reloadTime>3.0</reloadTime>
+						<ammoSet>AmmoSet_277Fury</ammoSet>
+					</AmmoUser>
+					<FireModes>
+						<aimedBurstShotCount>3</aimedBurstShotCount>
+						<aiUseBurstMode>TRUE</aiUseBurstMode>
+						<aiAimMode>AimedShot</aiAimMode>
+					</FireModes>
+					<weaponTags>
+						<li>CE_Rifle</li>
+						<li>CE_AI_AssaultWeapon</li>
+						<li>AdvancedGun</li>
+					</weaponTags>
+				</li>
+				<!-- ========== Smart Sniper Rifle =========== -->
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>Gun_SniperRifleSmart</defName>
+					<statBases>
+						<SightsEfficiency>4</SightsEfficiency>
+						<ShotSpread>0.06</ShotSpread>
+						<SwayFactor>0.98</SwayFactor>
+						<Bulk>11.92</Bulk>
+						<Mass>6.8</Mass>
+						<RangedWeapon_Cooldown>1.38</RangedWeapon_Cooldown>
+					</statBases>
+					<Properties>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_338Lapua_FMJ</defaultProjectile>
+						<warmupTime>1.6</warmupTime>
+						<range>86</range>
+						<soundCast>Shot_SniperRifle</soundCast>
+						<soundCastTail>GunTail_Heavy</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+					<AmmoUser>
+						<magazineSize>5</magazineSize>
+						<reloadTime>3.0</reloadTime>
+						<ammoSet>AmmoSet_338Lapua</ammoSet>
+					</AmmoUser>
+					<FireModes>
+						<aiAimMode>AimedShot</aiAimMode>
+					</FireModes>
+					<weaponTags>
+						<li>CE_Rifle</li>
+						<li>AdvancedGun</li>
+						<li>Bipod_DMR</li>
+					</weaponTags>
+				</li>
+				<!-- ========== Minigun =========== -->
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>Gun_SmartMinigun</defName>
+					<statBases>
+						<SightsEfficiency>1.20</SightsEfficiency>
+						<ShotSpread>0.05</ShotSpread>
+						<SwayFactor>2.42</SwayFactor>
+						<Bulk>8.02</Bulk>
+						<Mass>20.00</Mass>
+						<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
+					</statBases>
+					<Properties>
+						<recoilAmount>0.49</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_277Fury_FMJ</defaultProjectile>
+						<warmupTime>1.9</warmupTime>
+						<range>68</range>
+						<burstShotCount>50</burstShotCount>
+						<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+						<soundCast>Shot_Minigun</soundCast>
+						<soundCastTail>GunTail_Medium</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+					<AmmoUser>
+						<magazineSize>250</magazineSize>
+						<reloadTime>7.1</reloadTime>
+						<ammoSet>AmmoSet_277Fury</ammoSet>
+					</AmmoUser>
+					<FireModes>
+						<aimedBurstShotCount>25</aimedBurstShotCount>
+						<aiAimMode>Snapshot</aiAimMode>
+					</FireModes>
+					<weaponTags>
+						<li>CE_AI_Suppressive</li>
+						<li>AdvancedGun</li>
+					</weaponTags>
+				</li>
+				<!-- ========== Smart Rifle (Charge) =========== -->
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>Gun_SmartChargeRifle</defName>
+					<statBases>
+						<SightsEfficiency>1.20</SightsEfficiency>
+						<ShotSpread>0.06</ShotSpread>
+						<SwayFactor>0.90</SwayFactor>
+						<Bulk>7.00</Bulk>
+						<Mass>3.00</Mass>
+						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					</statBases>
+					<Properties>
+						<recoilAmount>0.73</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_6x24mmCharged</defaultProjectile>
+						<warmupTime>0.9</warmupTime>
+						<range>62</range>
+						<burstShotCount>6</burstShotCount>
+						<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+						<soundCast>Shot_ChargeRifle</soundCast>
+						<soundCastTail>GunTail_Medium</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+					<AmmoUser>
+						<magazineSize>30</magazineSize>
+						<reloadTime>3.0</reloadTime>
+						<ammoSet>AmmoSet_6x24mmCharged</ammoSet>
+					</AmmoUser>
+					<FireModes>
+						<aimedBurstShotCount>3</aimedBurstShotCount>
+						<aiUseBurstMode>TRUE</aiUseBurstMode>
+						<aiAimMode>AimedShot</aiAimMode>
+					</FireModes>
+					<weaponTags>
+						<li>CE_AI_AR</li>
+						<li>CE_Rifle</li>
+						<li>CE_AI_AssaultWeapon</li>
+						<li>AdvancedGun</li>
+					</weaponTags>
+				</li>
+				<!-- ========== Smart Lance (Charge Sniper) =========== -->
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>Gun_SmartChargeLance</defName>
+					<statBases>
+						<SightsEfficiency>1.2</SightsEfficiency>
+						<ShotSpread>0.04</ShotSpread>
+						<SwayFactor>1.43</SwayFactor>
+						<Bulk>12.00</Bulk>
+						<Mass>8.00</Mass>
+						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					</statBases>
+					<Properties>
+						<recoilAmount>0.75</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_8x50mmCharged</defaultProjectile>
+						<warmupTime>0.95</warmupTime>
+						<range>75</range>
+						<soundCast>ChargeLance_Fire</soundCast>
+						<soundCastTail>GunTail_Heavy</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+					<AmmoUser>
+						<magazineSize>5</magazineSize>
+						<reloadTime>3.0</reloadTime>
+						<ammoSet>AmmoSet_8x50mmCharged</ammoSet>
+					</AmmoUser>
+					<FireModes>
+						<aiAimMode>AimedShot</aiAimMode>
+					</FireModes>
+					<weaponTags>
+						<li>CE_Rifle</li>
+						<li>AdvancedGun</li>
+					</weaponTags>
+				</li>
+				<!-- ========== Slug Spitter =========== -->
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>Gun_SlugSpitter</defName>
+					<statBases>
+						<SightsEfficiency>1.00</SightsEfficiency>
+						<ShotSpread>0.09</ShotSpread>
+						<SwayFactor>0.88</SwayFactor>
+						<Bulk>13.00</Bulk>
+						<Mass>8.00</Mass>
+						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					</statBases>
+					<Properties>
+						<recoilAmount>0.89</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_5x100mmCaseless_Sabot_LV</defaultProjectile>
+						<warmupTime>1.3</warmupTime>
+						<range>44</range>
+						<burstShotCount>6</burstShotCount>
+						<ticksBetweenBurstShots>8</ticksBetweenBurstShots>
+						<soundCast>Shot_AssaultRifle</soundCast>
+						<soundCastTail>GunTail_Medium</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+					<AmmoUser>
+						<magazineSize>24</magazineSize>
+						<reloadTime>4</reloadTime>
+						<ammoSet>AmmoSet_5x100mmCaseless_LV</ammoSet>
+					</AmmoUser>
+					<FireModes>
+						<aimedBurstShotCount>3</aimedBurstShotCount>
+						<aiUseBurstMode>TRUE</aiUseBurstMode>
+						<aiAimMode>AimedShot</aiAimMode>
+					</FireModes>
+					<weaponTags>
+						<li>CE_AI_AR</li>
+						<li>NoSwitch</li>
+					</weaponTags>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="Gun_SlugSpitterBase"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>bayonet</label>
+								<capacities>
+									<li>Stab</li>
+								</capacities>
+								<power>18</power>
+								<cooldownTime>1.38</cooldownTime>
+								<armorPenetrationBlunt>1.15</armorPenetrationBlunt>
+								<armorPenetrationSharp>2.50</armorPenetrationSharp>
+								<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+							</li>
+						</tools>
+					</value>
+				</li>
+				<!-- ========== Smart Sword =========== -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="MeleeWeapon_SmartSword"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>handle</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>3</power>
+								<cooldownTime>1.69</cooldownTime>
+								<chanceFactor>0.10</chanceFactor>
+								<armorPenetrationBlunt>0.80</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>edge</label>
+								<capacities>
+									<li>Cut</li>
+								</capacities>
+								<power>47</power>
+								<cooldownTime>1.17</cooldownTime>
+								<armorPenetrationBlunt>4.06</armorPenetrationBlunt>
+								<armorPenetrationSharp>12</armorPenetrationSharp>
+								<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>point</label>
+								<capacities>
+									<li>Stab</li>
+								</capacities>
+								<power>25</power>
+								<cooldownTime>1.05</cooldownTime>
+								<armorPenetrationBlunt>2.048</armorPenetrationBlunt>
+								<armorPenetrationSharp>16</armorPenetrationSharp>
+							</li>
+						</tools>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="MeleeWeapon_SmartSword"]/statBases</xpath>
+					<value>
+						<MeleeCounterParryBonus>1.5</MeleeCounterParryBonus>
+						<Bulk>8.5</Bulk>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="MeleeWeapon_SmartSword"]/equippedStatOffsets/MeleeDodgeChance</xpath>
+					<value>
+						<MeleeCritChance>1.1</MeleeCritChance>
+						<MeleeParryChance>0.7</MeleeParryChance>
+						<MeleeDodgeChance>0.6</MeleeDodgeChance>
+					</value>
+				</li>
+				<!-- ========== Stun Prod =========== -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="MeleeWeapon_StunProd"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>handle</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>2</power>
+								<cooldownTime>1.59</cooldownTime>
+								<armorPenetrationBlunt>0.625</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>5</power>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>8</amount>
+										<chance>0.50</chance>
+									</li>
+								</extraMeleeDamages>
+								<cooldownTime>1.68</cooldownTime>
+								<chanceFactor>1.33</chanceFactor>
+								<armorPenetrationBlunt>3.375</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+							</li>
+						</tools>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="MeleeWeapon_StunProd"]/statBases</xpath>
+					<value>
+						<MeleeCounterParryBonus>0.9</MeleeCounterParryBonus>
+						<Bulk>5</Bulk>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="MeleeWeapon_StunProd"]</xpath>
+					<value>
+						<equippedStatOffsets>
+							<MeleeCritChance>0.17</MeleeCritChance>
+							<MeleeParryChance>0.9</MeleeParryChance>
+							<MeleeDodgeChance>0.3</MeleeDodgeChance>
+						</equippedStatOffsets>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -422,6 +422,7 @@ Rimsenal - Enhanced Vanilla |
 Rimsenal - Federation Faction Pack |
 Rimsenal - Feral Faction Pack |
 Rimsenal - Security Pack |
+Rimsenal - Spacer Faction Pack  |
 RimTraits - General Traits  |
 RimTraits – Medieval Talents    |
 Rimworld - The Dark Descent |


### PR DESCRIPTION
## Additions

Patches for new smartguns, mechs and the two apparels.

## Reasoning

Saw a while ago that some people wanted the super-industrial ammo as the primary ammo type for the smart guns, so given these are all techncially new guns, they now mostly all just use either 277 or 5.7 as their ammo. Lance uses sniper like stats and thankfully isn't craftable.
Smart weapons are set up with general -25% sway and spread, and half recoil.

## Alternatives

Could change for more varied ammo strength/caliber

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
