### PR TITLE
Rambo weapons pack - weapontag modernisation pass

### DIFF
--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_amrifles.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_amrifles.xml
@@ -42,6 +42,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>SniperRifle</li>
+						<li>Bipod_AMR</li>
+						<li>CE_AI_Rifle</li>
 					</weaponTags>
 				</li>
 
@@ -80,6 +82,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>SniperRifle</li>
+						<li>Bipod_AMR</li>
+						<li>CE_AI_Rifle</li>
 					</weaponTags>
 				</li>
 
@@ -119,6 +123,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>SniperRifle</li>
+						<li>Bipod_AMR</li>
+						<li>CE_AI_Rifle</li>
 					</weaponTags>
 				</li>
 
@@ -157,6 +163,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>SniperRifle</li>
+						<li>Bipod_AMR</li>
+						<li>CE_AI_Rifle</li>
 					</weaponTags>
 				</li>
 

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_assaultrifles.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_assaultrifles.xml
@@ -1642,6 +1642,7 @@
 					</FireModes>
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
+						<li>Bipod_Rifle</li>
 					</weaponTags>
 				</li>
 
@@ -2632,6 +2633,7 @@
 					</FireModes>
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
+						<li>CE_AI_Rifle</li>
 					</weaponTags>
 				</li>
 

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_assaultrifles.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_assaultrifles.xml
@@ -1469,7 +1469,6 @@
 					</FireModes>
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
-						<li>Bipod_Rifle</li>
 					</weaponTags>
 				</li>
 

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_assaultrifles.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_assaultrifles.xml
@@ -1122,6 +1122,7 @@
 					</FireModes>
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
+						<li>Bipod_Rifle</li>
 					</weaponTags>
 				</li>
 
@@ -1165,6 +1166,7 @@
 					</FireModes>
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
+						<li>Bipod_Rifle</li>
 					</weaponTags>
 				</li>
 
@@ -1208,6 +1210,7 @@
 					</FireModes>
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
+						<li>Bipod_Rifle</li>
 					</weaponTags>
 				</li>
 
@@ -1466,6 +1469,7 @@
 					</FireModes>
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
+						<li>Bipod_Rifle</li>
 					</weaponTags>
 				</li>
 
@@ -2326,6 +2330,7 @@
 					</FireModes>
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
+						<li>Bipod_Rifle</li>
 					</weaponTags>
 				</li>
 

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_battlerifles.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_battlerifles.xml
@@ -388,6 +388,7 @@
 					</FireModes>
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
+						<li>Bipod_Rifle</li>
 					</weaponTags>
 				</li>
 

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_heavy.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_heavy.xml
@@ -47,6 +47,7 @@
 					</FireModes>
 					<weaponTags>
 						<li>GrenadeDestructive</li>
+						<li>CE_AI_Launcher</li>
 					</weaponTags>
 				</li>
 
@@ -91,6 +92,7 @@
 					</FireModes>
 					<weaponTags>
 						<li>GrenadeDestructive</li>
+						<li>CE_AI_Launcher</li>
 					</weaponTags>
 				</li>
 
@@ -134,6 +136,7 @@
 					</FireModes>
 					<weaponTags>
 						<li>GrenadeDestructive</li>
+						<li>CE_AI_Launcher</li>
 					</weaponTags>
 				</li>
 

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_machineguns.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_machineguns.xml
@@ -252,8 +252,7 @@
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
 						<li>CE_MachineGun</li>
-						<li>Bipod_SAW</li>
-						<li>CE_AI_Suppressive</li>
+						<li>Bipod_Rifle</li>
 					</weaponTags>
 				</li>
 

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_machineguns.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_machineguns.xml
@@ -53,6 +53,7 @@
 						<li>IndustrialGunAdvanced</li>
 						<li>CE_MachineGun</li>
 						<li>Bipod_LMG</li>
+						<li>CE_AI_Suppressive</li>
 					</weaponTags>
 				</li>
 
