### PR TITLE
Fix repeat shots

### DIFF
--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -1129,6 +1129,7 @@
       <soundCastTail>GunTail_Heavy</soundCastTail>
       <onlyManualCast>true</onlyManualCast>
       <stopBurstWithoutLos>false</stopBurstWithoutLos>
+      <interruptibleBurst>false</interruptibleBurst>
       <targetParams>
         <canTargetLocations>true</canTargetLocations>
       </targetParams>

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -930,13 +930,30 @@ namespace CombatExtended
                               new Vector3(1f, height, 1f));
         }
 
+        public static CollisionVertical GetCollisionVertical(this Thing thing)
+        {
+            if (thing is Pawn pawn)
+            {
+                return pawn.GetTacticalManager().Collision;
+            }
+            return new CollisionVertical(thing);
+        }
+
         public static Bounds GetBoundsFor(Thing thing)
         {
             if (thing == null)
             {
                 return new Bounds();
             }
-            var height = new CollisionVertical(thing);
+            CollisionVertical height;
+            if (thing is Pawn pawn)
+            {
+                height = pawn.GetTacticalManager().Collision;
+            }
+            else
+            {
+                height = new CollisionVertical(thing);
+            }
             float length;
             float width;
             var thingPos = thing.DrawPos;
@@ -1504,5 +1521,8 @@ namespace CombatExtended
         }
 
         public static FactionStrengthTracker GetStrengthTracker(this Faction faction) => Find.World.GetComponent<WorldStrengthTracker>().GetFactionTracker(faction);
+
+        public static CompTacticalManager GetTacticalManager(this Pawn pawn) => pawn.TryGetComp<CompTacticalManager>();
+
     }
 }

--- a/Source/CombatExtended/CombatExtended/Comps/CompTacticalManager.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompTacticalManager.cs
@@ -7,11 +7,26 @@ using MonoMod.Utils;
 using RimWorld;
 using Verse;
 using Verse.AI;
