### PR TITLE
Patch [K4G] Empires of Old - Core & Factions

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -85,6 +85,7 @@
 		<li>OskarPotocki.VFE.Deserters</li>
 		<li>OskarPotocki.VFE.Tribals</li>
 		<li>Sarg.AlphaMemes</li>
+		<li>K4G.Sultanate</li>
 	</loadAfter>
 
 </ModMetaData>

--- a/Patches/K4G Empires of Old - Core/Apparel.xml
+++ b/Patches/K4G Empires of Old - Core/Apparel.xml
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[K4G] Empires of Old - Core</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<!-- Thawb, Kimono -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+					@Name="K4GThawb" or
+					@Name="K4GKimono"
+					]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<Bulk>1.5</Bulk>
+						<WornBulk>1</WornBulk>
+						<StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+
+				<!-- Headgear -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+					@Name="K4GTurban" or
+					@Name="K4GHeadScarf" or
+					defName="K4G_Apparel_TricornHat" or
+					defName="K4G_Apparel_ConeHat" or
+					defName="K4G_Apparel_HoodedMask"
+					]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+						<Bulk>1</Bulk>
+						<WornBulk>0</WornBulk>
+					</value>
+				</li>
+
+				<!-- Imperial & Outlander Helmet -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="K4GImperialHelmet" or defName="K4G_Apparel_OutlanderHelmet"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
+						<Bulk>3</Bulk>
+						<WornBulk>1</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="K4GImperialHelmet" or defName="K4G_Apparel_OutlanderHelmet"]/stuffCategories/li[.="Metallic"]</xpath>
+					<value>
+						<li>Steeled</li>
+					</value>
+				</li>
+
+				<!-- Goggled & Advanced Outlander Helmet -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+					defName="K4G_Apparel_AdvancedOutlanderHelmet" or
+					defName="K4G_Apparel_GoggledHelmet" or
+					defName="K4G_Apparel_LegionaryHelmet"
+					]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>
+						<Bulk>3</Bulk>
+						<WornBulk>1</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+					defName="K4G_Apparel_AdvancedOutlanderHelmet" or
+					defName="K4G_Apparel_GoggledHelmet" or
+					defName="K4G_Apparel_LegionaryHelmet"					
+					]/stuffCategories/li[.="Metallic"]</xpath>
+					<value>
+						<li>Steeled</li>
+					</value>
+				</li>
+
+				<!-- Flak Mask -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="K4G_Apparel_FlakMask"]/statBases/ArmorRating_Sharp </xpath>
+					<value>
+						<ArmorRating_Sharp>5</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="K4G_Apparel_FlakMask"]/statBases/ArmorRating_Blunt </xpath>
+					<value>
+						<ArmorRating_Blunt>6</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="K4G_Apparel_FlakMask"]/apparel/layers/li[.="EyeCover"] </xpath>
+					<value>
+						<li>StrappedHead</li>
+					</value>
+				</li>
+
+				<!-- Coveralls & Overcoat-->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="K4GCoveralls" or @Name="K4GOvercoat"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<Bulk>2</Bulk>
+						<WornBulk>1</WornBulk>
+						<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+
+				<!-- Advanced Flak Vest -->
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="K4G_Apparel_AdvancedFlakVest"]/statBases/ArmorRating_Sharp </xpath>
+					<value>
+						<ArmorRating_Sharp>6</ArmorRating_Sharp>
+						<Bulk>5</Bulk>
+						<WornBulk>3.5</WornBulk>						
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="K4G_Apparel_AdvancedFlakVest"]/statBases/ArmorRating_Blunt </xpath>
+					<value>
+						<ArmorRating_Blunt>8</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="K4G_Apparel_AdvancedFlakVest"]/statBases/MaxHitPoints</xpath>
+					<value>
+						<MaxHitPoints>150</MaxHitPoints>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/ThingDef[defName="K4G_Apparel_AdvancedFlakVest"]</xpath>
+					<value>
+						<li Class="CombatExtended.PartialArmorExt">
+							<stats>
+								<li>
+									<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
+									<parts>
+										<li>Neck</li>
+										<li>Shoulder</li>
+									</parts>
+								</li>
+								<li>
+									<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
+									<parts>
+										<li>Neck</li>
+										<li>Shoulder</li>
+									</parts>
+								</li>
+							</stats>
+						</li>
+					</value>
+				</li>
+
+				<!-- Goggles -->
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="K4G_Apparel_Goggles"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>0.5</StuffEffectMultiplierArmor>
+						<Bulk>0.5</Bulk>
+						<WornBulk>0</WornBulk>
+					</value>
+				</li>
+
+				<!-- Lab Coat -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="K4G_Apparel_LabCoat"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<Bulk>7.5</Bulk>
+						<WornBulk>1</WornBulk>
+						<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/K4G Empires of Old - Core/Apparel_Royalty.xml
+++ b/Patches/K4G Empires of Old - Core/Apparel_Royalty.xml
@@ -8,13 +8,24 @@
 		<match Class="PatchOperationSequence">
 			<operations>
 
