### PR TITLE
Check for leaning pawns along shotLine for friendly fire avoidance.

### DIFF
--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -1296,6 +1296,7 @@ namespace CombatExtended
 
                 foreach (Pawn pawn in shotSource.ToIntVec3().PawnsNearSegment(targetLoc, caster.Map, 1, behind: false, infront: true))
                 {
+                    Log.Messsage($"Pawn: {pawn} may be in the way");
                     if (pawn.Faction != null && ShooterPawn != null && !ShooterPawn.HostileTo(pawn))
                     {
                         if (pawn == ShooterPawn || pawn.Downed)
@@ -1305,6 +1306,25 @@ namespace CombatExtended
                         var bounds = CE_Utility.GetBoundsFor(pawn);
                         if (bounds.IntersectRay(shotLine, out var dist))
                         {
+                            Log.Message($"intersects? {dist}");
+                            return false;
+                        }
+                    }
+                }
+
+                foreach (Pawn pawn in shotSource.ToIntVec3().PawnsNearSegment(targetLoc, caster.Map, 2, behind: false, infront: true))
+                {
+                    Log.Messsage($"Pawn: {pawn} may be in the way (2)");
+                    if (pawn.Faction != null && ShooterPawn != null && !ShooterPawn.HostileTo(pawn))
+                    {
+                        if (pawn == ShooterPawn || pawn.Downed)
+                        {
+                            continue;
+                        }
+                        var bounds = CE_Utility.GetBoundsFor(pawn);
+                        if (bounds.IntersectRay(shotLine, out var dist))
+                        {
+                            Log.Message($"intersects? {dist}");
                             return false;
                         }
                     }

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -1291,7 +1291,24 @@ namespace CombatExtended
                 {
                     targetPos = targetLoc.ToVector3Shifted();
                 }
+
                 Ray shotLine = new Ray(shotSource, (targetPos - shotSource));
+
+                foreach (Pawn pawn in shotSource.ToIntVec3().PawnsNearSegment(targetLoc, caster.Map, 1, behind: false, infront: true))
+                {
+                    if (pawn.Faction == ShooterPawn?.Faction)
+                    {
+                        if (pawn == ShooterPawn || pawn.Downed)
+                        {
+                            continue;
+                        }
+                        var bounds = CE_Utility.GetBoundsFor(pawn);
+                        if (bounds.IntersectRay(shotLine, out var dist))
+                        {
+                            return false;
+                        }
+                    }
+                }
 
                 // Create validator to check for intersection with partial cover
                 var aimMode = CompFireModes?.CurrentAimMode;

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -1296,7 +1296,7 @@ namespace CombatExtended
 
                 foreach (Pawn pawn in shotSource.ToIntVec3().PawnsNearSegment(targetLoc, caster.Map, 1, behind: false, infront: true))
                 {
-                    if (pawn.Faction != null && !ShooterPawn?.HostileTo(pawn) ?? false)
+                    if (pawn.Faction != null && ShooterPawn != null && !ShooterPawn.HostileTo(pawn))
                     {
                         if (pawn == ShooterPawn || pawn.Downed)
                         {

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -1296,7 +1296,7 @@ namespace CombatExtended
 
                 foreach (Pawn pawn in shotSource.ToIntVec3().PawnsNearSegment(targetLoc, caster.Map, 1, behind: false, infront: true))
                 {
-                    Log.Messsage($"Pawn: {pawn} may be in the way");
+                    Log.Message($"Pawn: {pawn} may be in the way");
                     if (pawn.Faction != null && ShooterPawn != null && !ShooterPawn.HostileTo(pawn))
                     {
                         if (pawn == ShooterPawn || pawn.Downed)
@@ -1314,7 +1314,7 @@ namespace CombatExtended
 
                 foreach (Pawn pawn in shotSource.ToIntVec3().PawnsNearSegment(targetLoc, caster.Map, 2, behind: false, infront: true))
                 {
-                    Log.Messsage($"Pawn: {pawn} may be in the way (2)");
+                    Log.Message($"Pawn: {pawn} may be in the way (2)");
                     if (pawn.Faction != null && ShooterPawn != null && !ShooterPawn.HostileTo(pawn))
                     {
                         if (pawn == ShooterPawn || pawn.Downed)

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -1296,7 +1296,7 @@ namespace CombatExtended
 
                 foreach (Pawn pawn in shotSource.ToIntVec3().PawnsNearSegment(targetLoc, caster.Map, 1, behind: false, infront: true))
                 {
-                    if (pawn.Faction == ShooterPawn?.Faction)
+                    if (pawn.Faction != null && !ShooterPawn?.HostileTo(pawn))
                     {
                         if (pawn == ShooterPawn || pawn.Downed)
                         {

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -1296,7 +1296,7 @@ namespace CombatExtended
 
                 foreach (Pawn pawn in shotSource.ToIntVec3().PawnsNearSegment(targetLoc, caster.Map, 1, behind: false, infront: true))
                 {
-                    if (pawn.Faction != null && !ShooterPawn?.HostileTo(pawn))
+                    if (pawn.Faction != null && !ShooterPawn?.HostileTo(pawn) ?? false)
                     {
                         if (pawn == ShooterPawn || pawn.Downed)
                         {


### PR DESCRIPTION

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #2934 

## Reasoning

Pawns leaning into the line of fire but with an origin not directly along the bullet flight path don't trigger friendly fire avoidance.  This checks 1 cell to either side along the entire line for pawns and checks if the aim line intersects them.

For future work, it should probably also trigger on friendly factions.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
