### PR TITLE
Add missing startup loc string

### DIFF
--- a/Languages/English/Keyed/LongEventHandler.xml
+++ b/Languages/English/Keyed/LongEventHandler.xml
@@ -5,5 +5,6 @@
 	<CE_LongEvent_AmmoInjector>Injecting ammunition</CE_LongEvent_AmmoInjector>
 	<CE_LongEvent_BoundingBoxes>Generating CombatExtended bounding boxes</CE_LongEvent_BoundingBoxes>
 	<CE_LongEvent_TutorialPopup>Loading tutorial pop-up</CE_LongEvent_TutorialPopup>
+	<CE_LongEvent_CompatibilityPatches>Applying compatibility patches</CE_LongEvent_CompatibilityPatches>
 
 </LanguageData>

--- a/Languages/Russian/Keyed/LongEventHandler.xml
+++ b/Languages/Russian/Keyed/LongEventHandler.xml
@@ -5,5 +5,6 @@
 	<CE_LongEvent_AmmoInjector>Injecting ammunition</CE_LongEvent_AmmoInjector>
 	<CE_LongEvent_BoundingBoxes>Создание ограничивающих рамок CombatExtended</CE_LongEvent_BoundingBoxes>
 	<CE_LongEvent_TutorialPopup>Loading tutorial pop-up</CE_LongEvent_TutorialPopup>
+	<CE_LongEvent_CompatibilityPatches>Применение модулей совместимости</CE_LongEvent_CompatibilityPatches>
 
 </LanguageData>


### PR DESCRIPTION
## Additions

- Added a missing loc string to the `CE_LongEvent_CompatibilityPatches` event during startup, along with a russian version.

## Alternatives

- The russian string may not be using the correct technical terms, so could be replaced.

## Testing

Check tests you have performed:
- [x] Game runs without errors
