### PR TITLE
Fix bipodded weapons causing pawns to drop carried pawns

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/BipodComp.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/BipodComp.cs
@@ -32,7 +32,8 @@ namespace CombatExtended
                 if (Controller.settings.AutoSetUp)
                 {
                     var varA = this.parent.TryGetComp<CompFireModes>();
-                    result = (((varA.CurrentAimMode == Props.catDef.autosetMode) | (!Props.catDef.useAutoSetMode && varA.CurrentAimMode != AimMode.Snapshot)) && !IsSetUpRn);
+                    Pawn pawn = ((Pawn_EquipmentTracker)this.ParentHolder).pawn;
+                    result = (((varA.CurrentAimMode == Props.catDef.autosetMode) | (!Props.catDef.useAutoSetMode && varA.CurrentAimMode != AimMode.Snapshot)) && !IsSetUpRn && !PawnUtility.IsCarryingPawn(pawn));
                 }
                 else
                 {


### PR DESCRIPTION
## Changes

- Automatic bipod setup will no longer trigger if the pawn is carrying another pawn, preventing them from dropping them every time they stop moving.

## Alternatives

- Manually put away weapons whenever you need a pawn to carry someone.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (hour)
