### PR TITLE
Revert the HCB accuracy nerf

### DIFF
--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -1187,7 +1187,7 @@
 		</AmmoUser>
 		<FireModes>
 			<aimedBurstShotCount>10</aimedBurstShotCount>
-			<aiAimMode>SuppressFire</aiAimMode>
+			<aiAimMode>Snapshot</aiAimMode>
 		</FireModes>
 		<weaponTags>
 			<li>CE_AI_Suppressive</li>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
@@ -646,7 +646,7 @@
 					</AmmoUser>
 					<FireModes>
 						<aimedBurstShotCount>15</aimedBurstShotCount>
-						<aiAimMode>SuppressFire</aiAimMode>
+						<aiAimMode>Snapshot</aiAimMode>
 					</FireModes>
 					<weaponTags>
 						<li>VFE_AdvMechanoidGunHeavy</li>


### PR DESCRIPTION
## Changes

- Reverts the changes made to the HCB fire mode here: https://github.com/CombatExtended-Continued/CombatExtended/pull/2925.

## Reasoning

- It's a "I told you so" moment. As expected, blasterpedes are not hitting anything according to the two reports already made in the discord. (There will be more similar reports until the next update). Changing the default fire mode just to counter an edge-case strategy that is not common enough is not a good idea.

https://discord.com/channels/278818534069501953/278818534069501953/1202697911859941496
https://discord.com/channels/278818534069501953/303988654492090370/1202827629778968576

## Alternatives

- Keep HCBs the mockery they currently are.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
