### PR TITLE
List Null check in VF compat ammo injector

### DIFF
--- a/Source/VehiclesCompat/VehiclesCompat/VehiclesCompat.cs
+++ b/Source/VehiclesCompat/VehiclesCompat/VehiclesCompat.cs
@@ -82,7 +82,13 @@ namespace CombatExtended.Compatibility.VehiclesCompat
 
         public static Def LookupAmmosetCE(string defName)
         {
-            return DefDatabase<AmmoSetDef>.AllDefs.Where(x => x.defName == defName).First();
+            var list = DefDatabase<AmmoSetDef>.AllDefs.Where(x => x.defName == defName);
+            if (list.EnumerableNullOrEmpty())
+            {
+                Log.Error($"Combat Extended Vehicle Compat: ammoset named {defName} not found.");
+                return null;
+            }
+            return list.First();
         }
 
         public static IEnumerable<ThingDef> _GetUsedAmmo()


### PR DESCRIPTION
## Changes

A null or empty check in VF compat, and an error message if null check occured

## Reasoning

So that a mistake in vehicle ammoset patch doesn't break the entire ammo injector, and patcher can know what is going wrong

## Alternatives

Suffer.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