-			<!-- Dynasty Crown -->
+			<li Class="PatchOperationFindMod">
+				<mods>
+					<li>Royalty</li>
+				</mods>
+				<match Class="PatchOperationSequence">
+					<operations>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="K4G_Apparel_DynastyCrown"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>
-				</value>
+					<!-- Dynasty Crown -->
+
+					<li Class="PatchOperationReplace">
+						<xpath>Defs/ThingDef[defName="K4G_Apparel_DynastyCrown"]/statBases/StuffEffectMultiplierArmor</xpath>
+						<value>
+							<StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>
+						</value>
+					</li>				
+
+					</operations>
+				</match>
 			</li>
 
 			</operations>

--- a/Patches/K4G Empires of Old - Core/Apparel_Royalty.xml
+++ b/Patches/K4G Empires of Old - Core/Apparel_Royalty.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[K4G] Empires of Old - Core</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- Dynasty Crown -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="K4G_Apparel_DynastyCrown"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/K4G Empires of Old - Core/WeaponsMelee.xml
+++ b/Patches/K4G Empires of Old - Core/WeaponsMelee.xml
@@ -130,12 +130,14 @@
 				</value>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="K4G_MeleeWeapon_Katana"]/equippedStatOffsets/MeleeDodgeChance</xpath>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="K4G_MeleeWeapon_Katana"]</xpath>
 				<value>
-					<MeleeCritChance>0.95</MeleeCritChance>
-					<MeleeParryChance>0.54</MeleeParryChance>
-					<MeleeDodgeChance>0.33</MeleeDodgeChance>
+					<equippedStatOffsets>
+						<MeleeCritChance>0.95</MeleeCritChance>
+						<MeleeParryChance>0.54</MeleeParryChance>
+						<MeleeDodgeChance>0.33</MeleeDodgeChance>
+					</equippedStatOffsets>
 				</value>
 			</li>
 
@@ -251,13 +253,6 @@
 				<value>
 					<Bulk>4</Bulk>
 					<MeleeCounterParryBonus>0.38</MeleeCounterParryBonus>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="K4G_MeleeWeapon_Scimitar"]/statBases/Mass</xpath>
-				<value>
-					<Mass>1.1</Mass>
 				</value>
 			</li>
 
@@ -392,7 +387,6 @@
 					</tools>
 				</value>
 			</li>
-
 
 			</operations>
 		</match>

