### PR TITLE
better flamethrower graphics

### DIFF
--- a/Defs/Ammo/Flamethrower.xml
+++ b/Defs/Ammo/Flamethrower.xml
@@ -1,195 +1,213 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
 
-	<ThingCategoryDef>
-		<defName>AmmoFlamethrower</defName>
-		<label>flamethrower fuel</label>
-		<parent>AmmoAdvanced</parent>
-		<iconPath>UI/Icons/ThingCategories/CaliberFuel</iconPath>
-	</ThingCategoryDef>
+  <ThingCategoryDef>
+    <defName>AmmoFlamethrower</defName>
+    <label>flamethrower fuel</label>
+    <parent>AmmoAdvanced</parent>
+    <iconPath>UI/Icons/ThingCategories/CaliberFuel</iconPath>
+  </ThingCategoryDef>
 
-	<!-- ==================== AmmoSet ========================== -->
+  <!-- ==================== AmmoSet ========================== -->
 
-	<CombatExtended.AmmoSetDef>
-		<defName>AmmoSet_Flamethrower</defName>
-		<label>flamethrower fuel</label>
-		<ammoTypes>
-			<Ammo_Flamethrower_Napalm>Bullet_Flamethrower_Napalm</Ammo_Flamethrower_Napalm>
-			<Ammo_Flamethrower_Prometheum>Bullet_Flamethrower_Prometheum</Ammo_Flamethrower_Prometheum>
-		</ammoTypes>
-	</CombatExtended.AmmoSetDef>
+  <CombatExtended.AmmoSetDef>
+    <defName>AmmoSet_Flamethrower</defName>
+    <label>flamethrower fuel</label>
+    <ammoTypes>
+      <Ammo_Flamethrower_Napalm>Bullet_Flamethrower_Napalm</Ammo_Flamethrower_Napalm>
+      <Ammo_Flamethrower_Prometheum>Bullet_Flamethrower_Prometheum</Ammo_Flamethrower_Prometheum>
+    </ammoTypes>
+  </CombatExtended.AmmoSetDef>
 
-	<!-- ==================== Ammo ========================== -->
+  <!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="FlamethrowerBase" ParentName="SpacerSmallAmmoBase" Abstract="True">
-		<description>Fuel for use with a flamethrower.</description>
-		<statBases>
-			<MaxHitPoints>70</MaxHitPoints>
-			<Flammability>1.0</Flammability>
-			<Mass>0.05</Mass>
-			<Bulk>0.1</Bulk>
-		</statBases>
-		<tradeTags>
-			<li>CE_AutoEnableTrade</li>
-			<li>CE_AutoEnableCrafting_DrugLab</li>
-		</tradeTags>
-		<thingCategories>
-			<li>AmmoFlamethrower</li>
-		</thingCategories>
-		<stackLimit>500</stackLimit>
-	</ThingDef>
+  <ThingDef Class="CombatExtended.AmmoDef" Name="FlamethrowerBase" ParentName="SpacerSmallAmmoBase" Abstract="True">
+    <description>Fuel for use with a flamethrower.</description>
+    <statBases>
+      <MaxHitPoints>70</MaxHitPoints>
+      <Flammability>1.0</Flammability>
+      <Mass>0.05</Mass>
+      <Bulk>0.1</Bulk>
+    </statBases>
+    <tradeTags>
+      <li>CE_AutoEnableTrade</li>
+      <li>CE_AutoEnableCrafting_DrugLab</li>
+    </tradeTags>
+    <thingCategories>
+      <li>AmmoFlamethrower</li>
+    </thingCategories>
+    <stackLimit>500</stackLimit>
+  </ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="FlamethrowerBase">
-		<defName>Ammo_Flamethrower_Napalm</defName>
-		<label>jellied chemfuel</label>
-		<graphicData>
-			<texPath>Things/Ammo/FuelTank/Incendiary</texPath>
-			<graphicClass>Graphic_StackCount</graphicClass>
-		</graphicData>
-		<statBases>
-			<MarketValue>0.3</MarketValue>
-		</statBases>
-		<ammoClass>NapalmFuel</ammoClass>
-		<comps>
-			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>2</damageAmountBase>
-				<explosiveDamageType>Flame</explosiveDamageType>
-				<explosiveRadius>1</explosiveRadius>
-				<preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
-				<preExplosionSpawnChance>1</preExplosionSpawnChance>
-			</li>
-		</comps>
-	</ThingDef>
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="FlamethrowerBase">
+    <defName>Ammo_Flamethrower_Napalm</defName>
+    <label>jellied chemfuel</label>
+    <graphicData>
+      <texPath>Things/Ammo/FuelTank/Incendiary</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.3</MarketValue>
+    </statBases>
+    <ammoClass>NapalmFuel</ammoClass>
+    <comps>
+      <li Class="CombatExtended.CompProperties_ExplosiveCE">
+        <damageAmountBase>2</damageAmountBase>
+        <explosiveDamageType>Flame</explosiveDamageType>
+        <explosiveRadius>1</explosiveRadius>
+        <preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
+        <preExplosionSpawnChance>1</preExplosionSpawnChance>
+      </li>
+    </comps>
+  </ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="FlamethrowerBase">
-		<defName>Ammo_Flamethrower_Prometheum</defName>
-		<label>jellied prometheum</label>
-		<graphicData>
-			<texPath>Things/Ammo/FuelTank/Prometheum</texPath>
-			<graphicClass>Graphic_StackCount</graphicClass>
-		</graphicData>
-		<statBases>
-			<MarketValue>0.7</MarketValue>
-		</statBases>
-		<ammoClass>JelliedPrometheumFuel</ammoClass>
-		<comps>
-			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>5</damageAmountBase>
-				<explosiveDamageType>PrometheumFlame</explosiveDamageType>
-				<explosiveRadius>1.2</explosiveRadius>
-				<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
-				<preExplosionSpawnChance>1</preExplosionSpawnChance>
-			</li>
-		</comps>
-	</ThingDef>
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="FlamethrowerBase">
+    <defName>Ammo_Flamethrower_Prometheum</defName>
+    <label>jellied prometheum</label>
+    <graphicData>
+      <texPath>Things/Ammo/FuelTank/Prometheum</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.7</MarketValue>
+    </statBases>
+    <ammoClass>JelliedPrometheumFuel</ammoClass>
+    <comps>
+      <li Class="CombatExtended.CompProperties_ExplosiveCE">
+        <damageAmountBase>5</damageAmountBase>
+        <explosiveDamageType>PrometheumFlame</explosiveDamageType>
+        <explosiveRadius>1.2</explosiveRadius>
+        <preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
+        <preExplosionSpawnChance>1</preExplosionSpawnChance>
+      </li>
+    </comps>
+  </ThingDef>
 
