### PR TITLE
Update Divine Order Patch

### DIFF
--- a/Patches/Divine Order/PawnKindDefs/Divine_Order_CE_Pawnkinds.xml
+++ b/Patches/Divine Order/PawnKindDefs/Divine_Order_CE_Pawnkinds.xml
@@ -31,7 +31,6 @@
 					</value>
 				</li>
 
-				<!--Give ammo to pistols -->
 				<li Class="PatchOperationAddModExtension">
 					<xpath>Defs/PawnKindDef[defName="BotchJob_DivineOrderSharpshooter" or defName="BotchJob_DivineOrderInquisitor"]</xpath>
 					<value>
@@ -53,7 +52,6 @@
 					</value>
 				</li>
 
-				<!--Give ammo to grenadier -->
 				<li Class="PatchOperationAddModExtension">
 					<xpath>Defs/PawnKindDef[defName="BotchJob_DivineOrderHerald" or defName="BotchJob_DivineOrderMerchant"]</xpath>
 					<value>
@@ -75,12 +73,25 @@
 					</value>
 				</li>
 
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/PawnKindDef[defName="BotchJob_DivineOrderConscript"]</xpath>
+					<value>
+						<li Class="CombatExtended.LoadoutPropertiesExtension">
+							<primaryMagazineCount>
+								<min>30</min>
+								<max>40</max>
+							</primaryMagazineCount>
+						</li>
+					</value>
+				</li>
+
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/PawnKindDef[
 						defName="BotchJob_DivineOrderScout" or
 						defName="BotchJob_DivineOrderSharpshooter" or
 						defName="BotchJob_DivineOrderInquisitor" or
-						defName="BotchJob_DivineOrderMerchant"]
+						defName="BotchJob_DivineOrderMerchant" or
+						defName="BotchJob_DivineOrderConscript"]
 					</xpath>
 					<value>
 						<apparelRequired>
@@ -110,24 +121,11 @@
 					</match>
 				</li>
 
-				<li Class="PatchOperationFindMod">
-					<mods>
-						<li>Medieval Fantasy Themed Quest Rewards</li>
-					</mods>
-					<match Class="PatchOperationAdd">
-						<xpath>Defs/PawnKindDef[defName="BotchJob_DivineOrderHerald"]/apparelRequired</xpath>
-						<value>
-							<li>CE_Apparel_TribalBackpack</li>
-						</value>
-					</match>
-					<nomatch Class="PatchOperationAdd">
-						<xpath>Defs/PawnKindDef[defName="BotchJob_DivineOrderHerald"]</xpath>
-						<value>
-							<apparelRequired>
-								<li>CE_Apparel_TribalBackpack</li>
-							</apparelRequired>
-						</value>
-					</nomatch>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/PawnKindDef[defName="BotchJob_DivineOrderHerald"]/apparelRequired</xpath>
+					<value>
+						<li>CE_Apparel_TribalBackpack</li>
+					</value>
 				</li>
 
 			</operations>

--- a/Patches/Divine Order/Scenario/DivineOrder_CE_Scenario_Patch.xml
+++ b/Patches/Divine Order/Scenario/DivineOrder_CE_Scenario_Patch.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Divine Order</li>
+		</mods>
+		<match Class="PatchOperationAdd">
+			<xpath>Defs/ScenarioDef[defName="BotchJob_DivineOrderStart"]/scenario/parts</xpath>
+			<value>
+				<li Class="ScenPart_StartingThing_Defined">
+					<def>StartingThing_Defined</def>
+					<thingDef>Ammo_CrossbowBolt_Steel</thingDef>
+					<count>50</count>
+				</li>
+			</value>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Divine Order/ThingDef_Misc/Divine_Order_CE_Apparel.xml
+++ b/Patches/Divine Order/ThingDef_Misc/Divine_Order_CE_Apparel.xml
@@ -40,10 +40,26 @@
 						<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
 					</value>
 				</li>
+				
+				<!-- Zealot Robes -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="BotchJob_DivineOrderZealotRobes"]/statBases</xpath>
+					<value>
+						<Bulk>20</Bulk>
+						<WornBulk>6</WornBulk>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="BotchJob_DivineOrderZealotRobes"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
+					</value>
+				</li>
 
 				<!-- Headstuff -->
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="BotchJob_DivineOrderHood"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="BotchJob_DivineOrderHood" or defName="BotchJob_DivineOrderFurHood"]/statBases</xpath>
 					<value>
 						<Bulk>3</Bulk>
 						<WornBulk>0.5</WornBulk>