@@ -102,6 +103,7 @@
 						<li>IndustrialGunAdvanced</li>
 						<li>CE_MachineGun</li>
 						<li>Bipod_LMG</li>
+						<li>CE_AI_Suppressive</li>
 					</weaponTags>
 				</li>
 
@@ -151,6 +153,7 @@
 						<li>IndustrialGunAdvanced</li>
 						<li>CE_MachineGun</li>
 						<li>Bipod_LMG</li>
+						<li>CE_AI_Suppressive</li>
 					</weaponTags>
 				</li>
 
@@ -200,6 +203,7 @@
 						<li>IndustrialGunAdvanced</li>
 						<li>CE_MachineGun</li>
 						<li>Bipod_LMG</li>
+						<li>CE_AI_Suppressive</li>
 					</weaponTags>
 				</li>
 
@@ -248,7 +252,8 @@
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
 						<li>CE_MachineGun</li>
-						<li>Bipod_LMG</li>
+						<li>Bipod_SAW</li>
+						<li>CE_AI_Suppressive</li>
 					</weaponTags>
 				</li>
 
@@ -298,6 +303,7 @@
 						<li>IndustrialGunAdvanced</li>
 						<li>CE_MachineGun</li>
 						<li>Bipod_LMG</li>
+						<li>CE_AI_Suppressive</li>
 					</weaponTags>
 				</li>
 
@@ -347,6 +353,7 @@
 						<li>IndustrialGunAdvanced</li>
 						<li>CE_MachineGun</li>
 						<li>Bipod_LMG</li>
+						<li>CE_AI_Suppressive</li>
 					</weaponTags>
 				</li>
 
@@ -396,6 +403,7 @@
 						<li>IndustrialGunAdvanced</li>
 						<li>CE_MachineGun</li>
 						<li>Bipod_LMG</li>
+						<li>CE_AI_Suppressive</li>
 					</weaponTags>
 				</li>
 
@@ -445,6 +453,7 @@
 						<li>IndustrialGunAdvanced</li>
 						<li>CE_MachineGun</li>
 						<li>Bipod_LMG</li>
+						<li>CE_AI_Suppressive</li>
 					</weaponTags>
 				</li>
 
@@ -493,7 +502,8 @@
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
 						<li>CE_MachineGun</li>
-						<li>Bipod_LMG</li>
+						<li>Bipod_SAW</li>
+						<li>CE_AI_Suppressive</li>
 					</weaponTags>
 				</li>
 
@@ -542,7 +552,7 @@
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
 						<li>CE_MachineGun</li>
-						<li>Bipod_LMG</li>
+						<li>CE_AI_Suppressive</li>
 					</weaponTags>
 				</li>
 
@@ -592,6 +602,7 @@
 						<li>IndustrialGunAdvanced</li>
 						<li>CE_MachineGun</li>
 						<li>Bipod_LMG</li>
+						<li>CE_AI_Suppressive</li>
 					</weaponTags>
 				</li>
 
@@ -641,6 +652,7 @@
 						<li>IndustrialGunAdvanced</li>
 						<li>CE_MachineGun</li>
 						<li>Bipod_LMG</li>
+						<li>CE_AI_Suppressive</li>
 					</weaponTags>
 				</li>
 
@@ -690,6 +702,7 @@
 						<li>IndustrialGunAdvanced</li>
 						<li>CE_MachineGun</li>
 						<li>Bipod_LMG</li>
+						<li>CE_AI_Suppressive</li>
 					</weaponTags>
 				</li>
 
@@ -739,6 +752,7 @@
 						<li>IndustrialGunAdvanced</li>
 						<li>CE_MachineGun</li>
 						<li>Bipod_LMG</li>
+						<li>CE_AI_Suppressive</li>
 					</weaponTags>
 				</li>
 
@@ -788,6 +802,7 @@
 						<li>IndustrialGunAdvanced</li>
 						<li>CE_MachineGun</li>
 						<li>Bipod_LMG</li>