--- a/Patches/K4G Empires of Old - Core/WeaponsMelee.xml
+++ b/Patches/K4G Empires of Old - Core/WeaponsMelee.xml
@@ -1,0 +1,400 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[K4G] Empires of Old - Core</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- === Sabre === -->
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="K4G_MeleeWeapon_Sabre"]/statBases</xpath>
+				<value>
+					<Bulk>3.5</Bulk>
+					<MeleeCounterParryBonus>0.35</MeleeCounterParryBonus>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="K4G_MeleeWeapon_Sabre"]</xpath>
+				<value>
+					<equippedStatOffsets>
+						<MeleeCritChance>0.2</MeleeCritChance>
+						<MeleeParryChance>0.35</MeleeParryChance>
+						<MeleeDodgeChance>0.2</MeleeDodgeChance>
+					</equippedStatOffsets>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="K4G_MeleeWeapon_Sabre"]/weaponTags</xpath>
+				<value>
+					<li>CE_OneHandedWeapon</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="K4G_MeleeWeapon_Sabre"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>handle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>1.44</cooldownTime>
+							<armorPenetrationBlunt>0.425</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>point</label>
+							<capacities>
+								<li>Stab</li>
+							</capacities>
+							<power>27</power>
+							<cooldownTime>1.44</cooldownTime>
+							<armorPenetrationBlunt>0.425</armorPenetrationBlunt>
+							<armorPenetrationSharp>0.48</armorPenetrationSharp>
+							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>edge</label>
+							<capacities>
+								<li>Cut</li>
+							</capacities>
+							<power>20</power>
+							<cooldownTime>1.34</cooldownTime>
+							<chanceFactor>1.33</chanceFactor>
+							<armorPenetrationBlunt>0.956</armorPenetrationBlunt>
+							<armorPenetrationSharp>0.43</armorPenetrationSharp>
+							<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<!-- === Katanna === -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="K4G_MeleeWeapon_Katana"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>handle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>1.42</cooldownTime>
+							<chanceFactor>0.15</chanceFactor>
+							<armorPenetrationBlunt>0.4</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>point</label>
+							<capacities>
+								<li>Stab</li>
+							</capacities>
+							<power>13</power>
+							<cooldownTime>1.42</cooldownTime>
+							<chanceFactor>1</chanceFactor>
+							<armorPenetrationSharp>1.34</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.4</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>edge</label>
+							<capacities>
+								<li>Cut</li>
+							</capacities>
+							<power>28</power>
+							<cooldownTime>0.88</cooldownTime>
+							<chanceFactor>1</chanceFactor>
+							<armorPenetrationSharp>1.3</armorPenetrationSharp>
+							<armorPenetrationBlunt>1.936</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="K4G_MeleeWeapon_Katana"]/statBases</xpath>
+				<value>
+					<Bulk>8</Bulk>
+					<MeleeCounterParryBonus>1.27</MeleeCounterParryBonus>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="K4G_MeleeWeapon_Katana"]/equippedStatOffsets/MeleeDodgeChance</xpath>
+				<value>
+					<MeleeCritChance>0.95</MeleeCritChance>
+					<MeleeParryChance>0.54</MeleeParryChance>
+					<MeleeDodgeChance>0.33</MeleeDodgeChance>
+				</value>
+			</li>
+
+			<!-- === Cleaver === -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="K4G_MeleeWeapon_Cleaver"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>handle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>4</power>
+							<cooldownTime>1.83</cooldownTime>
+							<chanceFactor>0.15</chanceFactor>
+							<armorPenetrationBlunt>1.1</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>point</label>
+							<capacities>
+								<li>Stab</li>
+							</capacities>
+							<power>30</power>
+							<cooldownTime>1.89</cooldownTime>
+							<chanceFactor>1</chanceFactor>
+							<armorPenetrationSharp>0.84</armorPenetrationSharp>
+							<armorPenetrationBlunt>1.25</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>edge</label>
+							<capacities>
+								<li>Cut</li>
+							</capacities>
+							<power>44</power>
+							<cooldownTime>1.75</cooldownTime>
+							<chanceFactor>1</chanceFactor>
+							<armorPenetrationSharp>0.3</armorPenetrationSharp>
+							<armorPenetrationBlunt>4.05</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="K4G_MeleeWeapon_Cleaver"]/statBases</xpath>
+				<value>
+					<Bulk>11</Bulk>
+					<MeleeCounterParryBonus>0.35</MeleeCounterParryBonus>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="K4G_MeleeWeapon_Cleaver"]</xpath>
+				<value>
+					<equippedStatOffsets>
+						<MeleeCritChance>0.50</MeleeCritChance>
+						<MeleeParryChance>0.4</MeleeParryChance>
+						<MeleeDodgeChance>0.27</MeleeDodgeChance>
+					</equippedStatOffsets>
+				</value>
+			</li>
+
+			<!-- === Scimitar === -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="K4G_MeleeWeapon_Scimitar"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>handle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>1.54</cooldownTime>
+							<armorPenetrationBlunt>0.55</armorPenetrationBlunt>
+							<chanceFactor>0.15</chanceFactor>
+							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>point</label>
+							<capacities>
+								<li>Stab</li>
+							</capacities>
+							<power>23</power>
+							<cooldownTime>1.54</cooldownTime>
+							<armorPenetrationBlunt>0.55</armorPenetrationBlunt>
+							<armorPenetrationSharp>0.31</armorPenetrationSharp>
+							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>edge</label>
+							<capacities>
+								<li>Cut</li>
+							</capacities>
+							<power>28</power>
+							<cooldownTime>1.25</cooldownTime>
+							<armorPenetrationBlunt>1.782</armorPenetrationBlunt>
+							<armorPenetrationSharp>0.8</armorPenetrationSharp>
+							<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="K4G_MeleeWeapon_Scimitar"]/statBases</xpath>
+				<value>
+					<Bulk>4</Bulk>
+					<MeleeCounterParryBonus>0.38</MeleeCounterParryBonus>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="K4G_MeleeWeapon_Scimitar"]/statBases/Mass</xpath>
+				<value>
+					<Mass>1.1</Mass>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="K4G_MeleeWeapon_Scimitar"]</xpath>
+				<value>
+					<equippedStatOffsets>
+						<MeleeCritChance>0.24</MeleeCritChance>
+						<MeleeParryChance>0.38</MeleeParryChance>
+						<MeleeDodgeChance>0.28</MeleeDodgeChance>
+					</equippedStatOffsets>
+				</value>
+			</li>
+
+			<!-- === Glaive === -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="K4G_MeleeWeapon_Glaive"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>shaft</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>6</power>
+							<cooldownTime>1.16</cooldownTime>
+							<armorPenetrationBlunt>2.025</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Shaft</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>edge</label>
+							<capacities>
+								<li>Cut</li>
+							</capacities>
+							<power>47</power>
+							<cooldownTime>1.74</cooldownTime>
+							<chanceFactor>1.165</chanceFactor>
+							<armorPenetrationBlunt>8.1</armorPenetrationBlunt>
+							<armorPenetrationSharp>1.62</armorPenetrationSharp>
+							<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>point</label>
+							<capacities>
+								<li>Stab</li>
+							</capacities>
+							<power>40</power>
+							<cooldownTime>1.16</cooldownTime>
+							<chanceFactor>1.165</chanceFactor>
+							<armorPenetrationBlunt>2.025</armorPenetrationBlunt>
+							<armorPenetrationSharp>2.03</armorPenetrationSharp>
+							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="K4G_MeleeWeapon_Glaive"]/statBases</xpath>
+				<value>
+					<Bulk>10</Bulk>
+					<MeleeCounterParryBonus>0.89</MeleeCounterParryBonus>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="K4G_MeleeWeapon_Glaive"]</xpath>
+				<value>
+					<equippedStatOffsets>
+						<MeleeCritChance>0.22</MeleeCritChance>
+						<MeleeParryChance>1.33</MeleeParryChance>
+						<MeleeDodgeChance>0.57</MeleeDodgeChance>
+					</equippedStatOffsets>
+				</value>
+			</li>
+
+			<!-- === Baton === -->
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="K4G_MeleeWeapon_Baton"]/statBases</xpath>
+				<value>
+					<Bulk>2.75</Bulk>
+					<MeleeCounterParryBonus>0.9</MeleeCounterParryBonus>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="K4G_MeleeWeapon_Baton"]</xpath>
+				<value>
+					<equippedStatOffsets>
+						<MeleeCritChance>0.17</MeleeCritChance>
+						<MeleeParryChance>0.9</MeleeParryChance>
+						<MeleeDodgeChance>0.3</MeleeDodgeChance>
+					</equippedStatOffsets>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="K4G_MeleeWeapon_Baton"]/weaponTags</xpath>
+				<value>
+					<li>CE_Sidearm_Melee</li>
+					<li>CE_OneHandedWeapon</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="K4G_MeleeWeapon_Baton"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>handle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>2</power>
+							<chanceFactor>0.33</chanceFactor>
+							<cooldownTime>1.59</cooldownTime>
+							<armorPenetrationBlunt>0.625</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>9</power>
+							<cooldownTime>1.68</cooldownTime>
+							<armorPenetrationBlunt>3.375</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/K4G Empires of Old - Core/WeaponsRanged.xml
+++ b/Patches/K4G Empires of Old - Core/WeaponsRanged.xml
@@ -136,7 +136,7 @@
 				easier to make it a sort of 9mm pipe pistol. -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