@@ -51,7 +67,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="BotchJob_DivineOrderHood"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>Defs/ThingDef[defName="BotchJob_DivineOrderHood" or defName="BotchJob_DivineOrderFurHood"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
 					</value>

--- a/Patches/Divine Order/ThingDef_Misc/Divine_Order_CE_Armor.xml
+++ b/Patches/Divine Order/ThingDef_Misc/Divine_Order_CE_Armor.xml
@@ -25,15 +25,15 @@
 					</value>
 				</li>
 
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="BotchJob_DivineOrderSkirmisherArmor"]/statBases</xpath>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="BotchJob_DivineOrderSkirmisherArmor"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>1</ArmorRating_Sharp>
 					</value>
 				</li>
 
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="BotchJob_DivineOrderSkirmisherArmor"]/statBases</xpath>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="BotchJob_DivineOrderSkirmisherArmor"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>1.5</ArmorRating_Blunt>
 					</value>

--- a/Patches/Divine Order/ThingDef_Misc/Divine_Order_CE_Shield.xml
+++ b/Patches/Divine Order/ThingDef_Misc/Divine_Order_CE_Shield.xml
@@ -9,96 +9,102 @@
 		<match Class="PatchOperationSequence">
 			<operations>
 
-				<!--Replace ThingClass-->
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="BotchJob_DivineOrderShield"]/thingClass</xpath>
-					<value>
-						<thingClass>CombatExtended.Apparel_Shield</thingClass>
-					</value>
-				</li>
-
-				<!--Replace Parent-->
-				<li Class="PatchOperationAttributeSet">
-					<xpath>Defs/ThingDef[defName="BotchJob_DivineOrderShield"]</xpath>
-					<attribute>ParentName</attribute>
-					<value>ArmorSmithableBase</value>
-				</li>
-
-				<!--Replace Apparel Layer & BodyPart Group-->
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="BotchJob_DivineOrderShield"]/apparel/layers</xpath>
-					<value>
-						<layers>
-							<li>Shield</li>
-						</layers>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="BotchJob_DivineOrderShield"]/apparel/bodyPartGroups</xpath>
-					<value>
-						<bodyPartGroups>
-							<li>LeftShoulder</li>
-						</bodyPartGroups>
-					</value>
-				</li>
-
-				<!--Remove VFE Shield Stuff-->
-				<li Class="PatchOperationRemove">
-					<xpath>Defs/ThingDef[defName="BotchJob_DivineOrderShield"]/tools</xpath>
-				</li>
-
-				<li Class="PatchOperationRemove">
-					<xpath>Defs/ThingDef[defName="BotchJob_DivineOrderShield"]/comps/li[@Class="VFECore.CompProperties_Shield"]</xpath>
-				</li>
-
-				<!--Add CE Shield Stuff-->
-				<li Class="PatchOperationAddModExtension">
 					<xpath>Defs/ThingDef[defName="BotchJob_DivineOrderShield"]</xpath>
 					<value>
-						<li Class="CombatExtended.ShieldDefExtension">
-							<shieldCoverage>
-								<li>Hands</li>
-								<li>Arms</li>
-								<li>Shoulders</li>
-								<li>Torso</li>
-								<li>Neck</li>
-							</shieldCoverage>
-						</li>
+
+						<ThingDef ParentName="ShieldBase">
+							<defName>BotchJob_DivineOrderShield</defName>
+							<label>divine order shield</label>
+							<description>A sturdy, reinforced shield that bears the insignia of the Divine Order.</description>
+							<techLevel>Medieval</techLevel>
+							<graphicData>
+								<texPath>Things/Pawn/Humanlike/Apparel/Other/DivineOrderShield</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+								<drawSize>1</drawSize>
+								<shaderType>CutoutComplex</shaderType>
+							</graphicData>
+							<thingCategories Inherit="False">
+								<li>Shields</li>
+							</thingCategories>
+							<stuffCategories>
+								<li>Metallic</li>
+							</stuffCategories>
+							<costStuffCount>150</costStuffCount>
+							<costList>
+								<Gold>5</Gold>
+							</costList>
+							<recipeMaker>
+								<researchPrerequisite>BotchJob_DivineOrderSmithing</researchPrerequisite>
+								<recipeUsers>
+									<li>FueledSmithy</li>
+									<li>ElectricSmithy</li>
+								</recipeUsers>
+								<skillRequirements>
+									<Crafting>8</Crafting>
+								</skillRequirements>
+							</recipeMaker>
+							<statBases>
+								<WorkToMake>3000</WorkToMake>
+								<MaxHitPoints>145</MaxHitPoints>
+								<StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
+								<Mass>8</Mass>
+								<Bulk>9</Bulk>
+								<WornBulk>6</WornBulk>
+							</statBases>
+							<equippedStatOffsets>
+								<ReloadSpeed>-0.2</ReloadSpeed>
+								<MeleeHitChance>-1</MeleeHitChance>
+								<ShootingAccuracyPawn>-0.15</ShootingAccuracyPawn>
+								<AimingAccuracy>-0.08</AimingAccuracy>
+								<Suppressability>-0.25</Suppressability>
+								<MeleeCritChance>-0.05</MeleeCritChance>
+								<MeleeParryChance>1.0</MeleeParryChance>
+							</equippedStatOffsets>
+							<apparel>
+								<tags>
+									<li>KiteShield</li>
+								</tags>
+								<defaultOutfitTags>
+									<li>Soldier</li>
+								</defaultOutfitTags>
+								<countsAsClothingForNudity>false</countsAsClothingForNudity>
+								<canBeDesiredForIdeo>false</canBeDesiredForIdeo>
+							</apparel>
+							<comps>
+								<li>
+									<compClass>CompColorable</compClass>
+								</li>
+							</comps>
+							<modExtensions>
+								<li Class="CombatExtended.ShieldDefExtension">
+									<shieldCoverage>
+										<li>Hands</li>
+										<li>Arms</li>
+										<li>Shoulders</li>
+										<li>Torso</li>
+										<li>Neck</li>
+									</shieldCoverage>
+									<drawAsTall>false</drawAsTall>
+								</li>
+							</modExtensions>
+						</ThingDef>
+
 					</value>
 				</li>
 
