### PR TITLE
Outer Rim Patches Update/Balancing

### DIFF
--- a/Defs/Ammo/AmmoCategoryDefs/AmmoCategories_Advanced.xml
+++ b/Defs/Ammo/AmmoCategoryDefs/AmmoCategories_Advanced.xml
@@ -147,4 +147,34 @@
 		<description>A concentrated beam of scorching plasma, capable of reducing even the heaviest of armor to molten slag.</description>
 	</CombatExtended.AmmoCategoryDef>
 
+	<!-- ========== For Star Wars ========== -->
+
+	<CombatExtended.AmmoCategoryDef>
+		<defName>BlasterStandard</defName>
+		<label>blaster</label>
+		<labelShort>blaster</labelShort>
+		<description>Energy bolts created with tibanna gas. Causes neat punctures and burns that tend to carbonize and char. Low chance of wound infection.</description>
+	</CombatExtended.AmmoCategoryDef>
+
+	<CombatExtended.AmmoCategoryDef>
+		<defName>BlasterAP</defName>
+		<label>concentrated tibanna</label>
+		<labelShort>conc.</labelShort>
+		<description>Energy bolts created with tibanna gas. Causes neat punctures and burns that tend to carbonize and char. Low chance of wound infection. Spun to a higher pressure to create bolts with improved penetration, at the loss of wounding potential.</description>
+	</CombatExtended.AmmoCategoryDef>
+
+	<CombatExtended.AmmoCategoryDef>
+		<defName>BlasterIonized</defName>
+		<label>ionized tibanna</label>
+		<labelShort>ion.</labelShort>
+		<description>Energy bolts created with tibanna gas. Causes neat punctures and burns that tend to carbonize and char. Low chance of wound infection. Ionized during the firing process to cause extra damage to droids and mechanoids, at the cost of reduced lethality against organics.</description>
+	</CombatExtended.AmmoCategoryDef>
+
+	<CombatExtended.AmmoCategoryDef>
+		<defName>SWRocketPlasma</defName>
+		<label>hi-energy plasma charge</label>
+		<labelShort>HEPC</labelShort>
+		<description>A compressed plasma charge produces a powerful armour-penetrating explosion, along with a concentrated secondary blast. Lacks fragmentation effects, unlike earlier warhead designs, limiting effective radius.</description>
+	</CombatExtended.AmmoCategoryDef>
+
 </Defs>

--- a/Defs/DamageDefs/Damages_LocalInjury.xml
+++ b/Defs/DamageDefs/Damages_LocalInjury.xml
@@ -129,6 +129,19 @@
 		</additionalHediffs>
 	</DamageDef>
 
+	<DamageDef ParentName="Electrical">
+		<defName>Neuralizer</defName>
+		<label>neuralizer</label>
+		<harmsHealth>false</harmsHealth>
+		<additionalHediffs>
+			<li>
+				<hediff>Neuralizer</hediff>
+				<severityPerDamageDealt>0.9</severityPerDamageDealt>
+				<victimSeverityScalingByInvBodySize>true</victimSeverityScalingByInvBodySize>
+			</li>
+		</additionalHediffs>
+	</DamageDef>
+
 	<DamageDef ParentName="StunBase">
 		<defName>Flashbang</defName>
 		<label>flashbang</label>

--- a/Defs/HediffDefs/Hediffs_CE.xml
+++ b/Defs/HediffDefs/Hediffs_CE.xml
@@ -382,7 +382,35 @@
 	<HediffDef>
 		<defName>Tranquilizer</defName>
 		<label>tranquilizer</label>
-		<description>the effects of a tranquilizer dart</description>
+		<description>The effects of a tranquilizer dart</description>
+		<hediffClass>HediffWithComps</hediffClass>
+		<defaultLabelColor>(0.8, 0.8, 0.35)</defaultLabelColor>
+		<initialSeverity>0.001</initialSeverity>
+		<isBad>false</isBad>
+		<comps>
+			<li Class="HediffCompProperties_Disappears">
+				<disappearsAfterTicks>
+					<min>7500</min>
+					<max>15000</max>
+				</disappearsAfterTicks>
+			</li>
+		</comps>
+		<stages>
+			<li>
+				<capMods>
+					<li>
+						<capacity>Consciousness</capacity>
+						<setMax>0.1</setMax>
+					</li>
+				</capMods>
+			</li>
+		</stages>
+	</HediffDef>
+
+	<HediffDef>
+		<defName>Neuralizer</defName>
+		<label>neuralizer</label>
+		<description>Stunned by a powerful but nonlethal energy pulse, disrupting the nervous system.</description>
 		<hediffClass>HediffWithComps</hediffClass>
 		<defaultLabelColor>(0.8, 0.8, 0.35)</defaultLabelColor>
 		<initialSeverity>0.001</initialSeverity>

--- a/Patches/Outer Rim - Chiss Ascendancy/Outer_Rim_Chiss_Ascendancy_Ranged_Weapons.xml
+++ b/Patches/Outer Rim - Chiss Ascendancy/Outer_Rim_Chiss_Ascendancy_Ranged_Weapons.xml
@@ -73,6 +73,7 @@
 						<soundCast>OuterRim_Shot_MaserBlasterBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>9</muzzleFlashScale>
+						<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
@@ -109,6 +110,7 @@
 						<soundCast>OuterRim_Shot_MaserBlasterBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>9</muzzleFlashScale>
+						<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>

--- a/Patches/Outer Rim - Core/Outer_Rim_Core_Ammo.xml
+++ b/Patches/Outer Rim - Core/Outer_Rim_Core_Ammo.xml
@@ -35,6 +35,7 @@
 								<Ammo_PlasmaGasCartridge_Standard>Bullet_BlasterPistol_Red</Ammo_PlasmaGasCartridge_Standard>
 								<Ammo_PlasmaGasCartridge_AP>Bullet_BlasterPistol_RedAP</Ammo_PlasmaGasCartridge_AP>
 								<Ammo_PlasmaGasCartridge_Ion>Bullet_BlasterPistol_Ion</Ammo_PlasmaGasCartridge_Ion>
+								<Ammo_PlasmaGasCartridge_Stun>Bullet_BlasterPistol_Stun</Ammo_PlasmaGasCartridge_Stun>
 							</ammoTypes>
 						</CombatExtended.AmmoSetDef>
 						
@@ -44,7 +45,8 @@
 							<ammoTypes>
 								<Ammo_PlasmaGasCartridge_Standard>Bullet_BlasterRifle_Red</Ammo_PlasmaGasCartridge_Standard>
 								<Ammo_PlasmaGasCartridge_AP>Bullet_BlasterRifle_RedAP</Ammo_PlasmaGasCartridge_AP>
-								<Ammo_PlasmaGasCartridge_Ion>Bullet_BlasterPistol_Ion</Ammo_PlasmaGasCartridge_Ion>
+								<Ammo_PlasmaGasCartridge_Ion>Bullet_BlasterRifle_Ion</Ammo_PlasmaGasCartridge_Ion>
+								<Ammo_PlasmaGasCartridge_Stun>Bullet_BlasterRifle_Stun</Ammo_PlasmaGasCartridge_Stun>
 							</ammoTypes>
 						</CombatExtended.AmmoSetDef>
 						