+						<li>CE_AI_Suppressive</li>
 					</weaponTags>
 				</li>
 
@@ -837,6 +852,7 @@
 						<li>IndustrialGunAdvanced</li>
 						<li>CE_MachineGun</li>
 						<li>Bipod_LMG</li>
+						<li>CE_AI_Suppressive</li>
 					</weaponTags>
 				</li>
 
@@ -885,7 +901,8 @@
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
 						<li>CE_MachineGun</li>
-						<li>Bipod_LMG</li>
+						<li>Bipod_SAW</li>
+						<li>CE_AI_Suppressive</li>
 					</weaponTags>
 				</li>
 
@@ -934,7 +951,8 @@
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
 						<li>CE_MachineGun</li>
-						<li>Bipod_LMG</li>
+						<li>Bipod_SAW</li>
+						<li>CE_AI_Suppressive</li>
 					</weaponTags>
 				</li>
 
@@ -983,7 +1001,8 @@
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
 						<li>CE_MachineGun</li>
-						<li>Bipod_LMG</li>
+						<li>Bipod_SAW</li>
+						<li>CE_AI_Suppressive</li>
 					</weaponTags>
 				</li>
 
@@ -1032,7 +1051,8 @@
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
 						<li>CE_MachineGun</li>
-						<li>Bipod_LMG</li>
+						<li>Bipod_SAW</li>
+						<li>CE_AI_Suppressive</li>
 					</weaponTags>
 				</li>
 
@@ -1081,7 +1101,8 @@
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
 						<li>CE_MachineGun</li>
-						<li>Bipod_LMG</li>
+						<li>Bipod_SAW</li>
+						<li>CE_AI_Suppressive</li>
 					</weaponTags>
 				</li>
 
@@ -1131,6 +1152,7 @@
 						<li>IndustrialGunAdvanced</li>
 						<li>CE_MachineGun</li>
 						<li>Bipod_LMG</li>
+						<li>CE_AI_Suppressive</li>
 					</weaponTags>
 				</li>
 
@@ -1179,7 +1201,8 @@
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
 						<li>CE_MachineGun</li>
-						<li>Bipod_LMG</li>
+						<li>Bipod_SAW</li>
+						<li>CE_AI_Suppressive</li>
 					</weaponTags>
 				</li>
 

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_machineguns.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_machineguns.xml
@@ -51,6 +51,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
+						<li>CE_MachineGun</li>
+						<li>Bipod_LMG</li>
 					</weaponTags>
 				</li>
 
@@ -98,6 +100,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
+						<li>CE_MachineGun</li>
+						<li>Bipod_LMG</li>
 					</weaponTags>
 				</li>
 
@@ -145,6 +149,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
+						<li>CE_MachineGun</li>
+						<li>Bipod_LMG</li>
 					</weaponTags>
 				</li>
 
@@ -192,6 +198,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
+						<li>CE_MachineGun</li>
+						<li>Bipod_LMG</li>
 					</weaponTags>
 				</li>
 
@@ -239,6 +247,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
+						<li>CE_MachineGun</li>
+						<li>Bipod_LMG</li>
 					</weaponTags>
 				</li>
 
@@ -286,6 +296,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
+						<li>CE_MachineGun</li>
+						<li>Bipod_LMG</li>
 					</weaponTags>
 				</li>
 
@@ -333,6 +345,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
+						<li>CE_MachineGun</li>
+						<li>Bipod_LMG</li>
 					</weaponTags>
 				</li>
 
@@ -380,6 +394,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
+						<li>CE_MachineGun</li>
+						<li>Bipod_LMG</li>
 					</weaponTags>
 				</li>
 
@@ -427,6 +443,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
+						<li>CE_MachineGun</li>
+						<li>Bipod_LMG</li>
 					</weaponTags>
 				</li>
 
@@ -474,6 +492,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
+						<li>CE_MachineGun</li>
+						<li>Bipod_LMG</li>
 					</weaponTags>
 				</li>
 
