### PR TITLE
Incorrect adjacent cells collect

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -849,8 +849,18 @@ namespace CombatExtended
 
             //Find pawns in adjacent cells and append them to main list
             var adjList = new List<IntVec3>();
-            adjList.AddRange(GenAdj.CellsAdjacentCardinal(cell, Rot4.FromAngleFlat(shotRotation), new IntVec2(collisionCheckSize, 0)).ToList());
-
+            var rot4 = Rot4.FromAngleFlat(shotRotation);
+            if (rot4.rotInt > 1)
+            {
+                //For some reason south and west returns incorrect adjacent cells collection
+                rot4 = rot4.Opposite;
+            }
+            adjList.AddRange(GenAdj.CellsAdjacentCardinal(cell, rot4, new IntVec2(collisionCheckSize, 0)).ToList());
+            if (Controller.settings.DebugDrawInterceptChecks)
+            {
+                Map.debugDrawer.debugCells.Clear();
+                Map.debugDrawer.DebugDrawerUpdate();
+            }
             //Iterate through adjacent cells and find all the pawns
             foreach (var curCell in adjList)
             {


### PR DESCRIPTION
## Reasoning
Incorrect adjacent cells when shoting some directions (south and west).
Adjacent cells when shoting/throwing from south to north (red = projectile pos, blue checked cell):
![image](https://github.com/CombatExtended-Continued/CombatExtended/assets/78953324/dfa8fc08-a085-40b0-83ea-c1486c9f6e18)
Adjacent cells when shoting/throwing from north to south:
![image](https://github.com/CombatExtended-Continued/CombatExtended/assets/78953324/f7381c2f-6e1a-426c-9b59-4061d83c4ffc)

For some reason GenAdj.CellsAdjacentCardinal() works incorrect for rot4.South and rot4.West

## Changes

Grenades now hit high pawns (centipede and other) correctly from each direction

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Checked grenades)
