### PR TITLE
5.6 final fixes

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -84,6 +84,7 @@
 		<li>botchjob.divineorder</li>
 		<li>OskarPotocki.VFE.Deserters</li>
 		<li>OskarPotocki.VFE.Tribals</li>
+		<li>Sarg.AlphaMemes</li>
 	</loadAfter>
 
 </ModMetaData>

--- a/About/About.xml
+++ b/About/About.xml
@@ -83,6 +83,7 @@
 		<li>Killathon.MechHumanlikes.MechanicalBiomimetics</li>
 		<li>botchjob.divineorder</li>
 		<li>OskarPotocki.VFE.Deserters</li>
+		<li>OskarPotocki.VFE.Tribals</li>
 	</loadAfter>
 
 </ModMetaData>

--- a/Patches/Alpha Memes/StyleCategoryDefs/StyleCategoryDefs.xml
+++ b/Patches/Alpha Memes/StyleCategoryDefs/StyleCategoryDefs.xml
@@ -14,6 +14,18 @@
 				<xpath>Defs/StyleCategoryDef/thingDefStyles/li[thingDef="Flamebow"]</xpath>
 			</li>
 
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/StyleCategoryDef/thingDefStyles/li[thingDef="Gun_EmpLauncher"]</xpath>
+			</li>
+
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/StyleCategoryDef/thingDefStyles/li[thingDef="Gun_ToxbombLauncher"]</xpath>
+			</li>
+
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/StyleCategoryDef/thingDefStyles/li[thingDef="Gun_SmokeLauncher"]</xpath>
+			</li>
+
 			</operations>
 		</match>
 	</Operation>

--- a/Patches/Alpha Memes/StyleCategoryDefs/StyleCategoryDefs.xml
+++ b/Patches/Alpha Memes/StyleCategoryDefs/StyleCategoryDefs.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Alpha Memes</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- Remove styles for weapons that no longer exist. -->
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/StyleCategoryDef/thingDefStyles/li[thingDef="Flamebow"]</xpath>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Rimsenal - Spacer Faction Pack/Explosives_Smart_CE.xml
+++ b/Patches/Rimsenal - Spacer Faction Pack/Explosives_Smart_CE.xml
@@ -180,21 +180,6 @@
 					<xpath>Defs</xpath>
 					<value>
 
-						<RecipeDef Name="RSExplosive_RecipeBase" Abstract="true">
-							<workSpeedStat>GeneralLaborSpeed</workSpeedStat>
-							<effectWorking>Cook</effectWorking>
-							<soundWorking>Recipe_Smith</soundWorking>
-							<workSkill>Crafting</workSkill>
-							<unfinishedThingDef>UnfinishedGun</unfinishedThingDef>
-							<fixedIngredientFilter>
-								<thingDefs>
-									<li>Plasteel</li>
-									<li>ComponentIndustrial</li>
-									<li>FSX</li>
-								</thingDefs>
-							</fixedIngredientFilter>
-						</RecipeDef>
-
 						<!-- YP BaegYa Microwave Grenades -->
 						<RecipeDef ParentName="RSExplosive_RecipeBase">
 

--- a/Patches/Rimsenal Collection/Core/Weapons_Explosives.xml
+++ b/Patches/Rimsenal Collection/Core/Weapons_Explosives.xml
@@ -493,21 +493,6 @@
 					<xpath>Defs</xpath>
 					<value>
 
-						<RecipeDef Name="RSExplosive_RecipeBase" Abstract="true">
-							<workSpeedStat>GeneralLaborSpeed</workSpeedStat>
-							<effectWorking>Cook</effectWorking>
-							<soundWorking>Recipe_Smith</soundWorking>
-							<workSkill>Crafting</workSkill>
-							<unfinishedThingDef>UnfinishedGun</unfinishedThingDef>
-							<fixedIngredientFilter>
-								<thingDefs>
-									<li>Plasteel</li>
-									<li>ComponentIndustrial</li>
-									<li>FSX</li>
-								</thingDefs>
-							</fixedIngredientFilter>
-						</RecipeDef>
-
 						<!-- YP BaegYa Microwave Grenades -->
 						<RecipeDef ParentName="RSExplosive_RecipeBase">
 							<defName>Craft_10_BaegYa</defName>

--- a/Patches/Rimsenal Collection/Core/Weapons_ExplosivesRecipeBase.xml
+++ b/Patches/Rimsenal Collection/Core/Weapons_ExplosivesRecipeBase.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Rimsenal - Core</li>
+		</mods>
+		<match Class="PatchOperationAdd">
+			<value>
+
+			<RecipeDef Name="RSExplosive_RecipeBase" Abstract="true">
+				<workSpeedStat>GeneralLaborSpeed</workSpeedStat>
+				<effectWorking>Cook</effectWorking>
+				<soundWorking>Recipe_Smith</soundWorking>
+				<workSkill>Crafting</workSkill>
+				<unfinishedThingDef>UnfinishedGun</unfinishedThingDef>
+				<fixedIngredientFilter>
+					<thingDefs>
+						<li>Plasteel</li>
+						<li>ComponentIndustrial</li>
+						<li>FSX</li>
+					</thingDefs>
+				</fixedIngredientFilter>
+			</RecipeDef>
+
+			</value>
+
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Rimsenal Collection/Core/Weapons_ExplosivesRecipeBase.xml
+++ b/Patches/Rimsenal Collection/Core/Weapons_ExplosivesRecipeBase.xml
@@ -4,8 +4,10 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>Rimsenal - Core</li>
+			<li>Rimsenal - Spacer Faction Pack</li>			
 		</mods>
 		<match Class="PatchOperationAdd">
+			<xpath>Defs</xpath>
 			<value>
 
 			<RecipeDef Name="RSExplosive_RecipeBase" Abstract="true">

--- a/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Buildings/TurretGatlingGun.xml
+++ b/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Buildings/TurretGatlingGun.xml
@@ -77,8 +77,8 @@
 				</li>
 
 				<!-- == costList == -->
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="Turret_GatlingGun"]</xpath>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Turret_GatlingGun"]/costList</xpath>
 					<value>
 						<costList>
 							<Steel>325</Steel>


### PR DESCRIPTION
A handful of small fixes for the 5.6 release.

## Changes
- Load VFE - Tribals before CE. It modifies some of the VWE - Tribal weapons we also modify, causing the patch to fail.
- Resolve duplicate explosive recipe base for the Rimsenal series--easiest to just load it in a separate file.
- Fix a duplicate `costList` for the VWE - Settlers Gatling gun.
- Alpha Memes: Patch out styles for weapons CE removes and make AM load before CE to prevent errors.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