@@ -521,6 +541,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
+						<li>CE_MachineGun</li>
+						<li>Bipod_LMG</li>
 					</weaponTags>
 				</li>
 
@@ -568,6 +590,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
+						<li>CE_MachineGun</li>
+						<li>Bipod_LMG</li>
 					</weaponTags>
 				</li>
 
@@ -615,6 +639,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
+						<li>CE_MachineGun</li>
+						<li>Bipod_LMG</li>
 					</weaponTags>
 				</li>
 
@@ -662,6 +688,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
+						<li>CE_MachineGun</li>
+						<li>Bipod_LMG</li>
 					</weaponTags>
 				</li>
 
@@ -709,6 +737,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
+						<li>CE_MachineGun</li>
+						<li>Bipod_LMG</li>
 					</weaponTags>
 				</li>
 
@@ -756,6 +786,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
+						<li>CE_MachineGun</li>
+						<li>Bipod_LMG</li>
 					</weaponTags>
 				</li>
 
@@ -803,6 +835,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
+						<li>CE_MachineGun</li>
+						<li>Bipod_LMG</li>
 					</weaponTags>
 				</li>
 
@@ -850,6 +884,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
+						<li>CE_MachineGun</li>
+						<li>Bipod_LMG</li>
 					</weaponTags>
 				</li>
 
@@ -897,6 +933,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
+						<li>CE_MachineGun</li>
+						<li>Bipod_LMG</li>
 					</weaponTags>
 				</li>
 
@@ -944,6 +982,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
+						<li>CE_MachineGun</li>
+						<li>Bipod_LMG</li>
 					</weaponTags>
 				</li>
 
@@ -991,6 +1031,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
+						<li>CE_MachineGun</li>
+						<li>Bipod_LMG</li>
 					</weaponTags>
 				</li>
 
@@ -1038,6 +1080,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
+						<li>CE_MachineGun</li>
+						<li>Bipod_LMG</li>
 					</weaponTags>
 				</li>
 
@@ -1085,6 +1129,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
+						<li>CE_MachineGun</li>
+						<li>Bipod_LMG</li>
 					</weaponTags>
 				</li>
 
@@ -1132,6 +1178,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
+						<li>CE_MachineGun</li>
+						<li>Bipod_LMG</li>
 					</weaponTags>
 				</li>
 

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_pistols.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_pistols.xml
@@ -40,7 +40,9 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -77,7 +79,9 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -114,7 +118,9 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -151,7 +157,9 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -189,7 +197,9 @@
 					<weaponTags>
 						<li>SimpleGun</li>
 						<li>Revolver</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -227,7 +237,9 @@
 					<weaponTags>
 						<li>SimpleGun</li>
 						<li>Revolver</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -264,7 +276,9 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -304,7 +318,9 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -341,7 +357,9 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -378,7 +396,9 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -415,7 +435,9 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -452,7 +474,9 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -489,7 +513,8 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
-						<li>CE_OneHandedWeapon</li>
+						<li>CE_Sidearm</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -526,7 +551,9 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -563,7 +590,9 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -605,7 +634,9 @@
 					</FireModes>
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -642,7 +673,9 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -679,7 +712,9 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -716,7 +751,9 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -753,7 +790,9 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -790,7 +829,9 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -827,7 +868,9 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -865,7 +908,9 @@
 					<weaponTags>
 						<li>SimpleGun</li>
 						<li>Revolver</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -902,7 +947,9 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -939,7 +986,9 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -977,7 +1026,9 @@
 					<weaponTags>
 						<li>SimpleGun</li>
 						<li>Revolver</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -1014,7 +1065,9 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -1051,7 +1104,9 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -1088,7 +1143,9 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -1124,7 +1181,9 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -1161,7 +1220,9 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -1198,7 +1259,9 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -1236,7 +1299,9 @@
 					<weaponTags>
 						<li>SimpleGun</li>
 						<li>Revolver</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -1272,7 +1337,9 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -1309,7 +1376,9 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -1346,7 +1415,9 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -1383,7 +1454,9 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -1420,7 +1493,9 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -1457,7 +1532,9 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -1494,7 +1571,9 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -1531,7 +1610,9 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -1568,7 +1649,9 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -1605,7 +1688,9 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_Sidearm</li>
 						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -1640,7 +1725,8 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
