### PR TITLE
Simplify magless ammo pickup fallback

### DIFF
--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_TakeAndEquip.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_TakeAndEquip.cs
@@ -490,7 +490,7 @@ namespace CombatExtended
                                                 {
                                                     Job job = JobMaker.MakeJob(JobDefOf.TakeInventory, th);
                                                     int maxAmmoToPickup = (primaryAmmoUserWithInventoryCheck.MagSizeOverride > 0) ? primaryAmmoUserWithInventoryCheck.MagSizeOverride * 4 : primaryAmmoUserWithInventoryCheck.MagSize * 4;
-                                                    job.count = (maxAmmoToPickup > 0) ? Mathf.Min(numToCarry, maxAmmoToPickup) : Mathf.CeilToInt(numToCarry / 4);
+                                                    job.count = (maxAmmoToPickup > 0) ? Mathf.Min(numToCarry, maxAmmoToPickup) : numToCarry; // fallback to pick up all available ammo
                                                     return job;
                                                 }
                                             }


### PR DESCRIPTION
## Changes

- Simplified the pickup behavior for mag-less weapons to pick up the entire available stack. Pickups for weapons with magazines remain unchanged.

## Reasoning

- Previous behavior led to potential pickup loops when pawns' available bulk was still in range of the pickup check as bows don't check for having <2 mags already picked up.
- The resulting small stacks of ammo sometimes also ended up below the minimun bulk check for the pickup job, leading to more undesireable behavior.
- Ideally bows and other mag-less weapons should get a mag size override added to them and this should be kept as the last fallback.

## Alternatives

- Add a more robust check for ammo already picked up for mag-less weapons.
- Rely exclusively on mag size override for mag-less weapons.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] Playtested a colony (specify how long)
