### PR TITLE
Rambo Weapons Pack - Recipe change

### DIFF
--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_amrifles.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_amrifles.xml
@@ -95,7 +95,8 @@
 						<RangedWeapon_Cooldown>4.05</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>260</Steel>
+						<WoodLog>3</WoodLog>
+						<Steel>257</Steel>
 						<ComponentIndustrial>10</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -134,7 +135,8 @@
 						<RangedWeapon_Cooldown>4.05</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>250</Steel>
+						<WoodLog>3</WoodLog>
+						<Steel>247</Steel>
 						<ComponentIndustrial>9</ComponentIndustrial>
 					</costList>
 					<Properties>

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_amrifles.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_amrifles.xml
@@ -95,8 +95,8 @@
 						<RangedWeapon_Cooldown>4.05</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<WoodLog>3</WoodLog>
-						<Steel>257</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>250</Steel>
 						<ComponentIndustrial>10</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -135,8 +135,8 @@
 						<RangedWeapon_Cooldown>4.05</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<WoodLog>3</WoodLog>
-						<Steel>247</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>240</Steel>
 						<ComponentIndustrial>9</ComponentIndustrial>
 					</costList>
 					<Properties>

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_assaultrifles.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_assaultrifles.xml
@@ -502,8 +502,8 @@
 						<RangedWeapon_Cooldown>1.61</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<WoodLog>2</WoodLog>
-						<Steel>84</Steel>
+						<WoodLog>3</WoodLog>
+						<Steel>83</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_assaultrifles.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_assaultrifles.xml
@@ -19,7 +19,8 @@
 						<RangedWeapon_Cooldown>1.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>75</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>70</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -105,7 +106,8 @@
 						<RangedWeapon_Cooldown>1.59</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>95</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>90</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -148,7 +150,8 @@
 						<RangedWeapon_Cooldown>1.29</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>80</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>75</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -191,7 +194,8 @@
 						<RangedWeapon_Cooldown>1.27</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>82</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>77</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -234,7 +238,8 @@
 						<RangedWeapon_Cooldown>1.27</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>82</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>77</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -277,7 +282,8 @@
 						<RangedWeapon_Cooldown>1.31</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>83</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>78</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -320,7 +326,8 @@
 						<RangedWeapon_Cooldown>1.57</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>83</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>78</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -363,7 +370,8 @@
 						<RangedWeapon_Cooldown>1.61</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>87</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>82</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -406,7 +414,8 @@
 						<RangedWeapon_Cooldown>1.31</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>87</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>82</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -449,7 +458,8 @@
 						<RangedWeapon_Cooldown>1.58</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>86</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>81</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -492,7 +502,8 @@
 						<RangedWeapon_Cooldown>1.61</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>86</Steel>
+						<WoodLog>2</WoodLog>
+						<Steel>84</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -535,7 +546,8 @@
 						<RangedWeapon_Cooldown>1.61</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>91</Steel>
+						<WoodLog>3</WoodLog>
+						<Steel>88</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -578,7 +590,8 @@
 						<RangedWeapon_Cooldown>1.32</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>91</Steel>
+						<WoodLog>3</WoodLog>
+						<Steel>88</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -621,7 +634,8 @@
 						<RangedWeapon_Cooldown>1.19</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>62</Steel>
+						<WoodLog>3</WoodLog>
+						<Steel>59</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -664,7 +678,8 @@
 						<RangedWeapon_Cooldown>1.19</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>62</Steel>
+						<WoodLog>3</WoodLog>
+						<Steel>59</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -707,7 +722,8 @@
 						<RangedWeapon_Cooldown>0.80</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>90</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>85</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -750,7 +766,8 @@
 						<RangedWeapon_Cooldown>1.20</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>110</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>107</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -793,7 +810,8 @@
 						<RangedWeapon_Cooldown>2.55</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>110</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>105</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -836,7 +854,8 @@
 						<RangedWeapon_Cooldown>1.28</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>85</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>75</Steel>
 						<ComponentIndustrial>9</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -879,7 +898,8 @@
 						<RangedWeapon_Cooldown>1.33</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>82</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>72</Steel>
 						<ComponentIndustrial>9</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -922,7 +942,8 @@
 						<RangedWeapon_Cooldown>1.30</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>80</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>70</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -965,7 +986,8 @@
 						<RangedWeapon_Cooldown>1.30</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>74</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>69</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1008,7 +1030,8 @@
 						<RangedWeapon_Cooldown>1.23</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>74</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>64</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1051,7 +1074,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>100</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>90</Steel>
 						<ComponentIndustrial>9</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1094,7 +1118,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>68</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>58</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1137,7 +1162,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>69</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>59</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1180,7 +1206,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>71</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>61</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1223,7 +1250,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>110</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>100</Steel>
 						<ComponentIndustrial>10</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1266,7 +1294,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>85</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>75</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1309,7 +1338,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>79</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>69</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1352,6 +1382,7 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
+						<Chemfuel>10</Chemfuel>
 						<Steel>82</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
@@ -1395,7 +1426,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>86</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>83</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1438,7 +1470,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>66</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>63</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1481,7 +1514,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>82</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>79</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1524,7 +1558,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>92</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>89</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1567,7 +1602,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>92</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>89</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1610,7 +1646,8 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>80</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>75</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1653,7 +1690,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>80</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>75</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1696,6 +1734,7 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
+						<Chemfuel>5</Chemfuel>
 						<Steel>72</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