-				<defName>K4G_Gun_Snubgun</defName>
+				<defName>K4G_Gun_Bolter</defName>
 				<statBases>
 					<Mass>1.33</Mass>
 					<RangedWeapon_Cooldown>0.42</RangedWeapon_Cooldown>

--- a/Patches/K4G Empires of Old - Core/WeaponsRanged.xml
+++ b/Patches/K4G Empires of Old - Core/WeaponsRanged.xml
@@ -131,6 +131,46 @@
 				</weaponTags>
 			</li>
 
+			<!-- ========== Bolter (Makeshift 9mm) ========== -->
+			<!-- Mod says it fires 'a sharp metal rod known as a bolt' and is generally junk,
+				easier to make it a sort of 9mm pipe pistol. -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>K4G_Gun_Snubgun</defName>
+				<statBases>
+					<Mass>1.33</Mass>
+					<RangedWeapon_Cooldown>0.42</RangedWeapon_Cooldown>
+					<SightsEfficiency>0.70</SightsEfficiency>
+					<ShotSpread>0.60</ShotSpread>
+					<SwayFactor>1.30</SwayFactor>
+					<Bulk>2.62</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>2.75</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_9x19mmParaSD_FMJ</defaultProjectile>
+					<warmupTime>0.5</warmupTime>
+					<range>10</range>
+					<soundCast>Shot_Autopistol</soundCast>
+					<soundCastTail>GunTail_Light</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>5</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_9x19mmParaSD</ammoSet> <!-- Simulate low velocity from poor construction.-->
+				</AmmoUser>
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>Snapshot</aiAimMode>
+				</FireModes>
+				<weaponTags>
+					<li>CE_AI_Pistol</li>
+					<li>CE_OneHandedWeapon</li>
+				</weaponTags>
+			</li>
+
 			<!-- ========== Advanced Autopistol (Glock 21) ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -168,6 +208,345 @@
 					<li>CE_AI_BROOM</li>
 					<li>CE_OneHandedWeapon</li>
 				</weaponTags>