-	<!-- ================== Projectiles ================== -->
+  <!-- ================== Projectiles ================== -->
 
-	<ThingDef Name="BaseFlamethrowerBullet" ParentName="BaseExplosiveBullet" Abstract="true">
-		<graphicData>
-			<texPath>Things/Projectile/Flame_CE</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-			<shaderType>TransparentPostLight</shaderType>
-		</graphicData>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>20</speed>
-			<flyOverhead>false</flyOverhead>
-			<castShadow>false</castShadow>
-		</projectile>
-	</ThingDef>
+  <ThingDef Name="BaseFlamethrowerBullet" ParentName="BaseExplosiveBullet" Abstract="true">
+    <graphicData>
+      <texPath>Things/Mote/FireGlow</texPath>
+      <shaderType>MoteGlow</shaderType>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <speed>20</speed>
+      <flyOverhead>false</flyOverhead>
+      <castShadow>false</castShadow>
+    </projectile>
+    <comps>
+      <li Class="CombatExtended.CompProperties_ProjectileFleck">
+        <FleckDatas>
+          <li>
+            <fleck>Fleck_CEFlamethrowerTrail</fleck>
+            <emissionsPerTick>2</emissionsPerTick>
+            <flecksPerEmission>2</flecksPerEmission>
+            <scale>1</scale>
+          </li>
+          <li>
+            <fleck>Fleck_CEFlamethrowerSmokeTrail</fleck>
+            <emissionsPerTick>2</emissionsPerTick>
+            <flecksPerEmission>1</flecksPerEmission>
+            <scale>1</scale>
+          </li>
+        </FleckDatas>
+      </li>
+    </comps>
+  </ThingDef>
 
-	<ThingDef ParentName="BaseFlamethrowerBullet">
-		<defName>Bullet_Flamethrower_Napalm</defName>
-		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
-		<label>jellied chemfuel stream</label>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>Flame</damageDef>
-			<damageAmountBase>3</damageAmountBase>
-			<preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
-			<preExplosionSpawnChance>0.33</preExplosionSpawnChance>
-			<soundExplode>CE_FlamethrowerExplosion</soundExplode>
-			<explosionRadius>1.0</explosionRadius>
-			<ai_IsIncendiary>true</ai_IsIncendiary>
-			<screenShakeFactor>0</screenShakeFactor>
-		</projectile>
-	</ThingDef>
+  <ThingDef ParentName="BaseFlamethrowerBullet">
+    <defName>Bullet_Flamethrower_Napalm</defName>
+    <thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+    <label>jellied chemfuel stream</label>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageDef>Flame</damageDef>
+      <damageAmountBase>3</damageAmountBase>
+      <preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
+      <preExplosionSpawnChance>0.33</preExplosionSpawnChance>
+      <soundExplode>CE_FlamethrowerExplosion</soundExplode>
+      <explosionRadius>1.0</explosionRadius>
+      <ai_IsIncendiary>true</ai_IsIncendiary>
+      <screenShakeFactor>0</screenShakeFactor>
+    </projectile>
+  </ThingDef>
 
-	<ThingDef ParentName="BaseFlamethrowerBullet">
-		<defName>Bullet_Flamethrower_Prometheum</defName>
-		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
-		<label>jellied prometheum stream</label>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>PrometheumFlame</damageDef>
-			<damageAmountBase>5</damageAmountBase>
-			<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
-			<preExplosionSpawnChance>0.67</preExplosionSpawnChance>
-			<soundExplode>CE_FlamethrowerExplosion</soundExplode>
-			<explosionRadius>1.2</explosionRadius>
-			<ai_IsIncendiary>true</ai_IsIncendiary>
-			<screenShakeFactor>0</screenShakeFactor>
-		</projectile>
-	</ThingDef>
+  <ThingDef ParentName="BaseFlamethrowerBullet">
+    <defName>Bullet_Flamethrower_Prometheum</defName>
+    <thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+    <label>jellied prometheum stream</label>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageDef>PrometheumFlame</damageDef>
+      <damageAmountBase>5</damageAmountBase>
+      <preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
+      <preExplosionSpawnChance>0.67</preExplosionSpawnChance>
+      <soundExplode>CE_FlamethrowerExplosion</soundExplode>
+      <explosionRadius>1.2</explosionRadius>
+      <ai_IsIncendiary>true</ai_IsIncendiary>
+      <screenShakeFactor>0</screenShakeFactor>
+    </projectile>
+  </ThingDef>
 
-	<!-- ==================== Recipes ========================== -->
+  <!-- ==================== Recipes ========================== -->
 
-	<RecipeDef Name="FlamethrowerAmmoRecipeBase" ParentName="AmmoRecipeBase" Abstract="true">
-		<workSpeedStat>DrugSynthesisSpeed</workSpeedStat>
-		<effectWorking>Cook</effectWorking>
-		<soundWorking>Recipe_CookMeal</soundWorking>
-		<workSkill>Intellectual</workSkill>
-	</RecipeDef>
+  <RecipeDef Name="FlamethrowerAmmoRecipeBase" ParentName="AmmoRecipeBase" Abstract="true">
+    <workSpeedStat>DrugSynthesisSpeed</workSpeedStat>
+    <effectWorking>Cook</effectWorking>
+    <soundWorking>Recipe_CookMeal</soundWorking>
+    <workSkill>Intellectual</workSkill>
+  </RecipeDef>
 
