### PR TITLE
Set chargePerAmmoCount to 1 if ammo enabled

### DIFF
--- a/Patches/Alpha Vehicle/Alpha_Vehicle_Hwacha.xml
+++ b/Patches/Alpha Vehicle/Alpha_Vehicle_Hwacha.xml
@@ -31,10 +31,6 @@
 					</value>
 				</li>
 
-				<li Class="PatchOperationRemove">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="AV_Hwacha_Turret"]/chargePerAmmoCount</xpath>
-				</li>
-
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleTurretDef[defName="AV_Hwacha_Turret"]/magazineCapacity</xpath>
 					<value>

--- a/Patches/Alpha Vehicle/Alpha_Vehicle_WarChariot.xml
+++ b/Patches/Alpha Vehicle/Alpha_Vehicle_WarChariot.xml
@@ -32,10 +32,6 @@
 					</value>
 				</li>
 
-				<li Class="PatchOperationRemove">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="AV_WarChariot_Turret"]/chargePerAmmoCount</xpath>
-				</li>
-
 				<!--li Class="PatchOperationReplace">
 						<xpath>Defs/Vehicles.VehicleTurretDef[defName="AV_WarChariot"]/magazineCapacity</xpath>
 						<value>

--- a/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Marshal.xml
+++ b/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Marshal.xml
@@ -31,10 +31,6 @@
 					</value>
 				</li>
 
-				<li Class="PatchOperationRemove">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Marshal_MainTurret"]/chargePerAmmoCount</xpath>
-				</li>
-
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Marshal_MainTurret"]/maxRange</xpath>
 					<value>
@@ -75,10 +71,6 @@
 					<value>
 						<warmUpTimer>1.3</warmUpTimer>
 					</value>
-				</li>
-
-				<li Class="PatchOperationRemove">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Marshal_MountedTurret"]/chargePerAmmoCount</xpath>
 				</li>
 
 				<li Class="PatchOperationReplace">

--- a/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Paladin.xml
+++ b/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Paladin.xml
@@ -18,13 +18,6 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Paladin_MainTurret"]/chargePerAmmoCount</xpath>
-					<value>
-						<chargePerAmmoCount>1</chargePerAmmoCount>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Paladin_MainTurret"]/reloadTimer</xpath>
 					<value>
 						<reloadTimer>7.8</reloadTimer>

--- a/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier1/Bunsen.xml
+++ b/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier1/Bunsen.xml
@@ -32,10 +32,6 @@
 					</value>
 				</li>
 
-				<li Class="PatchOperationRemove">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/chargePerAmmoCount</xpath>
-				</li>
-
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/magazineCapacity</xpath>
 					<value>

--- a/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier1/Roadkill.xml
+++ b/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier1/Roadkill.xml
@@ -31,10 +31,6 @@
 					</value>
 				</li>
 
-				<li Class="PatchOperationRemove">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Roadkill_MainTurret"]/chargePerAmmoCount</xpath>
-				</li>
-
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Roadkill_MainTurret"]/maxRange</xpath>
 					<value>

--- a/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier2/Bulldog.xml
+++ b/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier2/Bulldog.xml
@@ -31,10 +31,6 @@
 					</value>
 				</li>
 
-				<li Class="PatchOperationRemove">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Bulldog_MainTurret"]/chargePerAmmoCount</xpath>
-				</li>
-
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleTurretDef[defName="Bulldog_MainTurret"]/maxRange</xpath>
 					<value>

--- a/Patches/Vehicle Framework Expanded - Classic Mechs/Mech_BattleCannon.xml
+++ b/Patches/Vehicle Framework Expanded - Classic Mechs/Mech_BattleCannon.xml
@@ -36,10 +36,6 @@
 					</value>
 				</li>
 
-				<li Class="PatchOperationRemove">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_BattleCannon"]/chargePerAmmoCount</xpath>
-				</li>
-
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_BattleCannon"]/maxRange</xpath>
 					<value>

--- a/Patches/Vehicle Framework Expanded - Classic Mechs/Mech_MissileLauncher.xml
+++ b/Patches/Vehicle Framework Expanded - Classic Mechs/Mech_MissileLauncher.xml
@@ -36,10 +36,6 @@
 					</value>
 				</li>
 
-				<li Class="PatchOperationRemove">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_MissileLauncher"]/chargePerAmmoCount</xpath>
-				</li>
-
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/Vehicles.VehicleTurretDef[defName="HighMacs_MissileLauncher"]/maxRange</xpath>
 					<value>

--- a/Source/VehiclesCompat/VehiclesCompat/VehiclesCompat.cs
+++ b/Source/VehiclesCompat/VehiclesCompat/VehiclesCompat.cs
@@ -105,6 +105,7 @@ namespace CombatExtended.Compatibility.VehiclesCompat
                                 cetddme._ammoSet = asd;
                                 var ammunition = vtd.ammunition = new ThingFilter();
                                 vtd.genericAmmo = false;
+                                vtd.chargePerAmmoCount = 1f;
                                 HashSet<ThingDef> allowedAmmo = (HashSet<ThingDef>)ammunition.AllowedThingDefs;
 
                                 foreach (var al in asd.ammoTypes)


### PR DESCRIPTION
## Changes

Charge per ammo is set to 1 automatically for all VF turrets if ammo is enabled.

## Reasoning

This was done in XML for some vehicles, but doing it in XML opens the possibility of missing some, and interferes with no-ammo mode.


## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