-						<li>CE_OneHandedWeapon</li>
+						<li>CE_Sidearm</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 
@@ -1675,7 +1761,8 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
-						<li>CE_OneHandedWeapon</li>
+						<li>CE_Sidearm</li>
+						<li>CE_AI_Pistol</li>
 					</weaponTags>
 				</li>
 

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_pistols.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_pistols.xml
@@ -40,6 +40,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -76,6 +77,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -112,6 +114,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -148,6 +151,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -185,6 +189,7 @@
 					<weaponTags>
 						<li>SimpleGun</li>
 						<li>Revolver</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -222,6 +227,7 @@
 					<weaponTags>
 						<li>SimpleGun</li>
 						<li>Revolver</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -258,6 +264,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -297,6 +304,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -333,6 +341,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -369,6 +378,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -405,6 +415,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -441,6 +452,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -477,6 +489,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -513,6 +526,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -549,6 +563,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -590,6 +605,7 @@
 					</FireModes>
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -626,6 +642,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -662,6 +679,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -698,6 +716,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -734,6 +753,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -770,6 +790,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -806,6 +827,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -843,6 +865,7 @@
 					<weaponTags>
 						<li>SimpleGun</li>
 						<li>Revolver</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -879,6 +902,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -915,6 +939,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -952,6 +977,7 @@
 					<weaponTags>
 						<li>SimpleGun</li>
 						<li>Revolver</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -988,6 +1014,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -1024,6 +1051,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -1060,6 +1088,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -1095,6 +1124,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -1131,6 +1161,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -1167,6 +1198,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -1204,6 +1236,7 @@
 					<weaponTags>
 						<li>SimpleGun</li>
 						<li>Revolver</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -1239,6 +1272,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -1275,6 +1309,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -1311,6 +1346,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -1347,6 +1383,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -1383,6 +1420,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -1419,6 +1457,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -1455,6 +1494,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -1491,6 +1531,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -1527,6 +1568,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -1563,6 +1605,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -1597,6 +1640,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 
@@ -1631,6 +1675,7 @@
 					<FireModes />
 					<weaponTags>
 						<li>SimpleGun</li>
+						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
 

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_rifles.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_rifles.xml
@@ -40,6 +40,9 @@
 					<FireModes>
 						<aiAimMode>AimedShot</aiAimMode>
 					</FireModes>
+					<weaponTags>
+						<li>CE_AI_Rifle</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -75,6 +78,9 @@
 					<FireModes>
 						<aiAimMode>AimedShot</aiAimMode>
 					</FireModes>
+					<weaponTags>
+						<li>CE_AI_Rifle</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -110,6 +116,9 @@
 					<FireModes>
 						<aiAimMode>AimedShot</aiAimMode>
 					</FireModes>
+					<weaponTags>
+						<li>CE_AI_Rifle</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -248,6 +257,9 @@
 					<FireModes>
 						<aiAimMode>AimedShot</aiAimMode>
 					</FireModes>
+					<weaponTags>
+						<li>CE_AI_Rifle</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -428,6 +440,9 @@
 					<FireModes>
 						<aiAimMode>AimedShot</aiAimMode>
 					</FireModes>
+					<weaponTags>
+						<li>CE_AI_Rifle</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -463,6 +478,9 @@
 					<FireModes>
 						<aiAimMode>AimedShot</aiAimMode>
 					</FireModes>
+					<weaponTags>
+						<li>CE_AI_Rifle</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -498,6 +516,9 @@
 					<FireModes>
 						<aiAimMode>AimedShot</aiAimMode>
 					</FireModes>
