### PR TITLE
Leather armor multiplier consistency check

### DIFF
--- a/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_Resources_Leathers.xml
+++ b/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_Resources_Leathers.xml
@@ -88,7 +88,7 @@
 
 				<!--aerofleet stuff and plant leather -->
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="AA_Leather_Aerofleet" or defName="Leather_Cactus"]/statBases/StuffPower_Armor_Sharp</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Leather_Aerofleet"]/statBases/StuffPower_Armor_Sharp</xpath>
 					<value>
 						<StuffPower_Armor_Sharp>0.03</StuffPower_Armor_Sharp>
 					</value>
@@ -99,10 +99,16 @@
 						<StuffPower_Armor_Blunt>0.032</StuffPower_Armor_Blunt>
 					</value>
 				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Leather_Cactus"]/statBases/StuffPower_Armor_Sharp</xpath>
+					<value>
+						<StuffPower_Armor_Sharp>0.05</StuffPower_Armor_Sharp>
+					</value>
+				</li>
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="Leather_Cactus"]/statBases</xpath>
 					<value>
-						<StuffPower_Armor_Blunt>0.032</StuffPower_Armor_Blunt>
+						<StuffPower_Armor_Blunt>0.04</StuffPower_Armor_Blunt>
 					</value>
 				</li>
 
@@ -110,13 +116,13 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="AA_ArcticLion_Leather" or defName="AA_SandLion_Leather"]/statBases/StuffPower_Armor_Sharp</xpath>
 					<value>
-						<StuffPower_Armor_Sharp>0.08</StuffPower_Armor_Sharp>
+						<StuffPower_Armor_Sharp>0.1</StuffPower_Armor_Sharp>
 					</value>
 				</li>
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="AA_ArcticLion_Leather" or defName="AA_SandLion_Leather"]/statBases</xpath>
 					<value>
-						<StuffPower_Armor_Blunt>0.06</StuffPower_Armor_Blunt>
+						<StuffPower_Armor_Blunt>0.08</StuffPower_Armor_Blunt>
 					</value>
 				</li>
 
@@ -124,13 +130,13 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="Leather_Night"]/statBases/StuffPower_Armor_Sharp</xpath>
 					<value>
-						<StuffPower_Armor_Sharp>0.08</StuffPower_Armor_Sharp>
+						<StuffPower_Armor_Sharp>0.01</StuffPower_Armor_Sharp>
 					</value>
 				</li>
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="Leather_Night"]/statBases</xpath>
 					<value>
-						<StuffPower_Armor_Blunt>0.064</StuffPower_Armor_Blunt>
+						<StuffPower_Armor_Blunt>0.08</StuffPower_Armor_Blunt>
 					</value>
 				</li>
 
@@ -138,7 +144,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="Leather_Chitin"]/statBases/StuffPower_Armor_Sharp</xpath>
 					<value>
-						<StuffPower_Armor_Sharp>0.21</StuffPower_Armor_Sharp>
+						<StuffPower_Armor_Sharp>0.15</StuffPower_Armor_Sharp>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
@@ -156,7 +162,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="Leather_Chitin"]/statBases</xpath>
 					<value>
-						<StuffPower_Armor_Blunt>0.09</StuffPower_Armor_Blunt>
+						<StuffPower_Armor_Blunt>0.08</StuffPower_Armor_Blunt>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">

