### PR TITLE
Laser damage type

### DIFF
--- a/Defs/Ammo/Lasers/BaseLaserProjectiles.xml
+++ b/Defs/Ammo/Lasers/BaseLaserProjectiles.xml
@@ -17,7 +17,7 @@
 		<seam>0</seam>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<isInstant>true</isInstant>
-			<damageDef>Bullet</damageDef>
+			<damageDef>CE_Laser</damageDef>
 		</projectile>
 		<modExtensions>
 			<li Class="ProjectileImpactFX.EffectProjectileExtension">

--- a/Defs/Ammo/Modded/Warhammer 40k/LasGun.xml
+++ b/Defs/Ammo/Modded/Warhammer 40k/LasGun.xml
@@ -80,7 +80,7 @@
 		<defName>Bullet_Lasgun_Pistol</defName>
 		<label>laser beam</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>Burn</damageDef>
+			<damageDef>CE_Laser</damageDef>
 			<damageAmountBase>12</damageAmountBase>
 			<armorPenetrationSharp>8</armorPenetrationSharp>
 			<armorPenetrationBlunt>0.001</armorPenetrationBlunt>
@@ -91,7 +91,7 @@
 		<defName>Bullet_Lasgun_Rifle</defName>
 		<label>laser beam</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>Burn</damageDef>
+			<damageDef>CE_Laser</damageDef>
 			<damageAmountBase>20</damageAmountBase>
 			<armorPenetrationSharp>14</armorPenetrationSharp>
 			<armorPenetrationBlunt>0.001</armorPenetrationBlunt>
@@ -102,7 +102,7 @@
 		<defName>Bullet_Lasgun_HellGun</defName>
 		<label>laser beam</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>Burn</damageDef>
+			<damageDef>CE_Laser</damageDef>
 			<damageAmountBase>26</damageAmountBase>
 			<armorPenetrationSharp>20</armorPenetrationSharp>
 			<armorPenetrationBlunt>0.001</armorPenetrationBlunt>
@@ -113,7 +113,7 @@
 		<defName>Bullet_Lasgun_Cannon</defName>
 		<label>laser beam</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>Burn</damageDef>
+			<damageDef>CE_Laser</damageDef>
 			<damageAmountBase>34</damageAmountBase>
 			<armorPenetrationSharp>30</armorPenetrationSharp>
 			<armorPenetrationBlunt>0.001</armorPenetrationBlunt>

--- a/Defs/Ammo/Modded/Warhammer 40k/MeltaGun.xml
+++ b/Defs/Ammo/Modded/Warhammer 40k/MeltaGun.xml
@@ -30,7 +30,7 @@
 		</textures>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<isInstant>true</isInstant>
-			<damageDef>Bullet</damageDef>
+			<damageDef>CE_Laser</damageDef>
 			<damageAmountBase>150</damageAmountBase>
 			<armorPenetrationSharp>500</armorPenetrationSharp>
 			<armorPenetrationBlunt>0.001</armorPenetrationBlunt><!-- The overall pressure exerted by a laser beam striking something is, unsuprisingly, negligable. -->

--- a/Defs/DamageDefs/Damages_LocalInjury.xml
+++ b/Defs/DamageDefs/Damages_LocalInjury.xml
@@ -136,5 +136,26 @@
 		<soundExplosion>Explosion_Stun</soundExplosion>
 		<hediff>Flashbanged</hediff>
 	</DamageDef>
-
+	
+  <DamageDef Name="Bullet">
+		<defName>CE_Laser</defName>
+		<label>laser</label>
+    <workerClass>DamageWorker_AddInjury</workerClass>
+    <externalViolence>true</externalViolence>
+		<deathMessage>{0} has been scorched to death.</deathMessage>
+		<hediff>BurnSecondary</hediff>
+    <harmAllLayersUntilOutside>true</harmAllLayersUntilOutside>
+    <hasForcefulImpact>false</hasForcefulImpact>
+    <impactSoundType>Bullet</impactSoundType>
+    <armorCategory>Sharp</armorCategory>
+    <overkillPctToDestroyPart>0~0.7</overkillPctToDestroyPart>
+    <isRanged>true</isRanged>
+    <makesAnimalsFlee>true</makesAnimalsFlee>
+		<minDamageToFragment>99999</minDamageToFragment>
+    <defaultDamage>1</defaultDamage>
+    <defaultArmorPenetration>0</defaultArmorPenetration>
+		<buildingDamageFactor>0.100</buildingDamageFactor>
+		<plantDamageFactor>2</plantDamageFactor>
+  </DamageDef>
+	
 </Defs>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Misc/Weapons.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Misc/Weapons.xml