+using CombatExtended.Compatibility;
 
 namespace CombatExtended
 {
     public class CompTacticalManager : ThingComp
     {
+        public CollisionVertical? collision = null;
+
+        public CollisionVertical Collision
+        {
+            get
+            {
+                if (collision == null)
+                {
+                    collision = new CollisionVertical(SelPawn);
+                }
+                return (CollisionVertical)collision;
+            }
+        }
+
         private Job curJob = null;
         private List<Verse.WeakReference<Pawn>> targetedBy = new List<Verse.WeakReference<Pawn>>();
 
@@ -141,6 +156,9 @@ namespace CombatExtended
         public override void CompTick()
         {
             base.CompTick();
+            float heightAdjust = CETrenches.GetHeightAdjust(SelPawn.Position, SelPawn.Map);
+            this.Collision.RecalculateHeight(SelPawn, heightAdjust);
+
             if (parent.IsHashIntervalTick(120))
             {
                 /*

--- a/Source/CombatExtended/CombatExtended/Verbs/VerbPropertiesCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/VerbPropertiesCE.cs
@@ -18,6 +18,7 @@ namespace CombatExtended
         public float meleeArmorPenetration = 0;
         public bool ejectsCasings = true;
         public bool ignorePartialLoSBlocker = false;
+        public bool interruptibleBurst = true;
 
         public float AdjustedArmorPenetrationCE(Verb ownerVerb, Pawn attacker)
         {

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -301,6 +301,12 @@ namespace CombatExtended
             if (Projectile == null || (IsAttacking && CompAmmo != null && !CompAmmo.CanBeFiredNow))
             {
                 CompAmmo?.TryStartReload();
+                shootingAtDowned = false;
+                lastTarget = null;
+                lastTargetPos = IntVec3.Invalid;
+                lastShootLine = null;
+                repeating = false;
+                storedShotReduction = null;
                 return false;
             }
             return true;

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -579,7 +579,11 @@ namespace CombatExtended
             // ----------------------------------- STEP 5: Finalization
 
             var w = (newTargetLoc - sourceLoc);
-            shotRotation = (-90 + Mathf.Rad2Deg * Mathf.Atan2(w.y, w.x) + rotationDegrees + spreadVec.x) % 360;
+            if (!midBurst)
+            {
+                lastShotRotation = -90 + Mathf.Rad2Deg * Mathf.Atan2(w.y, w.x);
+            }
+            shotRotation = (lastShotRotation + rotationDegrees + spreadVec.x) % 360;
             shotAngle = angleRadians + spreadVec.y * Mathf.Deg2Rad;
             distance = (newTargetLoc - sourceLoc).magnitude;
         }

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -1033,7 +1033,7 @@ namespace CombatExtended
                     {
                         return false;
                     }
-                    shootLine = (ShootLine) lastShootLine;
+                    shootLine = (ShootLine)lastShootLine;
                     currentTarget = new LocalTargetInfo(lastTargetPos);
                 }
                 else // case 4,5,8

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -1036,7 +1036,7 @@ namespace CombatExtended
 
                 ProjectileCE projectile = (ProjectileCE)ThingMaker.MakeThing(Projectile, null);
                 GenSpawn.Spawn(projectile, shootLine.Source, caster.Map);
-                ShiftTarget(report, pelletMechanicsOnly, instant);
+                ShiftTarget(report, pelletMechanicsOnly, instant, midBurst);
 
                 //New aiming algorithm
                 projectile.canTargetSelf = false;

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -1048,9 +1048,6 @@ namespace CombatExtended
                 projectile.mount = caster.Position.GetThingList(caster.Map).FirstOrDefault(t => t is Pawn && t != caster);
                 projectile.AccuracyFactor = report.accuracyFactor * report.swayDegrees * ((numShotsFired + 1) * 0.75f);
 
-                this.lastShotAngle = shotAngle;
-                this.lastShotRotation = shotRotation;
-                this.lastShootLine = shootLine;
                 if (instant)
                 {
                     var shotHeight = ShotHeight;

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -999,6 +999,20 @@ namespace CombatExtended
             doRetarget = true;
             storedShotReduction = null;
             if (!TryFindCEShootLineFromTo(caster.Position, currentTarget, out var shootLine)) // If we are mid burst & suppressive & target is unreachable but alive, keep shooting suppressively.
+            // Cases
+            // 1: Can hit target, set our previous shoot line
+            //    Cannot hit target
+            //      Target exists
+            //        Mid burst
+            // 2:       Interruptible -> stop shooting
+            // 3:       Not interruptible -> continue shooting at last position (do *not* shoot at target position as it will play badly with skip or other teleport effects)
+            // 4:     Suppressing fire -> set our shoot line and continue
+            // 5:     else -> stop
+            //      Target missing
+            //        Mid burst
+            // 6:       Interruptible -> stop shooting
+            // 7:       Not interruptible -> shoot along previous line
+            // 8:     else -> stop
             {
                 if (numShotsFired == 0 || (CompFireModes != null && CompFireModes.CurrentAimMode != AimMode.SuppressFire) || currentTarget.ThingDestroyed)
                 {

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -60,7 +60,7 @@ namespace CombatExtended
         protected float lastShotRotation;
         protected float lastRecoilDeg;
         protected float? storedShotReduction = null;
-        protected ShootLine lastShootLine;
+        protected ShootLine? lastShootLine;
         protected bool repeating = false;
         private bool doRetarget = true;
 
@@ -261,6 +261,7 @@ namespace CombatExtended
             shootingAtDowned = false;
             lastTarget = null;
             lastTargetPos = IntVec3.Invalid;
+            lastShootLine = null;
 
             repeating = false;
             storedShotReduction = null;

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -999,6 +999,10 @@ namespace CombatExtended
             doRetarget = true;
             storedShotReduction = null;
             if (!TryFindCEShootLineFromTo(caster.Position, currentTarget, out var shootLine)) // If we are mid burst & suppressive & target is unreachable but alive, keep shooting suppressively.
+            var props = VerbPropsCE;
+            var midBurst = numShotsFired > 0;
+            var suppressing = CompFireModes?.CurrentAimMode == AimMode.SuppressFire;
+
             // Cases
             // 1: Can hit target, set our previous shoot line
             //    Cannot hit target

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -351,7 +351,7 @@ namespace CombatExtended
         /// <summary>
         /// Shifts the original target position in accordance with target leading, range estimation and weather/lighting effects
         /// </summary>
-        public virtual void ShiftTarget(ShiftVecReport report, bool calculateMechanicalOnly = false, bool isInstant = false)
+        public virtual void ShiftTarget(ShiftVecReport report, bool calculateMechanicalOnly = false, bool isInstant = false, bool midBurst = false)
         {
             if (!calculateMechanicalOnly)
             {
@@ -558,14 +558,18 @@ namespace CombatExtended
                         targetHeight = CollisionVertical.WallCollisionHeight;
                     }
                 }
-                if (projectilePropsCE.isInstant)
+                if (!midBurst)
                 {
-                    angleRadians += Mathf.Atan2(targetHeight - ShotHeight, (newTargetLoc - sourceLoc).magnitude);
+                    if (projectilePropsCE.isInstant)
+                    {
+                        lastShotAngle = Mathf.Atan2(targetHeight - ShotHeight, (newTargetLoc - sourceLoc).magnitude);
+                    }
+                    else
+                    {
+                        lastShotAngle = ProjectileCE.GetShotAngle(ShotSpeed, (newTargetLoc - sourceLoc).magnitude, targetHeight - ShotHeight, Projectile.projectile.flyOverhead, projectilePropsCE.Gravity);
+                    }
                 }
-                else
-                {
-                    angleRadians += ProjectileCE.GetShotAngle(ShotSpeed, (newTargetLoc - sourceLoc).magnitude, targetHeight - ShotHeight, Projectile.projectile.flyOverhead, projectilePropsCE.Gravity);
-                }
+                angleRadians += lastShotAngle;
             }
 
             // ----------------------------------- STEP 4: Mechanical variation

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -129,7 +129,7 @@ namespace CombatExtended
                 return shotSpeed;
             }
         }
-        public float ShotHeight => (new CollisionVertical(caster)).shotHeight;
+        public float ShotHeight => caster.GetCollisionVertical().shotHeight;
         private Vector3 ShotSource
         {
             get
@@ -391,7 +391,7 @@ namespace CombatExtended
                 // Height difference calculations for ShotAngle
                 float targetHeight = 0f;
 
-                var coverRange = new CollisionVertical(report.cover).HeightRange;   //Get " " cover, assume it is the edifice
+                var coverRange = report.cover.GetCollisionVertical().HeightRange;   //Get " " cover, assume it is the edifice
 
                 // Projectiles with flyOverhead target the surface in front of the target
                 if (Projectile.projectile.flyOverhead)
@@ -400,7 +400,7 @@ namespace CombatExtended
                 }
                 else
                 {
-                    var victimVert = new CollisionVertical(currentTarget.Thing);
+                    var victimVert = currentTarget.Thing.GetCollisionVertical();
                     var targetRange = victimVert.HeightRange;   //Get lower and upper heights of the target
                     if (targetRange.min < coverRange.max)   //Some part of the target is hidden behind some cover
                     {
@@ -782,7 +782,7 @@ namespace CombatExtended
                             && newCover.def.Fillage == FillCategory.Partial
                             && !newCover.IsPlant())
                     {
-                        float newCoverHeight = new CollisionVertical(newCover).Max;
+                        float newCoverHeight = newCover.GetCollisionVertical().Max;
 
                         if (highestCover == null || highestCoverHeight < newCoverHeight)
                         {
@@ -1280,7 +1280,7 @@ namespace CombatExtended
                     AdjustShotHeight(caster, targetThing, ref shotHeight);
                     shotSource.y = shotHeight;
                     Vector3 targDrawPos = targetThing.DrawPos;
-                    targetPos = new Vector3(targDrawPos.x, new CollisionVertical(targetThing).Max, targDrawPos.z);
+                    targetPos = new Vector3(targDrawPos.x, targetThing.GetCollisionVertical().Max, targDrawPos.z);
                     var targPawn = targetThing as Pawn;
                     if (targPawn != null)
                     {

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -219,12 +219,14 @@ namespace CombatExtended
                 if (caster is Building_TurretGunCE turret)
                 {
                     turret.burstWarmupTicksLeft += aimTicks;
+                    RecalculateWarmupTicks();
                     _isAiming = true;
                     return;
                 }
                 if (ShooterPawn != null)
                 {
                     ShooterPawn.stances.SetStance(new Stance_Warmup(aimTicks, currentTarget, this));
+                    RecalculateWarmupTicks();
                     _isAiming = true;
                     return;
                 }

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -226,7 +226,7 @@ namespace CombatExtended
                 if (ShooterPawn != null)
                 {
                     ShooterPawn.stances.SetStance(new Stance_Warmup(aimTicks, currentTarget, this));
-                    ulateWarmupTicks();
+                    RecalculateWarmupTicks();
                     _isAiming = true;
                     return;
                 }

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -343,7 +343,7 @@ namespace CombatExtended
             {
                 if (caster is Building_TurretGunCE turret)
                 {
-                    if (!_isAiming && turret.burstWarmupTicksLeft > 0)  //Turrets call beginBurst() when starting to fire a burst, and when starting the final aiming part of an aimed shot.  We only want apply changes to warmup.
+                    if (turret.burstWarmupTicksLeft > 0)  //Turrets call beginBurst() when starting to fire a burst, and when starting the final aiming part of an aimed shot.  We only want apply changes to warmup.
                     {
                         turret.burstWarmupTicksLeft = (int)(turret.burstWarmupTicksLeft * reduction);
                     }

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -148,7 +148,7 @@ namespace CombatExtended
             }
             if (ShouldAimFor(mode))
             {
-                return sway * Mathf.Max(0, 1 - AimingAccuracy) / Mathf.Max(1, sightsEfficiency);
+                return sway * (0, 1 - AimingAccuracy) / (1, sightsEfficiency);
             }
             else if (IsSuppressed)
             {
@@ -339,7 +339,7 @@ namespace CombatExtended
             var delta = Mathf.Abs(newShotRotation - lastShotRotation) + lastRecoilDeg;
             lastRecoilDeg = 0;
             var maxReduction = storedShotReduction ?? (CompFireModes?.CurrentAimMode == AimMode.SuppressFire ? 0.1f : 0.25f);
-            var reduction = Mathf.Max(maxReduction, delta / 45f);
+            var reduction = Mathf.Min(maxReduction, delta / 45f);
             storedShotReduction = reduction;
             if (reduction < 1.0f)
             {

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -333,9 +333,7 @@ namespace CombatExtended
             }
 
             var d = v - u;
-            var w = new Vector2();
-            w.Set(d.x, d.z);
-            var newShotRotation = (-90 + Mathf.Rad2Deg * Mathf.Atan2(w.y, w.x)) % 360;
+            var newShotRotation = (-90 + Mathf.Rad2Deg * Mathf.Atan2(d.z, d.x)) % 360;
             var delta = Mathf.Abs(newShotRotation - lastShotRotation) + lastRecoilDeg;
             lastRecoilDeg = 0;
             var maxReduction = storedShotReduction ?? (CompFireModes?.CurrentAimMode == AimMode.SuppressFire ? 0.1f : 0.25f);

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -148,7 +148,7 @@ namespace CombatExtended
             }
             if (ShouldAimFor(mode))
             {
-                return sway * (0, 1 - AimingAccuracy) / (1, sightsEfficiency);
+                return sway * Mathf.Max(0, 1 - AimingAccuracy) / Mathf.Max(1, sightsEfficiency);
             }
             else if (IsSuppressed)
             {
@@ -226,7 +226,7 @@ namespace CombatExtended
                 if (ShooterPawn != null)
                 {
                     ShooterPawn.stances.SetStance(new Stance_Warmup(aimTicks, currentTarget, this));
-                    RecalculateWarmupTicks();
+                    ulateWarmupTicks();
                     _isAiming = true;
                     return;
                 }


### PR DESCRIPTION
## Changes

Repeat shots are broken by reloading
Some bursts cannot be interrupted (trip rocket)
Long bursts without a valid target no longer wander from recoil
Repeat shot warmup time applies to aim-mode phase


## Reasoning

The repeat shot system lets automatics mag dump better, but did little to help snipers.
Tripple rockets would magically fail to fire their last shot

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