+					<weaponTags>
+						<li>CE_AI_Rifle</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -568,6 +589,9 @@
 					<FireModes>
 						<aiAimMode>AimedShot</aiAimMode>
 					</FireModes>
+					<weaponTags>
+						<li>CE_AI_Rifle</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -603,6 +627,9 @@
 					<FireModes>
 						<aiAimMode>AimedShot</aiAimMode>
 					</FireModes>
+					<weaponTags>
+						<li>CE_AI_Rifle</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -638,6 +665,9 @@
 					<FireModes>
 						<aiAimMode>AimedShot</aiAimMode>
 					</FireModes>
+					<weaponTags>
+						<li>CE_AI_Rifle</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_shotguns.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_shotguns.xml
@@ -44,6 +44,9 @@
 						<aiAimMode>Snapshot</aiAimMode>
 						<aimedBurstShotCount>2</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_AI_BROOM</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -79,6 +82,9 @@
 					<FireModes>
 						<aiAimMode>Snapshot</aiAimMode>
 					</FireModes>
+					<weaponTags>
+						<li>CE_AI_BROOM</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -118,6 +124,9 @@
 						<aiAimMode>Snapshot</aiAimMode>
 						<aimedBurstShotCount>2</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_AI_BROOM</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -153,6 +162,9 @@
 					<FireModes>
 						<aiAimMode>Snapshot</aiAimMode>
 					</FireModes>
+					<weaponTags>
+						<li>CE_AI_BROOM</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -188,6 +200,9 @@
 					<FireModes>
 						<aiAimMode>Snapshot</aiAimMode>
 					</FireModes>
+					<weaponTags>
+						<li>CE_AI_BROOM</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -223,6 +238,9 @@
 					<FireModes>
 						<aiAimMode>Snapshot</aiAimMode>
 					</FireModes>
+					<weaponTags>
+						<li>CE_AI_BROOM</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -258,6 +276,9 @@
 					<FireModes>
 						<aiAimMode>Snapshot</aiAimMode>
 					</FireModes>
+					<weaponTags>
+						<li>CE_AI_BROOM</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -293,6 +314,9 @@
 					<FireModes>
 						<aiAimMode>Snapshot</aiAimMode>
 					</FireModes>
+					<weaponTags>
+						<li>CE_AI_BROOM</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -328,6 +352,9 @@
 					<FireModes>
 						<aiAimMode>Snapshot</aiAimMode>
 					</FireModes>
+					<weaponTags>
+						<li>CE_AI_BROOM</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -363,6 +390,9 @@
 					<FireModes>
 						<aiAimMode>Snapshot</aiAimMode>
 					</FireModes>
+					<weaponTags>
+						<li>CE_AI_BROOM</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -398,6 +428,9 @@
 					<FireModes>
 						<aiAimMode>AimedShot</aiAimMode>
 					</FireModes>
+					<weaponTags>
+						<li>CE_AI_BROOM</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -433,6 +466,9 @@
 					<FireModes>
 						<aiAimMode>AimedShot</aiAimMode>
 					</FireModes>
+					<weaponTags>
+						<li>CE_AI_BROOM</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -468,6 +504,9 @@
 					<FireModes>
 						<aiAimMode>Snapshot</aiAimMode>
 					</FireModes>
+					<weaponTags>
+						<li>CE_AI_BROOM</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -503,6 +542,9 @@
 					<FireModes>
 						<aiAimMode>Snapshot</aiAimMode>
 					</FireModes>
+					<weaponTags>
+						<li>CE_AI_BROOM</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -541,6 +583,9 @@
 					<FireModes>
 						<aiAimMode>Snapshot</aiAimMode>
 					</FireModes>
+					<weaponTags>
+						<li>CE_AI_BROOM</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -579,6 +624,11 @@
 					<FireModes>
 						<aiAimMode>Snapshot</aiAimMode>
 					</FireModes>
