### PR TITLE
Fix VF Vehicles in No Ammo Mode

### DIFF
--- a/Patches/Alpha Vehicle/Alpha_Vehicle_Hwacha.xml
+++ b/Patches/Alpha Vehicle/Alpha_Vehicle_Hwacha.xml
@@ -36,13 +36,6 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="AV_Hwacha_Turret"]/genericAmmo</xpath>
-					<value>
-						<genericAmmo>false</genericAmmo>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleTurretDef[defName="AV_Hwacha_Turret"]/magazineCapacity</xpath>
 					<value>
 						<magazineCapacity>64</magazineCapacity>

--- a/Patches/Alpha Vehicle/Alpha_Vehicle_WarChariot.xml
+++ b/Patches/Alpha Vehicle/Alpha_Vehicle_WarChariot.xml
@@ -36,13 +36,6 @@
 					<xpath>Defs/Vehicles.VehicleTurretDef[defName="AV_WarChariot_Turret"]/chargePerAmmoCount</xpath>
 				</li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="AV_WarChariot_Turret"]/genericAmmo</xpath>
-					<value>
-						<genericAmmo>false</genericAmmo>
-					</value>
-				</li>
-
 				<!--li Class="PatchOperationReplace">
 						<xpath>Defs/Vehicles.VehicleTurretDef[defName="AV_WarChariot"]/magazineCapacity</xpath>
 						<value>

--- a/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Badger.xml
+++ b/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Badger.xml
@@ -39,13 +39,6 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Badger_MainTurret"]/genericAmmo</xpath>
-					<value>
-						<genericAmmo>false</genericAmmo>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Badger_MainTurret"]/maxRange</xpath>
 					<value>
 						<maxRange>74</maxRange>

--- a/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Marshal.xml
+++ b/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Marshal.xml
@@ -36,13 +36,6 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Marshal_MainTurret"]/genericAmmo</xpath>
-					<value>
-						<genericAmmo>false</genericAmmo>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Marshal_MainTurret"]/maxRange</xpath>
 					<value>
 						<maxRange>86</maxRange>
@@ -86,13 +79,6 @@
 
 				<li Class="PatchOperationRemove">
 					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Marshal_MountedTurret"]/chargePerAmmoCount</xpath>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Marshal_MountedTurret"]/genericAmmo</xpath>
-					<value>
-						<genericAmmo>false</genericAmmo>
-					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">

--- a/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Paladin.xml
+++ b/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Paladin.xml
@@ -39,13 +39,6 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Paladin_MainTurret"]/genericAmmo</xpath>
-					<value>
-						<genericAmmo>false</genericAmmo>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Paladin_MainTurret"]/magazineCapacity</xpath>
 					<value>
 						<magazineCapacity>50</magazineCapacity>

--- a/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier1/Bunsen.xml
+++ b/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier1/Bunsen.xml
@@ -37,13 +37,6 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/genericAmmo</xpath>
-					<value>
-						<genericAmmo>false</genericAmmo>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/magazineCapacity</xpath>
 					<value>
 						<magazineCapacity>200</magazineCapacity>

--- a/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier1/Highwayman.xml
+++ b/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier1/Highwayman.xml
@@ -38,13 +38,6 @@
 					</value>
 				</li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/genericAmmo</xpath>
-					<value>
-						<genericAmmo>false</genericAmmo>
-					</value>
-				</li>
-
 				<li Class="PatchOperationRemove">
 					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Highwayman_MainTurret"]/projectileShifting</xpath>
 				</li>

--- a/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier1/Roadkill.xml
+++ b/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier1/Roadkill.xml
@@ -36,13 +36,6 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Roadkill_MainTurret"]/genericAmmo</xpath>
-					<value>
-						<genericAmmo>false</genericAmmo>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Roadkill_MainTurret"]/maxRange</xpath>
 					<value>
 						<maxRange>62</maxRange>

--- a/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier2/Bulldog.xml
+++ b/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier2/Bulldog.xml
@@ -36,13 +36,6 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Bulldog_MainTurret"]/genericAmmo</xpath>
-					<value>
-						<genericAmmo>false</genericAmmo>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Bulldog_MainTurret"]/maxRange</xpath>
 					<value>
 						<maxRange>86</maxRange>

--- a/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier2/Tango.xml
+++ b/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier2/Tango.xml
@@ -38,13 +38,6 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]/genericAmmo</xpath>
-					<value>
-						<genericAmmo>false</genericAmmo>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Tango_MainTurret"]/maxRange</xpath>
 					<value>
 						<maxRange>78</maxRange>

--- a/Patches/Vehicle Framework Expanded - Classic Mechs/Mech_BattleCannon.xml
+++ b/Patches/Vehicle Framework Expanded - Classic Mechs/Mech_BattleCannon.xml
@@ -41,13 +41,6 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_BattleCannon"]/genericAmmo</xpath>
-					<value>
-						<genericAmmo>false</genericAmmo>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_BattleCannon"]/maxRange</xpath>
 					<value>
 						<maxRange>105</maxRange>

--- a/Patches/Vehicle Framework Expanded - Classic Mechs/Mech_GatlingCannon.xml
+++ b/Patches/Vehicle Framework Expanded - Classic Mechs/Mech_GatlingCannon.xml
@@ -37,13 +37,6 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_GatlingCannon"]/genericAmmo</xpath>
-				<value>
-					<genericAmmo>false</genericAmmo>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
 				<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_GatlingCannon"]/maxRange</xpath>
 				<value>
 					<maxRange>95</maxRange>

--- a/Patches/Vehicle Framework Expanded - Classic Mechs/Mech_MachineGun.xml
+++ b/Patches/Vehicle Framework Expanded - Classic Mechs/Mech_MachineGun.xml
@@ -37,13 +37,6 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_MachineGun"]/genericAmmo</xpath>
-					<value>
-						<genericAmmo>false</genericAmmo>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_MachineGun"]/maxRange</xpath>
 					<value>
 						<maxRange>80</maxRange>

--- a/Patches/Vehicle Framework Expanded - Classic Mechs/Mech_MissileLauncher.xml
+++ b/Patches/Vehicle Framework Expanded - Classic Mechs/Mech_MissileLauncher.xml
@@ -36,13 +36,6 @@
 					</value>
 				</li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_MissileLauncher"]/genericAmmo</xpath>
-					<value>
-						<genericAmmo>false</genericAmmo>
-					</value>
-				</li>
-
 				<li Class="PatchOperationRemove">
 					<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_MissileLauncher"]/chargePerAmmoCount</xpath>
 				</li>


### PR DESCRIPTION
## Changes
- Remove operations changing the state of `genericAmmo` from vehicle patches.

## Reasoning
- The swapping of generic/non-generic ammo is already appropriately handled in the assembly. The only thing including the operation does it prevent the vehicle from being able to load its generic ammo type when using No Ammo Mode, which is not desirable.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
