### PR TITLE
ADD RK_HeavyShield_Big modifiers

### DIFF
--- a/Patches/NewRatkinPlus/Bodies/Bodies_Ratkin.xml
+++ b/Patches/NewRatkinPlus/Bodies/Bodies_Ratkin.xml
@@ -40,7 +40,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/BodyDef[defName = "Ratkin"]/corePart/parts/li[def = "Ribcage"]/coverage</xpath>
 					<value>
-						<coverage>0.07</coverage>
+						<coverage>0.06</coverage>
 					</value>
 				</li>
 
@@ -61,14 +61,14 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/BodyDef[defName = "Ratkin"]/corePart/parts/li[def = "Heart"]/coverage</xpath>
 					<value>
-						<coverage>0.04</coverage>
+						<coverage>0.03</coverage>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/BodyDef[defName = "Ratkin"]/corePart/parts/li[def = "Lung"]/coverage</xpath>
 					<value>
-						<coverage>0.055</coverage>
+						<coverage>0.0525</coverage>
 					</value>
 				</li>
 
@@ -82,14 +82,14 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/BodyDef[defName = "Ratkin"]/corePart/parts/li[def = "Liver"]/coverage</xpath>
 					<value>
-						<coverage>0.06</coverage>
+						<coverage>0.055</coverage>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/BodyDef[defName = "Ratkin"]/corePart/parts/li[def = "Neck"]/coverage</xpath>
 					<value>
-						<coverage>0.055</coverage>
+						<coverage>0.05</coverage>
 					</value>
 				</li>
 

--- a/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_Apparel.xml
+++ b/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_Apparel.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 				<!--NOTE: Numerous pieces of apparel aren't patched here. Apparel without a specific value for Bulk or WornBulk
-		defaults to '1' for both. So, smaller pieces of clothing don't need patched.-->
+				defaults to '1' for both. So, smaller pieces of clothing don't need patched.-->
 
 				<!-- ========== CLOTHING =========== -->
 				<!-- ========== Apparel Base =========== -->
@@ -125,6 +125,7 @@
 						<WornBulk>1</WornBulk>
 					</value>
 				</li>
+				
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RK_CrossBack"]/equippedStatOffsets</xpath>
 					<value>
@@ -141,6 +142,7 @@
 						<Bulk>3</Bulk>
 					</value>
 				</li>
+				
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RK_Backpack"]/equippedStatOffsets</xpath>
 					<value>
@@ -158,6 +160,7 @@
 						<WornBulk>1</WornBulk>
 					</value>
 				</li>
+				
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RK_OutdoorBackpack"]/equippedStatOffsets</xpath>
 					<value>
@@ -174,6 +177,7 @@
 						<Bulk>10</Bulk>
 					</value>
 				</li>
+				
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RK_Sack"]/equippedStatOffsets</xpath>
 					<value>
@@ -191,6 +195,7 @@
 						<WornBulk>2</WornBulk>
 					</value>
 				</li>
+				
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RK_SantaSack"]/equippedStatOffsets</xpath>
 					<value>
@@ -209,18 +214,21 @@
 						<WornBulk>1</WornBulk>
 					</value>
 				</li>
+				
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RK_BulletProofHelmet"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
 					</value>
 				</li>
+				
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RK_BulletProofHelmet"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>1</ArmorRating_Sharp>
 					</value>
 				</li>
+				
 				<!-- ========== Order Uniform =========== -->
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RK_OrderUniform"]/statBases/Mass</xpath>
@@ -230,12 +238,14 @@
 						<Mass>10</Mass>
 					</value>
 				</li>
+				
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RK_OrderUniform"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
 					</value>
 				</li>
+				
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RK_OrderUniform"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
@@ -249,6 +259,7 @@
 						<ArmorRating_Blunt>7.875</ArmorRating_Blunt>
 					</value>
 				</li>
+				
 				<!-- ========== Battlesuit =========== -->
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="RK_BattleSuit"]/statBases</xpath>
@@ -257,21 +268,25 @@
 						<WornBulk>12</WornBulk>
 					</value>
 				</li>
+				
 				<li Class="PatchOperationRemove">
 					<xpath>Defs/ThingDef[defName="RK_BattleSuit"]/statBases/StuffEffectMultiplierArmor</xpath>
 				</li>
+				
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RK_BattleSuit"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>16</ArmorRating_Sharp>
 					</value>
 				</li>
