### PR TITLE
Additional Fixes for 5.6 Hotfix

### DIFF
--- a/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Buildings/TurretGatlingGun.xml
+++ b/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Buildings/TurretGatlingGun.xml
@@ -77,8 +77,8 @@
 				</li>
 
 				<!-- == costList == -->
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="Turret_GatlingGun"]/costList</xpath>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Turret_GatlingGun"]</xpath>
 					<value>
 						<costList>
 							<Steel>325</Steel>

--- a/Source/CombatExtended/CombatExtended/Comps/CompSuppressable.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompSuppressable.cs
@@ -246,7 +246,7 @@ namespace CombatExtended
         }
         public bool IgnoreSuppresion(IntVec3 origin)
         {
-            return BlockerRegistry.PawnUnsuppresableFromCallback(parent as Pawn, origin) || SuppressionUtility.InterceptorZonesFor((Pawn)parent).Where(x => x.Contains(parent.Position)).Any(x => !x.Contains(origin));
+            return BlockerRegistry.PawnUnsuppressableFromCallback(parent as Pawn, origin) || SuppressionUtility.InterceptorZonesFor((Pawn)parent).Where(x => x.Contains(parent.Position)).Any(x => !x.Contains(origin));
         }
 
         public override void CompTick()

--- a/Source/CombatExtended/Compatibility/BlockerRegistry.cs
+++ b/Source/CombatExtended/Compatibility/BlockerRegistry.cs
@@ -21,7 +21,7 @@ namespace CombatExtended.Compatibility
         private static List<Func<ProjectileCE, IntVec3, Thing, bool>> checkCellForCollisionCallbacks;
         private static List<Func<ProjectileCE, Thing, bool>> impactSomethingCallbacks;
         private static List<Func<ProjectileCE, Thing, bool>> beforeCollideWithCallbacks;
-        private static List<Func<Pawn, IntVec3, bool>> pawnUnsuppresableFromCallback;
+        private static List<Func<Pawn, IntVec3, bool>> pawnUnsuppressableFromCallback;
         private static List<Func<Thing, IEnumerable<IEnumerable<IntVec3>>>> shieldZonesCallback;
 
         private static void EnableCB()
@@ -47,7 +47,7 @@ namespace CombatExtended.Compatibility
         private static void EnablePUF()
         {
             enabledPUF = true;
-            pawnUnsuppresableFromCallback = new List<Func<Pawn, IntVec3, bool>>();
+            pawnUnsuppressableFromCallback = new List<Func<Pawn, IntVec3, bool>>();
         }
         private static void EnableBCW()
         {
@@ -118,7 +118,7 @@ namespace CombatExtended.Compatibility
             {
                 EnablePUF();
             }
-            pawnUnsuppresableFromCallback.Add(f);
+            pawnUnsuppressableFromCallback.Add(f);
         }
 
         public static bool CheckCellForCollisionCallback(ProjectileCE projectile, IntVec3 cell, Thing launcher)
@@ -159,13 +159,13 @@ namespace CombatExtended.Compatibility
             }
             return shieldZonesCallback.SelectMany(cb => cb(thing));
         }
-        public static bool PawnUnsuppresableFromCallback(Pawn pawn, IntVec3 origin)
+        public static bool PawnUnsuppressableFromCallback(Pawn pawn, IntVec3 origin)
         {
             if (!enabledPUF)
             {
                 return false;
             }
-            foreach (var cb in pawnUnsuppresableFromCallback)
+            foreach (var cb in pawnUnsuppressableFromCallback)
             {
                 if (cb(pawn, origin))
                 {


### PR DESCRIPTION
## Changes
- Correct spelling error `PawnUnsuppresableFromCallback` to `PawnUnsuppressableFromCallback`.
- Fix an error in the VFE - Settlers patch.

## Reasoning
- Spelling error could create confusion and inconsistency, and so should be fixed.
- Patch operation was broken.

## Alternatives
Suffer.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