@@ -350,7 +350,7 @@
 								<defName>Bullet_HeavyLaser</defName>
 								<label>laser shot</label>
 								<projectile Class="CombatExtended.ProjectilePropertiesCE">
-									<damageDef>Bullet</damageDef>
+									<damageDef>CE_Laser</damageDef>
 									<damageAmountBase>17</damageAmountBase>
 									<armorPenetrationSharp>20</armorPenetrationSharp>
 									<armorPenetrationBlunt>0.001</armorPenetrationBlunt>

--- a/Patches/Det's Energy Weapons/EnergyBoltAmmoSet.XML
+++ b/Patches/Det's Energy Weapons/EnergyBoltAmmoSet.XML
@@ -42,7 +42,7 @@
 						<graphicClass>Graphic_Single</graphicClass>
 					</graphicData>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
-						<damageDef>Bullet</damageDef>
+						<damageDef>CE_Laser</damageDef>
 						<speed>156</speed>
 						<dropsCasings>false</dropsCasings>
 					</projectile>

--- a/Patches/Halo - UNSC Armoury/Weapons_Laser.xml
+++ b/Patches/Halo - UNSC Armoury/Weapons_Laser.xml
@@ -81,7 +81,7 @@
 								<defName>Bullet_Laser_SpartanLaser</defName>
 								<label>laser beam</label>
 								<projectile Class="CombatExtended.ProjectilePropertiesCE">
-									<damageDef>Burn</damageDef>
+									<damageDef>CE_Laser</damageDef>
 									<damageAmountBase>300</damageAmountBase>
 									<armorPenetrationSharp>600</armorPenetrationSharp>
 									<armorPenetrationBlunt>0.001</armorPenetrationBlunt>

--- a/Patches/Halo UNSC Weapon Pack/UNSC_CE.xml
+++ b/Patches/Halo UNSC Weapon Pack/UNSC_CE.xml
@@ -176,7 +176,7 @@
 							<defName>Bullet_Laser_SpartanLaserInf</defName>
 							<label>laser beam</label>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<damageDef>Bullet</damageDef>
+								<damageDef>CE_Laser</damageDef>
 								<damageAmountBase>100</damageAmountBase>
 								<armorPenetrationSharp>600</armorPenetrationSharp>
 								<armorPenetrationBlunt>0.001</armorPenetrationBlunt>

--- a/Patches/Rim Flood/Sentinal_Laser_CE.xml
+++ b/Patches/Rim Flood/Sentinal_Laser_CE.xml
@@ -54,7 +54,7 @@
 							</textures>
 							<seam>0</seam>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<damageDef>Bullet</damageDef>
+								<damageDef>CE_Laser</damageDef>
 								<damageAmountBase>15</damageAmountBase>
 								<armorPenetrationSharp>15.75</armorPenetrationSharp>
 								<armorPenetrationBlunt>0.001</armorPenetrationBlunt>
@@ -69,7 +69,7 @@
 							</textures>
 							<seam>0</seam>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<damageDef>Bullet</damageDef>
+								<damageDef>CE_Laser</damageDef>
 								<damageAmountBase>20</damageAmountBase>
 								<armorPenetrationSharp>20</armorPenetrationSharp>
 								<armorPenetrationBlunt>0.001</armorPenetrationBlunt>

--- a/Patches/Save Our Ship 2/Holograms_Projectiles.xml
+++ b/Patches/Save Our Ship 2/Holograms_Projectiles.xml
@@ -18,7 +18,7 @@
 							<defName>Bullet_Laser_Hologram</defName>
 							<label>hologram laser</label>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<damageDef>Bullet</damageDef>