+			</li>
+
+			<!-- === Precision Pistol (M1911 w/ 3x Scope) === -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>K4G_Gun_PrecisionPistol</defName>
+				<statBases>
+					<Mass>1.30</Mass>
+					<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.88</SightsEfficiency>
+					<ShotSpread>0.17</ShotSpread>
+					<SwayFactor>1.16</SwayFactor>
+					<Bulk>2.20</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>2.51</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
+					<warmupTime>1.0</warmupTime>
+					<range>18</range>
+					<soundCast>Shot_Autopistol</soundCast>
+					<soundCastTail>GunTail_Light</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>7</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_45ACP</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+				<weaponTags>
+					<li>CE_Sidearm</li>
+					<li>CE_OneHandedWeapon</li>					
+				</weaponTags>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="K4G_Gun_PrecisionPistol"]</xpath>
+				<value>
+					<li Class="CombatExtended.GunDrawExtension">
+						<DrawSize>0.93,0.93</DrawSize>
+						<DrawOffset>0.0,0.0</DrawOffset>
+					</li>
+				</value>
+			</li>
+
+			<!-- === Long Gun === -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>K4G_Gun_LongGun</defName>
+				<statBases>
+					<Mass>4.30</Mass>
+					<Bulk>12.50</Bulk>
+					<SwayFactor>1.67</SwayFactor>
+					<ShotSpread>0.02</ShotSpread>
+					<SightsEfficiency>1</SightsEfficiency>
+					<RangedWeapon_Cooldown>0.77</RangedWeapon_Cooldown>
+				</statBases>
+				<Properties>
+					<recoilAmount>1.75</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>True</hasStandardCommand>
+					<defaultProjectile>Bullet_44-40Winchester_FMJ</defaultProjectile>
+					<warmupTime>1.1</warmupTime>
+					<range>31</range>
+					<soundCast>Shot_BoltActionRifle</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>7</magazineSize>
+					<reloadTime>0.85</reloadTime>
+					<ammoSet>AmmoSet_44-40Winchester</ammoSet>
+					<reloadOneAtATime>true</reloadOneAtATime>
+				</AmmoUser>
+				<FireModes>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+			</li>
+
+			<!-- === Carbiner (M1 Carbine) === -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>K4G_Gun_Carbiner</defName>
+				<statBases>
+					<Mass>2.40</Mass>
+					<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.00</SightsEfficiency>
+					<ShotSpread>0.08</ShotSpread>
+					<SwayFactor>1.14</SwayFactor>
+					<Bulk>6.00</Bulk>
+				</statBases>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_30Carbine_FMJ</defaultProjectile>
+					<warmupTime>1.1</warmupTime>
+					<range>37</range>
+					<soundCast>Shot_BoltActionRifle</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>15</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_30Carbine</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+			</li>
+
+			<!-- === Dune Rifle === -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>K4G_Gun_DuneRifle</defName>
+				<statBases>
+					<Mass>4.10</Mass>
+					<Bulk>11.26</Bulk>
+					<SwayFactor>1.54</SwayFactor>
+					<ShotSpread>0.06</ShotSpread>
+					<SightsEfficiency>1</SightsEfficiency>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+				</statBases>
+				<Properties>
+					<recoilAmount>1.75</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>True</hasStandardCommand>
+					<defaultProjectile>Bullet_303British_FMJ</defaultProjectile>
+					<burstShotCount>2</burstShotCount>
+					<ticksBetweenBurstShots>3</ticksBetweenBurstShots>					
+					<warmupTime>1.1</warmupTime>
+					<range>52</range>
+					<soundCast>Shot_BoltActionRifle</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>10</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_303British</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiAimMode>AimedShot</aiAimMode>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+				</FireModes>
+			</li>
+
+			<!-- ========== Heavy Shotgun (semi-auto USAS) ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>K4G_Gun_HeavyShotgun</defName>
+				<statBases>
+					<Mass>5.45</Mass>
+					<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+					<SightsEfficiency>1</SightsEfficiency>
+					<ShotSpread>0.14</ShotSpread>
+					<SwayFactor>1.51</SwayFactor>
+					<Bulk>9.60</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>2.36</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
+					<warmupTime>0.6</warmupTime>
+					<range>16</range>
+					<soundCast>Shot_Shotgun_NoRack</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>12</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_12Gauge</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiAimMode>Snapshot</aiAimMode>
+				</FireModes>
+				<weaponTags>
+					<li>CE_AI_AssaultWeapon</li>
+				</weaponTags>
+			</li>
+
+			<!-- === Light SMG (MP5) === -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>K4G_Gun_LightSMG</defName>
+				<statBases>
+					<Mass>2.50</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.00</SightsEfficiency>
+					<ShotSpread>0.16</ShotSpread>
+					<SwayFactor>0.85</SwayFactor>
+					<Bulk>3.68</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>1.55</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_9x19mmPara_FMJ</defaultProjectile>
+					<warmupTime>0.6</warmupTime>
+					<range>20</range>
+					<burstShotCount>6</burstShotCount>
+					<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+					<soundCast>Shot_HeavySMG</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>30</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_9x19mmPara</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>Snapshot</aiAimMode>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+				</FireModes>
+				<weaponTags>
+					<li>CE_AI_AssaultWeapon</li>
+					<li>CE_SMG</li>
+				</weaponTags>
+			</li>
+
+			<!-- ========== Advanced SMG (P90) ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>K4G_Gun_AdvancedSMG</defName>
+				<statBases>
+					<Mass>2.60</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.10</SightsEfficiency>
+					<ShotSpread>0.12</ShotSpread>
+					<SwayFactor>0.77</SwayFactor>
+					<Bulk>5.05</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>1.05</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_FN57x28mm_FMJ</defaultProjectile>
+					<warmupTime>0.5</warmupTime>
+					<range>31</range>
+					<burstShotCount>6</burstShotCount>
+					<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+					<soundCast>Shot_HeavySMG</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>50</magazineSize>
+					<reloadTime>4.5</reloadTime>
+					<ammoSet>AmmoSet_FN57x28mm</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>Snapshot</aiAimMode>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+				</FireModes>
+			</li>
+
+			<!-- ========== Compact Rifle (M4A1) ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>K4G_Gun_CompactRifle</defName>
+				<statBases>
+					<Mass>2.90</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.00</SightsEfficiency>
+					<ShotSpread>0.1</ShotSpread>
+					<SwayFactor>1.13</SwayFactor>
+					<Bulk>7.56</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>1.58</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+					<warmupTime>1.1</warmupTime>
+					<range>55</range>
+					<burstShotCount>6</burstShotCount>
+					<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+					<soundCast>Shot_AssaultRifle</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>30</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+				</FireModes>
+			</li>
+
+			<!-- ========== Batttle Rifle (G3A2) ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>K4G_Gun_BattleRifle</defName>
+				<statBases>
+					<SightsEfficiency>1</SightsEfficiency>
+					<ShotSpread>0.08</ShotSpread>
+					<SwayFactor>1.46</SwayFactor>
+					<Bulk>10.5</Bulk>
+					<Mass>4.50</Mass>
+					<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+				</statBases>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>True</hasStandardCommand>
+					<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
+					<recoilAmount>2.00</recoilAmount>
+					<burstShotCount>6</burstShotCount>
+					<ticksBetweenBurstShots>7</ticksBetweenBurstShots>
+					<warmupTime>1.1</warmupTime>
+					<range>57</range>
+					<soundCast>Shot_AssaultRifle</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>12</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>20</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+				</FireModes>
 			</li>
 
 			</operations>