@@ -55,6 +57,7 @@
 								<Ammo_PlasmaGasCartridge_Standard>Bullet_BlasterSniper_Red</Ammo_PlasmaGasCartridge_Standard>
 								<Ammo_PlasmaGasCartridge_AP>Bullet_BlasterSniper_RedAP</Ammo_PlasmaGasCartridge_AP>
 								<Ammo_PlasmaGasCartridge_Ion>Bullet_BlasterSniper_Ion</Ammo_PlasmaGasCartridge_Ion>
+								<Ammo_PlasmaGasCartridge_Stun>Bullet_BlasterSniper_Stun</Ammo_PlasmaGasCartridge_Stun>
 							</ammoTypes>
 						</CombatExtended.AmmoSetDef>
 
@@ -65,6 +68,7 @@
 								<Ammo_PlasmaGasCartridge_Standard>Bullet_BlasterPistol_Green</Ammo_PlasmaGasCartridge_Standard>
 								<Ammo_PlasmaGasCartridge_AP>Bullet_BlasterPistol_GreenAP</Ammo_PlasmaGasCartridge_AP>
 								<Ammo_PlasmaGasCartridge_Ion>Bullet_BlasterPistol_Ion</Ammo_PlasmaGasCartridge_Ion>
+								<Ammo_PlasmaGasCartridge_Stun>Bullet_BlasterPistol_Stun</Ammo_PlasmaGasCartridge_Stun>
 							</ammoTypes>
 						</CombatExtended.AmmoSetDef>
 
@@ -74,7 +78,8 @@
 							<ammoTypes>
 								<Ammo_PlasmaGasCartridge_Standard>Bullet_BlasterRifle_Green</Ammo_PlasmaGasCartridge_Standard>
 								<Ammo_PlasmaGasCartridge_AP>Bullet_BlasterRifle_GreenAP</Ammo_PlasmaGasCartridge_AP>
-								<Ammo_PlasmaGasCartridge_Ion>Bullet_BlasterPistol_Ion</Ammo_PlasmaGasCartridge_Ion>
+								<Ammo_PlasmaGasCartridge_Ion>Bullet_BlasterRifle_Ion</Ammo_PlasmaGasCartridge_Ion>
+								<Ammo_PlasmaGasCartridge_Stun>Bullet_BlasterRifle_Stun</Ammo_PlasmaGasCartridge_Stun>
 							</ammoTypes>
 						</CombatExtended.AmmoSetDef>
 
@@ -85,6 +90,7 @@
 								<Ammo_PlasmaGasCartridge_Standard>Bullet_BlasterSniper_Green</Ammo_PlasmaGasCartridge_Standard>
 								<Ammo_PlasmaGasCartridge_AP>Bullet_BlasterSniper_GreenAP</Ammo_PlasmaGasCartridge_AP>
 								<Ammo_PlasmaGasCartridge_Ion>Bullet_BlasterSniper_Ion</Ammo_PlasmaGasCartridge_Ion>
+								<Ammo_PlasmaGasCartridge_Stun>Bullet_BlasterSniper_Stun</Ammo_PlasmaGasCartridge_Stun>
 							</ammoTypes>
 						</CombatExtended.AmmoSetDef>
 
@@ -95,6 +101,7 @@
 								<Ammo_PlasmaGasCartridge_Standard>Bullet_BlasterPistol_Blue</Ammo_PlasmaGasCartridge_Standard>
 								<Ammo_PlasmaGasCartridge_AP>Bullet_BlasterPistol_BlueAP</Ammo_PlasmaGasCartridge_AP>
 								<Ammo_PlasmaGasCartridge_Ion>Bullet_BlasterPistol_Ion</Ammo_PlasmaGasCartridge_Ion>
+								<Ammo_PlasmaGasCartridge_Stun>Bullet_BlasterPistol_Stun</Ammo_PlasmaGasCartridge_Stun>
 							</ammoTypes>
 						</CombatExtended.AmmoSetDef>
 
@@ -105,6 +112,7 @@
 								<Ammo_PlasmaGasCartridge_Standard>Bullet_BlasterRifle_Blue</Ammo_PlasmaGasCartridge_Standard>
 								<Ammo_PlasmaGasCartridge_AP>Bullet_BlasterRifle_BlueAP</Ammo_PlasmaGasCartridge_AP>
 								<Ammo_PlasmaGasCartridge_Ion>Bullet_BlasterRifle_Ion</Ammo_PlasmaGasCartridge_Ion>
+								<Ammo_PlasmaGasCartridge_Stun>Bullet_BlasterRifle_Stun</Ammo_PlasmaGasCartridge_Stun>
 							</ammoTypes>
 						</CombatExtended.AmmoSetDef>
 
@@ -115,6 +123,7 @@
 								<Ammo_PlasmaGasCartridge_Standard>Bullet_BlasterSniper_Blue</Ammo_PlasmaGasCartridge_Standard>
 								<Ammo_PlasmaGasCartridge_AP>Bullet_BlasterSniper_BlueAP</Ammo_PlasmaGasCartridge_AP>
 								<Ammo_PlasmaGasCartridge_Ion>Bullet_BlasterSniper_Ion</Ammo_PlasmaGasCartridge_Ion>
+								<Ammo_PlasmaGasCartridge_Stun>Bullet_BlasterSniper_Stun</Ammo_PlasmaGasCartridge_Stun>
 							</ammoTypes>
 						</CombatExtended.AmmoSetDef>
 
@@ -125,6 +134,7 @@
 								<Ammo_PlasmaGasCartridge_Standard>Bullet_BlasterPistol_Yellow</Ammo_PlasmaGasCartridge_Standard>
 								<Ammo_PlasmaGasCartridge_AP>Bullet_BlasterPistol_YellowAP</Ammo_PlasmaGasCartridge_AP>
 								<Ammo_PlasmaGasCartridge_Ion>Bullet_BlasterPistol_Ion</Ammo_PlasmaGasCartridge_Ion>
+								<Ammo_PlasmaGasCartridge_Stun>Bullet_BlasterPistol_Stun</Ammo_PlasmaGasCartridge_Stun>
 							</ammoTypes>
 						</CombatExtended.AmmoSetDef>
 
@@ -135,6 +145,7 @@
 								<Ammo_PlasmaGasCartridge_Standard>Bullet_BlasterRifle_Yellow</Ammo_PlasmaGasCartridge_Standard>
 								<Ammo_PlasmaGasCartridge_AP>Bullet_BlasterRifle_YellowAP</Ammo_PlasmaGasCartridge_AP>
 								<Ammo_PlasmaGasCartridge_Ion>Bullet_BlasterRifle_Ion</Ammo_PlasmaGasCartridge_Ion>
+								<Ammo_PlasmaGasCartridge_Stun>Bullet_BlasterRifle_Stun</Ammo_PlasmaGasCartridge_Stun>
 							</ammoTypes>
 						</CombatExtended.AmmoSetDef>
 
@@ -145,6 +156,7 @@
 								<Ammo_PlasmaGasCartridge_Standard>Bullet_BlasterSniper_Yellow</Ammo_PlasmaGasCartridge_Standard>
 								<Ammo_PlasmaGasCartridge_AP>Bullet_BlasterSniper_YellowAP</Ammo_PlasmaGasCartridge_AP>
 								<Ammo_PlasmaGasCartridge_Ion>Bullet_BlasterSniper_Ion</Ammo_PlasmaGasCartridge_Ion>