-	<RecipeDef ParentName="FlamethrowerAmmoRecipeBase">
-		<defName>MakeAmmo_Flamethrower_Napalm</defName>
-		<label>make jellied chemfuel x100</label>
-		<description>Craft 100 units of jellied chemfuel.</description>
-		<jobString>Making jellied chemfuel.</jobString>
-		<ingredients>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>Chemfuel</li>
-					</thingDefs>
-				</filter>
-				<count>10</count>
-			</li>
-		</ingredients>
-		<fixedIngredientFilter>
-			<thingDefs>
-				<li>Chemfuel</li>
-			</thingDefs>
-		</fixedIngredientFilter>
-		<products>
-			<Ammo_Flamethrower_Napalm>100</Ammo_Flamethrower_Napalm>
-		</products>
-	</RecipeDef>
+  <RecipeDef ParentName="FlamethrowerAmmoRecipeBase">
+    <defName>MakeAmmo_Flamethrower_Napalm</defName>
+    <label>make jellied chemfuel x100</label>
+    <description>Craft 100 units of jellied chemfuel.</description>
+    <jobString>Making jellied chemfuel.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Chemfuel</li>
+          </thingDefs>
+        </filter>
+        <count>10</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Chemfuel</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_Flamethrower_Napalm>100</Ammo_Flamethrower_Napalm>
+    </products>
+  </RecipeDef>
 
-	<RecipeDef ParentName="FlamethrowerAmmoRecipeBase">
-		<defName>MakeAmmo_Flamethrower_Prometheum</defName>
-		<label>make jellied prometheum x100</label>
-		<description>Craft 100 units of jellied prometheum.</description>
-		<jobString>Making jellied prometheum.</jobString>
-		<ingredients>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>Prometheum</li>
-					</thingDefs>
-				</filter>
-				<count>10</count>
-			</li>
-		</ingredients>
-		<fixedIngredientFilter>
-			<thingDefs>
-				<li>Prometheum</li>
-			</thingDefs>
-		</fixedIngredientFilter>
-		<products>
-			<Ammo_Flamethrower_Prometheum>100</Ammo_Flamethrower_Prometheum>
-		</products>
-		<skillRequirements>
-			<Crafting>4</Crafting>
-		</skillRequirements>
-	</RecipeDef>
+  <RecipeDef ParentName="FlamethrowerAmmoRecipeBase">
+    <defName>MakeAmmo_Flamethrower_Prometheum</defName>
+    <label>make jellied prometheum x100</label>
+    <description>Craft 100 units of jellied prometheum.</description>
+    <jobString>Making jellied prometheum.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Prometheum</li>
+          </thingDefs>
+        </filter>
+        <count>10</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Prometheum</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_Flamethrower_Prometheum>100</Ammo_Flamethrower_Prometheum>
+    </products>
+    <skillRequirements>
+      <Crafting>4</Crafting>
+    </skillRequirements>
+  </RecipeDef>
 
 </Defs>

--- a/Defs/Effects/Flecks.xml
+++ b/Defs/Effects/Flecks.xml
@@ -252,7 +252,7 @@
     <graphicData>
       <texPath>Things/Mote/FireGlow</texPath>
       <shaderType>MoteGlow</shaderType>
-      <color>(1, 0.9, 0.9)</color>
+      <color>(1, 0.7, 0.7)</color>
     </graphicData>
     <altitudeLayer>MoteOverhead</altitudeLayer>
     <fadeInTime>0</fadeInTime>

--- a/Defs/Effects/Flecks.xml
+++ b/Defs/Effects/Flecks.xml
@@ -1,249 +1,277 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Defs>
-	<FleckDef ParentName="FleckBase" Name="CE_CasingFleckBase" Abstract="True">
-		<fleckSystemClass>CombatExtended.FleckSystem_Casing</fleckSystemClass>
-		<acceleration>(0,0,-5)</acceleration>
-	</FleckDef>
+  <FleckDef ParentName="FleckBase" Name="CE_CasingFleckBase" Abstract="True">
+    <fleckSystemClass>CombatExtended.FleckSystem_Casing</fleckSystemClass>
+    <acceleration>(0,0,-5)</acceleration>
+  </FleckDef>
 
-	<!--=============== Thrown Bullet Casings ==============-->
+  <!--=============== Thrown Bullet Casings ==============-->
 
-	<FleckDef ParentName="CE_CasingFleckBase">
-		<defName>Fleck_EmptyCasing</defName>
-		<graphicData>
-			<texPath>Things/Flecks/Fleck_BulletCasing</texPath>
-			<renderInstanced>true</renderInstanced>
-		</graphicData>
-		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<solidTime>3.0</solidTime>
-		<fadeOutTime>0.2</fadeOutTime>
-		<landSound>C_Impact_BulletCasing</landSound>
-		<collide>true</collide>
-	</FleckDef>
+  <FleckDef ParentName="CE_CasingFleckBase">
+    <defName>Fleck_EmptyCasing</defName>
+    <graphicData>
+      <texPath>Things/Flecks/Fleck_BulletCasing</texPath>
+      <renderInstanced>true</renderInstanced>
+    </graphicData>
+    <altitudeLayer>MoteOverhead</altitudeLayer>
+    <solidTime>3.0</solidTime>
+    <fadeOutTime>0.2</fadeOutTime>
+    <landSound>C_Impact_BulletCasing</landSound>
+    <collide>true</collide>
+  </FleckDef>
 