+								<damageDef>CE_Laser</damageDef>
 								<damageAmountBase>12</damageAmountBase>
 								<armorPenetrationSharp>12.5</armorPenetrationSharp>
 								<armorPenetrationBlunt>0.001</armorPenetrationBlunt><!-- The overall pressure exerted by a laser beam striking something is, unsuprisingly, negligable. -->

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/Ammo_Laser.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/Ammo_Laser.xml
@@ -37,7 +37,7 @@
 								<defName>Bullet_Laser_SalvagedLaserEradicatorCE</defName>
 								<label>eradicator laser beam</label>
 								<projectile Class="CombatExtended.ProjectilePropertiesCE">
-									<damageDef>Bullet</damageDef>
+									<damageDef>CE_Laser</damageDef>
 									<damageAmountBase>20</damageAmountBase>
 									<armorPenetrationSharp>15.5</armorPenetrationSharp>
 									<armorPenetrationBlunt>0.001</armorPenetrationBlunt>

--- a/Patches/Vanilla Genetics Expanded/Patch_Projectiles.xml
+++ b/Patches/Vanilla Genetics Expanded/Patch_Projectiles.xml
@@ -86,7 +86,7 @@
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<flyOverhead>false</flyOverhead>
-							<damageDef>Flame</damageDef>
+							<damageDef>CE_Laser</damageDef>
 							<damageAmountBase>13</damageAmountBase>
 							<speed>300</speed>
 							<ai_IsIncendiary>true</ai_IsIncendiary>

--- a/Patches/Vanilla Weapons Expanded - Frontier/Patch_HighRoller_AddonAmmo.xml
+++ b/Patches/Vanilla Weapons Expanded - Frontier/Patch_HighRoller_AddonAmmo.xml
@@ -205,7 +205,7 @@
 								<defName>Bullet_Laser_SalvagedLaserRevolver_HR</defName>
 								<label>laser beam</label>
 								<projectile Class="CombatExtended.ProjectilePropertiesCE">
-									<damageDef>Bullet</damageDef>
+									<damageDef>CE_Laser</damageDef>
 									<damageAmountBase>12</damageAmountBase>
 									<armorPenetrationSharp>15.5</armorPenetrationSharp>
 									<armorPenetrationBlunt>0.001</armorPenetrationBlunt>
@@ -223,7 +223,7 @@
 								<defName>Bullet_Laser_SalvagedLaserRepeater_HR</defName>
 								<label>laser beam</label>
 								<projectile Class="CombatExtended.ProjectilePropertiesCE">
-									<damageDef>Bullet</damageDef>
+									<damageDef>CE_Laser</damageDef>
 									<damageAmountBase>20</damageAmountBase>
 									<armorPenetrationSharp>16.75</armorPenetrationSharp>
 									<armorPenetrationBlunt>0.001</armorPenetrationBlunt>
@@ -241,7 +241,7 @@
 								<defName>Bullet_Laser_SalvagedLaserHuntingRifle_HR</defName>
 								<label>laser beam</label>
 								<projectile Class="CombatExtended.ProjectilePropertiesCE">
-									<damageDef>Bullet</damageDef>
+									<damageDef>CE_Laser</damageDef>
 									<damageAmountBase>24</damageAmountBase>
 									<armorPenetrationSharp>18.75</armorPenetrationSharp>
 									<armorPenetrationBlunt>0.001</armorPenetrationBlunt>

--- a/Patches/Vanilla Weapons Expanded - Laser/Ammo.xml
+++ b/Patches/Vanilla Weapons Expanded - Laser/Ammo.xml
@@ -116,7 +116,7 @@
 								<li>Things/Projectile/Shot_SalvagedLaserPistol</li>
 							</textures>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<damageDef>Bullet</damageDef>
+								<damageDef>CE_Laser</damageDef>
 								<damageAmountBase>12</damageAmountBase>
 								<armorPenetrationSharp>15.5</armorPenetrationSharp>
 								<armorPenetrationBlunt>0.001</armorPenetrationBlunt><!-- The overall pressure exerted by a laser beam striking something is, unsuprisingly, negligable. -->
@@ -130,7 +130,7 @@
 								<li>Things/Projectile/Shot_LaserPistol</li>
 							</textures>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<damageDef>Bullet</damageDef>
+								<damageDef>CE_Laser</damageDef>
 								<damageAmountBase>10</damageAmountBase>
 								<armorPenetrationSharp>17.5</armorPenetrationSharp>
 								<armorPenetrationBlunt>0.001</armorPenetrationBlunt>
