### PR TITLE
Add link and description for windows batch builder

### DIFF
--- a/Building.md
+++ b/Building.md
@@ -30,6 +30,8 @@ After this, building is just building the solution, references will be pulled fr
 A GPL3 windows Batch file to automate updating and building mods via `dotnet build` is available [here](https://raw.githubusercontent.com/CombatExtended-Continued/CE-AutoInstaller-Updater-Builder/main/CE-AutoInstaller-Updater-Builder.bat).  
 Simply download the file to your Rimworld/Mods directory and run it.  Running it again will rebase your local copy to the latest upstream and rebuild it.
 
+This assumes you have `git` and `dotnet` configured to be available from windows batch files.
+
 The repository for it is https://github.com/CombatExtended-Continued/CE-AutoInstaller-Updater-Builder 
 
 ## Other options

--- a/Building.md
+++ b/Building.md
@@ -26,6 +26,12 @@ $ start CombatExtended/Source/CombatExtended.sln
 
 After this, building is just building the solution, references will be pulled from Nuget, and the assemblies should be automatically publicised by the msbuild task. The resulting assembly will be in `$(root)/Assemblies/CombatExtended.dll`.
 
+###
+A GPL3 windows Batch file to automate updating and building mods via `dotnet build` is available [here](https://raw.githubusercontent.com/CombatExtended-Continued/CE-AutoInstaller-Updater-Builder/main/CE-AutoInstaller-Updater-Builder.bat).  
+Simply download the file to your Rimworld/Mods directory and run it.  Running it again will rebase your local copy to the latest upstream and rebuild it.
+
+The repository for it is https://github.com/CombatExtended-Continued/CE-AutoInstaller-Updater-Builder 
+
 ## Other options
 
 

--- a/Building.md
+++ b/Building.md
@@ -26,11 +26,14 @@ $ start CombatExtended/Source/CombatExtended.sln
 
 After this, building is just building the solution, references will be pulled from Nuget, and the assemblies should be automatically publicised by the msbuild task. The resulting assembly will be in `$(root)/Assemblies/CombatExtended.dll`.
 
-###
-A GPL3 windows Batch file to automate updating and building mods via `dotnet build` is available [here](https://raw.githubusercontent.com/CombatExtended-Continued/CE-AutoInstaller-Updater-Builder/main/CE-AutoInstaller-Updater-Builder.bat).  
+### Dotnet Build
+
+If you want to compile without an IDE, you can clone the repo as usual, and then manually call `dotnet build CombatExtended.sln` from the `Source` directory.  
+
+This can be automated by a GPL3 windows Batch file available [here](https://raw.githubusercontent.com/CombatExtended-Continued/CE-AutoInstaller-Updater-Builder/main/CE-AutoInstaller-Updater-Builder.bat).  
 Simply download the file to your Rimworld/Mods directory and run it.  Running it again will rebase your local copy to the latest upstream and rebuild it.
 
-This assumes you have `git` and `dotnet` configured to be available from windows batch files.
+This assumes you have `git` and `dotnet` configured to be available from windows batch files.  See the readme file included in its repository for details.
 
 The repository for it is https://github.com/CombatExtended-Continued/CE-AutoInstaller-Updater-Builder 
 


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Windows batchfile builder provided by @Draconomial is linked from Building.md


## References

Links to the associated issues or other related pull requests, e.g.
- Closes #2902 

## Reasoning

Why did you choose to implement things this way, e.g.
The batch file runs with full user permissions, so needs to be under at least as strict branch protection rules as any of our other code.  
It is in its own repo so further changes from Draconomial can easily be pulled, and because it is GPL3, so can't sit in this repo.  Since it is supposed to help automate checking this repo out and building it, from the top level `Mods` directory, it makes more sense to have it in its own repo anyway.

## Alternatives

Have people manually call `dotnet build` on the solution file.  

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
