### PR TITLE
Casing Filth Housekeeping

### DIFF
--- a/Defs/ThingDefs_Misc/Filth_Casings.xml
+++ b/Defs/ThingDefs_Misc/Filth_Casings.xml
@@ -3,9 +3,8 @@
 
 	<ThingDef Name="BaseFilth_CE" ParentName="BaseFilth" Abstract="true">
 		<statBases>
-			<Beauty>-15</Beauty>
-			<Cleanliness>-6</Cleanliness>
-			<MaxHitPoints>35</MaxHitPoints>
+			<Beauty>-10</Beauty>
+			<Cleanliness>-5</Cleanliness>
 			<Flammability>0</Flammability>
 		</statBases>
 		<filth>

--- a/Defs/ThingDefs_Misc/Filth_Casings.xml
+++ b/Defs/ThingDefs_Misc/Filth_Casings.xml
@@ -1,12 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
 
-	<ThingDef ParentName="BaseFilth">
-		<defName>Filth_PistolAmmoCasings</defName>
-		<label>spent pistol casings</label>
-		<graphicData>
-			<texPath>Things/Filth/Filth_PistolAmmoCasings</texPath>
-		</graphicData>
+	<ThingDef Name="BaseFilth_CE" ParentName="BaseFilth" Abstract="true">
 		<statBases>
 			<Beauty>-15</Beauty>
 			<Cleanliness>-6</Cleanliness>
@@ -18,215 +13,102 @@
 			<disappearsInDays>20~30</disappearsInDays>
 			<maxThickness>5</maxThickness>
 		</filth>
+	</ThingDef>	
+
+	<ThingDef ParentName="BaseFilth_CE">
+		<defName>Filth_PistolAmmoCasings</defName>
+		<label>spent pistol casings</label>
+		<graphicData>
+			<texPath>Things/Filth/Filth_PistolAmmoCasings</texPath>
+		</graphicData>
 	</ThingDef>
 
-	<ThingDef ParentName="BaseFilth">
+	<ThingDef ParentName="BaseFilth_CE">
 		<defName>Filth_RifleAmmoCasings</defName>
 		<label>spent casings</label>
 		<graphicData>
 			<texPath>Things/Filth/Filth_RifleAmmoCasings</texPath>
 		</graphicData>
-		<statBases>
-			<Beauty>-15</Beauty>
-			<Cleanliness>-5</Cleanliness>
-			<MaxHitPoints>30</MaxHitPoints>
-			<Flammability>0</Flammability>
-		</statBases>
-		<filth>
-			<cleaningWorkToReduceThickness>10</cleaningWorkToReduceThickness>
-			<disappearsInDays>20~30</disappearsInDays>
-			<maxThickness>5</maxThickness>
-		</filth>
 	</ThingDef>
 
-	<ThingDef ParentName="BaseFilth">
+	<ThingDef ParentName="BaseFilth_CE">
 		<defName>Filth_RifleAmmoCasings_Steel</defName>
 		<label>spent steel rifle casings</label>
 		<graphicData>
 			<texPath>Things/Filth/Filth_SteelRifleAmmoCasings</texPath>
 		</graphicData>
-		<statBases>
-			<Beauty>-15</Beauty>
-			<Cleanliness>-4</Cleanliness>
-			<MaxHitPoints>25</MaxHitPoints>
-			<Flammability>0</Flammability>
-		</statBases>
-		<filth>
-			<cleaningWorkToReduceThickness>10</cleaningWorkToReduceThickness>
-			<disappearsInDays>20~30</disappearsInDays>
-			<maxThickness>5</maxThickness>
-		</filth>
 	</ThingDef>
 
-	<ThingDef ParentName="BaseFilth">
+	<ThingDef ParentName="BaseFilth_CE">
 		<defName>Filth_RifleAmmoCasings_HighCal</defName>
 		<label>spent large casings</label>
 		<graphicData>
 			<texPath>Things/Filth/Filth_RifleAmmoCasings_HighCal</texPath>
 		</graphicData>