-	<FleckDef ParentName="CE_CasingFleckBase">
-		<defName>Fleck_PistolAmmoCasings</defName>
-		<graphicData>
-			<texPath>Things/Flecks/Fleck_PistolAmmoCasings</texPath>
-			<renderInstanced>true</renderInstanced>
-		</graphicData>
-		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<solidTime>3.0</solidTime>
-		<fadeOutTime>0.2</fadeOutTime>
-		<landSound>C_Impact_BulletCasing</landSound>
-		<collide>true</collide>
-	</FleckDef>
+  <FleckDef ParentName="CE_CasingFleckBase">
+    <defName>Fleck_PistolAmmoCasings</defName>
+    <graphicData>
+      <texPath>Things/Flecks/Fleck_PistolAmmoCasings</texPath>
+      <renderInstanced>true</renderInstanced>
+    </graphicData>
+    <altitudeLayer>MoteOverhead</altitudeLayer>
+    <solidTime>3.0</solidTime>
+    <fadeOutTime>0.2</fadeOutTime>
+    <landSound>C_Impact_BulletCasing</landSound>
+    <collide>true</collide>
+  </FleckDef>
 
-	<FleckDef ParentName="CE_CasingFleckBase">
-		<defName>Fleck_RifleAmmoCasings_Steel</defName>
-		<graphicData>
-			<texPath>Things/Flecks/Fleck_SteelRifleAmmoCasings</texPath>
-			<renderInstanced>true</renderInstanced>
-		</graphicData>
-		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<solidTime>3.0</solidTime>
-		<fadeOutTime>0.2</fadeOutTime>
-		<landSound>C_Impact_BulletCasing</landSound>
-		<collide>true</collide>
-	</FleckDef>
+  <FleckDef ParentName="CE_CasingFleckBase">
+    <defName>Fleck_RifleAmmoCasings_Steel</defName>
+    <graphicData>
+      <texPath>Things/Flecks/Fleck_SteelRifleAmmoCasings</texPath>
+      <renderInstanced>true</renderInstanced>
+    </graphicData>
+    <altitudeLayer>MoteOverhead</altitudeLayer>
+    <solidTime>3.0</solidTime>
+    <fadeOutTime>0.2</fadeOutTime>
+    <landSound>C_Impact_BulletCasing</landSound>
+    <collide>true</collide>
+  </FleckDef>
 
-	<FleckDef ParentName="CE_CasingFleckBase">
-		<defName>Fleck_RifleAmmoCasings_HighCal</defName>
-		<graphicData>
-			<texPath>Things/Flecks/Fleck_RifleAmmoCasings_HighCal</texPath>
-			<renderInstanced>true</renderInstanced>
-		</graphicData>
-		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<solidTime>3.0</solidTime>
-		<fadeOutTime>0.2</fadeOutTime>
-		<landSound>C_Impact_BulletCasing</landSound>
-		<collide>true</collide>
-	</FleckDef>
+  <FleckDef ParentName="CE_CasingFleckBase">
+    <defName>Fleck_RifleAmmoCasings_HighCal</defName>
+    <graphicData>
+      <texPath>Things/Flecks/Fleck_RifleAmmoCasings_HighCal</texPath>
+      <renderInstanced>true</renderInstanced>
+    </graphicData>
+    <altitudeLayer>MoteOverhead</altitudeLayer>
+    <solidTime>3.0</solidTime>
+    <fadeOutTime>0.2</fadeOutTime>
+    <landSound>C_Impact_BulletCasing</landSound>
+    <collide>true</collide>
+  </FleckDef>
 
-	<FleckDef ParentName="CE_CasingFleckBase">
-		<defName>Fleck_ShotgunShell</defName>
-		<graphicData>
-			<texPath>Things/Flecks/Fleck_ShotgunShell</texPath>
-			<renderInstanced>true</renderInstanced>
-		</graphicData>
-		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<solidTime>3.0</solidTime>
-		<fadeOutTime>0.2</fadeOutTime>
-		<landSound>C_Impact_ShotgunCasingImpact</landSound>
-		<collide>true</collide>
-	</FleckDef>
+  <FleckDef ParentName="CE_CasingFleckBase">
+    <defName>Fleck_ShotgunShell</defName>
+    <graphicData>
+      <texPath>Things/Flecks/Fleck_ShotgunShell</texPath>
+      <renderInstanced>true</renderInstanced>
+    </graphicData>
+    <altitudeLayer>MoteOverhead</altitudeLayer>
+    <solidTime>3.0</solidTime>
+    <fadeOutTime>0.2</fadeOutTime>
+    <landSound>C_Impact_ShotgunCasingImpact</landSound>
+    <collide>true</collide>
+  </FleckDef>
 
-	<FleckDef ParentName="CE_CasingFleckBase">
-		<defName>Fleck_ShotgunShell_Green</defName>
-		<graphicData>
-			<texPath>Things/Flecks/Fleck_ShotgunShell_Green</texPath>
-			<renderInstanced>true</renderInstanced>
-		</graphicData>
-		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<solidTime>3.0</solidTime>
-		<fadeOutTime>0.2</fadeOutTime>
-		<landSound>C_Impact_ShotgunCasingImpact</landSound>
-		<collide>true</collide>
-	</FleckDef>
+  <FleckDef ParentName="CE_CasingFleckBase">
+    <defName>Fleck_ShotgunShell_Green</defName>
+    <graphicData>
+      <texPath>Things/Flecks/Fleck_ShotgunShell_Green</texPath>
+      <renderInstanced>true</renderInstanced>
+    </graphicData>
+    <altitudeLayer>MoteOverhead</altitudeLayer>
+    <solidTime>3.0</solidTime>
+    <fadeOutTime>0.2</fadeOutTime>
+    <landSound>C_Impact_ShotgunCasingImpact</landSound>
+    <collide>true</collide>
+  </FleckDef>
 
-	<FleckDef ParentName="CE_CasingFleckBase">
-		<defName>Fleck_ShotgunShell_White</defName>
-		<graphicData>
-			<texPath>Things/Flecks/Fleck_ShotgunShell_White</texPath>
-			<renderInstanced>true</renderInstanced>
-		</graphicData>
-		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<solidTime>3.0</solidTime>
-		<fadeOutTime>0.2</fadeOutTime>
-		<landSound>C_Impact_ShotgunCasingImpact</landSound>
-		<collide>true</collide>
-	</FleckDef>
+  <FleckDef ParentName="CE_CasingFleckBase">
+    <defName>Fleck_ShotgunShell_White</defName>
+    <graphicData>
+      <texPath>Things/Flecks/Fleck_ShotgunShell_White</texPath>
+      <renderInstanced>true</renderInstanced>
+    </graphicData>
+    <altitudeLayer>MoteOverhead</altitudeLayer>
+    <solidTime>3.0</solidTime>
+    <fadeOutTime>0.2</fadeOutTime>
+    <landSound>C_Impact_ShotgunCasingImpact</landSound>
+    <collide>true</collide>
+  </FleckDef>
 
