### PR TITLE
VRE Fungoid patch

### DIFF
--- a/Defs/Stats/Stats_NightVision.xml
+++ b/Defs/Stats/Stats_NightVision.xml
@@ -67,7 +67,7 @@
 	<StatDef ParentName="EquipmentNightVisionBase">
 		<defName>NightVisionEfficiency_Weapon</defName>
 		<label>night vision efficiency</label>
-		<description>The effect of a weapon's optics on a the wielder's ability to overcome the effects of darkness for the purpose of firing accurately.</description>
+		<description>The effect of a weapon's optics on the wielder's ability to overcome the effects of darkness for the purpose of firing accurately.</description>
 		<category>Weapon</category>
 		<parts>
 			<li Class="CombatExtended.StatPart_Attachments" />

--- a/Patches/Vanilla Races Expanded - Fungoid/Apparel_Various.xml
+++ b/Patches/Vanilla Races Expanded - Fungoid/Apparel_Various.xml
@@ -7,7 +7,7 @@
 		<match Class="PatchOperationSequence">
 			<operations>
 		
-			<!-- === Riot Armor === -->
+			<!-- === Space Suit === -->
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[@Name="VREF_ApparelArmorAstrosuitBase"]/statBases</xpath>
 				<value>

--- a/Patches/Vanilla Races Expanded - Fungoid/Apparel_Various.xml
+++ b/Patches/Vanilla Races Expanded - Fungoid/Apparel_Various.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Races Expanded - Fungoid</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+		
+			<!-- === Riot Armor === -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[@Name="VREF_ApparelArmorAstrosuitBase"]/statBases</xpath>
+				<value>
+					<Bulk>40</Bulk>
+					<WornBulk>15</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[@Name="VREF_ApparelArmorAstrosuitBase"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>14</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[@Name="VREF_ApparelArmorAstrosuitBase"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>28</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[@Name="VREF_ApparelArmorAstrosuitBase"]/equippedStatOffsets/MoveSpeed</xpath>
+				<value>
+					<MeleeDodgeChance>-0.15</MeleeDodgeChance>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[@Name="VREF_ApparelArmorAstrosuitBase"]/apparel/bodyPartGroups</xpath>
+				<value>
+					<li>Hands</li>
+					<li>Feet</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[@Name="VREF_ApparelArmorAstrosuitBase"]</xpath>
+				<value>
+					<li Class="CombatExtended.PartialArmorExt">
+						<stats>
+							<li>
+								<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
+								<parts>
+									<li>Neck</li>
+									<li>Hand</li>
+								</parts>
+							</li>
+							<li>
+								<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
+								<parts>
+									<li>Neck</li>
+									<li>Hand</li>
+								</parts>
+							</li>
+							<li>
+								<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+								<parts>
+									<li>Leg</li>
+								</parts>
+							</li>
+							<li>
+								<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+								<parts>
+									<li>Leg</li>
+								</parts>
+							</li>
+							<li>
+								<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+								<parts>
+									<li>Arm</li>
+								</parts>
+							</li>
+							<li>
+								<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+								<parts>
+									<li>Arm</li>
+								</parts>
+							</li>
+						</stats>
+					</li>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Vanilla Races Expanded - Fungoid/Fungoid_Hediffs_BodyParts.xml
+++ b/Patches/Vanilla Races Expanded - Fungoid/Fungoid_Hediffs_BodyParts.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Races Expanded - Fungoid</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+                <li Class="PatchOperationReplace">
+					<xpath>Defs/HediffDef[defName="VRE_InfectorMouth"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>infector mouth</label>
+								<capacities>
+									<li>VRE_Infection_Bite</li>
+								</capacities>
+								<power>15</power>
+								<cooldownTime>1.5</cooldownTime>
+								<armorPenetrationBlunt>0.15</armorPenetrationBlunt>
+								<armorPenetrationSharp>1.5</armorPenetrationSharp>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+							</li>
+						</tools>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/HediffDef[defName="VRE_InfectorHands"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>infector hand</label>
+								<capacities>
+									<li>VRE_Infection</li>
+								</capacities>
+								<power>8</power>
+								<armorPenetrationBlunt>0.2</armorPenetrationBlunt>
+								<armorPenetrationSharp>0.18</armorPenetrationSharp>
+								<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+								<cooldownTime>1.5</cooldownTime>
+							</li>
+						</tools>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Vanilla Races Expanded - Fungoid/Fungoid_Hediffs_BodyParts.xml
+++ b/Patches/Vanilla Races Expanded - Fungoid/Fungoid_Hediffs_BodyParts.xml
@@ -20,7 +20,6 @@
 								<cooldownTime>1.5</cooldownTime>
 								<armorPenetrationBlunt>0.15</armorPenetrationBlunt>
 								<armorPenetrationSharp>1.5</armorPenetrationSharp>
-								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 								<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 							</li>
 						</tools>

--- a/Patches/Vanilla Races Expanded - Fungoid/Fungoid_Hediffs_BodyParts.xml
+++ b/Patches/Vanilla Races Expanded - Fungoid/Fungoid_Hediffs_BodyParts.xml
@@ -7,43 +7,43 @@
 		<match Class="PatchOperationSequence">
 			<operations>
 
-                <li Class="PatchOperationReplace">
-					<xpath>Defs/HediffDef[defName="VRE_InfectorMouth"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
-					<value>
-						<tools>
-							<li Class="CombatExtended.ToolCE">
-								<label>infector mouth</label>
-								<capacities>
-									<li>VRE_Infection_Bite</li>
-								</capacities>
-								<power>15</power>
-								<cooldownTime>1.5</cooldownTime>
-								<armorPenetrationBlunt>0.15</armorPenetrationBlunt>
-								<armorPenetrationSharp>1.5</armorPenetrationSharp>
-								<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-							</li>
-						</tools>
-					</value>
-				</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/HediffDef[defName="VRE_InfectorMouth"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>infector mouth</label>
+							<capacities>
+								<li>VRE_Infection_Bite</li>
+							</capacities>
+							<power>15</power>
+							<cooldownTime>1.5</cooldownTime>
+							<armorPenetrationBlunt>0.15</armorPenetrationBlunt>
+							<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+						</li>
+					</tools>
+				</value>
+			</li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/HediffDef[defName="VRE_InfectorHands"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
-					<value>
-						<tools>
-							<li Class="CombatExtended.ToolCE">
-								<label>infector hand</label>
-								<capacities>
-									<li>VRE_Infection</li>
-								</capacities>
-								<power>8</power>
-								<armorPenetrationBlunt>0.2</armorPenetrationBlunt>
-								<armorPenetrationSharp>0.18</armorPenetrationSharp>
-								<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-								<cooldownTime>1.5</cooldownTime>
-							</li>
-						</tools>
-					</value>
-				</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/HediffDef[defName="VRE_InfectorHands"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>infector hand</label>
+							<capacities>
+								<li>VRE_Infection</li>
+							</capacities>
+							<power>8</power>
+							<armorPenetrationBlunt>0.2</armorPenetrationBlunt>
+							<armorPenetrationSharp>0.18</armorPenetrationSharp>
+							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+							<cooldownTime>1.5</cooldownTime>
+						</li>
+					</tools>
+				</value>
+			</li>
 
 			</operations>
 		</match>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -517,6 +517,7 @@ Vanilla Psycasts Expanded   |
 Vanilla Psycasts Expanded - Hemosage  |
 Vanilla Races Expanded - Android  |
 Vanilla Races Expanded - Archon |
+Vanilla Races Expanded - Fungoid |
 Vanilla Races Expanded - Highmate  |
 Vanilla Races Expanded - Hussar  |
 Vanilla Races Expanded - Phytokin  |


### PR DESCRIPTION
## Additions
patch fungoid melee tools in xml.
Describe new functionality added by your code, e.g.
- Tribal smoke bombs
- New tribal smoke bomb sprite
- Tribal smoke bomb recipes at smithing bench and crafting spot using prometheum

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased regular smoke bomb radius

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