@@ -1739,7 +1778,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>72</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>67</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1782,7 +1822,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>79</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>74</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1825,7 +1866,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>78</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>73</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1868,7 +1910,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>78</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>73</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1911,7 +1954,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>81</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>76</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1954,7 +1998,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>70</Steel>
+						<WoodLog>3</WoodLog>
+						<Steel>67</Steel>
 						<ComponentIndustrial>6</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1997,7 +2042,9 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>90</Steel>
+						<Chemfuel>3</Chemfuel>
+						<WoodLog>2</WoodLog>
+						<Steel>85</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -2040,7 +2087,9 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>97</Steel>
+						<Chemfuel>3</Chemfuel>
+						<WoodLog>2</WoodLog>
+						<Steel>92</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -2083,7 +2132,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>90</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>85</Steel>
 						<ComponentIndustrial>6</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -2126,7 +2176,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>92</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>89</Steel>
 						<ComponentIndustrial>6</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -2169,7 +2220,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>94</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>91</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -2212,7 +2264,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>105</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>102</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -2255,7 +2308,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>100</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>97</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -2298,7 +2352,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>83</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>78</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -2341,7 +2396,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>82</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>77</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -2384,7 +2440,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>79</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>74</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -2427,7 +2484,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>69</Steel>
+						<WoodLog>3</WoodLog>
+						<Steel>66</Steel>
 						<ComponentIndustrial>6</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -2470,7 +2528,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>78</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>68</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -2513,7 +2572,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>80</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>70</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -2556,7 +2616,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>80</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>70</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -2599,7 +2660,9 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>118</Steel>
+						<Chemfuel>3</Chemfuel>
+						<WoodLog>2</WoodLog>
+						<Steel>113</Steel>
 						<ComponentIndustrial>10</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -2642,6 +2705,7 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
+						<WoodLog>5</WoodLog>
 						<Steel>87</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
@@ -2685,7 +2749,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>89</Steel>
+						<WoodLog>3</WoodLog>
+						<Steel>86</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_assaultrifles.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_assaultrifles.xml
@@ -19,8 +19,8 @@
 						<RangedWeapon_Cooldown>1.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>5</Chemfuel>
-						<Steel>70</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>65</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -106,8 +106,8 @@
 						<RangedWeapon_Cooldown>1.59</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<WoodLog>5</WoodLog>
-						<Steel>90</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>85</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -150,8 +150,8 @@
 						<RangedWeapon_Cooldown>1.29</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<WoodLog>5</WoodLog>
-						<Steel>75</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>70</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -194,8 +194,8 @@
 						<RangedWeapon_Cooldown>1.27</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>5</Chemfuel>
-						<Steel>77</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>72</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -238,8 +238,8 @@
 						<RangedWeapon_Cooldown>1.27</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>5</Chemfuel>
-						<Steel>77</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>72</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -282,8 +282,8 @@
 						<RangedWeapon_Cooldown>1.31</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>5</Chemfuel>
-						<Steel>78</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>73</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -370,8 +370,8 @@
 						<RangedWeapon_Cooldown>1.61</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>5</Chemfuel>
-						<Steel>82</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>78</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -414,8 +414,8 @@
 						<RangedWeapon_Cooldown>1.31</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>5</Chemfuel>
-						<Steel>82</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>78</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -458,8 +458,8 @@
 						<RangedWeapon_Cooldown>1.58</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<WoodLog>5</WoodLog>
-						<Steel>81</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>77</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -502,8 +502,8 @@
 						<RangedWeapon_Cooldown>1.61</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<WoodLog>3</WoodLog>
-						<Steel>83</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>76</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -546,8 +546,8 @@
 						<RangedWeapon_Cooldown>1.61</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<WoodLog>3</WoodLog>
-						<Steel>88</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>75</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -590,8 +590,8 @@
 						<RangedWeapon_Cooldown>1.32</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<WoodLog>3</WoodLog>
-						<Steel>88</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>81</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -634,8 +634,8 @@
 						<RangedWeapon_Cooldown>1.19</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<WoodLog>3</WoodLog>
-						<Steel>59</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>52</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -678,8 +678,8 @@
 						<RangedWeapon_Cooldown>1.19</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<WoodLog>3</WoodLog>
-						<Steel>59</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>52</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -722,8 +722,8 @@
 						<RangedWeapon_Cooldown>0.80</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>5</Chemfuel>
-						<Steel>85</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>80</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -766,8 +766,8 @@
 						<RangedWeapon_Cooldown>1.20</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
-						<Steel>107</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>102</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -810,8 +810,8 @@
 						<RangedWeapon_Cooldown>2.55</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>5</Chemfuel>
-						<Steel>105</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>100</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -854,8 +854,8 @@
 						<RangedWeapon_Cooldown>1.28</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>10</Chemfuel>
-						<Steel>75</Steel>
+						<Chemfuel>20</Chemfuel>
+						<Steel>65</Steel>
 						<ComponentIndustrial>9</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -898,8 +898,8 @@
 						<RangedWeapon_Cooldown>1.33</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>10</Chemfuel>
-						<Steel>72</Steel>
+						<Chemfuel>15</Chemfuel>
+						<Steel>68</Steel>
 						<ComponentIndustrial>9</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -942,8 +942,8 @@
 						<RangedWeapon_Cooldown>1.30</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>10</Chemfuel>