-				<!--Add Bulk-->
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="BotchJob_DivineOrderShield"]/statBases </xpath>
-					<value>
-						<Bulk>8</Bulk>
-						<WornBulk>5</WornBulk>
-					</value>
-				</li>
-
-				<!--Replace Stat Offsets-->
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="BotchJob_DivineOrderShield"]</xpath>
-					<value>
-						<equippedStatOffsets>
-							<ReloadSpeed>-0.2</ReloadSpeed>
-							<MeleeHitChance>-1</MeleeHitChance>
-							<ShootingAccuracyPawn>-0.15</ShootingAccuracyPawn>
-							<AimingAccuracy>-0.08</AimingAccuracy>
-							<Suppressability>-0.25</Suppressability>
-							<MeleeCritChance>-0.05</MeleeCritChance>
-							<MeleeParryChance>1.0</MeleeParryChance>
-						</equippedStatOffsets>
-					</value>
-				</li>
-
-				<!--Replace Stuff Thickness-->
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="BotchJob_DivineOrderShield"]/statBases/StuffEffectMultiplierArmor</xpath>
-					<value>
-						<StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
-					</value>
+				<li Class="PatchOperationFindMod">
+					<mods>
+						<li>Vanilla Expanded Framework</li>
+					</mods>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/PawnKindDef[defName="BotchJob_DivineOrderKnight"]</xpath>
+						<value>
+							<apparelRequired>
+								<li>BotchJob_DivineOrderShield</li>
+							</apparelRequired>
+						</value>
+					</nomatch>
 				</li>
 
 			</operations>

--- a/Patches/Divine Order/ThingDef_Misc/Divine_Order_CE_Shield.xml
+++ b/Patches/Divine Order/ThingDef_Misc/Divine_Order_CE_Shield.xml
@@ -78,7 +78,6 @@
 				</li>
 
 				<!--Replace Stat Offsets-->
-
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="BotchJob_DivineOrderShield"]</xpath>
 					<value>
@@ -95,7 +94,6 @@
 				</li>
 
 				<!--Replace Stuff Thickness-->
-
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="BotchJob_DivineOrderShield"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>

--- a/Patches/Divine Order/ThingDef_Misc/Weapons/Divine_Order_CE_Melee.xml
+++ b/Patches/Divine Order/ThingDef_Misc/Weapons/Divine_Order_CE_Melee.xml
@@ -201,6 +201,13 @@
 						</tools>
 					</value>
 				</li>
+				
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="BotchJob_DivineOrderLongsword"]/weaponTags</xpath>
+					<value>
+						<li>CE_OneHandedWeapon</li>
+					</value>
+				</li>
 
 				<!-- Battle Standard -->
 

--- a/Patches/Divine Order/ThingDef_Misc/Weapons/Divine_Order_CE_Ranged.xml
+++ b/Patches/Divine Order/ThingDef_Misc/Weapons/Divine_Order_CE_Ranged.xml
@@ -50,7 +50,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="BotchJob_DivineOrderCrossbow"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="BotchJob_DivineOrderCrossbow" or defName="BotchJob_DivineOrderHandCrossbow"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -129,6 +129,37 @@
 					</FireModes>
 					<weaponTags>
 						<li>CE_XBow</li>