@@ -144,7 +144,7 @@
 								<li>Things/Projectile/Shot_LaserPistol</li>
 							</textures>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<damageDef>Bullet</damageDef>
+								<damageDef>CE_Laser</damageDef>
 								<damageAmountBase>11</damageAmountBase>
 								<armorPenetrationSharp>18.25</armorPenetrationSharp>
 								<armorPenetrationBlunt>0.001</armorPenetrationBlunt>
@@ -158,7 +158,7 @@
 								<li>Things/Projectile/Shot_SalvagedLaserRifle</li>
 							</textures>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<damageDef>Bullet</damageDef>
+								<damageDef>CE_Laser</damageDef>
 								<damageAmountBase>20</damageAmountBase>
 								<armorPenetrationSharp>16.75</armorPenetrationSharp>
 								<armorPenetrationBlunt>0.001</armorPenetrationBlunt>
@@ -172,7 +172,7 @@
 								<li>Things/Projectile/Shot_LaserRifle</li>
 							</textures>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<damageDef>Bullet</damageDef>
+								<damageDef>CE_Laser</damageDef>
 								<damageAmountBase>18</damageAmountBase>
 								<armorPenetrationSharp>17.5</armorPenetrationSharp>
 								<armorPenetrationBlunt>0.001</armorPenetrationBlunt>
@@ -186,7 +186,7 @@
 								<li>Things/Projectile/Shot_SalvagedLaserShotgun</li>
 							</textures>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<damageDef>Bullet</damageDef>
+								<damageDef>CE_Laser</damageDef>
 								<damageAmountBase>9</damageAmountBase>
 								<armorPenetrationSharp>14.25</armorPenetrationSharp>
 								<armorPenetrationBlunt>0.001</armorPenetrationBlunt>
@@ -201,7 +201,7 @@
 								<li>Things/Projectile/Shot_LaserShotgun</li>
 							</textures>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<damageDef>Bullet</damageDef>
+								<damageDef>CE_Laser</damageDef>
 								<damageAmountBase>8</damageAmountBase>
 								<armorPenetrationSharp>15.75</armorPenetrationSharp>
 								<armorPenetrationBlunt>0.001</armorPenetrationBlunt>
@@ -216,7 +216,7 @@
 								<li>Things/Projectile/Shot_SalvagedLaserSniperRifle</li>
 							</textures>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<damageDef>Bullet</damageDef>
+								<damageDef>CE_Laser</damageDef>
 								<damageAmountBase>24</damageAmountBase>
 								<armorPenetrationSharp>18.75</armorPenetrationSharp>
 								<armorPenetrationBlunt>0.001</armorPenetrationBlunt>
@@ -230,7 +230,7 @@
 								<li>Things/Projectile/Shot_LaserSniperRifle</li>
 							</textures>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<damageDef>Bullet</damageDef>
+								<damageDef>CE_Laser</damageDef>
 								<damageAmountBase>20</damageAmountBase>
 								<armorPenetrationSharp>20.25</armorPenetrationSharp>
 								<armorPenetrationBlunt>0.001</armorPenetrationBlunt>
@@ -244,7 +244,7 @@
 								<li>Things/Projectile/Shot_LaserMinigun</li>
 							</textures>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<damageDef>Bullet</damageDef>
+								<damageDef>CE_Laser</damageDef>
 								<damageAmountBase>16</damageAmountBase>
 								<armorPenetrationSharp>16</armorPenetrationSharp>
 								<armorPenetrationBlunt>0.001</armorPenetrationBlunt>

--- a/Patches/Vanilla XCOM weapons/Laser Weapons/Ammo.xml
+++ b/Patches/Vanilla XCOM weapons/Laser Weapons/Ammo.xml
@@ -300,7 +300,7 @@
 							<defName>XCOM_Bullet_LaserRifleCEInc</defName>
 							<label>laser beam</label>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<damageDef>Bullet</damageDef>
+								<damageDef>CE_Laser</damageDef>
 								<damageAmountBase>12</damageAmountBase>
 								<armorPenetrationSharp>17.5</armorPenetrationSharp>
 								<armorPenetrationBlunt>0.001</armorPenetrationBlunt>
@@ -317,7 +317,7 @@
 							<defName>XCOM_Bullet_LaserRifleCEHP</defName>
 							<label>laser beam</label>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<damageDef>Bullet</damageDef>
