### PR TITLE
make last partialarmorext apply instead of first

### DIFF
--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -415,7 +415,7 @@ namespace CombatExtended
 
         #region Misc
         /// <summary>
-        /// Generates a random Vector2 in a circle with given radius
+        /// Returns the last occurance (instead of first) of a modextension
         /// </summary>
 
         public static T GetLastModExtension<T>(this Def def) where T : DefModExtension

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -414,6 +414,25 @@ namespace CombatExtended
         #endregion
 
         #region Misc
+        /// <summary>
+        /// Generates a random Vector2 in a circle with given radius
+        /// </summary>
+
+        public static T GetLastModExtension<T>(this Def def) where T : DefModExtension
+        {
+            if (def.modExtensions == null)
+            {
+                return null;
+            }
+            for (int i = def.modExtensions.Count - 1; i >= 0; i--)
+            {
+                if (def.modExtensions[i] is T)
+                {
+                    return def.modExtensions[i] as T;
+                }
+            }
+            return null;
+        }
 
         /// <summary>
         /// Gets the true rating of armor with partial stats taken into account

--- a/Source/CombatExtended/Harmony/Harmony_ThingDef.cs
+++ b/Source/CombatExtended/Harmony/Harmony_ThingDef.cs
@@ -120,4 +120,31 @@ namespace CombatExtended.HarmonyCE
             }
         }
     }
+
+    [HarmonyPatch(typeof(ThingDef), "PostLoad")]
+    static class PostLoad_PostFix
+    {
+        [HarmonyPostfix]
+        public static void Postfix(ThingDef __instance)
+        {
+            if (__instance.HasModExtension<PartialArmorExt>())
+            {
+                List<DefModExtension> list = __instance.modExtensions.Where(e => e.GetType() == typeof(PartialArmorExt)).ToList();
+                if (list.Count > 1)
+                {
+                    PartialArmorExt mergedExt = new PartialArmorExt();
+                    mergedExt.stats = new List<ApparelPartialStat>();
+                    foreach (PartialArmorExt ext in list)
+                    {
+                        foreach (ApparelPartialStat partial in ext.stats)
+                        {
+                            mergedExt.stats.Add(partial);
+                        }
+                        __instance.modExtensions.Remove(ext);
+                    }
+                    __instance.modExtensions.Add(mergedExt);
+                }
+            }
+        }
+    }
 }

--- a/Source/CombatExtended/Harmony/Harmony_ThingDef.cs
+++ b/Source/CombatExtended/Harmony/Harmony_ThingDef.cs
@@ -132,17 +132,10 @@ namespace CombatExtended.HarmonyCE
                 List<DefModExtension> list = __instance.modExtensions.Where(e => e.GetType() == typeof(PartialArmorExt)).ToList();
                 if (list.Count > 1)
                 {
-                    PartialArmorExt mergedExt = new PartialArmorExt();
-                    mergedExt.stats = new List<ApparelPartialStat>();
-                    foreach (PartialArmorExt ext in list)
+                    for (int i = 0; i < list.Count - 1; i++)
                     {
-                        foreach (ApparelPartialStat partial in ext.stats)
-                        {
-                            mergedExt.stats.Add(partial);
-                        }
-                        __instance.modExtensions.Remove(ext);
+                        __instance.modExtensions.Remove(list[i]);
                     }
-                    __instance.modExtensions.Add(mergedExt);
                 }
             }
         }


### PR DESCRIPTION
## Additions

Added a def.GetLastModExtension<T> function for returning last modextension for future use

## Changes

A patch in def postload will remove every occurance of partialarmorext except the last. so that partialarmorext in parent defs won't intefere

## Reasoning

so that the partialarmorext in base mechanoid won't prevent editing partial armor.

## Alternatives

Suffer.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