-						<Steel>70</Steel>
+						<Chemfuel>15</Chemfuel>
+						<Steel>65</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -986,8 +986,8 @@
 						<RangedWeapon_Cooldown>1.30</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>5</Chemfuel>
-						<Steel>69</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>64</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1030,8 +1030,8 @@
 						<RangedWeapon_Cooldown>1.23</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>10</Chemfuel>
-						<Steel>64</Steel>
+						<Chemfuel>15</Chemfuel>
+						<Steel>59</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1074,8 +1074,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>10</Chemfuel>
-						<Steel>90</Steel>
+						<Chemfuel>15</Chemfuel>
+						<Steel>85</Steel>
 						<ComponentIndustrial>9</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1118,8 +1118,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>10</Chemfuel>
-						<Steel>58</Steel>
+						<Chemfuel>15</Chemfuel>
+						<Steel>53</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1162,8 +1162,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>10</Chemfuel>
-						<Steel>59</Steel>
+						<Chemfuel>15</Chemfuel>
+						<Steel>53</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1206,8 +1206,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>10</Chemfuel>
-						<Steel>61</Steel>
+						<Chemfuel>15</Chemfuel>
+						<Steel>56</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1250,8 +1250,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>10</Chemfuel>
-						<Steel>100</Steel>
+						<Chemfuel>15</Chemfuel>
+						<Steel>95</Steel>
 						<ComponentIndustrial>10</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1294,8 +1294,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>10</Chemfuel>
-						<Steel>75</Steel>
+						<Chemfuel>15</Chemfuel>
+						<Steel>70</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1338,8 +1338,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>10</Chemfuel>
-						<Steel>69</Steel>
+						<Chemfuel>15</Chemfuel>
+						<Steel>64</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1382,8 +1382,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>10</Chemfuel>
-						<Steel>82</Steel>
+						<Chemfuel>15</Chemfuel>
+						<Steel>77</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1426,8 +1426,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
-						<Steel>83</Steel>
+						<Chemfuel>8</Chemfuel>
+						<Steel>78</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1470,8 +1470,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
-						<Steel>63</Steel>
+						<Chemfuel>8</Chemfuel>
+						<Steel>58</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1514,8 +1514,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
-						<Steel>79</Steel>
+						<Chemfuel>8</Chemfuel>
+						<Steel>74</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1558,8 +1558,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
-						<Steel>89</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>82</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1602,8 +1602,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
-						<Steel>89</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>79</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1646,8 +1646,8 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>5</Chemfuel>
-						<Steel>75</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>70</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1690,8 +1690,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>5</Chemfuel>
-						<Steel>75</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>70</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1734,8 +1734,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>5</Chemfuel>
-						<Steel>72</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>68</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1778,8 +1778,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>5</Chemfuel>
-						<Steel>67</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>62</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1822,8 +1822,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>5</Chemfuel>
-						<Steel>74</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>69</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1866,8 +1866,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>5</Chemfuel>
-						<Steel>73</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>68</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1910,8 +1910,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>5</Chemfuel>
-						<Steel>73</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>68</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1954,8 +1954,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>5</Chemfuel>
-						<Steel>76</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>71</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1998,8 +1998,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<WoodLog>3</WoodLog>
-						<Steel>67</Steel>
+						<WoodLog>8</WoodLog>
+						<Steel>62</Steel>
 						<ComponentIndustrial>6</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -2042,9 +2042,9 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
-						<WoodLog>2</WoodLog>
-						<Steel>85</Steel>
+						<Chemfuel>8</Chemfuel>
+						<WoodLog>10</WoodLog>
+						<Steel>78</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -2087,9 +2087,9 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
-						<WoodLog>2</WoodLog>
-						<Steel>92</Steel>
+						<Chemfuel>8</Chemfuel>
+						<WoodLog>10</WoodLog>
+						<Steel>83</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -2132,8 +2132,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>5</Chemfuel>
-						<Steel>85</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>80</Steel>
 						<ComponentIndustrial>6</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -2176,8 +2176,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
-						<Steel>89</Steel>
+						<Chemfuel>8</Chemfuel>
+						<Steel>81</Steel>
 						<ComponentIndustrial>6</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -2220,8 +2220,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
-						<Steel>91</Steel>
+						<Chemfuel>15</Chemfuel>
+						<Steel>78</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -2264,8 +2264,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
-						<Steel>102</Steel>
+						<Chemfuel>15</Chemfuel>
+						<Steel>81</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -2308,8 +2308,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
-						<Steel>97</Steel>
+						<Chemfuel>15</Chemfuel>
+						<Steel>79</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -2352,8 +2352,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>5</Chemfuel>
-						<Steel>78</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>73</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -2396,8 +2396,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>5</Chemfuel>
-						<Steel>77</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>72</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -2440,8 +2440,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>5</Chemfuel>
-						<Steel>74</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>70</Steel>
 						<ComponentIndustrial>7</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -2484,8 +2484,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<WoodLog>3</WoodLog>
-						<Steel>66</Steel>
+						<WoodLog>8</WoodLog>
+						<Steel>63</Steel>
 						<ComponentIndustrial>6</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -2660,9 +2660,9 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
-						<WoodLog>2</WoodLog>
-						<Steel>113</Steel>
+						<Chemfuel>8</Chemfuel>
+						<WoodLog>10</WoodLog>
+						<Steel>100</Steel>
 						<ComponentIndustrial>10</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -2705,8 +2705,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<WoodLog>5</WoodLog>