-	<FleckDef ParentName="CE_CasingFleckBase">
-		<defName>Fleck_ShotgunShell_Black</defName>
-		<graphicData>
-			<texPath>Things/Flecks/Fleck_ShotgunShell_Black</texPath>
-			<renderInstanced>true</renderInstanced>
-		</graphicData>
-		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<solidTime>3.0</solidTime>
-		<fadeOutTime>0.2</fadeOutTime>
-		<landSound>C_Impact_ShotgunCasingImpact</landSound>
-		<collide>true</collide>
-	</FleckDef>
+  <FleckDef ParentName="CE_CasingFleckBase">
+    <defName>Fleck_ShotgunShell_Black</defName>
+    <graphicData>
+      <texPath>Things/Flecks/Fleck_ShotgunShell_Black</texPath>
+      <renderInstanced>true</renderInstanced>
+    </graphicData>
+    <altitudeLayer>MoteOverhead</altitudeLayer>
+    <solidTime>3.0</solidTime>
+    <fadeOutTime>0.2</fadeOutTime>
+    <landSound>C_Impact_ShotgunCasingImpact</landSound>
+    <collide>true</collide>
+  </FleckDef>
 
-	<FleckDef ParentName="CE_CasingFleckBase">
-		<defName>Fleck_GrenadeLauncherAmmoCasings</defName>
-		<graphicData>
-			<texPath>Things/Flecks/Fleck_GrenadeLauncherAmmoCasings</texPath>
-			<renderInstanced>true</renderInstanced>
-		</graphicData>
-		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<solidTime>3.0</solidTime>
-		<fadeOutTime>0.2</fadeOutTime>
-		<landSound>C_Impact_CannonShellCasing</landSound>
-		<collide>true</collide>
-	</FleckDef>
+  <FleckDef ParentName="CE_CasingFleckBase">
+    <defName>Fleck_GrenadeLauncherAmmoCasings</defName>
+    <graphicData>
+      <texPath>Things/Flecks/Fleck_GrenadeLauncherAmmoCasings</texPath>
+      <renderInstanced>true</renderInstanced>
+    </graphicData>
+    <altitudeLayer>MoteOverhead</altitudeLayer>
+    <solidTime>3.0</solidTime>
+    <fadeOutTime>0.2</fadeOutTime>
+    <landSound>C_Impact_CannonShellCasing</landSound>
+    <collide>true</collide>
+  </FleckDef>
 
-	<FleckDef ParentName="CE_CasingFleckBase">
-		<defName>Fleck_BigShell</defName>
-		<graphicData>
-			<texPath>Things/Flecks/Fleck_BigShell</texPath>
-			<renderInstanced>true</renderInstanced>
-		</graphicData>
-		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<solidTime>3.0</solidTime>
-		<fadeOutTime>0.2</fadeOutTime>
-		<landSound>C_Impact_CannonShellCasing</landSound>
-		<collide>true</collide>
-	</FleckDef>
+  <FleckDef ParentName="CE_CasingFleckBase">
+    <defName>Fleck_BigShell</defName>
+    <graphicData>
+      <texPath>Things/Flecks/Fleck_BigShell</texPath>
+      <renderInstanced>true</renderInstanced>
+    </graphicData>
+    <altitudeLayer>MoteOverhead</altitudeLayer>
+    <solidTime>3.0</solidTime>
+    <fadeOutTime>0.2</fadeOutTime>
+    <landSound>C_Impact_CannonShellCasing</landSound>
+    <collide>true</collide>
+  </FleckDef>
 
-	<FleckDef ParentName="CE_CasingFleckBase">
-		<defName>Fleck_GrenadePin</defName>
-		<graphicData>
-			<texPath>Things/Flecks/Fleck_GrenadePin</texPath>
-			<renderInstanced>true</renderInstanced>
-		</graphicData>
-		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<solidTime>3.0</solidTime>
-		<fadeOutTime>0.2</fadeOutTime>
-		<landSound>C_Impact_BulletCasing</landSound>
-		<collide>true</collide>
-	</FleckDef>
+  <FleckDef ParentName="CE_CasingFleckBase">
+    <defName>Fleck_GrenadePin</defName>
+    <graphicData>
+      <texPath>Things/Flecks/Fleck_GrenadePin</texPath>
+      <renderInstanced>true</renderInstanced>
+    </graphicData>
+    <altitudeLayer>MoteOverhead</altitudeLayer>
+    <solidTime>3.0</solidTime>
+    <fadeOutTime>0.2</fadeOutTime>
+    <landSound>C_Impact_BulletCasing</landSound>
+    <collide>true</collide>
+  </FleckDef>
 
-	<FleckDef ParentName="CE_CasingFleckBase">
-		<defName>Fleck_DisposableLauncherCasing</defName>
-		<graphicData>
-			<texPath>Things/Filth/Filth_DisposableLauncherCasings/Filth_DisposableLauncherCasings</texPath>
-			<renderInstanced>true</renderInstanced>
-			<drawSize>(1.5,1.5)</drawSize>
-		</graphicData>
-		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<solidTime>3.0</solidTime>
-		<fadeOutTime>0.2</fadeOutTime>
-		<landSound>C_Impact_BulletCasing</landSound>
-		<collide>true</collide>
-	</FleckDef>
+  <FleckDef ParentName="CE_CasingFleckBase">
+    <defName>Fleck_DisposableLauncherCasing</defName>
+    <graphicData>
+      <texPath>Things/Filth/Filth_DisposableLauncherCasings/Filth_DisposableLauncherCasings</texPath>
+      <renderInstanced>true</renderInstanced>
+      <drawSize>(1.5,1.5)</drawSize>
+    </graphicData>
+    <altitudeLayer>MoteOverhead</altitudeLayer>
+    <solidTime>3.0</solidTime>
+    <fadeOutTime>0.2</fadeOutTime>
+    <landSound>C_Impact_BulletCasing</landSound>
+    <collide>true</collide>
+  </FleckDef>
 