+				
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RK_BattleSuit"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>36</ArmorRating_Blunt>
 					</value>
 				</li>
+				
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RK_BattleSuit"]/equippedStatOffsets</xpath>
 					<value>
@@ -282,6 +297,7 @@
 						</equippedStatOffsets>
 					</value>
 				</li>
+				
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="RK_BattleSuit"]/apparel/bodyPartGroups</xpath>
 					<value>
@@ -289,6 +305,7 @@
 						<li>Feet</li>
 					</value>
 				</li>
+				
 				<!-- ========== Combat Mask =========== -->
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="RK_Mask" or defName="RK_MaskB"]/statBases</xpath>
@@ -297,6 +314,7 @@
 						<WornBulk>1</WornBulk>
 					</value>
 				</li>
+				
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="RK_Mask" or defName="RK_MaskB"]/equippedStatOffsets</xpath>
 					<value>
@@ -305,21 +323,25 @@
 						<SmokeSensitivity>-1</SmokeSensitivity>
 					</value>
 				</li>
+				
 				<li Class="PatchOperationRemove">
 					<xpath>Defs/ThingDef[defName="RK_Mask" or defName="RK_MaskB"]/statBases/StuffEffectMultiplierArmor</xpath>
 				</li>
+				
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RK_Mask" or defName="RK_MaskB"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>13</ArmorRating_Sharp>
 					</value>
 				</li>
+				
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RK_Mask" or defName="RK_MaskB"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>32</ArmorRating_Blunt>
 					</value>
 				</li>
+				
 				<!-- ========== Plate Armor =========== -->
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="RK_Plate"]/statBases</xpath>
@@ -328,12 +350,14 @@
 						<WornBulk>8</WornBulk>
 					</value>
 				</li>
+				
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RK_Plate"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>2.1</StuffEffectMultiplierArmor>
 					</value>
 				</li>
+				
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="RK_Plate"]/apparel/bodyPartGroups</xpath>
 					<value>
@@ -341,6 +365,7 @@
 						<li>Feet</li>
 					</value>
 				</li>
+				
 				<!-- ========== Plate Armor - Helmets =========== -->
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="RK_PlateHelmA" or
@@ -351,6 +376,7 @@
 						<WornBulk>1</WornBulk>
 					</value>
 				</li>
+				
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RK_PlateHelmA" or
 						defName="RK_PlateHelmB" or
@@ -359,6 +385,7 @@
 						<StuffEffectMultiplierArmor>2.1</StuffEffectMultiplierArmor>
 					</value>
 				</li>
+				
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="RK_PlateHelmA" or
 						defName="RK_PlateHelmB" or
@@ -371,7 +398,7 @@
 
 				<!-- ========== Shields =========== -->
 				
-						<!-- ========== WoodenShield =========== -->
+				<!-- ========== WoodenShield =========== -->
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="RK_WoodenShield"]/statBases</xpath>
 					<value>
@@ -379,18 +406,21 @@
 						<WornBulk>4</WornBulk>
 					</value>
 				</li>
+				
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RK_WoodenShield"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>1.2</ArmorRating_Sharp>
 					</value>
 				</li>
+				
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RK_WoodenShield"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>1.75</ArmorRating_Blunt>
 					</value>
 				</li>
+				
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="RK_WoodenShield"]/equippedStatOffsets</xpath>
 					<value>
@@ -403,7 +433,8 @@
 						<MeleeParryChance>1.0</MeleeParryChance>
 					</value>
 				</li>
-						<!-- ========== HeavyShield =========== -->
+					
+				<!-- ========== HeavyShield =========== -->
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RK_HeavyShield"]/statBases/Mass</xpath>
 					<value>
@@ -412,24 +443,28 @@
 						<WornBulk>8</WornBulk>
 					</value>
 				</li>
+				
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RK_HeavyShield"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>6</StuffEffectMultiplierArmor>
 					</value>
 				</li>
+				
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RK_HeavyShield"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>1</ArmorRating_Sharp>
 					</value>
 				</li>
+				
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RK_HeavyShield"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>1.5</ArmorRating_Blunt>
 					</value>
 				</li>
+				
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="RK_HeavyShield"]/equippedStatOffsets</xpath>
 					<value>
@@ -443,7 +478,7 @@
 					</value>
 				</li>
 				
-						<!-- ========== HeavyShield_Big =========== -->
+				<!-- ========== HeavyShield_Big =========== -->
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RK_HeavyShield_Big"]/statBases/Mass</xpath>
 					<value>