+					<weaponTags>
+						<li>CE_AI_BROOM</li>
+						<li>CE_Sidearm</li>
+						<li>CE_OneHandedWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -617,6 +667,9 @@
 					<FireModes>
 						<aiAimMode>Snapshot</aiAimMode>
 					</FireModes>
+					<weaponTags>
+						<li>CE_AI_BROOM</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -655,6 +708,11 @@
 					<FireModes>
 						<aiAimMode>Snapshot</aiAimMode>
 					</FireModes>
+					<weaponTags>
+						<li>CE_AI_BROOM</li>
+						<li>CE_Sidearm</li>
+						<li>CE_OneHandedWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -690,6 +748,9 @@
 					<FireModes>
 						<aiAimMode>Snapshot</aiAimMode>
 					</FireModes>
+					<weaponTags>
+						<li>CE_AI_BROOM</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -725,6 +786,9 @@
 					<FireModes>
 						<aiAimMode>Snapshot</aiAimMode>
 					</FireModes>
+					<weaponTags>
+						<li>CE_AI_BROOM</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -760,6 +824,9 @@
 					<FireModes>
 						<aiAimMode>Snapshot</aiAimMode>
 					</FireModes>
+					<weaponTags>
+						<li>CE_AI_BROOM</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -795,6 +862,9 @@
 					<FireModes>
 						<aiAimMode>Snapshot</aiAimMode>
 					</FireModes>
+					<weaponTags>
+						<li>CE_AI_BROOM</li>
+					</weaponTags>
 				</li>
 
 			</operations>

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_sniperrifles.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_sniperrifles.xml
@@ -43,6 +43,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>SniperRifle</li>
+						<li>Bipod_DMR</li>
+						<li>CE_AI_Rifle</li>
 					</weaponTags>
 				</li>
 
@@ -82,6 +84,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>SniperRifle</li>
+						<li>Bipod_DMR</li>
+						<li>CE_AI_Rifle</li>
 					</weaponTags>
 				</li>
 
@@ -121,6 +125,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>SniperRifle</li>
+						<li>Bipod_DMR</li>
+						<li>CE_AI_Rifle</li>
 					</weaponTags>
 				</li>
 
@@ -160,6 +166,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>SniperRifle</li>
+						<li>Bipod_DMR</li>
+						<li>CE_AI_Rifle</li>
 					</weaponTags>
 				</li>
 
@@ -199,6 +207,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>SniperRifle</li>
+						<li>Bipod_DMR</li>
+						<li>CE_AI_Rifle</li>
 					</weaponTags>
 				</li>
 
@@ -238,6 +248,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>SniperRifle</li>
+						<li>Bipod_DMR</li>
+						<li>CE_AI_Rifle</li>
 					</weaponTags>
 				</li>
 
@@ -277,6 +289,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>SniperRifle</li>
+						<li>Bipod_DMR</li>
+						<li>CE_AI_Rifle</li>
 					</weaponTags>
 				</li>
 
@@ -316,6 +330,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>SniperRifle</li>
+						<li>Bipod_DMR</li>
+						<li>CE_AI_Rifle</li>
 					</weaponTags>
 				</li>
 
@@ -355,6 +371,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>SniperRifle</li>
+						<li>Bipod_DMR</li>
+						<li>CE_AI_Rifle</li>
 					</weaponTags>
 				</li>
 
@@ -393,6 +411,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>SniperRifle</li>
+						<li>Bipod_DMR</li>
+						<li>CE_AI_Rifle</li>
 					</weaponTags>
 				</li>
 
@@ -432,6 +452,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>SniperRifle</li>
+						<li>Bipod_DMR</li>
+						<li>CE_AI_Rifle</li>
 					</weaponTags>
 				</li>
 
@@ -471,6 +493,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>SniperRifle</li>
+						<li>Bipod_DMR</li>
+						<li>CE_AI_Rifle</li>
 					</weaponTags>
 				</li>
 
