### PR TITLE
Patch fire related genes

### DIFF
--- a/Biotech/Patches/GeneDefs/GeneDefs_Misc.xml
+++ b/Biotech/Patches/GeneDefs/GeneDefs_Misc.xml
@@ -44,5 +44,21 @@
 			</statFactors>
 		</value>
 	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/GeneDef[defName="FireResistant"]/damageFactors</xpath>
+		<value>
+			<PrometheumFlame>0.25</PrometheumFlame>
+			<Flame_Secondary>0.25</Flame_Secondary>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/GeneDef[defName="FireWeakness"]/damageFactors</xpath>
+		<value>
+			<PrometheumFlame>4</PrometheumFlame>
+			<Flame_Secondary>4</Flame_Secondary>
+		</value>
+	</Operation>
 
 </Patch>

--- a/Patches/Alpha Genes/GeneDefs/GeneDefs_Archite.xml
+++ b/Patches/Alpha Genes/GeneDefs/GeneDefs_Archite.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/GeneDef[defName="AG_HeatImmunity"]/damageFactors</xpath>
+		<value>
+			<PrometheumFlame>0.0</PrometheumFlame>
+			<Flame_Secondary>0.0</Flame_Secondary>
+		</value>
+	</Operation>
+
+</Patch>

--- a/Patches/Alpha Genes/GeneDefs/GeneDefs_Archite.xml
+++ b/Patches/Alpha Genes/GeneDefs/GeneDefs_Archite.xml
@@ -20,5 +20,4 @@
 		</match>
 	</Operation>
   
-
 </Patch>

--- a/Patches/Alpha Genes/GeneDefs/GeneDefs_Archite.xml
+++ b/Patches/Alpha Genes/GeneDefs/GeneDefs_Archite.xml
@@ -1,12 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
-	
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/GeneDef[defName="AG_HeatImmunity"]/damageFactors</xpath>
-		<value>
-			<PrometheumFlame>0.0</PrometheumFlame>
-			<Flame_Secondary>0.0</Flame_Secondary>
-		</value>
+
+	<Operation Class="PatchOperationFindMod">
+    <mods>
+		<li>Alpha Genes</li>
+    </mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+			
+    	<li Class="PatchOperationAdd">
+    		<xpath>Defs/GeneDef[defName="AG_HeatImmunity"]/damageFactors</xpath>
+    		<value>
+    			<PrometheumFlame>0.0</PrometheumFlame>
+    			<Flame_Secondary>0.0</Flame_Secondary>
+    		</value>
+    	</li>
+			
+		</operations>
+		</match>
 	</Operation>
+  
 
 </Patch>

--- a/Patches/Big and Small/Big and Small Genes/Genes/GeneDefs_Temperature.xml
+++ b/Patches/Big and Small/Big and Small Genes/Genes/GeneDefs_Temperature.xml
@@ -1,12 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
-	
-	<Operation Class="PatchOperationAdd">
+
+<Operation Class="PatchOperationFindMod">
+<mods>
+  <li>Big and Small Genes</li>
+</mods>
+  <match Class="PatchOperationSequence">
+  <operations>
+  
+	<li Class="PatchOperationAdd">
 		<xpath>Defs/GeneDef[defName="FireImmunity"]/damageFactors</xpath>
 		<value>
 			<PrometheumFlame>0.0</PrometheumFlame>
 			<Flame_Secondary>0.0</Flame_Secondary>
 		</value>
-	</Operation>
+	</li>
 
+  </operations>
+  </match>
+</Operation>
+  
 </Patch>

--- a/Patches/Big and Small/Big and Small Genes/Genes/GeneDefs_Temperature.xml
+++ b/Patches/Big and Small/Big and Small Genes/Genes/GeneDefs_Temperature.xml
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 
-<Operation Class="PatchOperationFindMod">
-<mods>
-  <li>Big and Small Genes</li>
-</mods>
-  <match Class="PatchOperationSequence">
-  <operations>
-  
-	<li Class="PatchOperationAdd">
-		<xpath>Defs/GeneDef[defName="FireImmunity"]/damageFactors</xpath>
-		<value>
-			<PrometheumFlame>0.0</PrometheumFlame>
-			<Flame_Secondary>0.0</Flame_Secondary>
-		</value>
-	</li>
+	<Operation Class="PatchOperationFindMod">
+	<mods>
+		<li>Big and Small Genes</li>
+	</mods>
+		<match Class="PatchOperationSequence">
+		<operations>
 
-  </operations>
-  </match>
-</Operation>
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/GeneDef[defName="FireImmunity"]/damageFactors</xpath>
+			<value>
+				<PrometheumFlame>0.0</PrometheumFlame>
+				<Flame_Secondary>0.0</Flame_Secondary>
+			</value>
+		</li>
+
+		</operations>
+		</match>
+	</Operation>
   
 </Patch>

--- a/Patches/Big and Small/Big and Small Genes/Genes/GeneDefs_Temperature.xml
+++ b/Patches/Big and Small/Big and Small Genes/Genes/GeneDefs_Temperature.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/GeneDef[defName="FireImmunity"]/damageFactors</xpath>
+		<value>
+			<PrometheumFlame>0.0</PrometheumFlame>
+			<Flame_Secondary>0.0</Flame_Secondary>
+		</value>
+	</Operation>
+
+</Patch>


### PR DESCRIPTION
## Additions

Adds patch to include PrometheumFlame and Flame_Secondary to the effects of fire related genes (Biotech, Big and Small Genes and Alpha Genes)


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (1 year in-game)