@@ -452,26 +487,30 @@
 						<WornBulk>10</WornBulk>
 					</value>
 				</li>
+				
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RK_HeavyShield_Big"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
 					</value>
 				</li>
+				
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RK_HeavyShield_Big"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>2</ArmorRating_Sharp>
 					</value>
 				</li>
+				
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RK_HeavyShield_Big"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>3</ArmorRating_Blunt>
 					</value>
 				</li>
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="RK_HeavyShield_Big"]/equippedStatOffsets</xpath>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RK_HeavyShield_Big"]/equippedStatOffsets/MeleeHitChance</xpath>
 					<value>
 						<ReloadSpeed>-0.3</ReloadSpeed>
 						<MeleeHitChance>-1.2</MeleeHitChance>
@@ -505,6 +544,7 @@
 						<li>RK_Loadbearing</li>
 					</value>
 				</li>
+				
 				<!-- ========== Fix apparel layer for loadbearing gear. =========== -->
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[

--- a/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_Apparel.xml
+++ b/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_Apparel.xml
@@ -370,6 +370,8 @@
 				</li>
 
 				<!-- ========== Shields =========== -->
+				
+						<!-- ========== WoodenShield =========== -->
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="RK_WoodenShield"]/statBases</xpath>
 					<value>
@@ -401,7 +403,7 @@
 						<MeleeParryChance>1.0</MeleeParryChance>
 					</value>
 				</li>
-
+						<!-- ========== HeavyShield =========== -->
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RK_HeavyShield"]/statBases/Mass</xpath>
 					<value>
@@ -440,8 +442,49 @@
 						<MeleeParryChance>1.0</MeleeParryChance>
 					</value>
 				</li>
+				
+						<!-- ========== HeavyShield_Big =========== -->
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="RK_HeavyShield" or defName="RK_WoodenShield"]/apparel/layers</xpath>
+					<xpath>Defs/ThingDef[defName="RK_HeavyShield_Big"]/statBases/Mass</xpath>
+					<value>
+						<Mass>12</Mass>
+						<Bulk>18</Bulk>
+						<WornBulk>10</WornBulk>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RK_HeavyShield_Big"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RK_HeavyShield_Big"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>2</ArmorRating_Sharp>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RK_HeavyShield_Big"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>3</ArmorRating_Blunt>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RK_HeavyShield_Big"]/equippedStatOffsets</xpath>
+					<value>
+						<ReloadSpeed>-0.3</ReloadSpeed>
+						<MeleeHitChance>-1.2</MeleeHitChance>
+						<ShootingAccuracyPawn>-0.40</ShootingAccuracyPawn>
+						<AimingAccuracy>-0.40</AimingAccuracy>
+						<Suppressability>-0.50</Suppressability>
+						<MeleeCritChance>-0.05</MeleeCritChance>
+						<MeleeParryChance>1.0</MeleeParryChance>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RK_HeavyShield" or defName="RK_WoodenShield" or defName="RK_HeavyShield_Big"]/apparel/layers</xpath>
 					<value>
 						<layers>
 							<li>Shield</li>


### PR DESCRIPTION
I try to add defense value on RK_HeavyShield_big (Ratkin Bigshields) which based on normal RK_HeavyShield and CE default Shield modifiers 
If the better value exist Please comment 

I'm noob to GitHub project pull requests. So if this is not good work Please announce it. 

## Testing

Check tests you have performed:
- [ ] Compiles without warnings 
* simple XML changes 
- [ ] Game runs without errors 
* continued with existing changes 
- [ ] (For compatibility patches) ...with and without patched mod loaded 
* I'm can't understand of this. Is this has issue? 
- [ ] Playtested a colony (specify how long)
* works with equip and RHA defense modifer works 



![2024-03-08_012900](https://github.com/CombatExtended-Continued/CombatExtended/assets/23658398/73b977e3-bf4a-41fb-ad1e-1f79e30b95b6)
![2024-03-08_013000](https://github.com/CombatExtended-Continued/CombatExtended/assets/23658398/fd8af059-7730-49b6-bc38-7bf6d418d568)
![2024-03-08_013031](https://github.com/CombatExtended-Continued/CombatExtended/assets/23658398/725f032b-c505-4150-a07e-43e53b017cee)
![2024-03-08_013402](https://github.com/CombatExtended-Continued/CombatExtended/assets/23658398/332e4d86-53ac-4f2d-baa2-23e9381d14c5)