+								<Ammo_PlasmaGasCartridge_Stun>Bullet_BlasterSniper_Stun</Ammo_PlasmaGasCartridge_Stun>
 							</ammoTypes>
 						</CombatExtended.AmmoSetDef>
 
@@ -207,7 +219,7 @@
 							<statBases>
 								<MarketValue>1.55</MarketValue>
 							</statBases>
-							<ammoClass>Charged</ammoClass>
+							<ammoClass>BlasterStandard</ammoClass>
 							<cookOffProjectile>Bullet_BlasterPistol_Red</cookOffProjectile>
 						</ThingDef>
 
@@ -222,7 +234,7 @@
 							<statBases>
 								<MarketValue>1.95</MarketValue>
 							</statBases>
-							<ammoClass>ChargedAP</ammoClass>
+							<ammoClass>BlasterAP</ammoClass>
 							<generateAllowChance>0.25</generateAllowChance>
 							<cookOffProjectile>Bullet_BlasterPistol_RedAP</cookOffProjectile>
 						</ThingDef>
@@ -238,9 +250,25 @@
 							<statBases>
 								<MarketValue>1.95</MarketValue>
 							</statBases>
-							<ammoClass>Ionized</ammoClass>
+							<ammoClass>BlasterIonized</ammoClass>
 							<generateAllowChance>0.05</generateAllowChance>
 							<cookOffProjectile>Bullet_BlasterPistol_Ion</cookOffProjectile>
+						</ThingDef>
+
+						<ThingDef Class="CombatExtended.AmmoDef" ParentName="PlasmaGasCartridgeBase">
+							<defName>Ammo_PlasmaGasCartridge_Stun</defName>
+							<description>Plasma gas ammo used by advanced blaster designs. Modulated energy pulse emission generates a non-lethal pulse that can disable organics, but is highly ineffective against mechanical targets.</description>
+							<label>Plasma Gas Cartridges (Stun)</label>
+							<graphicData>
+								<texPath>Things/Ammo/Charged/MediumTox</texPath>
+								<graphicClass>Graphic_StackCount</graphicClass>
+							</graphicData>
+							<statBases>
+								<MarketValue>1.95</MarketValue>
+							</statBases>
+							<ammoClass>BlasterStun</ammoClass>
+							<generateAllowChance>0</generateAllowChance>
+							<cookOffProjectile>Bullet_BlasterPistol_Stun</cookOffProjectile>
 						</ThingDef>
 
 						<!-- ================== Projectiles ================== -->
@@ -278,7 +306,7 @@
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
 								<damageAmountBase>11</damageAmountBase>
 								<armorPenetrationBlunt>3</armorPenetrationBlunt>
-								<armorPenetrationSharp>21</armorPenetrationSharp>
+								<armorPenetrationSharp>18</armorPenetrationSharp>
 							</projectile>
 						</ThingDef>
 
@@ -313,9 +341,9 @@
 							</graphicData>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
 								<speed>175</speed>
-								<damageAmountBase>22</damageAmountBase>
+								<damageAmountBase>30</damageAmountBase>
 								<armorPenetrationBlunt>4</armorPenetrationBlunt>
-								<armorPenetrationSharp>24</armorPenetrationSharp>
+								<armorPenetrationSharp>20</armorPenetrationSharp>
 							</projectile>
 						</ThingDef>
 
@@ -326,7 +354,7 @@
 							</graphicData>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
 								<speed>175</speed>
-								<damageAmountBase>14</damageAmountBase>
+								<damageAmountBase>20</damageAmountBase>
 								<armorPenetrationBlunt>6</armorPenetrationBlunt>
 								<armorPenetrationSharp>36</armorPenetrationSharp>
 							</projectile>
@@ -578,6 +606,45 @@
 							</projectile>
 						</ThingDef>
 
+						<ThingDef ParentName="BaseBlasterBolt_Pistol">
+							<defName>Bullet_BlasterPistol_Stun</defName>
+							<graphicData>
+								<texPath>OuterRim/Projectile/Proj_StunPulse</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+							</graphicData>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<damageDef>Neuralizer</damageDef>
+								<damageAmountBase>1</damageAmountBase>
+								<speed>80</speed>
+							</projectile>
+						</ThingDef>
+
+						<ThingDef ParentName="BaseBlasterBolt_Rifle">
+							<defName>Bullet_BlasterRifle_Stun</defName>
+							<graphicData>
+								<texPath>OuterRim/Projectile/Proj_StunPulse</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+							</graphicData>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<damageDef>Neuralizer</damageDef>
+								<damageAmountBase>1</damageAmountBase>
+								<speed>90</speed>
+							</projectile>
+						</ThingDef>
+
+						<ThingDef ParentName="BaseBlasterBolt_Sniper">
+							<defName>Bullet_BlasterSniper_Stun</defName>
+							<graphicData>
+								<texPath>OuterRim/Projectile/Proj_StunPulse</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+							</graphicData>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<damageDef>Neuralizer</damageDef>
+								<damageAmountBase>1</damageAmountBase>
+								<speed>100</speed>
+							</projectile>
+						</ThingDef>
+
 						<ThingDef ParentName="BaseBlasterBolt">
 							<defName>Bullet_BlasterBolt_Scatter</defName>
 							<graphicData>
@@ -653,7 +720,7 @@
 
 						<ThingDef Class="CombatExtended.AmmoDef" ParentName="RPS6RocketBase">
 							<defName>Ammo_RPS6_HEDP</defName>
-							<label>RPS-6 rocket (HEDP)</label>
+							<label>RPS-6 rocket</label>
 							<graphicData>
 								<texPath>ThirdParty/StarWars/Ammo/OR_RPS6</texPath>
 								<graphicClass>Graphic_StackCount</graphicClass>
@@ -663,7 +730,7 @@
 								<Mass>6.3</Mass>
 								<Bulk>17.91</Bulk>
 							</statBases>
-							<ammoClass>RocketHEAT</ammoClass>
+							<ammoClass>SWRocketPlasma</ammoClass>
 							<detonateProjectile>Bullet_RPS6_HEDP</detonateProjectile>
 						</ThingDef>
 
@@ -915,6 +982,53 @@
 							</recipeUsers>
 							<products>
 								<Ammo_PlasmaGasCartridge_Ion>500</Ammo_PlasmaGasCartridge_Ion>
+							</products>
+							<researchPrerequisite>OuterRim_HypertechFabrication</researchPrerequisite>
+						</RecipeDef>
+
+						<RecipeDef ParentName="ChargeAmmoRecipeBase">
+							<defName>MakeAmmo_PlasmaGasCartridge_Stun</defName>
+							<label>make Plasma Gas Cartridges (Stun) x500</label>
+							<description>Craft 500 PlasmaGas Cartridges (Stun).</description>
+							<jobString>Making Plasma Gas Cartridges (Stun).</jobString>
+							<ingredients>
+								<li>
+									<filter>
+										<thingDefs>
+											<li>OuterRim_Durasteel</li>
+										</thingDefs>
+									</filter>
+									<count>30</count>
+								</li>
+								<li>
+									<filter>
+										<thingDefs>
+											<li>OuterRim_Tibanna</li>
+										</thingDefs>
+									</filter>
+									<count>60</count>
+								</li>
+								<li>
+									<filter>
+										<thingDefs>
+											<li>OuterRim_ComponentHypertech</li>
+										</thingDefs>
+									</filter>
+									<count>3</count>
+								</li>
+							</ingredients>
+							<fixedIngredientFilter>
+								<thingDefs>
+									<li>OuterRim_Durasteel</li>
+									<li>OuterRim_Tibanna</li>
+									<li>OuterRim_ComponentHypertech</li>
+								</thingDefs>
+							</fixedIngredientFilter>
+							<recipeUsers Inherit="False">
+								<li>OuterRim_HypertechFabricator</li>
+							</recipeUsers>
+							<products>
+								<Ammo_PlasmaGasCartridge_Stun>500</Ammo_PlasmaGasCartridge_Stun>
 							</products>
 							<researchPrerequisite>OuterRim_HypertechFabrication</researchPrerequisite>
 						</RecipeDef>