--- a/Patches/Core/ThingDefs_Items/Items_Resource_Stuff_Leather.xml
+++ b/Patches/Core/ThingDefs_Items/Items_Resource_Stuff_Leather.xml
@@ -11,14 +11,14 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[@Name="LeatherBase" or defName="Leather_Wolf" or defName="Leather_Panthera" or defName="Leather_Human" or defName="Leather_Pig" or defName="Leather_Elephant"]/statBases/StuffPower_Armor_Sharp</xpath>
+		<xpath>Defs/ThingDef[@Name="LeatherBase" or defName="Leather_Fox" or defName="Leather_Lizard"]/statBases/StuffPower_Armor_Sharp</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>0.05</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[@Name="LeatherBase" or defName="Leather_Wolf" or defName="Leather_Panthera" or defName="Leather_Human" or defName="Leather_Pig" or defName="Leather_Elephant"]/statBases/StuffPower_Armor_Blunt</xpath>
+		<xpath>Defs/ThingDef[@Name="LeatherBase" or defName="Leather_Fox" or defName="Leather_Lizard"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.04</StuffPower_Armor_Blunt>
 		</value>
@@ -34,48 +34,62 @@
 	<!-- Lightleather -->
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Leather_Light" or defName="Leather_Bird" or defName="Leather_Chinchilla" or defName="Leather_Fox" or defName="Leather_GuineaPig"]/statBases/StuffPower_Armor_Sharp</xpath>
+		<xpath>Defs/ThingDef[defName="Leather_Light" or defName="Leather_Bird" or defName="Leather_Chinchilla" or defName="Leather_Pig" or defName="Leather_GuineaPig" or defName="Leather_Human"]/statBases/StuffPower_Armor_Sharp</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>0.03</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Leather_Light" or defName="Leather_Bird" or defName="Leather_Chinchilla" or defName="Leather_Fox" or defName="Leather_GuineaPig"]/statBases/StuffPower_Armor_Blunt</xpath>
+		<xpath>Defs/ThingDef[defName="Leather_Light" or defName="Leather_Bird" or defName="Leather_Chinchilla" or defName="Leather_Pig" or defName="Leather_GuineaPig" or defName="Leather_Human"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.024</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
 
-	<!-- Lizardskin -->
+	<!-- Wolf and Panthera leather -->
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Leather_Lizard"]/statBases/StuffPower_Armor_Sharp</xpath>
+		<xpath>Defs/ThingDef[defName="Leather_Wolf" or defName="Leather_Panthera"]/statBases/StuffPower_Armor_Sharp</xpath>
 		<value>
-			<StuffPower_Armor_Sharp>0.08</StuffPower_Armor_Sharp>
+			<StuffPower_Armor_Sharp>0.07</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Leather_Lizard"]/statBases/StuffPower_Armor_Blunt</xpath>
+		<xpath>Defs/ThingDef[defName="Leather_Wolf" or defName="Leather_Panthera"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
-			<StuffPower_Armor_Blunt>0.064</StuffPower_Armor_Blunt>
+			<StuffPower_Armor_Blunt>0.056</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
 
 	<!-- Heavy Fur -->
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Leather_Heavy" or defName="Leather_Bear" or defName="Leather_Rhinoceros"]/statBases/StuffPower_Armor_Sharp</xpath>
+		<xpath>Defs/ThingDef[defName="Leather_Bear" or defName="Leather_Elephant"]/statBases/StuffPower_Armor_Sharp</xpath>
 		<value>
-			<StuffPower_Armor_Sharp>0.07</StuffPower_Armor_Sharp>
+			<StuffPower_Armor_Sharp>0.08</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Leather_Heavy" or defName="Leather_Bear" or defName="Leather_Rhinoceros"]/statBases</xpath>
+		<xpath>Defs/ThingDef[defName="Leather_Bear" or defName="Leather_Elephant"]/statBases</xpath>
 		<value>
-			<StuffPower_Armor_Blunt>0.056</StuffPower_Armor_Blunt>
+			<StuffPower_Armor_Blunt>0.064</StuffPower_Armor_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Leather_Heavy" or defName="Leather_Rhinoceros"]/statBases/StuffPower_Armor_Sharp</xpath>
+		<value>
+			<StuffPower_Armor_Sharp>0.1</StuffPower_Armor_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Leather_Heavy" or defName="Leather_Rhinoceros"]/statBases</xpath>
+		<value>
+			<StuffPower_Armor_Blunt>0.08</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Items/Items_Resource_Stuff_Leather.xml
+++ b/Patches/Core/ThingDefs_Items/Items_Resource_Stuff_Leather.xml
@@ -82,14 +82,14 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Leather_Heavy" or defName="Leather_Rhinoceros"]/statBases/StuffPower_Armor_Sharp</xpath>
 		<value>
-			<StuffPower_Armor_Sharp>0.1</StuffPower_Armor_Sharp>
+			<StuffPower_Armor_Sharp>0.09</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Leather_Heavy" or defName="Leather_Rhinoceros"]/statBases</xpath>
 		<value>
-			<StuffPower_Armor_Blunt>0.08</StuffPower_Armor_Blunt>
+			<StuffPower_Armor_Blunt>0.064</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
 

--- a/Patches/Vanilla Animals Expanded/AridShrubland_Resources.xml
+++ b/Patches/Vanilla Animals Expanded/AridShrubland_Resources.xml
@@ -17,7 +17,7 @@
 					<xpath>Defs/ThingDef[defName="AEXP_Leather_Hippopotamus"]/statBases</xpath>
 
 					<value>
-						<StuffPower_Armor_Sharp>0.36</StuffPower_Armor_Sharp>
+						<StuffPower_Armor_Sharp>0.1</StuffPower_Armor_Sharp>
 						<StuffPower_Armor_Blunt>0.08</StuffPower_Armor_Blunt>
 					</value>
 				</li>
@@ -31,8 +31,8 @@
 					<xpath>Defs/ThingDef[defName="AEXP_Leather_Wildebeest"]/statBases</xpath>
 
 					<value>
-						<StuffPower_Armor_Sharp>0.05</StuffPower_Armor_Sharp>
-						<StuffPower_Armor_Blunt>0.04</StuffPower_Armor_Blunt>
+						<StuffPower_Armor_Sharp>0.08</StuffPower_Armor_Sharp>
+						<StuffPower_Armor_Blunt>0.064</StuffPower_Armor_Blunt>
 					</value>
 				</li>
 			</operations>

--- a/Patches/Vanilla Animals Expanded/Desert_Resources.xml
+++ b/Patches/Vanilla Animals Expanded/Desert_Resources.xml
@@ -17,8 +17,8 @@
 					<xpath>Defs/ThingDef[defName="AEXP_Leather_Lion"]/statBases</xpath>
 
 					<value>
-						<StuffPower_Armor_Sharp>0.04</StuffPower_Armor_Sharp>
-						<StuffPower_Armor_Blunt>0.07</StuffPower_Armor_Blunt>
+						<StuffPower_Armor_Sharp>0.07</StuffPower_Armor_Sharp>
+						<StuffPower_Armor_Blunt>0.056</StuffPower_Armor_Blunt>
 					</value>
 				</li>
 			</operations>

--- a/Patches/Vanilla Animals Expanded/IceSheet_Resources.xml
+++ b/Patches/Vanilla Animals Expanded/IceSheet_Resources.xml
@@ -29,8 +29,8 @@
 					<xpath>Defs/ThingDef[defName="AEXP_Leather_Pinniped"]/statBases</xpath>
 
 					<value>
-						<StuffPower_Armor_Sharp>0.05</StuffPower_Armor_Sharp>
-						<StuffPower_Armor_Blunt>0.04</StuffPower_Armor_Blunt>
+						<StuffPower_Armor_Sharp>0.07</StuffPower_Armor_Sharp>
+						<StuffPower_Armor_Blunt>0.056</StuffPower_Armor_Blunt>
 					</value>
 				</li>
 			</operations>

--- a/Patches/Vanilla Animals Expanded/TropicalRainforest_Resources.xml
+++ b/Patches/Vanilla Animals Expanded/TropicalRainforest_Resources.xml
@@ -20,8 +20,8 @@
 					<xpath>Defs/ThingDef[defName="AEXP_Leather_Tiger"]/statBases</xpath>
 
 					<value>
-						<StuffPower_Armor_Sharp>0.03</StuffPower_Armor_Sharp>
-						<StuffPower_Armor_Blunt>0.07</StuffPower_Armor_Blunt>
+						<StuffPower_Armor_Sharp>0.07</StuffPower_Armor_Sharp>
+						<StuffPower_Armor_Blunt>0.056</StuffPower_Armor_Blunt>
 					</value>
 				</li>
 			</operations>

--- a/Patches/Vanilla Animals Expanded/Tundra_Resources.xml
+++ b/Patches/Vanilla Animals Expanded/Tundra_Resources.xml
@@ -17,7 +17,7 @@
 					<xpath>Defs/ThingDef[defName="AEXP_MuskOxWool"]/statBases</xpath>
 
 					<value>
-						<StuffPower_Armor_Sharp>0.05</StuffPower_Armor_Sharp>
+						<StuffPower_Armor_Sharp>0.02</StuffPower_Armor_Sharp>
 						<StuffPower_Armor_Blunt>0.03</StuffPower_Armor_Blunt>
 					</value>
 				</li>


### PR DESCRIPTION
## Changes

- What it says on the tin, various animals leathers now provide armor consistent with their vanilla counterparts.

## Reasoning

- The stats were all over the place and seemingly arbitrary with no cohesion between their vanilla counterpart. Top end of the leather types being heavy and rhino leather provide the most armor among the vanilla leathers now as intended by the game and the rest are scaled accordingly based on them.

## Alternatives

- Leave Lizardskin the best leather in terms of armor and suffer.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
