### PR TITLE
Specially handle fire damage based on apparel flammability

### DIFF
--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -350,7 +350,14 @@ namespace CombatExtended
                         }
 			else
                         {
-                            armorDamage = (dmgAmount - newDmgAmount) * Mathf.Min(1.0f, (penAmount * penAmount) / (armorAmount * armorAmount)) + newDmgAmount * Mathf.Clamp01(armorAmount / penAmount);
+                            if (penAmount == 0 || armorAmount == 0)
+                            {
+                                Log.ErrorOnce($"penAmount or armorAmount are zero for {def.armorCategory} on {armor}", 846532021);
+                            }
+                            else
+                            {
+                                armorDamage = (dmgAmount - newDmgAmount) * Mathf.Min(1.0f, (penAmount * penAmount) / (armorAmount * armorAmount)) + newDmgAmount * Mathf.Clamp01(armorAmount / penAmount);
+                            }
                         }
 			armorDamage *= HardArmorDamageFactor;
                     }

--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -300,6 +300,7 @@ namespace CombatExtended
         {
             // Calculate deflection
             var isSharpDmg = def.armorCategory == DamageArmorCategoryDefOf.Sharp;
+            var isFireDmg = def.armorCategory == CE_DamageArmorCategoryDefOf.Heat;
             //var rand = UnityEngine.Random.Range(penAmount - PenetrationRandVariation, penAmount + PenetrationRandVariation);
             var deflected = isSharpDmg && armorAmount > penAmount;
 
@@ -321,6 +322,10 @@ namespace CombatExtended
                 if (isSoftArmor)
                 {
                     // Soft armor takes absorbed damage from sharp and no damage from blunt
+                    if (isFireDmg)
+                    {
+                        armorDamage = armor.GetStatValue(StatDefOf.Flammability, true) * dmgAmount;
+                    }
                     if (isSharpDmg)
                     {
                         armorDamage = Mathf.Max(dmgAmount * SoftArmorMinDamageFactor, dmgAmount - newDmgAmount);
@@ -339,8 +344,15 @@ namespace CombatExtended
                     }
                     else
                     {
-                        armorDamage = (dmgAmount - newDmgAmount) * Mathf.Min(1.0f, (penAmount * penAmount) / (armorAmount * armorAmount)) + newDmgAmount * Mathf.Clamp01(armorAmount / penAmount);
-                        armorDamage *= HardArmorDamageFactor;
+                        if (isFireDmg)
+			{
+                            armorDamage = armor.GetStatValue(StatDefOf.Flammability, true) * dmgAmount;
+                        }
+			else
+                        {
+                            armorDamage = (dmgAmount - newDmgAmount) * Mathf.Min(1.0f, (penAmount * penAmount) / (armorAmount * armorAmount)) + newDmgAmount * Mathf.Clamp01(armorAmount / penAmount);
+                        }
+			armorDamage *= HardArmorDamageFactor;
                     }
 
                     TryDamageArmor(def, penAmount, armorAmount, ref armorDamage, armor);

--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -344,7 +344,7 @@ namespace CombatExtended
                     }
                     else
                     {
-                        if (isFireDmg)   
+                        if (isFireDmg)
                         {
                             armorDamage = armor.GetStatValue(StatDefOf.Flammability, true) * dmgAmount;
                         }

--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -344,11 +344,11 @@ namespace CombatExtended
                     }
                     else
                     {
-                        if (isFireDmg)
-			{
+                        if (isFireDmg)   
+                        {
                             armorDamage = armor.GetStatValue(StatDefOf.Flammability, true) * dmgAmount;
                         }
-			else
+                        else
                         {
                             if (penAmount == 0 || armorAmount == 0)
                             {
@@ -359,7 +359,7 @@ namespace CombatExtended
                                 armorDamage = (dmgAmount - newDmgAmount) * Mathf.Min(1.0f, (penAmount * penAmount) / (armorAmount * armorAmount)) + newDmgAmount * Mathf.Clamp01(armorAmount / penAmount);
                             }
                         }
-			armorDamage *= HardArmorDamageFactor;
+                        armorDamage *= HardArmorDamageFactor;
                     }
 
                     TryDamageArmor(def, penAmount, armorAmount, ref armorDamage, armor);


### PR DESCRIPTION
## Changes

Damage to armor when armor amount and pen amount are both 0 no longer instagibbs hard armor.  

## Alternatives

- Always ignore armor damage for fire
- Pick an arbitrary amount of damage to do to armor
- Let armor get erased

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
