### PR TITLE
Add ammoConsumedPerShot to ammosetdefs

### DIFF
--- a/Source/CombatExtended/CombatExtended/Defs/AmmoSetDef.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/AmmoSetDef.cs
@@ -16,6 +16,8 @@ namespace CombatExtended
 
         public AmmoSetDef similarTo;
 
+        public int ammoConsumedPerShot = 1;
+
         public override IEnumerable<StatDrawEntry> SpecialDisplayStats(StatRequest req)
         {
             foreach (StatDrawEntry entry in base.SpecialDisplayStats(req)) { yield return entry; }

--- a/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_AmmoConsumedPerShotCount.cs
+++ b/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_AmmoConsumedPerShotCount.cs
@@ -30,13 +30,15 @@ namespace CombatExtended
 
         public override bool ShouldShowFor(StatRequest req)
         {
-            return base.ShouldShowFor(req) && (GunDef(req)?.Verbs?
-                                               .Any(x => ((x as VerbPropertiesCE)?.ammoConsumedPerShotCount ?? 1) > 1) ?? false);
+            return base.ShouldShowFor(req) &&
+            (((GunDef(req)?.GetCompProperties<CompProperties_AmmoUser>() as CompProperties_AmmoUser)?.ammoSet.ammoConsumedPerShot != 1) ||
+             (GunDef(req)?.Verbs?.Any(x => ((x as VerbPropertiesCE)?.ammoConsumedPerShotCount ?? 1) > 1) ?? false));
         }
 
         public override float GetValueUnfinalized(StatRequest req, bool applyPostProcess = true)
         {
-            return ((VerbPropertiesCE)GunDef(req)?.Verbs?.FirstOrDefault(x => ((VerbPropertiesCE)x).ammoConsumedPerShotCount > 1))?.ammoConsumedPerShotCount ?? 1;
+            return ((GunDef(req)?.GetCompProperties<CompProperties_AmmoUser>() as CompProperties_AmmoUser)?.ammoSet?.ammoConsumedPerShot ?? 1 *
+            ((VerbPropertiesCE)GunDef(req)?.Verbs?.FirstOrDefault(x => ((VerbPropertiesCE)x).ammoConsumedPerShotCount > 1))?.ammoConsumedPerShotCount ?? 1);
         }
 
         public override string GetExplanationUnfinalized(StatRequest req, ToStringNumberSense numberSense)

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -363,7 +363,7 @@ namespace CombatExtended
             //Reduce ammunition
             if (CompAmmo != null)
             {
-                if (!CompAmmo.TryReduceAmmoCount(VerbPropsCE.ammoConsumedPerShotCount))
+                if (!CompAmmo.TryReduceAmmoCount(CompAmmo.Props.ammoSet.ammoConsumedPerShot * VerbPropsCE.ammoConsumedPerShotCount))
                 {
                     return false;
                 }

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootMortarCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootMortarCE.cs
@@ -227,7 +227,7 @@ namespace CombatExtended
             }
             if (CompAmmo != null)
             {
-                if (!CompAmmo.TryReduceAmmoCount(VerbPropsCE.ammoConsumedPerShotCount))
+                if (!CompAmmo.TryReduceAmmoCount(CompAmmo.Props.ammoSet.ammoConsumedPerShot * VerbPropsCE.ammoConsumedPerShotCount))
                 {
                     return false;
                 }

--- a/Source/VehiclesCompat/VehiclesCompat/VehiclesCompat.cs
+++ b/Source/VehiclesCompat/VehiclesCompat/VehiclesCompat.cs
@@ -105,6 +105,7 @@ namespace CombatExtended.Compatibility.VehiclesCompat
                                 cetddme._ammoSet = asd;
                                 var ammunition = vtd.ammunition = new ThingFilter();
                                 vtd.genericAmmo = false;
+                                vtd.chargePerAmmoCount = 1f / asd.ammoConsumedPerShot;
                                 HashSet<ThingDef> allowedAmmo = (HashSet<ThingDef>)ammunition.AllowedThingDefs;
 
                                 foreach (var al in asd.ammoTypes)


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- A new field is added to ammoSetDefs to support modifying ammo used per shot across entire ammosets.  Mostly matters for vehicles.
- The existing per-verb property is left unmodified, but the effects multiply

## Reasoning
- Vehicles do not have ammosets, so moving the value to the ammoset is  the simplest way to expose the data for VF use.  
- Multi-verb frameworks might want to set different values for different verbs, so removing the value from the verbs is probably a poor choice.

## Alternatives

Describe alternative implementations you have considered, e.g.
- Explicitly add a separate mult value for vehicles to use
- Disable the per-verb value

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
