### PR TITLE
Patch Medical Supplement's bandage bulk stat

### DIFF
--- a/Patches/Medicine Supplements (Continued)/Items_Bandages.xml
+++ b/Patches/Medicine Supplements (Continued)/Items_Bandages.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Medical Supplements (Continued)</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<!-- Give bandages appropriate bulk. -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="MSBandage"]/statBases</xpath>
+					<value>
+						<Bulk>0.1</Bulk>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="MSASBandage"]/statBases</xpath>
+					<value>
+						<Bulk>0.1</Bulk>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="MSNanoBandage"]/statBases</xpath>
+					<value>
+						<Bulk>0.1</Bulk>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Medicine Supplements (Continued)/Items_Bandages.xml
+++ b/Patches/Medicine Supplements (Continued)/Items_Bandages.xml
@@ -11,19 +11,11 @@
 				<!-- Give bandages appropriate bulk. -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="MSBandage"]/statBases</xpath>
-					<value>
-						<Bulk>0.1</Bulk>
-					</value>
-				</li>
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="MSASBandage"]/statBases</xpath>
-					<value>
-						<Bulk>0.1</Bulk>
-					</value>
-				</li>
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="MSNanoBandage"]/statBases</xpath>
+					<xpath>Defs/ThingDef[
+					defName="MSBandage" or
+					defName="MSASBandage" or
+					defName="MSNanoBandage"
+					]/statBases</xpath>
 					<value>
 						<Bulk>0.1</Bulk>
 					</value>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -299,6 +299,7 @@ Mechanoid Bench 3   |
 Mechanoids Extraordinaire	|
 Mechanoid Master Blaser |
 Medieval Medicines 1.4 Medieval Overhaul Edition |
+Medical Supplements |
 Medical System Expansion	|
 Medieval Overhaul   |
 Medieval Quest Rewards  |


### PR DESCRIPTION
## Changes

Patch Medical Supplement's bandages bulk from 1.0 to 0.1 per piece

## Reasoning

Bandages are supposed to be a weaker, lighter alternative to a full medicine kit. The bulk stat didn't reflect this at all without the patch.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
