### PR TITLE
Patch for Thrumbo Plushie

### DIFF
--- a/Patches/Thrumbo Plushie/ThrumboPlushie.xml
+++ b/Patches/Thrumbo Plushie/ThrumboPlushie.xml
@@ -6,48 +6,50 @@
 		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>
-				<!-- ========== Thrumbo Plushie ========== -->
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="ThrumboPlushie"]/tools</xpath>
-					<value>
-						<tools>
-							<li Class="CombatExtended.ToolCE">
-								<label>base</label>
-								<capacities>
-									<li>Blunt</li>
-								</capacities>
-								<power>1</power>
-								<cooldownTime>2</cooldownTime>
-								<armorPenetrationBlunt>0.05</armorPenetrationBlunt>
-								<linkedBodyPartsGroup>Base</linkedBodyPartsGroup>
-							</li>
-						</tools>
-					</value>
-				</li>
 
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="ThrumboPlushie"]/statBases</xpath>
-					<value>
-						<Bulk>2</Bulk>
-					</value>
-				</li>
+			<!-- ========== Thrumbo Plushie ========== -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ThrumboPlushie"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>base</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>1</power>
+							<cooldownTime>2</cooldownTime>
+							<armorPenetrationBlunt>0.05</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Base</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
 
-				<li Class="PatchOperationConditional">
-					<xpath>Defs/ThingDef[defName="ThrumboPlushie"]/weaponTags</xpath>
-					<nomatch Class="PatchOperationAdd">
-						<xpath>Defs/ThingDef[defName="ThrumboPlushie"]</xpath>
-						<value>
-							<weaponTags />
-						</value>
-					</nomatch>
-				</li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="ThrumboPlushie"]/statBases</xpath>
+				<value>
+					<Bulk>2</Bulk>
+				</value>
+			</li>
 
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="ThrumboPlushie"]/weaponTags</xpath>
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="ThrumboPlushie"]/weaponTags</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="ThrumboPlushie"]</xpath>
 					<value>
-						<li>CE_OneHandedWeapon</li>
+						<weaponTags />
 					</value>
-				</li>
+				</nomatch>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="ThrumboPlushie"]/weaponTags</xpath>
+				<value>
+					<li>CE_OneHandedWeapon</li>
+				</value>
+			</li>
+
 			</operations>
 		</match>
 	</Operation>

--- a/Patches/Thrumbo Plushie/ThrumboPlushie.xml
+++ b/Patches/Thrumbo Plushie/ThrumboPlushie.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Thrumbo Plushie</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- ========== Thrumbo Plushie ========== -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="ThrumboPlushie"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>base</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>1</power>
+								<cooldownTime>2</cooldownTime>
+								<armorPenetrationBlunt>0.05</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Base</linkedBodyPartsGroup>
+							</li>
+						</tools>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="ThrumboPlushie"]/statBases</xpath>
+					<value>
+						<Bulk>2</Bulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[defName="ThrumboPlushie"]/weaponTags</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="ThrumboPlushie"]</xpath>
+						<value>
+							<weaponTags />
+						</value>
+					</nomatch>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="ThrumboPlushie"]/weaponTags</xpath>
+					<value>
+						<li>CE_OneHandedWeapon</li>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -470,6 +470,7 @@ The Joris Experience	|
 The Tuffalo |
 Thog's Armor    |
 Thog's Guns - More Brukka Pack  |
+Thrumbo Plushie |
 Toolmetrics Redux (Continued)   |
 TouhouStyle	|
 Trading Economy	|


### PR DESCRIPTION
Create ThrumboPlushie item patch.

## Additions

Describe new functionality added by your code, e.g.
- Tribal smoke bombs
- New tribal smoke bomb sprite
- Tribal smoke bomb recipes at smithing bench and crafting spot using prometheum

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased regular smoke bomb radius

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