--- a/Patches/K4G Empires of Old - Core/WeaponsRanged.xml
+++ b/Patches/K4G Empires of Old - Core/WeaponsRanged.xml
@@ -92,6 +92,84 @@
 				</value>
 			</li>
 
+			<!-- ========== Snubgun ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>K4G_Gun_Snubgun</defName>
+				<statBases>
+					<Mass>1.42</Mass>
+					<RangedWeapon_Cooldown>0.49</RangedWeapon_Cooldown>
+					<SightsEfficiency>0.7</SightsEfficiency>
+					<ShotSpread>0.18</ShotSpread>
+					<SwayFactor>1.31</SwayFactor>
+					<Bulk>2.41</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>2.96</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_44Magnum_FMJ</defaultProjectile>
+					<warmupTime>0.6</warmupTime>
+					<range>12</range>
+					<soundCast>Shot_Revolver</soundCast>
+					<soundCastTail>GunTail_Light</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>6</magazineSize>
+					<reloadTime>4.6</reloadTime>
+					<ammoSet>AmmoSet_44Magnum</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>Snapshot</aiAimMode>
+				</FireModes>
+				<weaponTags>
+					<li>CE_Sidearm</li>
+					<li>CE_AI_BROOM</li>
+					<li>CE_OneHandedWeapon</li>
+				</weaponTags>
+			</li>
+
+			<!-- ========== Advanced Autopistol (Glock 21) ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>K4G_Gun_AdvancedAutopistol</defName>
+				<statBases>
+					<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
+					<SightsEfficiency>0.7</SightsEfficiency>
+					<ShotSpread>0.17</ShotSpread>
+					<SwayFactor>1.07</SwayFactor>
+					<Mass>1.4</Mass>
+					<Bulk>2.0</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>2.72</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
+					<warmupTime>0.6</warmupTime>
+					<range>12</range>
+					<soundCast>Shot_Autopistol</soundCast>
+					<soundCastTail>GunTail_Light</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>13</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_45ACP</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>Snapshot</aiAimMode>
+				</FireModes>
+				<weaponTags>
+					<li>CE_Sidearm</li>
+					<li>CE_AI_BROOM</li>
+					<li>CE_OneHandedWeapon</li>
+				</weaponTags>
+			</li>
+
 			</operations>
 		</match>
 	</Operation>