+								<damageDef>CE_Laser</damageDef>
 								<damageAmountBase>18</damageAmountBase>
 								<armorPenetrationSharp>34.5</armorPenetrationSharp>
 								<armorPenetrationBlunt>0.001</armorPenetrationBlunt>
@@ -334,7 +334,7 @@
 							<defName>XCOM_Bullet_LaserRifleCEEMP</defName>
 							<label>laser beam</label>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<damageDef>Bullet</damageDef>
+								<damageDef>CE_Laser</damageDef>
 								<damageAmountBase>12</damageAmountBase>
 								<armorPenetrationSharp>17.5</armorPenetrationSharp>
 								<armorPenetrationBlunt>0.001</armorPenetrationBlunt>
@@ -364,7 +364,7 @@
 							<defName>XCOM_Bullet_LaserSniperRifleCE</defName>
 							<label>laser beam</label>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<damageDef>Bullet</damageDef>
+								<damageDef>CE_Laser</damageDef>
 								<damageAmountBase>16</damageAmountBase>
 								<armorPenetrationSharp>18.75</armorPenetrationSharp>
 								<armorPenetrationBlunt>0.001</armorPenetrationBlunt>
@@ -381,7 +381,7 @@
 							<defName>XCOM_Bullet_LaserSniperRifleCEInc</defName>
 							<label>laser beam</label>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<damageDef>Bullet</damageDef>
+								<damageDef>CE_Laser</damageDef>
 								<damageAmountBase>16</damageAmountBase>
 								<armorPenetrationSharp>18.75</armorPenetrationSharp>
 								<armorPenetrationBlunt>0.001</armorPenetrationBlunt>
@@ -398,7 +398,7 @@
 							<defName>XCOM_Bullet_LaserSniperRifleCEHP</defName>
 							<label>laser beam</label>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<damageDef>Bullet</damageDef>
+								<damageDef>CE_Laser</damageDef>
 								<damageAmountBase>24</damageAmountBase>
 								<armorPenetrationSharp>38.75</armorPenetrationSharp>
 								<armorPenetrationBlunt>0.001</armorPenetrationBlunt>
@@ -415,7 +415,7 @@
 							<defName>XCOM_Bullet_LaserSniperRifleCEEMP</defName>
 							<label>laser beam</label>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<damageDef>Bullet</damageDef>
+								<damageDef>CE_Laser</damageDef>
 								<damageAmountBase>18</damageAmountBase>
 								<armorPenetrationSharp>18.75</armorPenetrationSharp>
 								<armorPenetrationBlunt>0.001</armorPenetrationBlunt>
@@ -445,7 +445,7 @@
 							<defName>XCOM_Bullet_LaserShotgunCE</defName>
 							<label>laser beam</label>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<damageDef>Bullet</damageDef>
+								<damageDef>CE_Laser</damageDef>
 								<damageAmountBase>6</damageAmountBase>
 								<armorPenetrationSharp>15.75</armorPenetrationSharp>
 								<armorPenetrationBlunt>0.001</armorPenetrationBlunt>
@@ -463,7 +463,7 @@
 							<defName>XCOM_Bullet_LaserShotgunCEInc</defName>
 							<label>laser beam</label>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<damageDef>Bullet</damageDef>
+								<damageDef>CE_Laser</damageDef>
 								<damageAmountBase>6</damageAmountBase>
 								<armorPenetrationSharp>15.75</armorPenetrationSharp>
 								<armorPenetrationBlunt>0.001</armorPenetrationBlunt>
@@ -481,7 +481,7 @@
 							<defName>XCOM_Bullet_LaserShotgunCEHP</defName>
 							<label>laser beam</label>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<damageDef>Bullet</damageDef>
+								<damageDef>CE_Laser</damageDef>
 								<damageAmountBase>9</damageAmountBase>
 								<armorPenetrationSharp>24.75</armorPenetrationSharp>
 								<armorPenetrationBlunt>0.001</armorPenetrationBlunt>
@@ -499,7 +499,7 @@
 							<defName>XCOM_Bullet_LaserShotgunCEEMP</defName>
 							<label>laser beam</label>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<damageDef>Bullet</damageDef>