-						<Steel>87</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>82</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -2749,8 +2749,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<WoodLog>3</WoodLog>
-						<Steel>86</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>81</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_battlerifles.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_battlerifles.xml
@@ -63,7 +63,7 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<WoodLog>5</WoodLog>
+						<WoodLog>10</WoodLog>
 						<Steel>80</Steel>
 						<ComponentIndustrial>4</ComponentIndustrial>
 					</costList>
@@ -104,8 +104,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>5</Chemfuel>
-						<Steel>117</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>106</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -148,8 +148,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>5</Chemfuel>
-						<Steel>120</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>113</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -192,8 +192,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>5</Chemfuel>
-						<Steel>115</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>110</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -236,8 +236,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>5</Chemfuel>
-						<Steel>120</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>115</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -280,8 +280,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
-						<Steel>122</Steel>
+						<Chemfuel>8</Chemfuel>
+						<Steel>117</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -324,8 +324,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
-						<Steel>122</Steel>
+						<Chemfuel>8</Chemfuel>
+						<Steel>117</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -368,8 +368,8 @@
 						<RangedWeapon_Cooldown>0.57</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<WoodLog>3</WoodLog>
-						<Steel>112</Steel>
+						<WoodLog>8</WoodLog>
+						<Steel>104</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -412,8 +412,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<WoodLog>5</WoodLog>
-						<Steel>80</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>75</Steel>
 						<ComponentIndustrial>4</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -497,8 +497,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
-						<Steel>119</Steel>
+						<Chemfuel>12</Chemfuel>
+						<Steel>102</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -541,8 +541,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
-						<Steel>119</Steel>
+						<Chemfuel>12</Chemfuel>
+						<Steel>104</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -585,8 +585,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
-						<Steel>119</Steel>
+						<Chemfuel>12</Chemfuel>
+						<Steel>103</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_battlerifles.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_battlerifles.xml
@@ -19,7 +19,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>67</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>57</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -62,7 +63,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>85</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>80</Steel>
 						<ComponentIndustrial>4</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -102,7 +104,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>123</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>117</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -145,7 +148,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>125</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>120</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -188,7 +192,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>120</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>115</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -231,7 +236,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>125</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>120</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -274,7 +280,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>125</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>122</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -317,7 +324,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>125</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>122</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -360,7 +368,8 @@
 						<RangedWeapon_Cooldown>0.57</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>115</Steel>
+						<WoodLog>3</WoodLog>
+						<Steel>112</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -403,7 +412,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>85</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>80</Steel>
 						<ComponentIndustrial>4</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -443,7 +453,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>70</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>60</Steel>
 						<ComponentIndustrial>4</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -486,7 +497,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>122</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>119</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -529,7 +541,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>122</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>119</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -572,7 +585,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>122</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>119</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_heavy.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_heavy.xml
@@ -19,8 +19,7 @@
 						<RangedWeapon_Cooldown>1.01</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>2</Chemfuel>
-						<WoodLog>3</WoodLog>
+						<WoodLog>10</WoodLog>
 						<Steel>90</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
@@ -64,7 +63,7 @@
 						<RangedWeapon_Cooldown>0.43</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<WoodLog>5</WoodLog>
+						<WoodLog>10</WoodLog>
 						<Steel>75</Steel>
 						<ComponentIndustrial>4</ComponentIndustrial>
 					</costList>
@@ -109,8 +108,8 @@
 						<RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>5</Chemfuel>
-						<Steel>120</Steel>
+						<Chemfuel>15</Chemfuel>
+						<Steel>115</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_heavy.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_heavy.xml
@@ -19,7 +19,9 @@
 						<RangedWeapon_Cooldown>1.01</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>95</Steel>
+						<Chemfuel>2</Chemfuel>
+						<WoodLog>3</WoodLog>
+						<Steel>90</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -62,7 +64,8 @@
 						<RangedWeapon_Cooldown>0.43</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>80</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>75</Steel>
 						<ComponentIndustrial>4</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -106,7 +109,8 @@
 						<RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>125</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>120</Steel>
 						<ComponentIndustrial>8</ComponentIndustrial>
 					</costList>
 					<Properties>

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_machineguns.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_machineguns.xml
@@ -19,7 +19,8 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>150</Steel>
+						<WoodLog>3</WoodLog>
+						<Steel>147</Steel>
 						<ComponentIndustrial>9</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -66,7 +67,8 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>150</Steel>
+						<WoodLog>3</WoodLog>
+						<Steel>147</Steel>
 						<ComponentIndustrial>9</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -113,7 +115,8 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>176</Steel>
+						<WoodLog>3</WoodLog>
+						<Steel>173</Steel>
 						<ComponentIndustrial>12</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -160,7 +163,8 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>178</Steel>
+						<WoodLog>3</WoodLog>
+						<Steel>175</Steel>
 						<ComponentIndustrial>12</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -207,7 +211,8 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>86</Steel>
+						<WoodLog>3</WoodLog>
+						<Steel>83</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -254,7 +259,8 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>181</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>178</Steel>
 						<ComponentIndustrial>12</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -301,7 +307,8 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>178</Steel>
