### PR TITLE
Handle apparel that isn't armor more gracefully

### DIFF
--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -352,7 +352,10 @@ namespace CombatExtended
                         {
                             if (penAmount == 0 || armorAmount == 0)
                             {
-                                Log.ErrorOnce($"penAmount or armorAmount are zero for {def.armorCategory} on {armor}", 846532021);
+                                if (armor.GetStatValue(StatDefOf.ArmorRating_Sharp) == 0 && armor.GetStatValue(StatDefOf.ArmorRating_Blunt) == 0 && armor.GetStatValue(StatDefOf.ArmorRating_Heat) == 0)
+                                {
+                                    Log.ErrorOnce($"penAmount or armorAmount are zero for {def.armorCategory} on {armor}", armor.def.GetHashCode() + 846532021);
+                                }
                             }
                             else
                             {


### PR DESCRIPTION

## Changes

If apparel offers 0 protection against sharp, blunt, or fire, don't warn when the pen system can't handle it gracefully.

## Reasoning

Avoids log spam for nv goggles and the like.

## Alternatives

implement our own warnOnce like function to not drop red errors in the log

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
