### PR TITLE
Adjusting consistency between [RH2] Bounty Hunter and [RH2] DOOM

### DIFF
--- a/Patches/RH2 Faction - Bounty Hunters/BountyHunters_Gun.xml
+++ b/Patches/RH2 Faction - Bounty Hunters/BountyHunters_Gun.xml
@@ -73,7 +73,7 @@
 					<AmmoUser>
 						<magazineSize>60</magazineSize>
 						<reloadTime>4.9</reloadTime>
-						<ammoSet>AmmoSet_PlasmaCellRifle</ammoSet>
+						<ammoSet>AmmoSet_Doom2016PlasmaGun</ammoSet>
 					</AmmoUser>
 					<FireModes>
 						<aiAimMode>AimedShot</aiAimMode>


### PR DESCRIPTION
## Additions
-Changing what ammo the S3 Plasma Gun from [RH2] Bounty Hunter to use UAC Plasma Cell in place of the generic Plasma Cell Rifle to make it more consistent with the newly added [RH2] DOOM Patch.

## Changes
- Changing S3 AmmoSet from Plasma Cell Rifle to UAC Plasma Cell

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (2 hour of gameplay)