+						<WoodLog>3</WoodLog>
+						<Steel>175</Steel>
 						<ComponentIndustrial>12</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -348,7 +355,8 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>180</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>175</Steel>
 						<ComponentIndustrial>12</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -395,7 +403,8 @@
 						<RangedWeapon_Cooldown>0.55</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>182</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>179</Steel>
 						<ComponentIndustrial>12</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -442,7 +451,8 @@
 						<RangedWeapon_Cooldown>0.55</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>172</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>167</Steel>
 						<ComponentIndustrial>12</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -489,7 +499,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>160</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>155</Steel>
 						<ComponentIndustrial>9</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -536,7 +547,8 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>175</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>172</Steel>
 						<ComponentIndustrial>13</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -583,7 +595,8 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>180</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>177</Steel>
 						<ComponentIndustrial>12</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -630,7 +643,8 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>178</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>175</Steel>
 						<ComponentIndustrial>13</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -677,7 +691,8 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>182</Steel>
+						<WoodLog>3</WoodLog>
+						<Steel>179</Steel>
 						<ComponentIndustrial>12</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -724,7 +739,8 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>185</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>182</Steel>
 						<ComponentIndustrial>12</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -771,7 +787,8 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>190</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>187</Steel>
 						<ComponentIndustrial>12</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -818,7 +835,8 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>165</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>160</Steel>
 						<ComponentIndustrial>12</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -865,7 +883,8 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>167</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>162</Steel>
 						<ComponentIndustrial>11</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -912,7 +931,8 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>165</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>160</Steel>
 						<ComponentIndustrial>10</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -959,7 +979,8 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>170</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>165</Steel>
 						<ComponentIndustrial>10</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1006,7 +1027,8 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>168</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>163</Steel>
 						<ComponentIndustrial>10</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1053,7 +1075,8 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>178</Steel>
+						<WoodLog>3</WoodLog>
+						<Steel>175</Steel>
 						<ComponentIndustrial>13</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1100,7 +1123,8 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>140</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>135</Steel>
 						<ComponentIndustrial>6</ComponentIndustrial>
 					</costList>
 					<Properties>

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_machineguns.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_machineguns.xml
@@ -19,7 +19,7 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<WoodLog>3</WoodLog>
+						<WoodLog>8</WoodLog>
 						<Steel>147</Steel>
 						<ComponentIndustrial>9</ComponentIndustrial>
 					</costList>
@@ -67,7 +67,7 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<WoodLog>3</WoodLog>
+						<WoodLog>8</WoodLog>
 						<Steel>147</Steel>
 						<ComponentIndustrial>9</ComponentIndustrial>
 					</costList>
@@ -115,7 +115,7 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<WoodLog>3</WoodLog>
+						<WoodLog>8</WoodLog>
 						<Steel>173</Steel>
 						<ComponentIndustrial>12</ComponentIndustrial>
 					</costList>
@@ -163,7 +163,7 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<WoodLog>3</WoodLog>
+						<WoodLog>8</WoodLog>
 						<Steel>175</Steel>
 						<ComponentIndustrial>12</ComponentIndustrial>
 					</costList>
@@ -211,7 +211,7 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<WoodLog>3</WoodLog>
+						<WoodLog>8</WoodLog>
 						<Steel>83</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
@@ -259,7 +259,7 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
+						<Chemfuel>10</Chemfuel>
 						<Steel>178</Steel>
 						<ComponentIndustrial>12</ComponentIndustrial>
 					</costList>
@@ -307,7 +307,7 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<WoodLog>3</WoodLog>
+						<WoodLog>8</WoodLog>
 						<Steel>175</Steel>
 						<ComponentIndustrial>12</ComponentIndustrial>
 					</costList>
@@ -403,7 +403,7 @@
 						<RangedWeapon_Cooldown>0.55</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
+						<Chemfuel>10</Chemfuel>
 						<Steel>179</Steel>
 						<ComponentIndustrial>12</ComponentIndustrial>
 					</costList>
@@ -547,7 +547,7 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
+						<Chemfuel>10</Chemfuel>
 						<Steel>172</Steel>
 						<ComponentIndustrial>13</ComponentIndustrial>
 					</costList>
@@ -595,7 +595,7 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
+						<Chemfuel>10</Chemfuel>
 						<Steel>177</Steel>
 						<ComponentIndustrial>12</ComponentIndustrial>
 					</costList>
@@ -643,7 +643,7 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
+						<Chemfuel>10</Chemfuel>
 						<Steel>175</Steel>
 						<ComponentIndustrial>13</ComponentIndustrial>
 					</costList>
@@ -691,7 +691,7 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<WoodLog>3</WoodLog>
+						<WoodLog>8</WoodLog>
 						<Steel>179</Steel>
 						<ComponentIndustrial>12</ComponentIndustrial>
 					</costList>
@@ -739,7 +739,7 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
+						<Chemfuel>10</Chemfuel>
 						<Steel>182</Steel>
 						<ComponentIndustrial>12</ComponentIndustrial>
 					</costList>
@@ -787,7 +787,7 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
+						<Chemfuel>10</Chemfuel>
 						<Steel>187</Steel>
 						<ComponentIndustrial>12</ComponentIndustrial>
 					</costList>
@@ -1075,7 +1075,7 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<WoodLog>3</WoodLog>
+						<WoodLog>8</WoodLog>
 						<Steel>175</Steel>
 						<ComponentIndustrial>13</ComponentIndustrial>
 					</costList>

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_pistols.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_pistols.xml
@@ -492,7 +492,8 @@
 						<RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>26</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>23</Steel>
 						<ComponentIndustrial>2</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -528,7 +529,8 @@
 						<RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>33</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>30</Steel>
 						<ComponentIndustrial>2</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -564,7 +566,8 @@
 						<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>34</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>31</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -605,7 +608,8 @@
 						<RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>24</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>21</Steel>
 						<ComponentIndustrial>2</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -641,7 +645,8 @@
 						<RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>23</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>20</Steel>
 						<ComponentIndustrial>2</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -858,7 +863,8 @@
 						<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>37</Steel>