-		<statBases>
-			<Beauty>-15</Beauty>
-			<Cleanliness>-4</Cleanliness>
-			<MaxHitPoints>25</MaxHitPoints>
-			<Flammability>0</Flammability>
-		</statBases>
-		<filth>
-			<cleaningWorkToReduceThickness>10</cleaningWorkToReduceThickness>
-			<disappearsInDays>20~30</disappearsInDays>
-			<maxThickness>5</maxThickness>
-		</filth>
 	</ThingDef>
 
-	<ThingDef ParentName="BaseFilth">
+	<ThingDef ParentName="BaseFilth_CE">
 		<defName>Filth_ShotgunAmmoCasings</defName>
 		<label>spent casings</label>
 		<graphicData>
 			<texPath>Things/Filth/Filth_ShotgunAmmoCasings</texPath>
 		</graphicData>
-		<statBases>
-			<Beauty>-15</Beauty>
-			<Cleanliness>-5</Cleanliness>
-			<MaxHitPoints>30</MaxHitPoints>
-			<Flammability>0</Flammability>
-		</statBases>
-		<filth>
-			<cleaningWorkToReduceThickness>10</cleaningWorkToReduceThickness>
-			<disappearsInDays>20~30</disappearsInDays>
-			<maxThickness>5</maxThickness>
-		</filth>
 	</ThingDef>
 
-	<ThingDef ParentName="BaseFilth">
+	<ThingDef ParentName="BaseFilth_CE">
 		<defName>Filth_ShotgunAmmoCasings_Green</defName>
 		<label>spent casings</label>
 		<graphicData>
 			<texPath>Things/Filth/Filth_ShotgunAmmoCasings_Green</texPath>
 		</graphicData>
-		<statBases>
-			<Beauty>-15</Beauty>
-			<Cleanliness>-5</Cleanliness>
-			<MaxHitPoints>30</MaxHitPoints>
-			<Flammability>0</Flammability>
-		</statBases>
-		<filth>
-			<cleaningWorkToReduceThickness>10</cleaningWorkToReduceThickness>
-			<disappearsInDays>20~30</disappearsInDays>
-			<maxThickness>5</maxThickness>
-		</filth>
 	</ThingDef>
 
-	<ThingDef ParentName="BaseFilth">
+	<ThingDef ParentName="BaseFilth_CE">
 		<defName>Filth_ShotgunAmmoCasings_White</defName>
 		<label>spent casings</label>
 		<graphicData>
 			<texPath>Things/Filth/Filth_ShotgunAmmoCasings_White</texPath>
 		</graphicData>
-		<statBases>
-			<Beauty>-15</Beauty>
-			<Cleanliness>-5</Cleanliness>
-			<MaxHitPoints>30</MaxHitPoints>
-			<Flammability>0</Flammability>
-		</statBases>
-		<filth>
-			<cleaningWorkToReduceThickness>10</cleaningWorkToReduceThickness>
-			<disappearsInDays>20~30</disappearsInDays>
-			<maxThickness>5</maxThickness>
-		</filth>
 	</ThingDef>
 
-	<ThingDef ParentName="BaseFilth">
+	<ThingDef ParentName="BaseFilth_CE">
 		<defName>Filth_ShotgunAmmoCasings_Black</defName>
 		<label>spent casings</label>
 		<graphicData>
 			<texPath>Things/Filth/Filth_ShotgunAmmoCasings_Black</texPath>
 		</graphicData>
-		<statBases>
-			<Beauty>-15</Beauty>
-			<Cleanliness>-5</Cleanliness>
-			<MaxHitPoints>30</MaxHitPoints>
-			<Flammability>0</Flammability>
-		</statBases>
-		<filth>
-			<cleaningWorkToReduceThickness>10</cleaningWorkToReduceThickness>
-			<disappearsInDays>20~30</disappearsInDays>
-			<maxThickness>5</maxThickness>
-		</filth>
 	</ThingDef>
 