--- a/Patches/K4G Empires of Old - Core/WeaponsRanged.xml
+++ b/Patches/K4G Empires of Old - Core/WeaponsRanged.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[K4G] Empires of Old - Core</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- ========== Tools ========== -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="K4G_Gun_Snubgun" or
+				defName="K4G_Gun_Bolter" or
+				defName="K4G_Gun_AdvancedAutopistol" or
+				defName="K4G_Gun_PrecisionPistol"
+				]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>grip</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>1.54</cooldownTime>
+							<chanceFactor>1.5</chanceFactor>
+							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>muzzle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>1.54</cooldownTime>
+							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="K4G_Gun_LongGun" or
+				defName="K4G_Gun_Carbiner" or
+				defName="K4G_Gun_DuneRifle" or
+				defName="K4G_Gun_HeavyShotgun" or
+				defName="K4G_Gun_LightSMG" or
+				defName="K4G_Gun_AdvancedSMG" or
+				defName="K4G_Gun_CompactRifle" or
+				defName="K4G_Gun_BattleRifle"
+				]/tools </xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>stock</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
+							<chanceFactor>1.5</chanceFactor>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>barrel</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>5</power>
+							<cooldownTime>2.02</cooldownTime>
+							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>muzzle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/K4G Empires of Old - Factions/PawnKinds_Dynasty.xml
+++ b/Patches/K4G Empires of Old - Factions/PawnKinds_Dynasty.xml
@@ -1,0 +1,64 @@
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[K4G] Empires of Old - The Rising Sun</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- === Civilians === -->
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[defName="K4G_Dynasty_Common_Trader" or defName="K4G_Dynasty_Common_Worker"]</xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+						<primaryMagazineCount>
+							<min>3</min>
+							<max>4</max>
+						</primaryMagazineCount>
+					</li>
+				</value>
+			</li>
+
+			<!-- === Fighters === -->
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[@Name="K4GDynastyRoninBase" or @Name="K4GDynastyAshigaruBase"]</xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+						<primaryMagazineCount>
+							<min>4</min>
+							<max>6</max>
+						</primaryMagazineCount>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[defName="K4G_Dynasty_Fighter_Cataphract" or defName="K4G_Dynasty_Fighter_WarriorMonkRanged"]</xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+						<primaryMagazineCount>
+							<min>5</min>
+							<max>7</max>
+						</primaryMagazineCount>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[defName="K4G_Dynasty_Fighter_Grenadier"]</xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+						<primaryMagazineCount>
+							<min>8</min>
+							<max>12</max>
+						</primaryMagazineCount>
+					</li>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/K4G Empires of Old - Factions/PawnKinds_Guild.xml
+++ b/Patches/K4G Empires of Old - Factions/PawnKinds_Guild.xml
@@ -1,0 +1,68 @@
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[K4G] Empires of Old - The Engineers Institute</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- === Civilians / Royals === -->
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[
+				defName="K4G_Guild_Common_Trader" or
+				defName="K4G_Guild_Common_Worker" or
+				@Name="K4GGuildRoyalBase"
+				]</xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+						<primaryMagazineCount>
+							<min>3</min>
+							<max>4</max>
+						</primaryMagazineCount>
+					</li>
+				</value>
+			</li>
+
+			<!-- === Fighters === -->
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[@Name="K4GGuildGruntBase" or @Name="K4GGuildTrooperBase"]</xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+						<primaryMagazineCount>
+							<min>4</min>
+							<max>6</max>
+						</primaryMagazineCount>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[defName="K4G_Guild_Fighter_Cataphract" or defName="K4G_Guild_Fighter_SentinelGuardRanged"]</xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+						<primaryMagazineCount>
+							<min>5</min>
+							<max>7</max>
+						</primaryMagazineCount>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[defName="K4G_Guild_Fighter_Grenadier"]</xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+						<primaryMagazineCount>
+							<min>8</min>
+							<max>12</max>
+						</primaryMagazineCount>
+					</li>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/K4G Empires of Old - Factions/PawnKinds_Legion.xml
+++ b/Patches/K4G Empires of Old - Factions/PawnKinds_Legion.xml
@@ -1,0 +1,64 @@
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[K4G] Empires of Old - The Polluted Legion</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- === Civilians === -->
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[defName="K4G_Legion_Common_Trader" or defName="K4G_Legion_Common_Worker"]</xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+						<primaryMagazineCount>
+							<min>3</min>
+							<max>4</max>
+						</primaryMagazineCount>
+					</li>
+				</value>
+			</li>
+
+			<!-- === Fighters === -->
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[@Name="K4GLegionMilitesBase" or @Name="K4GLegionLegionaryBase"]</xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+						<primaryMagazineCount>
+							<min>4</min>
+							<max>6</max>
+						</primaryMagazineCount>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[defName="K4G_Legion_Fighter_HeavyLegionnaire" or defName="K4G_Legion_Fighter_PraetorianGuardRanged"]</xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+						<primaryMagazineCount>
+							<min>5</min>
+							<max>7</max>
+						</primaryMagazineCount>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[defName="K4G_Legion_Fighter_Grenadier"]</xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+						<primaryMagazineCount>
+							<min>8</min>
+							<max>12</max>
+						</primaryMagazineCount>
+					</li>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/K4G Empires of Old - Factions/PawnKinds_Sultanate.xml
+++ b/Patches/K4G Empires of Old - Factions/PawnKinds_Sultanate.xml
@@ -1,0 +1,67 @@
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[K4G] Empires of Old - The Faceless Sultanate</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- === Civilians / Royals === -->
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[defName="K4G_Sultanate_Common_Trader" or defName="K4G_Sultanate_Common_Worker"]</xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+						<primaryMagazineCount>
+							<min>3</min>
+							<max>4</max>
+						</primaryMagazineCount>
+					</li>
+				</value>
+			</li>
+
+			<!-- === Fighters === -->
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[@Name="K4GSultanateGuerrillaBase" or @Name="K4GSultanateJanissaryBase"]</xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+						<primaryMagazineCount>
+							<min>4</min>
+							<max>6</max>
+						</primaryMagazineCount>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[
+				defName="K4G_Sultanate_Fighter_Cataphract" or
+				defName="K4G_Sultanate_Fighter_KhanGuardRanged" or
+				defName="K4G_Sultanate_Fighter_BlackMarketMercenary"]</xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+						<primaryMagazineCount>
+							<min>5</min>
+							<max>7</max>
+						</primaryMagazineCount>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[defName="K4G_Sultanate_Fighter_Bomber"]</xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+						<primaryMagazineCount>
+							<min>8</min>
+							<max>12</max>
+						</primaryMagazineCount>
+					</li>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/K4G Empires of Old - Factions/TraderKinds_Sultanate.xml
+++ b/Patches/K4G Empires of Old - Factions/TraderKinds_Sultanate.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[K4G] Empires of Old - The Faceless Sultanate</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- ======= Trader Base =======-->
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/TraderKindDef[defName="K4G_Base_Sultanate_Standard"]/stockGenerators</xpath>
+				<value>
+					<li Class="StockGenerator_SingleDef">
+						<thingDef>FSX</thingDef>
+						<countRange>
+							<min>15</min>
+							<max>40</max>
+						</countRange>
+					</li>
+					<li Class="StockGenerator_SingleDef">
+						<thingDef>Prometheum</thingDef>
+						<countRange>
+							<min>15</min>
+							<max>40</max>
+						</countRange>
+					</li>
+					<li Class="StockGenerator_Tag">
+						<tradeTag>CE_Ammo</tradeTag>
+						<countRange>
+							<min>400</min>
+							<max>1000</max>
+						</countRange>
+						<thingDefCountRange>
+							<min>3</min>
+							<max>8</max>
+						</thingDefCountRange>
+					</li>
+					<li Class="StockGenerator_Tag">
+						<tradeTag>CE_MediumAmmo</tradeTag>
+						<countRange>
+							<min>400</min>
+							<max>1000</max>
+						</countRange>
+						<thingDefCountRange>
+							<min>3</min>
+							<max>8</max>
+						</thingDefCountRange>
+					</li>
+					<li Class="StockGenerator_Tag">
+						<tradeTag>CE_HeavyAmmo</tradeTag>
+						<countRange>
+							<min>10</min>
+							<max>50</max>
+						</countRange>
+						<thingDefCountRange>
+							<min>2</min>
+							<max>5</max>
+						</thingDefCountRange>
+					</li>
+					<li Class="StockGenerator_Category">
+						<categoryDef>Ammo</categoryDef>
+						<thingDefCountRange>
+							<min>0</min>
+							<max>0</max>
+						</thingDefCountRange>
+					</li>
+				</value>
+			</li>
+
+			<!-- ======= Trader Caravan Base =======-->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/TraderKindDef[defName="K4G_Base_Sultanate_Standard"]/stockGenerators</xpath>
+				<value>
+					<li Class="StockGenerator_SingleDef">
+						<thingDef>FSX</thingDef>
+						<countRange>
+							<min>15</min>
+							<max>40</max>
+						</countRange>
+					</li>
+					<li Class="StockGenerator_SingleDef">
+						<thingDef>Prometheum</thingDef>
+						<countRange>
+							<min>15</min>
+							<max>40</max>
+						</countRange>
+					</li>
+					<li Class="StockGenerator_Tag">
+						<tradeTag>CE_Ammo</tradeTag>
+						<countRange>
+							<min>400</min>
+							<max>1000</max>
+						</countRange>
+						<price>Cheap</price>
+						<thingDefCountRange>
+							<min>3</min>
+							<max>8</max>
+						</thingDefCountRange>
+					</li>
+					<li Class="StockGenerator_Tag">
+						<tradeTag>CE_MediumAmmo</tradeTag>
+						<countRange>
+							<min>10</min>
+							<max>50</max>
+						</countRange>
+						<thingDefCountRange>
+							<min>2</min>
+							<max>4</max>
+						</thingDefCountRange>
+					</li>
+					<li Class="StockGenerator_Tag">
+						<tradeTag>CE_HeavyAmmo</tradeTag>
+						<countRange>
+							<min>5</min>
+							<max>30</max>
+						</countRange>
+						<thingDefCountRange>
+							<min>2</min>
+							<max>6</max>
+						</thingDefCountRange>
+					</li>
+					<li Class="StockGenerator_Category">
+						<categoryDef>Ammo</categoryDef>
+						<thingDefCountRange>
+							<min>0</min>
+							<max>0</max>
+						</thingDefCountRange>
+					</li>
+					<li Class="StockGenerator_Tag">
+						<tradeTag>CE_Turret</tradeTag>
+						<thingDefCountRange>
+							<min>-4</min>
+							<max>2</max>
+						</thingDefCountRange>
+						<countRange>
+							<min>1</min>
+							<max>1</max>
+						</countRange>
+					</li>
+					<li Class="StockGenerator_Category">
+						<categoryDef>WeaponsTurrets</categoryDef>
+						<thingDefCountRange>
+							<min>0</min>
+							<max>0</max>
+						</thingDefCountRange>
+					</li>
+					<li Class="StockGenerator_Animals">
+						<tradeTagsSell>
+							<li>CE_AnimalBoom</li>
+						</tradeTagsSell>
+						<tradeTagsBuy>
+							<li>CE_AnimalBoom</li>
+						</tradeTagsBuy>
+						<kindCountRange>
+							<min>0</min>
+							<max>1</max>
+						</kindCountRange>
+						<countRange>
+							<min>-1</min>
+							<max>2</max>
+						</countRange>
+					</li>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -27,6 +27,7 @@ Mod |
 [JDS] Star Wars BlasTech Industries |
 [JDS] The Forge - Exiled Dawn |
 [JDS] The Forge - NCR Armory	|