+						<WoodLog>2</WoodLog>
+						<Steel>35</Steel>
 						<ComponentIndustrial>4</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1254,7 +1260,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>40</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>37</Steel>
 						<ComponentIndustrial>2</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1326,7 +1333,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>35</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>32</Steel>
 						<ComponentIndustrial>2</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1398,7 +1406,8 @@
 						<RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>35</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>32</Steel>
 						<ComponentIndustrial>2</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1434,7 +1443,8 @@
 						<RangedWeapon_Cooldown>0.40</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>38</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>35</Steel>
 						<ComponentIndustrial>2</ComponentIndustrial>
 					</costList>
 					<Properties>

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_pistols.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_pistols.xml
@@ -492,7 +492,7 @@
 						<RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
+						<Chemfuel>6</Chemfuel>
 						<Steel>23</Steel>
 						<ComponentIndustrial>2</ComponentIndustrial>
 					</costList>
@@ -529,7 +529,7 @@
 						<RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
+						<Chemfuel>6</Chemfuel>
 						<Steel>30</Steel>
 						<ComponentIndustrial>2</ComponentIndustrial>
 					</costList>
@@ -566,7 +566,7 @@
 						<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
+						<Chemfuel>6</Chemfuel>
 						<Steel>31</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
@@ -608,7 +608,7 @@
 						<RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
+						<Chemfuel>6</Chemfuel>
 						<Steel>21</Steel>
 						<ComponentIndustrial>2</ComponentIndustrial>
 					</costList>
@@ -645,7 +645,7 @@
 						<RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
+						<Chemfuel>6</Chemfuel>
 						<Steel>20</Steel>
 						<ComponentIndustrial>2</ComponentIndustrial>
 					</costList>
@@ -863,7 +863,7 @@
 						<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<WoodLog>2</WoodLog>
+						<WoodLog>5</WoodLog>
 						<Steel>35</Steel>
 						<ComponentIndustrial>4</ComponentIndustrial>
 					</costList>
@@ -1260,7 +1260,7 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
+						<Chemfuel>6</Chemfuel>
 						<Steel>37</Steel>
 						<ComponentIndustrial>2</ComponentIndustrial>
 					</costList>
@@ -1333,7 +1333,7 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
+						<Chemfuel>6</Chemfuel>
 						<Steel>32</Steel>
 						<ComponentIndustrial>2</ComponentIndustrial>
 					</costList>
@@ -1406,7 +1406,7 @@
 						<RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
+						<Chemfuel>6</Chemfuel>
 						<Steel>32</Steel>
 						<ComponentIndustrial>2</ComponentIndustrial>
 					</costList>
@@ -1443,7 +1443,7 @@
 						<RangedWeapon_Cooldown>0.40</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
+						<Chemfuel>6</Chemfuel>
 						<Steel>35</Steel>
 						<ComponentIndustrial>2</ComponentIndustrial>
 					</costList>

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_rifles.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_rifles.xml
@@ -19,7 +19,8 @@
 						<RangedWeapon_Cooldown>1.17</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>60</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>50</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -54,7 +55,8 @@
 						<RangedWeapon_Cooldown>1.17</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>56</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>46</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -89,7 +91,8 @@
 						<RangedWeapon_Cooldown>1.17</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>59</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>49</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -124,7 +127,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>55</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>45</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -159,6 +163,7 @@
 						<RangedWeapon_Cooldown>1.16</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
+						<WoodLog>5</WoodLog>
 						<Steel>50</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
@@ -192,7 +197,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>69</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>59</Steel>
 						<ComponentIndustrial>4</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -227,7 +233,8 @@
 						<RangedWeapon_Cooldown>1.18</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>58</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>48</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -262,7 +269,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>53</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>43</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -297,7 +305,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>63</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>53</Steel>
 						<ComponentIndustrial>4</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -332,7 +341,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>55</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>50</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -367,7 +377,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>55</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>45</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -407,7 +418,8 @@
 						<RangedWeapon_Cooldown>1.17</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>59</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>49</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -442,7 +454,8 @@
 						<RangedWeapon_Cooldown>1.17</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>55</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>45</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -477,7 +490,8 @@
 						<RangedWeapon_Cooldown>1.17</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>62</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>52</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -512,7 +526,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>55</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>45</Steel>
 						<ComponentIndustrial>4</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -547,7 +562,8 @@
 						<RangedWeapon_Cooldown>1.17</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>59</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>49</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -582,7 +598,8 @@
 						<RangedWeapon_Cooldown>1.17</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>61</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>51</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -617,7 +634,8 @@
 						<RangedWeapon_Cooldown>1.17</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>57</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>47</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -652,7 +670,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>66</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>56</Steel>
 						<ComponentIndustrial>4</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -687,7 +706,8 @@
 						<RangedWeapon_Cooldown>0.76</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>55</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>50</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_shotguns.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_shotguns.xml
@@ -315,7 +315,7 @@
 						<RangedWeapon_Cooldown>0.99</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
+						<Chemfuel>6</Chemfuel>
 						<Steel>51</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
@@ -424,7 +424,7 @@
 						<RangedWeapon_Cooldown>1.01</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