+						<li>CE_OneHandedWeapon</li>
+					</weaponTags>
+				</li>
+
+				<!-- === Hand Crossbow === -->
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>BotchJob_DivineOrderHandCrossbow</defName>
+					<statBases>
+						<Bulk>2.5</Bulk>
+						<SwayFactor>1.2</SwayFactor>
+						<ShotSpread>0.35</ShotSpread>
+						<SightsEfficiency>1</SightsEfficiency>
+						<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+					</statBases>
+					<Properties>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>True</hasStandardCommand>
+						<defaultProjectile>Projectile_CrossbowBolt_Steel</defaultProjectile>
+						<warmupTime>1</warmupTime>
+						<range>10</range>
+						<soundCast>Bow_Large</soundCast>
+					</Properties>
+					<AmmoUser>
+						<magazineSize>1</magazineSize>
+						<reloadTime>3.5</reloadTime>
+						<ammoSet>AmmoSet_CrossbowBolt</ammoSet>
+					</AmmoUser>
+					<FireModes>
+						<aiAimMode>AimedShot</aiAimMode>
+					</FireModes>
+					<weaponTags>
 						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>

--- a/Patches/Divine Order/TraderDefs/Divine_Order_CE_Traders.xml
+++ b/Patches/Divine Order/TraderDefs/Divine_Order_CE_Traders.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Divine Order</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/TraderKindDef[defName="BotchJob_DivineOrderBaseTrader"]/stockGenerators</xpath>
+					<value>
+						<li Class="StockGenerator_Category">
+							<categoryDef>CannonBall</categoryDef>
+							<countRange>
+								<min>12</min>
+								<max>36</max>
+							</countRange>
+							<price>Expensive</price>
+							<thingDefCountRange>
+								<min>1</min>
+								<max>3</max>
+							</thingDefCountRange>
+						</li>
+						<li Class="StockGenerator_Category">
+							<categoryDef>MiniCannonBall</categoryDef>
+							<countRange>
+								<min>50</min>
+								<max>100</max>
+							</countRange>
+							<price>Normal</price>
+							<thingDefCountRange>
+								<min>1</min>
+								<max>2</max>
+							</thingDefCountRange>
+						</li>
+						<li Class="StockGenerator_Tag">
+							<tradeTag>CE_PreIndustrialAmmo</tradeTag>
+							<countRange>
+								<min>300</min>
+								<max>1200</max>
+							</countRange>
+							<price>Cheap</price>
+							<thingDefCountRange>
+								<min>2</min>
+								<max>4</max>
+							</thingDefCountRange>
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/TraderKindDef[defName="BotchJob_DivineOrderCaravanTrader"]/stockGenerators</xpath>
+					<value>
+						<li Class="StockGenerator_Category">
+							<categoryDef>MiniCannonBall</categoryDef>
+							<countRange>
+								<min>25</min>
+								<max>50</max>
+							</countRange>
+							<price>Normal</price>
+							<thingDefCountRange>
+								<min>1</min>
+								<max>2</max>
+							</thingDefCountRange>
+						</li>
+						<li Class="StockGenerator_Tag">
+							<tradeTag>CE_PreIndustrialAmmo</tradeTag>
+							<countRange>
+								<min>100</min>
+								<max>200</max>
+							</countRange>
+							<price>Cheap</price>
+							<thingDefCountRange>
+								<min>1</min>
+								<max>3</max>
+							</thingDefCountRange>
+						</li>
+					</value>
+				</li>
+
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Divine Order/TraderDefs/Divine_Order_CE_Traders.xml
+++ b/Patches/Divine Order/TraderDefs/Divine_Order_CE_Traders.xml
@@ -81,7 +81,6 @@
 					</value>
 				</li>
 
-
 			</operations>
 		</match>
 	</Operation>


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Patch traders to stock CE cannonballs, miniballs, and pre-industrial tagged ammo
- Added crossbow bolts to Scenario
- Patched new weapon
- Patched new apparels

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Fixed duplicate xml errors due to updates in Divine Order
- Replaced shield def since CE replaces the VE shield comps.
- Patched PawnkindDef to utilize shield without VE

## Reasoning

- Hand crossbow given crossbow ammo set, but at vastly reduced ranged. 

## Alternatives

Describe alternative implementations you have considered, e.g.
- Patching hand crossbow to realistic values
  - Would make weapon functionally useless
  - Have to add new ammo set and projectiles
  - Breaks mods intent

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (couple minutes to verify patched)
