### PR TITLE
Misc. Tweaks & Fixes

### DIFF
--- a/Defs/Misc/TipSetDefs/Tips.xml
+++ b/Defs/Misc/TipSetDefs/Tips.xml
@@ -24,7 +24,7 @@
 			<!--<li>Targets in dense smoke may experience negative health effects without a gas mask. At least they become more difficult to hit.</li>-->
 			<li TKey="GoodSights">Good sights can help negate inaccuracy due to bad weather, darkness, or dense smoke.</li>
 			<li TKey="ProjectilesDodge">Shooters imperfectly lead their targets until they commit to a shot. Slower projectiles can be dodged.</li>
-			<li TKey="ReloadedOneRound">Some weapons, such as shotguns, are often reloaded one round at a time, allowing them to be fired mid-reload.</li>
+			<li TKey="ReloadedOneRound">Some weapons, such as shotguns, are reloaded one round at a time, allowing them to be fired mid-reload.</li>
 			<li TKey="ForceImpact">Even when a projectile doesn't penetrate a character's armor, they may still be injured by the force of the impact.</li>
 			<li TKey="SaveHead">Even when behind cover, a shooter's head will still be exposed as they scan for targets.</li>
 			<li TKey="RiskOfInfection">The longer a wound remains untreated, the higher the risk of infection. Lying in the dirt doesn't help things either.</li>

--- a/Defs/Stats/Stats_NightVision.xml
+++ b/Defs/Stats/Stats_NightVision.xml
@@ -50,14 +50,14 @@
 
 	<StatDef Name="EquipmentNightVisionBase" ParentName="BaseNightVisionPart" Abstract="true">
 		<parts>
-			<li Class="StatPart_Quality">
-				<factorAwful>0.50</factorAwful>
-				<factorPoor>0.65</factorPoor>
-				<factorNormal>0.80</factorNormal>
-				<factorGood>0.85</factorGood>
-				<factorExcellent>0.95</factorExcellent>
-				<factorMasterwork>1.05</factorMasterwork>
-				<factorLegendary>1.20</factorLegendary>
+			<li Class="StatPart_Quality"> <!-- Since this reduces darkness penalty, item stat maxes out at 100%.  -->
+				<factorAwful>0.70</factorAwful>
+				<factorPoor>0.85</factorPoor>
+				<factorNormal>1</factorNormal>
+				<factorGood>1.05</factorGood>
+				<factorExcellent>1.1</factorExcellent>
+				<factorMasterwork>1.15</factorMasterwork>
+				<factorLegendary>1.25</factorLegendary>
 			</li>
 		</parts>
 	</StatDef>

--- a/Patches/Apex - Rimworld Legends/ApexRimworldLegends_Weapons_AssaultRifles.xml
+++ b/Patches/Apex - Rimworld Legends/ApexRimworldLegends_Weapons_AssaultRifles.xml
@@ -271,7 +271,7 @@
 						<recoilAmount>1.96</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
-						<defaultProjectile>Bullet_5x35mmCharged</defaultProjectile>
+						<defaultProjectile>Bullet_8x40mmCharged</defaultProjectile>
 						<burstShotCount>6</burstShotCount>
 						<ticksBetweenBurstShots>5.2</ticksBetweenBurstShots>
 						<warmupTime>1</warmupTime>
@@ -283,7 +283,7 @@
 					<AmmoUser>
 						<magazineSize>36</magazineSize>
 						<reloadTime>4</reloadTime>
-						<ammoSet>AmmoSet_5x35mmCharged</ammoSet>
+						<ammoSet>AmmoSet_8x40mmCharged</ammoSet>
 					</AmmoUser>
 					<FireModes />
 					<weaponTags>

--- a/Patches/Biomes Caverns/ThingDefs_Races/CE_WoollySpider.xml
+++ b/Patches/Biomes Caverns/ThingDefs_Races/CE_WoollySpider.xml
@@ -8,7 +8,7 @@
 		<match Class="PatchOperationSequence">
 			<operations>
 				<li Class="PatchOperationAddModExtension">
-					<xpath>Defs/ThingDef[defName="BMT_WoolySpider"]</xpath>
+					<xpath>Defs/ThingDef[defName="BMT_WoollySpider"]</xpath>
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>QuadrupedLow</bodyShape>
@@ -17,7 +17,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="BMT_WoolySpider"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="BMT_WoollySpider"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.26</MeleeDodgeChance>
 						<MeleeCritChance>0.2</MeleeCritChance>
@@ -26,7 +26,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="BMT_WoolySpider"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="BMT_WoollySpider"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -1187,7 +1187,7 @@
     </AmmoUser>
     <FireModes>
       <aimedBurstShotCount>10</aimedBurstShotCount>
-      <aiAimMode>Snapshot</aiAimMode>
+      <aiAimMode>SuppressFire</aiAimMode>
     </FireModes>
     <weaponTags>
       <li>CE_AI_Suppressive</li>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
@@ -646,7 +646,7 @@
 					</AmmoUser>
 					<FireModes>
 						<aimedBurstShotCount>15</aimedBurstShotCount>
-						<aiAimMode>Snapshot</aiAimMode>
+						<aiAimMode>SuppressFire</aiAimMode>
 					</FireModes>
 					<weaponTags>
 						<li>VFE_AdvMechanoidGunHeavy</li>

--- a/Patches/Vanilla Races Expanded - Archon/Apparel_Various.xml
+++ b/Patches/Vanilla Races Expanded - Archon/Apparel_Various.xml
@@ -27,7 +27,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="VREA_Apparel_Archoplate"]/statBases/VEF_EnergyShieldEnergyMaxApparel</xpath>
 				<value>
-					<VEF_EnergyShieldEnergyMaxApparel>7</VEF_EnergyShieldEnergyMaxApparel>
+					<VEF_EnergyShieldEnergyMaxApparel>12</VEF_EnergyShieldEnergyMaxApparel>
 				</value>
 			</li>
 


### PR DESCRIPTION
## Changes
Another grab-bag PR of tweaks and changes.
1. Fix typo in Biomes! Caverns patch.
2. Adjust Night Vision quality factors.
3. Change HCB aim mode from Snapshot to SupressFire.
4. Change Apex Legends mech rifle caliber from 5x35 to 8x40. (#2888)

## References
Closes #2914
Closes #2924

## Reasoning
1. Typo in the patch makes it fail. Possibly caused by a minor mod update.
2. Existing scaling for NV quality factors in unusual compared to other RW quality stats, as 1x is not the "normal". This makes it somewhat counter-intuitive, and makes NV perhaps weaker than it really needs to be. With the new scaling, NV is somewhat stronger, but still very rarely hits the 100% reduction even with advanced NV systems of masterwork quality.
3. In SuppressFire, losing LoS will prevent will not interrupt the warm-up. So, rather than sitting and watching the player corner-peak them without firing (as they do currently), centis will actually open fire--making it far riskier to the player. This may come at a slight cost to accuracy, but with the HCB, firing for suppression is still preferable to not firing at all.
4. The ARL Mech Rifle is patched as an assault rifle, but was chambered in 5x35, which is more of a heavy battle rifle or sniper rifle round. Swapping it to the 8x40 matches the Centurion and is more suitable for a charge assault weapon.

## Alternatives
1. Suffer.
2. Could keep the existing quality factors or use a different scaling.
3. Could leave as-is.
4. Could leave as-is.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