+						<Chemfuel>6</Chemfuel>
 						<Steel>83</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
@@ -496,7 +496,7 @@
 						<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
+						<Chemfuel>6</Chemfuel>
 						<Steel>69</Steel>
 						<ComponentIndustrial>4</ComponentIndustrial>
 					</costList>

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_shotguns.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_shotguns.xml
@@ -19,7 +19,8 @@
 						<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>70</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>60</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -58,7 +59,8 @@
 						<RangedWeapon_Cooldown>0.99</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>60</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>55</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -93,7 +95,8 @@
 						<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>73</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>63</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -132,7 +135,8 @@
 						<RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>65</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>60</Steel>
 						<ComponentIndustrial>4</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -167,7 +171,8 @@
 						<RangedWeapon_Cooldown>0.99</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>59</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>54</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -202,7 +207,8 @@
 						<RangedWeapon_Cooldown>0.99</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>57</Steel>
+						<WoodLog>3</WoodLog>
+						<Steel>54</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -237,7 +243,8 @@
 						<RangedWeapon_Cooldown>1.00</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>57</Steel>
+						<WoodLog>3</WoodLog>
+						<Steel>54</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -272,7 +279,8 @@
 						<RangedWeapon_Cooldown>0.98</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>60</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>55</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -307,7 +315,8 @@
 						<RangedWeapon_Cooldown>0.99</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>54</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>51</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -342,7 +351,8 @@
 						<RangedWeapon_Cooldown>0.98</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>61</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>56</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -377,7 +387,9 @@
 						<RangedWeapon_Cooldown>1.01</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>88</Steel>
+						<WoodLog>3</WoodLog>
+						<Chemfuel>2</Chemfuel>
+						<Steel>83</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -412,7 +424,8 @@
 						<RangedWeapon_Cooldown>1.01</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>86</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>83</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -447,7 +460,8 @@
 						<RangedWeapon_Cooldown>1.01</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>72</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>67</Steel>
 						<ComponentIndustrial>4</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -482,7 +496,8 @@
 						<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>72</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>69</Steel>
 						<ComponentIndustrial>4</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -517,7 +532,8 @@
 						<RangedWeapon_Cooldown>0.41</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>45</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>40</Steel>
 						<ComponentIndustrial>1</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -555,7 +571,8 @@
 						<RangedWeapon_Cooldown>0.42</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>30</Steel>
+						<WoodLog>3</WoodLog>
+						<Steel>27</Steel>
 						<ComponentIndustrial>1</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -593,7 +610,8 @@
 						<RangedWeapon_Cooldown>0.41</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>45</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>40</Steel>
 						<ComponentIndustrial>1</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -631,7 +649,8 @@
 						<RangedWeapon_Cooldown>0.43</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>30</Steel>
+						<WoodLog>3</WoodLog>
+						<Steel>27</Steel>
 						<ComponentIndustrial>1</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -669,7 +688,8 @@
 						<RangedWeapon_Cooldown>0.99</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>56</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>51</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -704,7 +724,8 @@
 						<RangedWeapon_Cooldown>0.99</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>57</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>52</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -739,7 +760,8 @@
 						<RangedWeapon_Cooldown>1.00</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>57</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>52</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -774,7 +796,8 @@
 						<RangedWeapon_Cooldown>1.00</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>57</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>52</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_sniperrifles.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_sniperrifles.xml
@@ -19,7 +19,8 @@
 						<RangedWeapon_Cooldown>1.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>172</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>162</Steel>
 						<ComponentIndustrial>11</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -58,7 +59,8 @@
 						<RangedWeapon_Cooldown>1.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>200</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>190</Steel>
 						<ComponentIndustrial>12</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -97,7 +99,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>157</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>147</Steel>
 						<ComponentIndustrial>11</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -136,7 +139,8 @@
 						<RangedWeapon_Cooldown>1.17</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>165</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>155</Steel>
 						<ComponentIndustrial>10</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -175,7 +179,8 @@
 						<RangedWeapon_Cooldown>1.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>195</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>192</Steel>
 						<ComponentIndustrial>12</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -214,7 +219,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>194</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>189</Steel>
 						<ComponentIndustrial>14</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -253,7 +259,8 @@
 						<RangedWeapon_Cooldown>1.38</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>150</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>140</Steel>
 						<ComponentIndustrial>9</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -292,7 +299,8 @@
 						<RangedWeapon_Cooldown>1.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>177</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>167</Steel>
 						<ComponentIndustrial>10</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -331,7 +339,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>163</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>158</Steel>
 						<ComponentIndustrial>11</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -370,7 +379,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>160</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>155</Steel>
 						<ComponentIndustrial>12</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -408,7 +418,8 @@
 						<RangedWeapon_Cooldown>1.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>175</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>165</Steel>
 						<ComponentIndustrial>10</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -447,7 +458,8 @@
 						<RangedWeapon_Cooldown>1.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>180</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>170</Steel>
 						<ComponentIndustrial>10</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -486,7 +498,8 @@
 						<RangedWeapon_Cooldown>1.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>185</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>175</Steel>
 						<ComponentIndustrial>11</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -525,7 +538,8 @@
 						<RangedWeapon_Cooldown>1.38</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>195</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>185</Steel>
 						<ComponentIndustrial>12</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -564,7 +578,8 @@
 						<RangedWeapon_Cooldown>1.38</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>185</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>180</Steel>
 						<ComponentIndustrial>13</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -602,7 +617,8 @@
 						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>195</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>190</Steel>
 						<ComponentIndustrial>12</ComponentIndustrial>
 					</costList>
 					<Properties>

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_submachineguns.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_submachineguns.xml
@@ -57,7 +57,7 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
+						<Chemfuel>6</Chemfuel>
 						<Steel>42</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