+								<damageDef>CE_Laser</damageDef>
 								<damageAmountBase>6</damageAmountBase>
 								<armorPenetrationSharp>15.75</armorPenetrationSharp>
 								<armorPenetrationBlunt>0.001</armorPenetrationBlunt>
@@ -530,7 +530,7 @@
 							<defName>XCOM_Bullet_LaserCannonCE</defName>
 							<label>laser beam</label>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<damageDef>Bullet</damageDef>
+								<damageDef>CE_Laser</damageDef>
 								<damageAmountBase>10</damageAmountBase>
 								<armorPenetrationSharp>16.75</armorPenetrationSharp>
 								<armorPenetrationBlunt>0.001</armorPenetrationBlunt>
@@ -547,7 +547,7 @@
 							<defName>XCOM_Bullet_LaserCannonCEInc</defName>
 							<label>laser beam</label>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<damageDef>Bullet</damageDef>
+								<damageDef>CE_Laser</damageDef>
 								<damageAmountBase>10</damageAmountBase>
 								<armorPenetrationSharp>16.75</armorPenetrationSharp>
 								<armorPenetrationBlunt>0.001</armorPenetrationBlunt>
@@ -564,7 +564,7 @@
 							<defName>XCOM_Bullet_LaserCannonCEHP</defName>
 							<label>laser beam</label>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<damageDef>Bullet</damageDef>
+								<damageDef>CE_Laser</damageDef>
 								<damageAmountBase>15</damageAmountBase>
 								<armorPenetrationSharp>24.75</armorPenetrationSharp>
 								<armorPenetrationBlunt>0.001</armorPenetrationBlunt>
@@ -581,7 +581,7 @@
 							<defName>XCOM_Bullet_LaserCannonCEEMP</defName>
 							<label>laser beam</label>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<damageDef>Bullet</damageDef>
+								<damageDef>CE_Laser</damageDef>
 								<damageAmountBase>10</damageAmountBase>
 								<armorPenetrationSharp>16.75</armorPenetrationSharp>
 								<armorPenetrationBlunt>0.001</armorPenetrationBlunt>
@@ -611,7 +611,7 @@
 							<defName>XCOM_Bullet_Laser_PistolCE</defName>
 							<label>laser beam</label>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<damageDef>Bullet</damageDef>
+								<damageDef>CE_Laser</damageDef>
 								<damageAmountBase>6</damageAmountBase>
 								<armorPenetrationSharp>17.5</armorPenetrationSharp>
 								<armorPenetrationBlunt>0.001</armorPenetrationBlunt>
@@ -628,7 +628,7 @@
 							<defName>XCOM_Bullet_Laser_PistolCEInc</defName>
 							<label>laser beam</label>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<damageDef>Bullet</damageDef>
+								<damageDef>CE_Laser</damageDef>
 								<damageAmountBase>6</damageAmountBase>
 								<armorPenetrationSharp>17.5</armorPenetrationSharp>
 								<armorPenetrationBlunt>0.001</armorPenetrationBlunt>
@@ -645,7 +645,7 @@
 							<defName>XCOM_Bullet_Laser_PistolCEHP</defName>
 							<label>laser beam</label>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<damageDef>Bullet</damageDef>
+								<damageDef>CE_Laser</damageDef>
 								<damageAmountBase>9</damageAmountBase>
 								<armorPenetrationSharp>27.5</armorPenetrationSharp>
 								<armorPenetrationBlunt>0.001</armorPenetrationBlunt>
@@ -662,7 +662,7 @@
 							<defName>XCOM_Bullet_Laser_PistolCEEMP</defName>
 							<label>laser beam</label>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<damageDef>Bullet</damageDef>
+								<damageDef>CE_Laser</damageDef>
 								<damageAmountBase>6</damageAmountBase>
 								<armorPenetrationSharp>17.5</armorPenetrationSharp>
 								<armorPenetrationBlunt>0.001</armorPenetrationBlunt>


### PR DESCRIPTION
Added new laser damageDef, applies burn damage while properly checking against sharp armor, applied to relevant projectiles in patches.

Reasoning:
it was stupid. most of the laser projectiles had assinged sharp penetration values which wouldn't have been put there if patcher didn't want them to get used.
Current setup with burn damagedef on most is literally broken OP.

Testing:
tested new damage def ingame, was working as it should