-	<!--=============== For 40k Ammo ==============-->
+  <!--=============== For 40k Ammo ==============-->
 
-	<!-- === Casings === -->
-	<FleckDef ParentName="CE_CasingFleckBase">
-		<defName>Mote_BolterCasing</defName>
-		<graphicData>
-			<texPath>ThirdParty/Warhammer/Casings/Mote_CasingBolterSmall</texPath>
-		</graphicData>
-		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<solidTime>1.0</solidTime>
-		<fadeOutTime>0.2</fadeOutTime>
-		<landSound>C_Impact_BulletCasing</landSound>
-		<collide>true</collide>
-	</FleckDef>
+  <!-- === Casings === -->
+  <FleckDef ParentName="CE_CasingFleckBase">
+    <defName>Mote_BolterCasing</defName>
+    <graphicData>
+      <texPath>ThirdParty/Warhammer/Casings/Mote_CasingBolterSmall</texPath>
+    </graphicData>
+    <altitudeLayer>MoteOverhead</altitudeLayer>
+    <solidTime>1.0</solidTime>
+    <fadeOutTime>0.2</fadeOutTime>
+    <landSound>C_Impact_BulletCasing</landSound>
+    <collide>true</collide>
+  </FleckDef>
 
-	<FleckDef ParentName="CE_CasingFleckBase">
-		<defName>Mote_HeavyBolterCasing</defName>
-		<graphicData>
-			<texPath>ThirdParty/Warhammer/Casings/Mote_CasingBolterLarge</texPath>
-		</graphicData>
-		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<solidTime>1.0</solidTime>
-		<fadeOutTime>0.2</fadeOutTime>
-		<landSound>C_Impact_BulletCasing</landSound>
-		<collide>true</collide>
-	</FleckDef>
+  <FleckDef ParentName="CE_CasingFleckBase">
+    <defName>Mote_HeavyBolterCasing</defName>
+    <graphicData>
+      <texPath>ThirdParty/Warhammer/Casings/Mote_CasingBolterLarge</texPath>
+    </graphicData>
+    <altitudeLayer>MoteOverhead</altitudeLayer>
+    <solidTime>1.0</solidTime>
+    <fadeOutTime>0.2</fadeOutTime>
+    <landSound>C_Impact_BulletCasing</landSound>
+    <collide>true</collide>
+  </FleckDef>
 
-	<!-- === Melta Gun === -->
-	<ThingDef ParentName="MoteBase">
-		<defName>Mote_MeltaFlash</defName>
-		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<mote>
-			<landSound />
-			<solidTime>0.15</solidTime>
-			<fadeOutTime>0.2</fadeOutTime>
-		</mote>
-		<graphicData>
-			<texPath>ThirdParty/Warhammer/MeltaProjectile</texPath>
-			<shaderType>MoteGlow</shaderType>
-		</graphicData>
-	</ThingDef>
+  <!-- === Melta Gun === -->
+  <ThingDef ParentName="MoteBase">
+    <defName>Mote_MeltaFlash</defName>
+    <altitudeLayer>MoteOverhead</altitudeLayer>
+    <mote>
+      <landSound />
+      <solidTime>0.15</solidTime>
+      <fadeOutTime>0.2</fadeOutTime>
+    </mote>
+    <graphicData>
+      <texPath>ThirdParty/Warhammer/MeltaProjectile</texPath>
+      <shaderType>MoteGlow</shaderType>
+    </graphicData>
+  </ThingDef>
 
-	<FleckDef ParentName="FleckBase_Thrown">
-		<defName>Fleck_CERocketSmoke</defName>
-		<graphicData>
-			<texPath>Things/Mote/Smoke</texPath>
-			<shaderType>Transparent</shaderType>
-			<color>(1, 1, 1,0.6)</color>
-		</graphicData>
-		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<fadeInTime>0.14</fadeInTime>
-		<solidTime>0.05</solidTime>
-		<fadeOutTime>1.5</fadeOutTime>
-		<growthRate>2</growthRate>
-	</FleckDef>
+  <FleckDef ParentName="FleckBase_Thrown">
+    <defName>Fleck_CERocketSmoke</defName>
+    <graphicData>
+      <texPath>Things/Mote/Smoke</texPath>
+      <shaderType>Transparent</shaderType>
+      <color>(1, 1, 1,0.6)</color>
+    </graphicData>
+    <altitudeLayer>MoteOverhead</altitudeLayer>
+    <fadeInTime>0.14</fadeInTime>
+    <solidTime>0.05</solidTime>
+    <fadeOutTime>1.5</fadeOutTime>
+    <growthRate>2</growthRate>
+  </FleckDef>
 
-	<FleckDef ParentName="FleckBase_Thrown">
-		<defName>Fleck_CERocketSmokeTrail</defName>
-		<graphicData>
-			<texPath>Things/Mote/Smoke</texPath>
-			<shaderType>Transparent</shaderType>
-			<color>(1, 1, 1,0.3)</color>
-		</graphicData>
-		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<fadeInTime>0.14</fadeInTime>
-		<solidTime>0.05</solidTime>
-		<fadeOutTime>5</fadeOutTime>
-		<growthRate>1</growthRate>
-	</FleckDef>
+  <FleckDef ParentName="FleckBase_Thrown">
+    <defName>Fleck_CERocketSmokeTrail</defName>
+    <graphicData>
+      <texPath>Things/Mote/Smoke</texPath>
+      <shaderType>Transparent</shaderType>
+      <color>(1, 1, 1,0.3)</color>
+    </graphicData>
+    <altitudeLayer>MoteOverhead</altitudeLayer>
+    <fadeInTime>0.14</fadeInTime>
+    <solidTime>0.05</solidTime>
+    <fadeOutTime>5</fadeOutTime>
+    <growthRate>1</growthRate>
+  </FleckDef>
 