@@ -712,7 +712,7 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
+						<Chemfuel>6</Chemfuel>
 						<Steel>46</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
@@ -751,7 +751,7 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
+						<Chemfuel>6</Chemfuel>
 						<Steel>40</Steel>
 						<ComponentIndustrial>4</ComponentIndustrial>
 					</costList>
@@ -790,7 +790,7 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
+						<Chemfuel>6</Chemfuel>
 						<Steel>39</Steel>
 						<ComponentIndustrial>4</ComponentIndustrial>
 					</costList>
@@ -868,7 +868,7 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
+						<Chemfuel>6</Chemfuel>
 						<Steel>50</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
@@ -944,7 +944,7 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
+						<Chemfuel>6</Chemfuel>
 						<Steel>53</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
@@ -982,7 +982,7 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
+						<Chemfuel>6</Chemfuel>
 						<Steel>54</Steel>
 						<ComponentIndustrial>4</ComponentIndustrial>
 					</costList>
@@ -1329,7 +1329,7 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
+						<Chemfuel>6</Chemfuel>
 						<Steel>53</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
@@ -1368,7 +1368,7 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
+						<Chemfuel>6</Chemfuel>
 						<Steel>53</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
@@ -1407,7 +1407,7 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Chemfuel>3</Chemfuel>
+						<Chemfuel>6</Chemfuel>
 						<Steel>52</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_submachineguns.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_submachineguns.xml
@@ -2333,8 +2333,9 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>55</Steel>
-						<ComponentIndustrial>3</ComponentIndustrial>
+						<Chemfuel>5</Chemfuel>
+      					<Steel>50</Steel>
+      					<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_submachineguns.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_submachineguns.xml
@@ -57,7 +57,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>45</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>42</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -95,7 +96,8 @@
 						<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>50</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>45</Steel>
 						<ComponentIndustrial>4</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -211,7 +213,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>52</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>42</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -553,7 +556,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>58</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>53</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -591,7 +595,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>54</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>49</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -629,7 +634,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>46</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>41</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -667,7 +673,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>51</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>46</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -705,7 +712,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>49</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>46</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -743,7 +751,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>43</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>40</Steel>
 						<ComponentIndustrial>4</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -781,7 +790,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>42</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>39</Steel>
 						<ComponentIndustrial>4</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -819,7 +829,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>49</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>44</Steel>
 						<ComponentIndustrial>4</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -857,7 +868,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>53</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>50</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -894,7 +906,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>58</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>53</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -931,7 +944,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>56</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>53</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -968,7 +982,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>57</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>54</Steel>
 						<ComponentIndustrial>4</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1006,7 +1021,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>36</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>26</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1044,7 +1060,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>38</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>28</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1158,7 +1175,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>42</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>37</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1234,7 +1252,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>60</Steel>
+						<Chemfuel>10</Chemfuel>
+						<Steel>50</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1310,7 +1329,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>56</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>53</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1348,7 +1368,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>58</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>53</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1386,7 +1407,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>55</Steel>
+						<Chemfuel>3</Chemfuel>
+						<Steel>52</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1499,7 +1521,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>46</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>41</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1537,7 +1560,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>39</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>29</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1575,7 +1599,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>45</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>35</Steel>
 						<ComponentIndustrial>4</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1613,7 +1638,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>43</Steel>
+						<WoodLog>10</WoodLog>
+						<Steel>33</Steel>
 						<ComponentIndustrial>4</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1689,7 +1715,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>47</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>42</Steel>
 						<ComponentIndustrial>4</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1727,7 +1754,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>45</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>40</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1841,7 +1869,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>37</Steel>
+						<WoodLog>3</WoodLog>
+						<Steel>34</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -1955,7 +1984,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>37</Steel>
+						<WoodLog>3</WoodLog>
+						<Steel>34</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -2069,7 +2099,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>54</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>49</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -2107,7 +2138,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>55</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>50</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -2145,7 +2177,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>58</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>53</Steel>
 						<ComponentIndustrial>4</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -2183,7 +2216,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>60</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>55</Steel>
 						<ComponentIndustrial>4</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -2221,7 +2255,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>56</Steel>
+						<WoodLog>5</WoodLog>
+						<Steel>51</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -2259,7 +2294,8 @@
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>53</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>48</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
@@ -2335,7 +2371,8 @@
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					</statBases>
 					<costList>
-						<Steel>56</Steel>
+						<Chemfuel>5</Chemfuel>
+						<Steel>51</Steel>
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>


### PR DESCRIPTION
## Additions

N/A

## Changes

Changed weapon recipies in RWP to include furniture of weapons created. (i.e chemfuel for polymer, wood for wood furniture) 

## References

N/A

## Reasoning

Changed recipes to include materials required for furniture and amounts of furniture (i.e, just handguard/stock, handguard and stock, action inserted into furniture body). 

- Aims to further differentiate between separate instances of weapons within this weapon pack. 
             -  Providing slight incentivisation for using trying different weapons over a playthrough due to associated costs and material stocks.   

## Alternatives

None 

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (5mins - checking weapons table recipes)
