### PR TITLE
5.6 hotfix for broken projectiles

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompFragments.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompFragments.cs
@@ -96,7 +96,7 @@ namespace CombatExtended
                 FloatRange fragXZAngleRange;
                 if (parent is ProjectileCE projCE)
                 {
-                    height = projCE.Height;
+                    height = projCE.ExactPosition.y;
                     fragXZAngleRange = new FloatRange(projCE.shotRotation + PropsCE.fragXZAngleRange.min, projCE.shotRotation + PropsCE.fragXZAngleRange.max);
                 }
                 else

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -1210,16 +1210,16 @@ namespace CombatExtended
             LastPos = ExactPosition;
             ticksToImpact--;
             flightTicks++;
-            Vector3 nextPosition;
             if (lerpPosition)
             {
                 var v = Vec2Position();
-                nextPosition = new Vector3(v.x, GetHeightAtTicks(flightTicks), v.y);
+                ExactPosition = new Vector3(v.x, GetHeightAtTicks(flightTicks), v.y);
             }
             else
             {
-                nextPosition = MoveForward();
+                ExactPosition = MoveForward();
             }
+            Vector3 nextPosition = ExactPosition;
             if (!nextPosition.InBounds(Map))
             {
                 if (globalTargetInfo.IsValid)
@@ -1249,7 +1249,6 @@ namespace CombatExtended
                 Destroy();
                 return;
             }
-            ExactPosition = nextPosition;
             if (CheckForCollisionBetween())
             {
                 return;

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -248,7 +248,7 @@ namespace CombatExtended
             return Vector2.Lerp(origin, Destination, ticks / StartingTicksToImpact);
         }
 
-        private Vector3? exactPosition = null;
+        private Vector3 exactPosition;
         /// <summary>
         /// Exact x,y,z (x,height,y) position in terms of Vec2Position.x, .y (lerped origin to Destination) and Height.
         /// </summary>
@@ -256,16 +256,12 @@ namespace CombatExtended
         {
             set
             {
-                exactPosition = new Vector3(value.x, value.y, value.z);
-                Position = ((Vector3)exactPosition).ToIntVec3();
+                exactPosition = value;
+                Position = value.ToIntVec3();
             }
             get
             {
-                if (exactPosition == null)
-                {
-                    exactPosition = new Vector3(origin.x, shotHeight, origin.y);
-                }
-                return ((Vector3)exactPosition);
+                return exactPosition;
             }
         }
 
@@ -285,7 +281,7 @@ namespace CombatExtended
             }
         }
 
-        private Vector3 lastExactPos = new Vector3(-1000, 0, 0);
+        private Vector3 lastExactPos;
         public Vector3 LastPos
         {
             protected set
@@ -294,11 +290,6 @@ namespace CombatExtended
             }
             get
             {
-                if (lastExactPos.x < -999)
-                {
-                    var lastPos = Vec2Position(FlightTicks - 1);
-                    lastExactPos = new Vector3(lastPos.x, GetHeightAtTicks(FlightTicks - 1), lastPos.y);
-                }
                 return lastExactPos;
             }
         }
@@ -676,6 +667,7 @@ namespace CombatExtended
         {
             this.launcher = launcher;
             this.origin = origin;
+            this.exactPosition = this.lastExactPos = new Vector3(origin.x, shotHeight, origin.y);
             this.equipment = equipment;
             //For explosives/bullets, equipmentDef is important
             equipmentDef = (equipment != null) ? equipment.def : null;

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -1222,7 +1222,7 @@ namespace CombatExtended
             if (lerpPosition)
             {
                 var v = Vec2Position();
-                nextPosition = new Vector3(v.x, Height, v.y);
+                nextPosition = new Vector3(v.x, GetHeightAtTicks(flightTicks), v.y);
             }
             else
             {

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -152,6 +152,7 @@ namespace CombatExtended
         {
             get
             {
+                Log.ErrorOnce("ProjectileCE.Height is deprecated, use ProjectileCE.ExactPosition.y instead", 12748107);
                 return ExactPosition.y;
             }
         }

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -1325,7 +1325,7 @@ namespace CombatExtended
                     //TODO : EXPERIMENTAL Add edifice height
                     var shadowPos = new Vector3(ExactPosition.x,
                                                 def.Altitude - 0.01f,
-                                                ExactPosition.z - Mathf.Lerp(shotHeight, 0f, fTicks / StartingTicksToImpact));
+                                                ExactPosition.z - Mathf.Lerp(ExactPosition.y, 0f, fTicks / StartingTicksToImpact));
                     //EXPERIMENTAL: + (new CollisionVertical(ExactPosition.ToIntVec3().GetEdifice(Map))).Max);
 
                     //TODO : Vary ShadowMat plane

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_Flare.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_Flare.cs
@@ -36,7 +36,7 @@ namespace CombatExtended
             base.Tick();
             if (decentStarted)
             {
-                if (Height <= FLYOVER_FLARING_HEIGHT && Rand.Chance(FLYOVER_FLARING_CHANCE))
+                if (ExactPosition.y <= FLYOVER_FLARING_HEIGHT && Rand.Chance(FLYOVER_FLARING_CHANCE))
                 {
                     Impact(null);
                 }
@@ -53,7 +53,7 @@ namespace CombatExtended
             Flare flare;
             flare = (Flare)ThingMaker.MakeThing(CE_ThingDefOf.Flare, null);
             flare.DrawMode = Flare.FlareDrawMode.FlyOver;
-            flare.StartingAltitude = Height;
+            flare.StartingAltitude = ExactPosition.y;
             flare.Position = Position;
             flare.SpawnSetup(Map, false);
             base.Impact(null);

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_HeightFuse.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_HeightFuse.cs
@@ -32,7 +32,7 @@ namespace CombatExtended
             {
                 armed = true;
             }
-            if (armed && Height <= detonationHeight)
+            if (armed && ExactPosition.y <= detonationHeight)
             {
                 HeightFuseAirBurst();
             }
@@ -41,7 +41,7 @@ namespace CombatExtended
         public override void Impact(Thing hitThing)
         {
             //intercept impact if it hit something after where height fuse should have triggered
-            if (armed && Height <= detonationHeight)
+            if (armed && ExactPosition.y <= detonationHeight)
             {
                 HeightFuseAirBurst();
             }
@@ -53,7 +53,7 @@ namespace CombatExtended
 
         void HeightFuseAirBurst()
         {
-            float f = (LastPos.y - detonationHeight) / (LastPos.y - Height);
+            float f = (LastPos.y - detonationHeight) / (LastPos.y - ExactPosition.y);
             ExactPosition = f * (LastPos - ExactPosition);
             if (!ExactPosition.ToIntVec3().IsValid)
             {


### PR DESCRIPTION

## Reasoning
- Projectile Height returned a cached value.  Projectile next position relied on projectile height.  This lead to projectile height being frozen.  
- Deprecating ProjectileCE.Height makes it clear that ProjectileCE.ExactPosition is the sole authority on CE-related projectile positioning.  Also it removes a virtual lookup so will have marginally better performance.
- By storing the next "frame" directly into ExactPosition and then pulling a local copy inside Tick, subclasses of ProjectileCE can override how ExactPosition gets updated entirely, without forcing updating ExactPosition into a virtual call in the trivial case.
- Explicitly initializing ExactPosition and LastExactPosition during launch removes a messy and moderately expensive calculation and removes the need for a nullable, which should further help performance.
- Projectiles should use their *current* rather than *initial* height for determining where to draw shadows

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (minutes)