-	<FleckDef ParentName="FleckBase_Thrown">
-		<defName>Fleck_CERocketFlame</defName>
-		<graphicData>
-			<texPath>Things/Mote/FireGlow</texPath>
-			<shaderType>MoteGlow</shaderType>
-		</graphicData>
-		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<fadeInTime>0</fadeInTime>
-		<solidTime>0.03</solidTime>
-		<fadeOutTime>0.05</fadeOutTime>
-		<growthRate>-5</growthRate>
-	</FleckDef>
+  <FleckDef ParentName="FleckBase_Thrown">
+    <defName>Fleck_CERocketFlame</defName>
+    <graphicData>
+      <texPath>Things/Mote/FireGlow</texPath>
+      <shaderType>MoteGlow</shaderType>
+    </graphicData>
+    <altitudeLayer>MoteOverhead</altitudeLayer>
+    <fadeInTime>0</fadeInTime>
+    <solidTime>0.03</solidTime>
+    <fadeOutTime>0.05</fadeOutTime>
+    <growthRate>-5</growthRate>
+  </FleckDef>
+
+  <FleckDef ParentName="FleckBase_Thrown">
+    <defName>Fleck_CEFlamethrowerTrail</defName>
+    <graphicData>
+      <texPath>Things/Mote/FireGlow</texPath>
+      <shaderType>MoteGlow</shaderType>
+      <color>(1, 0.9, 0.9)</color>
+    </graphicData>
+    <altitudeLayer>MoteOverhead</altitudeLayer>
+    <fadeInTime>0</fadeInTime>
+    <solidTime>0.03</solidTime>
+    <fadeOutTime>0.25</fadeOutTime>
+    <growthRate>0</growthRate>
+  </FleckDef>
+
+  <FleckDef ParentName="FleckBase_Thrown">
+    <defName>Fleck_CEFlamethrowerSmokeTrail</defName>
+    <graphicData>
+      <texPath>Things/Mote/Smoke</texPath>
+      <shaderType>Transparent</shaderType>
+      <color>(0.5, 0.5, 0.5)</color>
+    </graphicData>
+    <altitudeLayer>MoteOverhead</altitudeLayer>
+    <fadeInTime>0.14</fadeInTime>
+    <solidTime>0.05</solidTime>
+    <fadeOutTime>2</fadeOutTime>
+    <growthRate>-0.15</growthRate>
+  </FleckDef>
 </Defs>

--- a/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier1/Bunsen.xml
+++ b/Patches/Vanilla Vehicles Expanded/VehicleDefs/Tier1/Bunsen.xml
@@ -1,246 +1,253 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 
-	<Operation Class="PatchOperationFindMod">
-		<mods>
-			<li>Vanilla Vehicles Expanded</li>
-		</mods>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Vehicles Expanded</li>
+    </mods>
 
-		<match Class="PatchOperationSequence">
-			<operations>
+    <match Class="PatchOperationSequence">
+      <operations>
 
-				<!-- Turret -->
+        <!-- Turret -->
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/projectile</xpath>
-					<value>
-						<projectile>Bullet_Flamethrower_Prometheum</projectile>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/projectile</xpath>
+          <value>
+            <projectile>Bullet_Flamethrower_Prometheum</projectile>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/reloadTimer</xpath>
-					<value>
-						<reloadTimer>7.0</reloadTimer>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/reloadTimer</xpath>
+          <value>
+            <reloadTimer>7.0</reloadTimer>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/warmUpTimer</xpath>
-					<value>
-						<warmUpTimer>1.0</warmUpTimer>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/warmUpTimer</xpath>
+          <value>
+            <warmUpTimer>1.0</warmUpTimer>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/magazineCapacity</xpath>
-					<value>
-						<magazineCapacity>200</magazineCapacity>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/magazineCapacity</xpath>
+          <value>
+            <magazineCapacity>200</magazineCapacity>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/maxRange</xpath>
-					<value>
-						<maxRange>40</maxRange>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/maxRange</xpath>
+          <value>
+            <maxRange>40</maxRange>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/fireModes</xpath>
-					<value>
-						<fireModes>
-							<li>
-								<shotsPerBurst>5</shotsPerBurst>
-								<ticksBetweenShots>3</ticksBetweenShots>
-								<ticksBetweenBursts>60</ticksBetweenBursts>
-								<label>Burst</label>
-								<texPath>UI/Gizmos/FireRate_Burst</texPath>
-							</li>
-							<li>
-								<shotsPerBurst>10</shotsPerBurst>
-								<ticksBetweenShots>3</ticksBetweenShots>
-								<ticksBetweenBursts>60</ticksBetweenBursts>
-								<label>Auto</label>
-								<texPath>UI/Gizmos/FireRate_Auto</texPath>
-							</li>
-						</fireModes>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/projectileOffset</xpath>
+          <value>
+            <projectileOffset>1</projectileOffset>
+          </value>
+        </li>
 
-				<li Class="PatchOperationAddModExtension">
-					<xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]</xpath>
-					<value>
-						<li Class="Vehicles.CETurretDataDefModExtension">
-							<ammoSet>AmmoSet_Flamethrower</ammoSet>
-							<shotHeight>2.0</shotHeight>
-							<speed>20</speed>
-							<sway>0.25</sway>
-							<spread>0.30</spread>
-						</li>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]/fireModes</xpath>
+          <value>
+            <fireModes>
+              <li>
+                <shotsPerBurst>5</shotsPerBurst>
+                <ticksBetweenShots>3</ticksBetweenShots>
+                <ticksBetweenBursts>60</ticksBetweenBursts>
+                <label>Burst</label>
+                <texPath>UI/Gizmos/FireRate_Burst</texPath>
+              </li>
+              <li>
+                <shotsPerBurst>10</shotsPerBurst>
+                <ticksBetweenShots>3</ticksBetweenShots>
+                <ticksBetweenBursts>60</ticksBetweenBursts>
+                <label>Auto</label>
+                <texPath>UI/Gizmos/FireRate_Auto</texPath>
+              </li>
+            </fireModes>
+          </value>
+        </li>
 
