### PR TITLE
Early intercept fix

### DIFF
--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -1033,7 +1033,15 @@ namespace CombatExtended
             float lp2sq = lp2.sqrMagnitude;
             Vector3 displacement;
             float displacementSq;
-
+            displacement = (lp2 - lp1);
+            displacementSq = displacement.sqrMagnitude;
+            if (Mathf.Abs(displacementSq) < 0.000001f)
+            {
+#if DEBUG
+                Message($"displacementSq zero ({displacementSq :F10})");
+#endif
+                return false;
+            }
             if (lp1sq < radSq) // Case 1, 2, or 3
             {
                 if (!catchOutbound || lp2sq < radSq) // Case 1 or 2
@@ -1047,16 +1055,14 @@ namespace CombatExtended
 #if DEBUG
                 Message($"Case 3");
 #endif
-                displacement = (lp2 - lp1);
-                displacementSq = displacement.sqrMagnitude;
+               
             }
             else // case 4 or 5
             {
 #if DEBUG
                 Message($"Case 4 or 5");
 #endif
-                displacement = (lp2 - lp1);
-                displacementSq = displacement.sqrMagnitude;
+                
                 if (lp2sq > radSq) // case 5
                 {
 #if DEBUG
@@ -1079,7 +1085,7 @@ namespace CombatExtended
                     }
                     Vector3 closestPoint = lp1 + (projectionDistance / length) * displacement;
 #if DEBUG
-                    Message($"Closest point {closestPoint}, distance: {closestPoint.sqrMagnitude}");
+                    Message($"Closest point {closestPoint}, distance: {closestPoint.sqrMagnitude}, {projectionDistance}, {length}, {direction}");
 #endif
                     if (closestPoint.sqrMagnitude > radSq) // closest point is still outside
                     {

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -778,11 +778,7 @@ namespace CombatExtended
                     this.Impact(null);
                     return true;
                 }
-            }
-            if (BlockerRegistry.CheckForCollisionBetweenCallback(this, LastPos, ExactPosition))
-            {
-                return true;
-            }
+            }  
 
             #region Sanity checks
             if (ticksToImpact < 0 || def.projectile.flyOverhead)
@@ -808,6 +804,10 @@ namespace CombatExtended
             //Order cells by distance from the last position
             foreach (var cell in cells)
             {
+                if (BlockerRegistry.CheckForCollisionBetweenCallback(this, LastPos, ExactPosition.ToIntVec3() == cell ? ExactPosition : cell.ToVector3Shifted()))
+                {
+                    return true;
+                }
                 if (CheckCellForCollision(cell))
                 {
                     newPosIV3 = cell;


### PR DESCRIPTION
## Changes

- Between check call now called w

## Reasoning

- If pawn stay out of a shield, that uses CheckForCollisionBetweenCallback, bullet may avoid a pawn and hit the shield behind the pawn
![image](https://github.com/CombatExtended-Continued/CombatExtended/assets/78953324/4f2b1deb-19b0-4606-94f3-444252b5a8b8)
![image](https://github.com/CombatExtended-Continued/CombatExtended/assets/78953324/6368dc67-8cbe-411f-a9c3-9ef9019600f7)
![image](https://github.com/CombatExtended-Continued/CombatExtended/assets/78953324/04f4a3de-0ff9-412d-a7e3-fb9d97465879)


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (tested the same situations)