+[K4G] Empires of Old    |
 [K4G] RimWorld War 2    |
 [KV] Hand 'n' Footwear	|
 [LF] Command And Conquer NOD Combat Armor |

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -27,7 +27,7 @@ Mod |
 [JDS] Star Wars BlasTech Industries |
 [JDS] The Forge - Exiled Dawn |
 [JDS] The Forge - NCR Armory	|
-[K4G] Empires of Old    |
+[K4G] Empires of Old Collection    |
 [K4G] RimWorld War 2    |
 [KV] Hand 'n' Footwear	|
 [LF] Command And Conquer NOD Combat Armor |


### PR DESCRIPTION
## Additions
- Patch new apparel, weapons, and factions from the [K4G] Kingdoms of Old mod series.
  - Wherever possible, used patches from existing equipment as templates. Should be reasonably balanced. 
- Patch factions added by the various K4G submods, adding ammo to pawnkinds and adjusting the Sultanate traders. 

## Reasoning
Many of the items were already patched in other places, or were comparable enough to patch with a few stat tweaks. Tried to stick reasonably close to vanilla balance.

Switched the 'bolter' from basically a very crude dart gun into a crude 9mm pistol, since the single, crappy weapon wasn't really worth making a whole new ammoset for.

Have to load the Sultanate faction before CE, because it otherwise adds a duplicate `weaponTag` field to the vanilla Bolt Action Rifle.

## Alternatives
- Could take a different balancing approach to make mod equipment more unique.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
