### PR TITLE
VRE Android Factions patch

### DIFF
--- a/Patches/VRE Android Factions/Factions_Misc.xml
+++ b/Patches/VRE Android Factions/Factions_Misc.xml
@@ -1,0 +1,55 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>VRE Android Factions</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/TraderKindDef[defName="R_AndroidTrader"]/stockGenerators</xpath>
+					<value>
+						<li Class="StockGenerator_Tag">
+							<tradeTag>CE_Ammo</tradeTag>
+							<countRange>
+								<min>200</min>
+								<max>500</max>
+							</countRange>
+							<thingDefCountRange>
+								<min>2</min>
+								<max>4</max>
+							</thingDefCountRange>
+						</li>
+						<li Class="StockGenerator_Tag">
+							<tradeTag>CE_MediumAmmo</tradeTag>
+							<countRange>
+								<min>20</min>
+								<max>50</max>
+							</countRange>
+							<thingDefCountRange>
+								<min>2</min>
+								<max>6</max>
+							</thingDefCountRange>
+						</li>
+						<li Class="StockGenerator_Tag">
+							<tradeTag>CE_HeavyAmmo</tradeTag>
+							<countRange>
+								<min>5</min>
+								<max>10</max>
+							</countRange>
+							<thingDefCountRange>
+								<min>2</min>
+								<max>4</max>
+							</thingDefCountRange>
+						</li>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -554,6 +554,7 @@ VFE - Mechanoids : Drones |
 VFE - Mechanoids : Unoffical Add-On |
 VGP Fabrics |
 VGP Garden Drinks UF    |
+VRE Android Factions  |
 Vulpine Race Pack	|
 Wall Mounted Turrets (Continued)    |
 WarCasket Expanded  |


### PR DESCRIPTION
## Additions

- Patched the trader from the aforementioned mod.

## Reasoning

- The trader is loosely based on the outlander exotics trader, with slightly different stock.
- The faction itself is completely based on normal outlander and pirate factions with no new pawnKinds.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (spawned a trader, works)