@@ -510,6 +534,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>SniperRifle</li>
+						<li>Bipod_DMR</li>
+						<li>CE_AI_Rifle</li>
 					</weaponTags>
 				</li>
 
@@ -549,6 +575,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>SniperRifle</li>
+						<li>Bipod_DMR</li>
+						<li>CE_AI_Rifle</li>
 					</weaponTags>
 				</li>
 
@@ -587,6 +615,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>SniperRifle</li>
+						<li>Bipod_DMR</li>
+						<li>CE_AI_Rifle</li>
 					</weaponTags>
 				</li>
 
@@ -626,6 +656,8 @@
 					</FireModes>
 					<weaponTags>
 						<li>SniperRifle</li>
+						<li>Bipod_DMR</li>
+						<li>CE_AI_Rifle</li>
 					</weaponTags>
 				</li>
 

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_submachineguns.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_submachineguns.xml
@@ -43,6 +43,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -81,6 +85,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -121,6 +129,10 @@
 						<aiAimMode>Snapshot</aiAimMode>
 						<aimedBurstShotCount>8</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -159,6 +171,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -197,6 +213,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -235,6 +255,10 @@
 					<FireModes>
 						<aimedBurstShotCount>2</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -273,6 +297,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -311,6 +339,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -349,6 +381,12 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_Sidearm</li>
+						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -387,6 +425,12 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_Sidearm</li>
+						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -425,6 +469,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -463,6 +511,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -501,6 +553,12 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_Sidearm</li>
+						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -539,6 +597,12 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_Sidearm</li>
+						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -577,6 +641,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -615,6 +683,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -653,6 +725,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -691,6 +767,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -729,6 +809,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -767,6 +851,11 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_Sidearm</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -805,6 +894,11 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_Sidearm</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -843,6 +937,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -880,6 +978,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -917,6 +1019,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -954,6 +1060,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -992,6 +1102,12 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_Sidearm</li>
+						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1030,6 +1146,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1068,6 +1188,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1106,6 +1230,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1144,6 +1272,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1182,6 +1314,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1220,6 +1356,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1258,6 +1398,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1296,6 +1440,11 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_Sidearm</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1334,6 +1483,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1372,6 +1525,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1410,6 +1567,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1448,6 +1609,11 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_Sidearm</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1485,6 +1651,11 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_Sidearm</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1523,6 +1694,12 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_Sidearm</li>
+						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1561,6 +1738,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1599,6 +1780,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1637,6 +1822,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1675,6 +1864,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1713,6 +1906,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1751,6 +1948,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1789,6 +1990,11 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_Sidearm</li>
+						<li>CE_OneHandedWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1827,6 +2033,11 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_Sidearm</li>
+						<li>CE_OneHandedWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1865,6 +2076,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1903,6 +2118,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1941,6 +2160,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1979,6 +2202,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -2017,6 +2244,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -2055,6 +2286,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -2093,6 +2328,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -2131,6 +2370,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -2169,6 +2412,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -2207,6 +2454,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -2245,6 +2496,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -2283,6 +2538,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -2321,6 +2580,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -2359,6 +2622,10 @@
 					<FireModes>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
+					<weaponTags>
+						<li>CE_SMG</li>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
 				</li>
 
 			</operations>


### PR DESCRIPTION
## Additions

None

## Changes

- Added weapontags for bipods to Rambo Weapons Pack 
- Added weapontags for one handed weapons to Rambo Weapons Pack
- Added weapontags for Sidearm and machinegunner flags to Rambo Weapons Pack
- Added weapontags for AI flags to Rambo Weapons Pack

## References

N/A

## Reasoning

Bring Rambo Weapons Pack up to date with more modern iterations of CE, taking advantage of new mechanics like bipods as well as flagging one handed weapons, pistols and machineguns correctly for CE to take advantage of. 

## Alternatives

non others considered

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
    - Tested with faction raids during in dev quick start instance (both with and without Rambo Weapons Pack enabled) as well as ensuring weapon functionality works as intended with a sample selection of weapons added by RWP. 
