### PR TITLE
Null check MakeIconOverlay

### DIFF
--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -887,6 +887,10 @@ namespace CombatExtended
 
         public static void MakeIconOverlay(Pawn pawn, ThingDef moteDef)
         {
+            if (pawn.Map == null)
+            {
+                return;
+            }
             MoteThrownAttached moteThrown = (MoteThrownAttached)ThingMaker.MakeThing(moteDef);
             moteThrown.Attach(pawn);
             moteThrown.exactPosition = pawn.DrawPos;


### PR DESCRIPTION
## Changes

Map null check for MakeIconOverlay

## Reasoning

Occassional red letter from trying to spawn suppression mote on not spawned pawn

## Alternatives

Suffer.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
