### PR TITLE
Fix vehicles (and zombies) not having a valid cached CollisionVertical

### DIFF
--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -948,7 +948,7 @@ namespace CombatExtended
             CollisionVertical height;
             if (thing is Pawn pawn)
             {
-                height = pawn.GetTacticalManager().Collision;
+                height = pawn.GetTacticalManager()?.Collision ?? new CollisionVertical(thing);
             }
             else
             {

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -934,7 +934,7 @@ namespace CombatExtended
         {
             if (thing is Pawn pawn)
             {
-                return pawn.GetTacticalManager().Collision;
+                return pawn.GetTacticalManager()?.Collision ?? new CollisionVertical(thing);
             }
             return new CollisionVertical(thing);
         }

--- a/Source/CombatExtended/Compatibility/Trenches.cs
+++ b/Source/CombatExtended/Compatibility/Trenches.cs
@@ -16,7 +16,12 @@ namespace CombatExtended.Compatibility
         private const string VFES_ModName = "Vanilla Furniture Expanded - Security";
         static CETrenches()
         {
+            Log.Message("Combat Extended :: Checking VFE Security");
             vfeInstalled = ModLister.HasActiveModWithName(VFES_ModName);
+            if (vfeInstalled)
+            {
+                Log.Message("Combat Extended :: Installing VFE Security");
+            }
         }
 
         private static bool checkVFE(IntVec3 cell, Map map, out float heightAdjust)


### PR DESCRIPTION
## Changes

If a pawn lacks a tactical manager, it cannot cache its collision vertical, so fall back to old behavior.


## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