-	<ThingDef ParentName="BaseFilth">
+	<ThingDef ParentName="BaseFilth_CE">
 		<defName>Filth_GrenadeLauncherAmmoCasings</defName>
 		<label>spent grenade casings</label>
 		<graphicData>
 			<texPath>Things/Filth/Filth_GrenadeLauncherAmmoCasings</texPath>
 		</graphicData>
-		<statBases>
-			<Beauty>-15</Beauty>
-			<Cleanliness>-5</Cleanliness>
-			<MaxHitPoints>30</MaxHitPoints>
-			<Flammability>0</Flammability>
-		</statBases>
-		<filth>
-			<cleaningWorkToReduceThickness>10</cleaningWorkToReduceThickness>
-			<disappearsInDays>20~30</disappearsInDays>
-			<maxThickness>5</maxThickness>
-		</filth>
 	</ThingDef>
 
-	<ThingDef ParentName="BaseFilth">
+	<ThingDef ParentName="BaseFilth_CE">
 		<defName>Filth_CannonAmmoCasings</defName>
 		<label>spent casings</label>
 		<graphicData>
 			<texPath>Things/Filth/Filth_CannonAmmoCasings</texPath>
 		</graphicData>
-		<statBases>
-			<Beauty>-15</Beauty>
-			<Cleanliness>-5</Cleanliness>
-			<MaxHitPoints>30</MaxHitPoints>
-			<Flammability>0</Flammability>
-		</statBases>
-		<filth>
-			<cleaningWorkToReduceThickness>10</cleaningWorkToReduceThickness>
-			<disappearsInDays>20~30</disappearsInDays>
-			<maxThickness>5</maxThickness>
-		</filth>
 	</ThingDef>
 
-	<ThingDef ParentName="BaseFilth">
+	<ThingDef ParentName="BaseFilth_CE">
 		<defName>Filth_GrenadeAmmoCasings</defName>
 		<label>grenade pin</label>
 		<graphicData>
 			<texPath>Things/Filth/Filth_GrenadeAmmoCasings</texPath>
 		</graphicData>
-		<statBases>
-			<Beauty>-15</Beauty>
-			<Cleanliness>-5</Cleanliness>
-			<MaxHitPoints>30</MaxHitPoints>
-			<Flammability>0</Flammability>
-		</statBases>
-		<filth>
-			<cleaningWorkToReduceThickness>10</cleaningWorkToReduceThickness>
-			<disappearsInDays>20~30</disappearsInDays>
-			<maxThickness>5</maxThickness>
-		</filth>
 	</ThingDef>
 
-	<ThingDef ParentName="BaseFilth">
+	<ThingDef ParentName="BaseFilth_CE">
 		<defName>Filth_DisposableLauncherCasings</defName>
 		<label>discarded launcher tube</label>
 		<graphicData>
 			<texPath>Things/Filth/Filth_DisposableLauncherCasings</texPath>
 		</graphicData>
-		<statBases>
-			<Beauty>-15</Beauty>
-			<Cleanliness>-5</Cleanliness>
-			<MaxHitPoints>30</MaxHitPoints>
-			<Flammability>0</Flammability>
-		</statBases>
-		<filth>
-			<cleaningWorkToReduceThickness>10</cleaningWorkToReduceThickness>
-			<disappearsInDays>20~30</disappearsInDays>
-			<maxThickness>5</maxThickness>
-		</filth>
 	</ThingDef>
 
 </Defs>


### PR DESCRIPTION
## Changes
- No functional changes. Simply consolidates the filth defs a bit, creating a unified parent (`BaseFilth_CE`) to reduce some redundancy since, aside from label and sprites, the filth defs have the same stats.

## Reasoning
- Housekeeping and general good practice.

## Alternatives
- Could leave it as-is.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