-				<!-- Vehicle -->
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]</xpath>
-					<value>
-						<descriptionHyperlinks>
-							<CombatExtended.AmmoSetDef>AmmoSet_Flamethrower</CombatExtended.AmmoSetDef>
-						</descriptionHyperlinks>
-					</value>
-				</li>
+        <li Class="PatchOperationAddModExtension">
+          <xpath>Defs/Vehicles.VehicleTurretDef[defName="VVE_Bunsen_MainTurret"]</xpath>
+          <value>
+            <li Class="Vehicles.CETurretDataDefModExtension">
+              <ammoSet>AmmoSet_Flamethrower</ammoSet>
+              <shotHeight>2.0</shotHeight>
+              <speed>20</speed>
+              <sway>0.25</sway>
+              <spread>0.30</spread>
+            </li>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/comps/li[@Class="Vehicles.CompProperties_VehicleTurrets"]</xpath>
-					<value>
-						<li Class="Vehicles.CompProperties_VehicleTurrets">
-							<turrets>
-								<li>
-									<turretDef>VVE_Bunsen_MainTurret</turretDef>
-									<renderProperties>
-										<north>(-0.05, 0.2)</north>
-										<south>(-0.02, 0.2)</south>
-										<east>(-0.02, 0.4)</east>
-									</renderProperties>
-									<gizmoLabel>Main Turret</gizmoLabel>
-									<angleRestricted />
-									<aimPieOffset>(0, 1.5)</aimPieOffset>
-									<key>mainTurret</key>
-								</li>
-							</turrets>
-						</li>
-					</value>
-				</li>
+        <!-- Vehicle -->
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]</xpath>
+          <value>
+            <descriptionHyperlinks>
+              <CombatExtended.AmmoSetDef>AmmoSet_Flamethrower</CombatExtended.AmmoSetDef>
+            </descriptionHyperlinks>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/comps/li[@Class="Vehicles.CompProperties_FueledTravel"]/fuelCapacity</xpath>
-					<value>
-						<fuelCapacity>120</fuelCapacity>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/comps/li[@Class="Vehicles.CompProperties_VehicleTurrets"]</xpath>
+          <value>
+            <li Class="Vehicles.CompProperties_VehicleTurrets">
+              <turrets>
+                <li>
+                  <turretDef>VVE_Bunsen_MainTurret</turretDef>
+                  <renderProperties>
+                    <north>(-0.05, 0.2)</north>
+                    <south>(-0.02, 0.2)</south>
+                    <east>(-0.02, 0.4)</east>
+                  </renderProperties>
+                  <gizmoLabel>Main Turret</gizmoLabel>
+                  <angleRestricted />
+                  <aimPieOffset>(0, 1.5)</aimPieOffset>
+                  <key>mainTurret</key>
+                </li>
+              </turrets>
+            </li>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/statBases/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>10</ArmorRating_Blunt>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/comps/li[@Class="Vehicles.CompProperties_FueledTravel"]/fuelCapacity</xpath>
+          <value>
+            <fuelCapacity>120</fuelCapacity>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/statBases/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>5</ArmorRating_Sharp>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/statBases/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>10</ArmorRating_Blunt>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="FrontArmorPlating"]/health</xpath>
-					<value>
-						<health>220</health>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/statBases/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>5</ArmorRating_Sharp>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>8</ArmorRating_Blunt>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="FrontArmorPlating"]/health</xpath>
+          <value>
+            <health>220</health>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>4</ArmorRating_Sharp>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>8</ArmorRating_Blunt>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="LeftArmorPlating"]/health</xpath>
-					<value>
-						<health>180</health>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>4</ArmorRating_Sharp>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>8</ArmorRating_Blunt>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="LeftArmorPlating"]/health</xpath>
+          <value>
+            <health>180</health>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>4</ArmorRating_Sharp>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>8</ArmorRating_Blunt>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="RightArmorPlating"]/health</xpath>
-					<value>
-						<health>180</health>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>4</ArmorRating_Sharp>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>10</ArmorRating_Blunt>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="RightArmorPlating"]/health</xpath>
+          <value>
+            <health>180</health>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>5</ArmorRating_Sharp>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>10</ArmorRating_Blunt>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="BackArmorPlating"]/health</xpath>
-					<value>
-						<health>180</health>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>5</ArmorRating_Sharp>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="BackArmorPlating"]/armor/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>10</ArmorRating_Blunt>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="BackArmorPlating"]/health</xpath>
+          <value>
+            <health>180</health>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="BackArmorPlating"]/armor/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>5</ArmorRating_Sharp>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="BackArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>10</ArmorRating_Blunt>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="Roof"]/health</xpath>
-					<value>
-						<health>180</health>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="BackArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>5</ArmorRating_Sharp>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="Roof"]/armor/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>8</ArmorRating_Blunt>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="Roof"]/health</xpath>
+          <value>
+            <health>180</health>
+          </value>
+        </li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="Roof"]/armor/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>4</ArmorRating_Sharp>
-					</value>
-				</li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="Roof"]/armor/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>8</ArmorRating_Blunt>
+          </value>
+        </li>
 
-			</operations>
-		</match>
-	</Operation>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/Vehicles.VehicleDef[defName="VVE_Bunsen"]/components/li[key="Roof"]/armor/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>4</ArmorRating_Sharp>
+          </value>
+        </li>
+
+      </operations>
+    </match>
+  </Operation>
 
 </Patch>


### PR DESCRIPTION
## Changes

Redone flamethrower projectile graphic using rocket trail function

## Reasoning

So that flamethrowers don't comically throw literal balls of fire, instead fires a trail of burning liquid
![image](https://github.com/CombatExtended-Continued/CombatExtended/assets/62052103/6ce37c9a-3438-4c3c-9997-e69350b24c1f)


## Alternatives

"firethrower"

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