--- a/Patches/Outer Rim - Core/Outer_Rim_Core_Apparel.xml
+++ b/Patches/Outer Rim - Core/Outer_Rim_Core_Apparel.xml
@@ -17,26 +17,6 @@
 					</value>
 				</li>
 
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="OuterRim_Hood"]</xpath>
-					<value>
-						<statBases>
-							<Bulk>1</Bulk>
-							<WornBulk>0</WornBulk>
-						</statBases>
-					</value>
-				</li>
-
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="OuterRim_DesertHood"]</xpath>
-					<value>
-						<statBases>
-							<Bulk>1</Bulk>
-							<WornBulk>0</WornBulk>
-						</statBases>
-					</value>
-				</li>
-
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[@Name="OuterRim_UniformBodyFabricatedBase"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
@@ -58,6 +38,28 @@
 							<ToxicEnvironmentResistance>0.25</ToxicEnvironmentResistance>
 							<CarryBulk>10</CarryBulk>
 						</equippedStatOffsets>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[@Name="OuterRim_UniformHeadwearFabricatedBase"]/statBases</xpath>
+					<value>
+						<Bulk>1</Bulk>
+						<WornBulk>0</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="OuterRim_UniformHeadwearFabricatedBase"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>1</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="OuterRim_UniformHeadwearFabricatedBase"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>2</ArmorRating_Blunt>
 					</value>
 				</li>
 

--- a/Patches/Outer Rim - Core/Outer_Rim_Core_Armour.xml
+++ b/Patches/Outer Rim - Core/Outer_Rim_Core_Armour.xml
@@ -33,13 +33,13 @@
 						<li Class="CombatExtended.PartialArmorExt">
 							<stats>
 								<li>
-									<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+									<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
 									<parts>
 										<li>Leg</li>
 									</parts>
 								</li>
 								<li>
-									<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+									<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
 									<parts>
 										<li>Leg</li>
 									</parts>
@@ -47,13 +47,13 @@
 								<li>
 									<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
 									<parts>
-										<li>Foot</li>
+										<li>Neck</li>
 									</parts>
 								</li>
 								<li>
 									<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
 									<parts>
-										<li>Foot</li>
+										<li>Neck</li>
 									</parts>
 								</li>
 							</stats>
@@ -111,25 +111,25 @@
 						<li Class="CombatExtended.PartialArmorExt">
 							<stats>
 								<li>
-									<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+									<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
 									<parts>
 										<li>Arm</li>
 									</parts>
 								</li>
 								<li>
-									<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+									<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
 									<parts>
 										<li>Arm</li>
 									</parts>
 								</li>
 								<li>
-									<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
+									<ArmorRating_Sharp>0.70</ArmorRating_Sharp>
 									<parts>
 										<li>Hand</li>
 									</parts>
 								</li>
 								<li>
-									<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
+									<ArmorRating_Blunt>0.70</ArmorRating_Blunt>
 									<parts>
 										<li>Hand</li>
 									</parts>
@@ -142,14 +142,14 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[@Name="OuterRim_LightArmorFabricatedBase"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>8</ArmorRating_Sharp>
+						<ArmorRating_Sharp>12</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[@Name="OuterRim_LightArmorFabricatedBase"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>16</ArmorRating_Blunt>
+						<ArmorRating_Blunt>22</ArmorRating_Blunt>
 					</value>
 				</li>
 
@@ -160,14 +160,14 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[@Name="OuterRim_LightHelmetFabricatedBase"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>8</ArmorRating_Sharp>
+						<ArmorRating_Sharp>12</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[@Name="OuterRim_LightHelmetFabricatedBase"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>16</ArmorRating_Blunt>
+						<ArmorRating_Blunt>22</ArmorRating_Blunt>
 					</value>
 				</li>
 
@@ -178,14 +178,14 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[@Name="OuterRim_LightPauldronsFabricatedBase"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>8</ArmorRating_Sharp>
+						<ArmorRating_Sharp>12</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[@Name="OuterRim_LightPauldronsFabricatedBase"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>16</ArmorRating_Blunt>
+						<ArmorRating_Blunt>22</ArmorRating_Blunt>
 					</value>
 				</li>
 
@@ -196,14 +196,14 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[@Name="OuterRim_MediumArmorFabricatedBase"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>10</ArmorRating_Sharp>
+						<ArmorRating_Sharp>16</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[@Name="OuterRim_MediumArmorFabricatedBase"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>20</ArmorRating_Blunt>
+						<ArmorRating_Blunt>32</ArmorRating_Blunt>
 					</value>
 				</li>
 
@@ -214,14 +214,14 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[@Name="OuterRim_MediumHelmetFabricatedBase"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>10</ArmorRating_Sharp>
+						<ArmorRating_Sharp>16</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[@Name="OuterRim_MediumHelmetFabricatedBase"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>20</ArmorRating_Blunt>
+						<ArmorRating_Blunt>32</ArmorRating_Blunt>
 					</value>
 				</li>
 
@@ -232,14 +232,14 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[@Name="OuterRim_MediumPauldronsFabricatedBase"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>10</ArmorRating_Sharp>
+						<ArmorRating_Sharp>16</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[@Name="OuterRim_MediumPauldronsFabricatedBase"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>20</ArmorRating_Blunt>
+						<ArmorRating_Blunt>32</ArmorRating_Blunt>
 					</value>
 				</li>
 
@@ -250,14 +250,14 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[@Name="OuterRim_HeavyArmorFabricatedBase"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>12</ArmorRating_Sharp>
+						<ArmorRating_Sharp>20</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[@Name="OuterRim_HeavyArmorFabricatedBase"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>24</ArmorRating_Blunt>
+						<ArmorRating_Blunt>48</ArmorRating_Blunt>
 					</value>
 				</li>
 
@@ -268,14 +268,14 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[@Name="OuterRim_HeavyHelmetFabricatedBase"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>12</ArmorRating_Sharp>
+						<ArmorRating_Sharp>20</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[@Name="OuterRim_HeavyHelmetFabricatedBase"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>24</ArmorRating_Blunt>
+						<ArmorRating_Blunt>48</ArmorRating_Blunt>
 					</value>
 				</li>
 
@@ -286,14 +286,14 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[@Name="OuterRim_HeavyPauldronsFabricatedBase"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>12</ArmorRating_Sharp>
+						<ArmorRating_Sharp>20</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[@Name="OuterRim_HeavyPauldronsFabricatedBase"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>24</ArmorRating_Blunt>
+						<ArmorRating_Blunt>48</ArmorRating_Blunt>
 					</value>
 				</li>
 

--- a/Patches/Outer Rim - Core/Outer_Rim_Core_Grenades.xml
+++ b/Patches/Outer Rim - Core/Outer_Rim_Core_Grenades.xml
@@ -548,6 +548,7 @@
 					<li>CE_AI_Grenade</li>
 					<li>CE_AI_AOE</li>
 					<li>CE_OneHandedWeapon</li>
+    					<li>CE_GrenadeFlashbang</li>
 				</weaponTags>
 			</li>
 
@@ -684,6 +685,7 @@
 					<li>CE_AI_Grenade</li>
 					<li>CE_AI_AOE</li>
 					<li>CE_OneHandedWeapon</li>
+    					<li>CE_GrenadeFlashbang</li>
 				</weaponTags>
 			</li>
 

--- a/Patches/Outer Rim - Core/Outer_Rim_Core_Ranged_Weapons.xml
+++ b/Patches/Outer Rim - Core/Outer_Rim_Core_Ranged_Weapons.xml
@@ -73,6 +73,7 @@
 						<soundCast>OuterRim_Shot_AB75BoRifle</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>9</muzzleFlashScale>
+						<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
@@ -199,6 +200,7 @@
 						<soundCast>OuterRim_Shot_MediumBlasterBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>9</muzzleFlashScale>
+						<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
@@ -208,7 +210,7 @@
 						<aiUseBurstMode>True</aiUseBurstMode>
 					</FireModes>
 					<AmmoUser>
-						<magazineSize>12</magazineSize>
+						<magazineSize>22</magazineSize>
 						<reloadTime>3</reloadTime>
 						<ammoSet>AmmoSet_PlasmaGasCartridgeRed_Rifle</ammoSet>
 					</AmmoUser>
@@ -282,6 +284,7 @@
 						<soundCast>OuterRim_Shot_DLT19DBlasterBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>9</muzzleFlashScale>
+						<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
@@ -316,6 +319,7 @@
 						<soundCast>OuterRim_Shot_DLT19DBlasterBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>9</muzzleFlashScale>
+						<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
@@ -350,6 +354,7 @@
 						<soundCast>OuterRim_Shot_DLT19DBlasterBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>9</muzzleFlashScale>
+						<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
@@ -420,6 +425,7 @@
 						<soundCast>OuterRim_Shot_E11BlasterBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>9</muzzleFlashScale>
+						<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
@@ -428,7 +434,7 @@
 						<aiAimMode>AimedShot</aiAimMode>
 					</FireModes>
 					<AmmoUser>
-						<magazineSize>50</magazineSize>
+						<magazineSize>80</magazineSize>
 						<reloadTime>4</reloadTime>
 						<ammoSet>AmmoSet_PlasmaGasCartridgeRed_Rifle</ammoSet>
 					</AmmoUser>
@@ -456,6 +462,7 @@
 						<soundCast>OuterRim_Shot_HeavyMinigunBlasterBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>12</muzzleFlashScale>
+						<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
@@ -465,7 +472,7 @@
 						<aimedBurstShotCount>5</aimedBurstShotCount>
 					</FireModes>
 					<AmmoUser>
-						<magazineSize>150</magazineSize>
+						<magazineSize>220</magazineSize>
 						<reloadTime>6.25</reloadTime>
 						<ammoSet>AmmoSet_PlasmaGasCartridgeRed_Rifle</ammoSet>
 					</AmmoUser>
@@ -499,6 +506,7 @@
 						<soundCast>OuterRim_Shot_E11BlasterBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>9</muzzleFlashScale>
+						<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
@@ -507,7 +515,7 @@
 						<aiAimMode>AimedShot</aiAimMode>
 					</FireModes>
 					<AmmoUser>
-						<magazineSize>30</magazineSize>
+						<magazineSize>44</magazineSize>
 						<reloadTime>3.7</reloadTime>
 						<ammoSet>AmmoSet_PlasmaGasCartridgeRed_Rifle</ammoSet>
 					</AmmoUser>

--- a/Patches/Outer Rim - Galactic Empire/Outer_Rim_Galactic_Empire_Apparel.xml
+++ b/Patches/Outer Rim - Galactic Empire/Outer_Rim_Galactic_Empire_Apparel.xml
@@ -9,16 +9,6 @@
 		<match Class="PatchOperationSequence">
 			<operations>
 
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[@Name="ImperialOfficerCapBase"]</xpath>
-					<value>
-						<statBases>
-							<Bulk>1</Bulk>
-							<WornBulk>0</WornBulk>
-						</statBases>
-					</value>
-				</li>
-
 				<li Class="PatchOperationRemove">
 					<xpath>Defs/ThingDef[defName="OuterRim_StormtrooperHelmet"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
 				</li>

--- a/Patches/Outer Rim - Galactic Empire/Outer_Rim_Galactic_Empire_Ranged_Weapons.xml
+++ b/Patches/Outer Rim - Galactic Empire/Outer_Rim_Galactic_Empire_Ranged_Weapons.xml
@@ -114,6 +114,7 @@
 						<soundCast>OuterRim_Shot_DLT20BBlasterBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>12</muzzleFlashScale>
+						<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
@@ -123,7 +124,7 @@
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
 					<AmmoUser>
-						<magazineSize>50</magazineSize>
+						<magazineSize>80</magazineSize>
 						<reloadTime>3.7</reloadTime>
 						<ammoSet>AmmoSet_PlasmaGasCartridgeRed_Rifle</ammoSet>
 					</AmmoUser>
@@ -151,6 +152,7 @@
 						<soundCast>OuterRim_Shot_E11BlasterBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>12</muzzleFlashScale>
+						<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
@@ -160,7 +162,7 @@
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
 					<AmmoUser>
-						<magazineSize>50</magazineSize>
+						<magazineSize>80</magazineSize>
 						<reloadTime>3.7</reloadTime>
 						<ammoSet>AmmoSet_PlasmaGasCartridgeRed_Rifle</ammoSet>
 					</AmmoUser>
@@ -188,6 +190,7 @@
 						<soundCast>OuterRim_Shot_E11BlasterBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>12</muzzleFlashScale>
+						<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
@@ -197,7 +200,7 @@
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
 					<AmmoUser>
-						<magazineSize>50</magazineSize>
+						<magazineSize>80</magazineSize>
 						<reloadTime>3.7</reloadTime>
 						<ammoSet>AmmoSet_PlasmaGasCartridgeRed_Rifle</ammoSet>
 					</AmmoUser>
@@ -225,6 +228,7 @@
 						<soundCast>OuterRim_Shot_E11BlasterBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>12</muzzleFlashScale>
+						<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
@@ -234,8 +238,8 @@
 						<aimedBurstShotCount>4</aimedBurstShotCount>
 					</FireModes>
 					<AmmoUser>
-						<magazineSize>50</magazineSize>
-						<reloadTime>3.7</reloadTime>
+						<magazineSize>100</magazineSize>
+						<reloadTime>4.4</reloadTime>
 						<ammoSet>AmmoSet_PlasmaGasCartridgeRed_Rifle</ammoSet>
 					</AmmoUser>
 				</li>
@@ -262,6 +266,7 @@
 						<soundCast>OuterRim_Shot_HeavyMinigunBlasterBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>12</muzzleFlashScale>
+						<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
@@ -271,7 +276,7 @@
 						<aimedBurstShotCount>5</aimedBurstShotCount>
 					</FireModes>
 					<AmmoUser>
-						<magazineSize>200</magazineSize>
+						<magazineSize>250</magazineSize>
 						<reloadTime>7.5</reloadTime>
 						<ammoSet>AmmoSet_PlasmaGasCartridgeRed_Rifle</ammoSet>
 					</AmmoUser>
@@ -298,6 +303,7 @@
 						<soundCast>OuterRim_Shot_DLT19DBlasterBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>12</muzzleFlashScale>
+						<ammoConsumedPerShotCount>3</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
@@ -306,7 +312,7 @@
 						<aiAimMode>AimedShot</aiAimMode>
 					</FireModes>
 					<AmmoUser>
-						<magazineSize>10</magazineSize>
+						<magazineSize>24</magazineSize>
 						<reloadTime>3.7</reloadTime>
 						<ammoSet>AmmoSet_PlasmaGasCartridgeRed_Sniper</ammoSet>
 					</AmmoUser>
@@ -334,6 +340,7 @@
 						<soundCast>OuterRim_Shot_HeavyMinigunBlasterBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>9</muzzleFlashScale>
+						<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>

--- a/Patches/Outer Rim - Galactic Republic/Outer_Rim_Galactic_Republic_Ranged_Weapons.xml
+++ b/Patches/Outer Rim - Galactic Republic/Outer_Rim_Galactic_Republic_Ranged_Weapons.xml
@@ -63,7 +63,7 @@
 						<recoilAmount>1.2</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
-						<defaultProjectile>Bullet_BlasterRifle_Red</defaultProjectile>
+						<defaultProjectile>Bullet_BlasterRifle_Blue</defaultProjectile>
 						<warmupTime>0.5</warmupTime>
 						<range>35</range>
 						<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
@@ -71,6 +71,7 @@
 						<soundCast>OuterRim_Shot_EE13BlasterBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>12</muzzleFlashScale>
+						<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
@@ -80,7 +81,7 @@
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
 					<AmmoUser>
-						<magazineSize>60</magazineSize>
+						<magazineSize>80</magazineSize>
 						<reloadTime>4</reloadTime>
 						<ammoSet>AmmoSet_PlasmaGasCartridgeBlue_Rifle</ammoSet>
 					</AmmoUser>
@@ -108,6 +109,7 @@
 						<soundCast>OuterRim_Shot_DC15BlasterBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>12</muzzleFlashScale>
+						<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
@@ -117,7 +119,7 @@
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
 					<AmmoUser>
-						<magazineSize>50</magazineSize>
+						<magazineSize>100</magazineSize>
 						<reloadTime>3.7</reloadTime>
 						<ammoSet>AmmoSet_PlasmaGasCartridgeBlue_Rifle</ammoSet>
 					</AmmoUser>
@@ -145,6 +147,7 @@
 						<soundCast>OuterRim_Shot_DC15BlasterBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>12</muzzleFlashScale>
+						<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
@@ -181,6 +184,7 @@
 						<soundCast>OuterRim_Shot_DLT20BBlasterBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>12</muzzleFlashScale>
+						<ammoConsumedPerShotCount>3</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
@@ -189,8 +193,8 @@
 						<aiAimMode>AimedShot</aiAimMode>
 					</FireModes>
 					<AmmoUser>
-						<magazineSize>10</magazineSize>
-						<reloadTime>3.7</reloadTime>
+						<magazineSize>30</magazineSize>
+						<reloadTime>5</reloadTime>
 						<ammoSet>AmmoSet_PlasmaGasCartridgeBlue_Sniper</ammoSet>
 					</AmmoUser>
 				</li>
@@ -217,6 +221,7 @@
 						<soundCast>OuterRim_Shot_HeavyMinigunBlasterBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>9</muzzleFlashScale>
+						<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
@@ -226,7 +231,7 @@
 						<aimedBurstShotCount>25</aimedBurstShotCount>
 					</FireModes>
 					<AmmoUser>
-						<magazineSize>400</magazineSize>
+						<magazineSize>600</magazineSize>
 						<reloadTime>9.5</reloadTime>
 						<ammoSet>AmmoSet_PlasmaGasCartridgeBlue_Rifle</ammoSet>
 					</AmmoUser>

--- a/Patches/Outer Rim - Mandalore/Outer_Rim_Mandalorian_Apparel.xml
+++ b/Patches/Outer Rim - Mandalore/Outer_Rim_Mandalorian_Apparel.xml
@@ -21,8 +21,8 @@
 					<value>
 						<Bulk>80</Bulk>
 						<WornBulk>15</WornBulk>
-						<ArmorRating_Sharp>4</ArmorRating_Sharp>
-						<ArmorRating_Blunt>12</ArmorRating_Blunt>
+						<ArmorRating_Sharp>5</ArmorRating_Sharp>
+						<ArmorRating_Blunt>18</ArmorRating_Blunt>
 					</value>
 				</li>
 
@@ -50,13 +50,13 @@
 						<li Class="CombatExtended.PartialArmorExt">
 							<stats>
 								<li>
-									<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+									<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
 									<parts>
 										<li>Leg</li>
 									</parts>
 								</li>
 								<li>
-									<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+									<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
 									<parts>
 										<li>Leg</li>
 									</parts>
@@ -64,13 +64,13 @@
 								<li>
 									<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
 									<parts>
-										<li>Foot</li>
+										<li>Neck</li>
 									</parts>
 								</li>
 								<li>
 									<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
 									<parts>
-										<li>Foot</li>
+										<li>Neck</li>
 									</parts>
 								</li>
 							</stats>
@@ -83,8 +83,8 @@
 					<value>
 						<Bulk>4</Bulk>
 						<WornBulk>2</WornBulk>
-						<ArmorRating_Sharp>4</ArmorRating_Sharp>
-						<ArmorRating_Blunt>12</ArmorRating_Blunt>
+						<ArmorRating_Sharp>5</ArmorRating_Sharp>
+						<ArmorRating_Blunt>18</ArmorRating_Blunt>
 					</value>
 				</li>
 
@@ -111,8 +111,8 @@
 					<value>
 						<Bulk>6</Bulk>
 						<WornBulk>3</WornBulk>
-						<ArmorRating_Sharp>4</ArmorRating_Sharp>
-						<ArmorRating_Blunt>12</ArmorRating_Blunt>
+						<ArmorRating_Sharp>5</ArmorRating_Sharp>
+						<ArmorRating_Blunt>18</ArmorRating_Blunt>
 					</value>
 				</li>
 
@@ -138,25 +138,25 @@
 						<li Class="CombatExtended.PartialArmorExt">
 							<stats>
 								<li>
-									<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+									<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
 									<parts>
 										<li>Arm</li>
 									</parts>
 								</li>
 								<li>
-									<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+									<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
 									<parts>
 										<li>Arm</li>
 									</parts>
 								</li>
 								<li>
-									<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
+									<ArmorRating_Sharp>0.70</ArmorRating_Sharp>
 									<parts>
 										<li>Hand</li>
 									</parts>
 								</li>
 								<li>
-									<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
+									<ArmorRating_Blunt>0.70</ArmorRating_Blunt>
 									<parts>
 										<li>Hand</li>
 									</parts>
@@ -172,7 +172,7 @@
 						<Bulk>40</Bulk>
 						<WornBulk>25</WornBulk>
 						<ArmorRating_Sharp>7.5</ArmorRating_Sharp>
-						<ArmorRating_Blunt>18</ArmorRating_Blunt>
+						<ArmorRating_Blunt>22.5</ArmorRating_Blunt>
 					</value>
 				</li>
 
@@ -189,7 +189,7 @@
 						<Bulk>8</Bulk>
 						<WornBulk>4</WornBulk>
 						<ArmorRating_Sharp>7.5</ArmorRating_Sharp>
-						<ArmorRating_Blunt>18</ArmorRating_Blunt>
+						<ArmorRating_Blunt>22.5</ArmorRating_Blunt>
 					</value>
 				</li>
 
@@ -206,7 +206,7 @@
 						<Bulk>8</Bulk>
 						<WornBulk>4</WornBulk>
 						<ArmorRating_Sharp>7.5</ArmorRating_Sharp>
-						<ArmorRating_Blunt>18</ArmorRating_Blunt>
+						<ArmorRating_Blunt>22.5</ArmorRating_Blunt>
 					</value>
 				</li>
 

--- a/Patches/Outer Rim - Mandalore/Outer_Rim_Mandalorian_Ranged_Weapons.xml
+++ b/Patches/Outer Rim - Mandalore/Outer_Rim_Mandalorian_Ranged_Weapons.xml
@@ -244,6 +244,7 @@
 						<soundCast>OuterRim_Shot_RepeaterBlasterBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>9</muzzleFlashScale>
+						<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
@@ -254,7 +255,7 @@
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
 					<AmmoUser>
-						<magazineSize>60</magazineSize>
+						<magazineSize>80</magazineSize>
 						<reloadTime>4</reloadTime>
 						<ammoSet>AmmoSet_PlasmaGasCartridgeYellow_Rifle</ammoSet>
 					</AmmoUser>
@@ -284,6 +285,7 @@
 						<soundCast>OuterRim_Shot_EE13BlasterBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>9</muzzleFlashScale>
+						<ammoConsumedPerShotCount>3</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
@@ -292,8 +294,8 @@
 						<aiAimMode>AimedShot</aiAimMode>
 					</FireModes>
 					<AmmoUser>
-						<magazineSize>12</magazineSize>
-						<reloadTime>4</reloadTime>
+						<magazineSize>24</magazineSize>
+						<reloadTime>6</reloadTime>
 						<ammoSet>AmmoSet_PlasmaGasCartridgeYellow_Sniper</ammoSet>
 					</AmmoUser>
 					<weaponTags>
@@ -324,6 +326,7 @@
 						<soundCast>OuterRim_Shot_EE13BlasterBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>9</muzzleFlashScale>
+						<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
@@ -334,7 +337,7 @@
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
 					<AmmoUser>
-						<magazineSize>50</magazineSize>
+						<magazineSize>80</magazineSize>
 						<reloadTime>4</reloadTime>
 						<ammoSet>AmmoSet_PlasmaGasCartridgeYellow_Rifle</ammoSet>
 					</AmmoUser>
@@ -365,6 +368,7 @@
 						<soundCast>OuterRim_Shot_EE3BlasterBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>9</muzzleFlashScale>
+						<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
@@ -375,7 +379,7 @@
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
 					<AmmoUser>
-						<magazineSize>50</magazineSize>
+						<magazineSize>80</magazineSize>
 						<reloadTime>4</reloadTime>
 						<ammoSet>AmmoSet_PlasmaGasCartridgeYellow_Rifle</ammoSet>
 					</AmmoUser>
@@ -405,6 +409,7 @@
 						<soundCast>OuterRim_Shot_DisintigratorBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>11</muzzleFlashScale>
+						<ammoConsumedPerShotCount>3</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
@@ -413,7 +418,7 @@
 						<aiAimMode>AimedShot</aiAimMode>
 					</FireModes>
 					<AmmoUser>
-						<magazineSize>1</magazineSize>
+						<magazineSize>3</magazineSize>
 						<reloadTime>0.25</reloadTime>
 						<ammoSet>AmmoSet_PlasmaGasCartridgeYellow_Sniper</ammoSet>
 					</AmmoUser>

--- a/Patches/Outer Rim - Old Republic/Outer_Rim_Old_Republic_Apparel.xml
+++ b/Patches/Outer Rim - Old Republic/Outer_Rim_Old_Republic_Apparel.xml
@@ -9,16 +9,6 @@
 		<match Class="PatchOperationSequence">
 			<operations>
 
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="OuterRim_SithOfficerCap" or defName="OuterRim_OldRepublicOfficerCap"]</xpath>
-					<value>
-						<statBases>
-							<Bulk>1</Bulk>
-							<WornBulk>0</WornBulk>
-						</statBases>
-					</value>
-				</li>
-
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="OuterRim_SithTrooperHelmet"]/equippedStatOffsets/ToxicEnvironmentResistance</xpath>
 					<value>

--- a/Patches/Outer Rim - Old Republic/Outer_Rim_Old_Republic_Ranged_Weapons.xml
+++ b/Patches/Outer Rim - Old Republic/Outer_Rim_Old_Republic_Ranged_Weapons.xml
@@ -116,6 +116,7 @@
 						<soundCast>OuterRim_Shot_MediumBlasterBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>12</muzzleFlashScale>
+						<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
@@ -125,7 +126,7 @@
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
 					<AmmoUser>
-						<magazineSize>50</magazineSize>
+						<magazineSize>80</magazineSize>
 						<reloadTime>3.7</reloadTime>
 						<ammoSet>AmmoSet_PlasmaGasCartridgeGreen_Rifle</ammoSet>
 					</AmmoUser>
@@ -153,6 +154,7 @@
 						<soundCast>OuterRim_Shot_MediumBlasterBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>12</muzzleFlashScale>
+						<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
@@ -162,7 +164,7 @@
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
 					<AmmoUser>
-						<magazineSize>50</magazineSize>
+						<magazineSize>80</magazineSize>
 						<reloadTime>3.7</reloadTime>
 						<ammoSet>AmmoSet_PlasmaGasCartridgeRed_Rifle</ammoSet>
 					</AmmoUser>
@@ -189,6 +191,7 @@
 						<soundCast>OuterRim_Shot_PowerBlasterBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>12</muzzleFlashScale>
+						<ammoConsumedPerShotCount>3</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
@@ -197,7 +200,7 @@
 						<aiAimMode>AimedShot</aiAimMode>
 					</FireModes>
 					<AmmoUser>
-						<magazineSize>10</magazineSize>
+						<magazineSize>30</magazineSize>
 						<reloadTime>3.7</reloadTime>
 						<ammoSet>AmmoSet_PlasmaGasCartridgeGreen_Sniper</ammoSet>
 					</AmmoUser>
@@ -224,6 +227,7 @@
 						<soundCast>OuterRim_Shot_PowerBlasterBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>12</muzzleFlashScale>
+						<ammoConsumedPerShotCount>3</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
@@ -232,7 +236,7 @@
 						<aiAimMode>AimedShot</aiAimMode>
 					</FireModes>
 					<AmmoUser>
-						<magazineSize>10</magazineSize>
+						<magazineSize>30</magazineSize>
 						<reloadTime>3.7</reloadTime>
 						<ammoSet>AmmoSet_PlasmaGasCartridgeRed_Sniper</ammoSet>
 					</AmmoUser>
@@ -260,6 +264,7 @@
 						<soundCast>OuterRim_Shot_AltHeavyBlasterBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>12</muzzleFlashScale>
+						<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
@@ -269,7 +274,7 @@
 						<aimedBurstShotCount>5</aimedBurstShotCount>
 					</FireModes>
 					<AmmoUser>
-						<magazineSize>200</magazineSize>
+						<magazineSize>300</magazineSize>
 						<reloadTime>7.5</reloadTime>
 						<ammoSet>AmmoSet_PlasmaGasCartridgeGreen_Rifle</ammoSet>
 					</AmmoUser>
@@ -297,6 +302,7 @@
 						<soundCast>OuterRim_Shot_AltHeavyBlasterBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>12</muzzleFlashScale>
+						<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
@@ -306,7 +312,7 @@
 						<aimedBurstShotCount>5</aimedBurstShotCount>
 					</FireModes>
 					<AmmoUser>
-						<magazineSize>200</magazineSize>
+						<magazineSize>300</magazineSize>
 						<reloadTime>7.5</reloadTime>
 						<ammoSet>AmmoSet_PlasmaGasCartridgeRed_Rifle</ammoSet>
 					</AmmoUser>

--- a/Patches/Outer Rim - Rebel Alliance/Outer_Rim_Rebel_Apparel.xml
+++ b/Patches/Outer Rim - Rebel Alliance/Outer_Rim_Rebel_Apparel.xml
@@ -10,16 +10,6 @@
 			<operations>
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="OuterRim_RebelOfficerCap"]</xpath>
-					<value>
-						<statBases>
-							<Bulk>1</Bulk>
-							<WornBulk>0</WornBulk>
-						</statBases>
-					</value>
-				</li>
-
-				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="OuterRim_RebelFleetTrooperHelmet"]</xpath>
 					<value>
 						<equippedStatOffsets>

--- a/Patches/Outer Rim - Rebel Alliance/Outer_Rim_Rebel_Ranged_Weapons.xml
+++ b/Patches/Outer Rim - Rebel Alliance/Outer_Rim_Rebel_Ranged_Weapons.xml
@@ -92,6 +92,7 @@
 						<soundCast>OuterRim_Shot_E11BlasterBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>12</muzzleFlashScale>
+						<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
@@ -101,8 +102,8 @@
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
 					<AmmoUser>
-						<magazineSize>50</magazineSize>
-						<reloadTime>3.7</reloadTime>
+						<magazineSize>60</magazineSize>
+						<reloadTime>2.6</reloadTime>
 						<ammoSet>AmmoSet_PlasmaGasCartridgeGreen_Rifle</ammoSet>
 					</AmmoUser>
 				</li>
@@ -136,6 +137,7 @@
 						<soundCast>OuterRim_Shot_E11BlasterBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>12</muzzleFlashScale>
+						<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
@@ -145,7 +147,7 @@
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
 					<AmmoUser>
-						<magazineSize>50</magazineSize>
+						<magazineSize>80</magazineSize>
 						<reloadTime>3.7</reloadTime>
 						<ammoSet>AmmoSet_PlasmaGasCartridgeGreen_Rifle</ammoSet>
 					</AmmoUser>
@@ -172,6 +174,7 @@
 						<soundCast>OuterRim_Shot_E11BlasterBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>9</muzzleFlashScale>
+						<ammoConsumedPerShotCount>3</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>

--- a/Patches/Outer Rim - Seperatists/Outer_Rim_Seperatist_Ranged_Weapons.xml
+++ b/Patches/Outer Rim - Seperatists/Outer_Rim_Seperatist_Ranged_Weapons.xml
@@ -71,6 +71,7 @@
 						<soundCast>OuterRim_Shot_MediumBlasterBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>12</muzzleFlashScale>
+						<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
@@ -80,7 +81,7 @@
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
 					<AmmoUser>
-						<magazineSize>50</magazineSize>
+						<magazineSize>80</magazineSize>
 						<reloadTime>3.7</reloadTime>
 						<ammoSet>AmmoSet_PlasmaGasCartridgeRed_Rifle</ammoSet>
 					</AmmoUser>
@@ -107,6 +108,7 @@
 						<soundCast>OuterRim_Shot_PowerBlasterBolt</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>12</muzzleFlashScale>
+						<ammoConsumedPerShotCount>3</ammoConsumedPerShotCount>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
@@ -115,7 +117,7 @@
 						<aiAimMode>AimedShot</aiAimMode>
 					</FireModes>
 					<AmmoUser>
-						<magazineSize>10</magazineSize>
+						<magazineSize>15</magazineSize>
 						<reloadTime>3.7</reloadTime>
 						<ammoSet>AmmoSet_PlasmaGasCartridgeRed_Sniper</ammoSet>
 					</AmmoUser>


### PR DESCRIPTION
## Changes
Builds on the patches in #2997 to improve balance and clarify a few things;
- Improves sharp armour (slightly) and blunt armour (noticeably) for all armours.
- Adjusts armour coverage %s for various bodyparts to match spacer armours. Feet no longer have reduced armour (but necks do).
- Improves penetration of blaster rifle shots, and lethality of blaster sniper shots. Standard blaster sniper shots got a slight sharp pen reduction.
- Makes blaster rifles consume 2 ammo per shot and sniper rifles 3 ammo per shot. Ammo capacities have been buffed up. I've noticed this may be incorrectly displayed in weapon infocards but I suspect that's a CE code issue that's out of scope for the patches.
- Adds custom AmmoCategoryDefs for blaster bolts and the RPS-6 rockets, to note differences from Charge ammo (blaster wounds get infected much less often than regular gunshots and burns, from what I've noticed) and other rocket/missile warheads.
- Offloads some headwear patching to the uniform headwear abstract.
- Added flashbang tags to a couple of grenades to indicate they're no good for damaging structures.
- Adds nonlethal 'neuralizer' damage type based off electrical damage that inflicts a new tranquilizer-like neuralizer hediff, and associated ammo (currently using tox charge ammo sprites).
- Fixes some mis-assigned projectiles for rifles using ion ammo (imp and rebel rifles were firing pistol-grade ion bolts).
- Patches the Galactic Republic's kamas (leg-guards) to have enough sharp def and material bonus to protect otherwise unarmoured legs from small fragments (they'll still bruise even when made out of suitably durable materials), but not from large fragments.

## Reasoning
Certain armours and ammo types were underperforming, and needed to be brought in line with spacer/ultra equivalents. Consuming 2 ammo per shot for rifles or 3 for snipers offsets the simple ammo logistics of only having three core ammo types for the entire range of guns. A couple of things just got overlooked.

Adding 'alt fire' modes for the stun function of blasters seemed like too much of a headache, so I bent the fluff/lore a bit to make it a nonlethal ammo instead. Stun projectiles are slower than lethal ones given they can instantly incapacitate a target at long range. I need to test how this stuff works more, and iron a couple of things out.

## To-Do
- [ ] Make Neuralizer stun only apply to organics. May need to tinker some more.
- [ ] Look at patching some of the vambraces and projectiles so they work a bit like grenade belts and jetpacks - use a manufacturable ammo to reload them, etc.

## Testing
Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] ...with and without patched mod loaded
- [x] Playtested a colony (this is based on active playtesting results)
