### PR TITLE
Cache pawn heights

### DIFF
--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -930,13 +930,30 @@ namespace CombatExtended
                               new Vector3(1f, height, 1f));
         }
 
+        public static CollisionVertical GetCollisionVertical(this Thing thing)
+        {
+            if (thing is Pawn pawn)
+            {
+                return pawn.GetTacticalManager().Collision;
+            }
+            return new CollisionVertical(thing);
+        }
+
         public static Bounds GetBoundsFor(Thing thing)
         {
             if (thing == null)
             {
                 return new Bounds();
             }
-            var height = new CollisionVertical(thing);
+            CollisionVertical height;
+            if (thing is Pawn pawn)
+            {
+                height = pawn.GetTacticalManager().Collision;
+            }
+            else
+            {
+                height = new CollisionVertical(thing);
+            }
             float length;
             float width;
             var thingPos = thing.DrawPos;
@@ -1504,5 +1521,8 @@ namespace CombatExtended
         }
 
         public static FactionStrengthTracker GetStrengthTracker(this Faction faction) => Find.World.GetComponent<WorldStrengthTracker>().GetFactionTracker(faction);
+
+        public static CompTacticalManager GetTacticalManager(this Pawn pawn) => pawn.TryGetComp<CompTacticalManager>();
+
     }
 }

--- a/Source/CombatExtended/CombatExtended/Comps/CompTacticalManager.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompTacticalManager.cs
@@ -7,11 +7,26 @@ using MonoMod.Utils;
 using RimWorld;
 using Verse;
 using Verse.AI;
+using CombatExtended.Compatibility;
 
 namespace CombatExtended
 {
     public class CompTacticalManager : ThingComp
     {
+        public CollisionVertical? collision = null;
+
+        public CollisionVertical Collision
+        {
+            get
+            {
+                if (collision == null)
+                {
+                    collision = new CollisionVertical(SelPawn);
+                }
+                return (CollisionVertical)collision;
+            }
+        }
+
         private Job curJob = null;
         private List<Verse.WeakReference<Pawn>> targetedBy = new List<Verse.WeakReference<Pawn>>();
 
@@ -141,6 +156,9 @@ namespace CombatExtended
         public override void CompTick()
         {
             base.CompTick();
+            float heightAdjust = CETrenches.GetHeightAdjust(SelPawn.Position, SelPawn.Map);
+            this.Collision.RecalculateHeight(SelPawn, heightAdjust);
+
             if (parent.IsHashIntervalTick(120))
             {
                 /*

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -129,7 +129,7 @@ namespace CombatExtended
                 return shotSpeed;
             }
         }
-        public float ShotHeight => (new CollisionVertical(caster)).shotHeight;
+        public float ShotHeight => caster.GetCollisionVertical().shotHeight;
         private Vector3 ShotSource
         {
             get
@@ -391,7 +391,7 @@ namespace CombatExtended
                 // Height difference calculations for ShotAngle
                 float targetHeight = 0f;
 
-                var coverRange = new CollisionVertical(report.cover).HeightRange;   //Get " " cover, assume it is the edifice
+                var coverRange = report.cover.GetCollisionVertical().HeightRange;   //Get " " cover, assume it is the edifice
 
                 // Projectiles with flyOverhead target the surface in front of the target
                 if (Projectile.projectile.flyOverhead)
@@ -400,7 +400,7 @@ namespace CombatExtended
                 }
                 else
                 {
-                    var victimVert = new CollisionVertical(currentTarget.Thing);
+                    var victimVert = currentTarget.Thing.GetCollisionVertical();
                     var targetRange = victimVert.HeightRange;   //Get lower and upper heights of the target
                     if (targetRange.min < coverRange.max)   //Some part of the target is hidden behind some cover
                     {
@@ -782,7 +782,7 @@ namespace CombatExtended
                             && newCover.def.Fillage == FillCategory.Partial
                             && !newCover.IsPlant())
                     {
-                        float newCoverHeight = new CollisionVertical(newCover).Max;
+                        float newCoverHeight = newCover.GetCollisionVertical().Max;
 
                         if (highestCover == null || highestCoverHeight < newCoverHeight)
                         {
@@ -1280,7 +1280,7 @@ namespace CombatExtended
                     AdjustShotHeight(caster, targetThing, ref shotHeight);
                     shotSource.y = shotHeight;
                     Vector3 targDrawPos = targetThing.DrawPos;
-                    targetPos = new Vector3(targDrawPos.x, new CollisionVertical(targetThing).Max, targDrawPos.z);
+                    targetPos = new Vector3(targDrawPos.x, targetThing.GetCollisionVertical().Max, targDrawPos.z);
                     var targPawn = targetThing as Pawn;
                     if (targPawn != null)
                     {


### PR DESCRIPTION
## Changes

Pawns cache their collision heights rather than calculating multiple times per tick

## Reasoning

Required for smarter height management.
Improves performance

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
