### PR TITLE
Flare gun loadout budget fixed

### DIFF
--- a/Defs/ThingDefs_Misc/Weapons_Ranged.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Ranged.xml
@@ -400,7 +400,7 @@
 		</graphicData>
 		<soundInteract>Interact_Autopistol</soundInteract>
 		<statBases>
-			<WorkToMake>6000</WorkToMake>
+			<WorkToMake>4000</WorkToMake>
 			<SightsEfficiency>0.7</SightsEfficiency>
 			<ShotSpread>0.18</ShotSpread>
 			<SwayFactor>0.87</SwayFactor>

--- a/Patches/Android Tiers Reforged/PawnkindDefs/PawnKinds_Android.xml
+++ b/Patches/Android Tiers Reforged/PawnkindDefs/PawnKinds_Android.xml
@@ -73,8 +73,8 @@
 										<li>
 											<generateChance>0.075</generateChance>
 											<sidearmMoney>
-												<min>10</min>
-												<max>100</max>
+												<min>80</min>
+												<max>160</max>
 											</sidearmMoney>
 											<weaponTags>
 												<li>CE_FlareLauncher</li>

--- a/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -118,8 +118,8 @@
 					<li>
 						<generateChance>0.075</generateChance>
 						<sidearmMoney>
-							<min>10</min>
-							<max>100</max>
+							<min>80</min>
+							<max>160</max>
 						</sidearmMoney>
 						<weaponTags>
 							<li>CE_FlareLauncher</li>
@@ -425,8 +425,8 @@
 					<li>
 						<generateChance>0.15</generateChance>
 						<sidearmMoney>
-							<min>10</min>
-							<max>100</max>
+							<min>80</min>
+							<max>160</max>
 						</sidearmMoney>
 						<weaponTags>
 							<li>CE_FlareLauncher</li>
@@ -506,8 +506,8 @@
 					<li>
 						<generateChance>0.125</generateChance>
 						<sidearmMoney>
-							<min>10</min>
-							<max>100</max>
+							<min>80</min>
+							<max>160</max>
 						</sidearmMoney>
 						<weaponTags>
 							<li>CE_FlareLauncher</li>

--- a/Patches/K4G Rimworld War 2/PawnKinds_Defs/PawnKinds_Japan.xml
+++ b/Patches/K4G Rimworld War 2/PawnKinds_Defs/PawnKinds_Japan.xml
@@ -191,8 +191,8 @@
 								<li>
 									<generateChance>0.075</generateChance>
 									<sidearmMoney>
-										<min>10</min>
-										<max>100</max>
+										<min>80</min>
+										<max>160</max>
 									</sidearmMoney>
 									<weaponTags>
 										<li>CE_FlareLauncher</li>

--- a/Patches/MH Android Tiers/PawnkindDefs/PawnKinds_Android.xml
+++ b/Patches/MH Android Tiers/PawnkindDefs/PawnKinds_Android.xml
@@ -70,8 +70,8 @@
 										<li>
 											<generateChance>0.075</generateChance>
 											<sidearmMoney>
-												<min>10</min>
-												<max>100</max>
+												<min>80</min>
+												<max>160</max>
 											</sidearmMoney>
 											<weaponTags>
 												<li>CE_FlareLauncher</li>

--- a/Patches/MH Military Tiers/PawnkindDefs/PawnKinds_Android.xml
+++ b/Patches/MH Military Tiers/PawnkindDefs/PawnKinds_Android.xml
@@ -63,8 +63,8 @@
 									<li>
 										<generateChance>0.075</generateChance>
 										<sidearmMoney>
-											<min>10</min>
-											<max>100</max>
+											<min>80</min>
+											<max>160</max>
 										</sidearmMoney>
 										<weaponTags>
 											<li>CE_FlareLauncher</li>

--- a/Patches/Rim-Effect Asari and Reapers/PawnKindDefs/Asari_Pawns.xml
+++ b/Patches/Rim-Effect Asari and Reapers/PawnKindDefs/Asari_Pawns.xml
@@ -38,8 +38,8 @@
 								<li>
 									<generateChance>0.075</generateChance>
 									<sidearmMoney>
-										<min>10</min>
-										<max>100</max>
+										<min>80</min>
+										<max>160</max>
 									</sidearmMoney>
 									<weaponTags>
 										<li>CE_FlareLauncher</li>

--- a/Patches/Rim-Effect Core/Alliance_Pawns.xml
+++ b/Patches/Rim-Effect Core/Alliance_Pawns.xml
@@ -43,8 +43,8 @@
 								<li>
 									<generateChance>0.075</generateChance>
 									<sidearmMoney>
-										<min>10</min>
-										<max>100</max>
+										<min>80</min>
+										<max>160</max>
 									</sidearmMoney>
 									<weaponTags>
 										<li>CE_FlareLauncher</li>

--- a/Patches/The Corporation - Mort's Factions/Pawnkinds_Corporation.xml
+++ b/Patches/The Corporation - Mort's Factions/Pawnkinds_Corporation.xml
@@ -106,8 +106,8 @@
 								<li>
 									<generateChance>0.05</generateChance>
 									<sidearmMoney>
-										<min>10</min>
-										<max>100</max>
+										<min>80</min>
+										<max>160</max>
 									</sidearmMoney>
 									<weaponTags>
 										<li>CE_FlareLauncher</li>

--- a/Patches/Vanilla Factions Expanded - Empire/PawnKinds.xml
+++ b/Patches/Vanilla Factions Expanded - Empire/PawnKinds.xml
@@ -82,8 +82,8 @@
 								<li>
 									<generateChance>0.1</generateChance>
 									<sidearmMoney>
-										<min>10</min>
-										<max>100</max>
+										<min>80</min>
+										<max>160</max>
 									</sidearmMoney>
 									<weaponTags>
 										<li>CE_FlareLauncher</li>

--- a/Patches/Xenohumans Expanded/Xenos_Pawns.xml
+++ b/Patches/Xenohumans Expanded/Xenos_Pawns.xml
@@ -30,8 +30,8 @@
 								<li>
 									<generateChance>0.075</generateChance>
 									<sidearmMoney>
-										<min>10</min>
-										<max>100</max>
+										<min>80</min>
+										<max>160</max>
 									</sidearmMoney>
 									<weaponTags>
 										<li>CE_FlareLauncher</li>
@@ -68,8 +68,8 @@
 								<li>
 									<generateChance>0.04</generateChance>
 									<sidearmMoney>
-										<min>10</min>
-										<max>100</max>
+										<min>80</min>
+										<max>160</max>
 									</sidearmMoney>
 									<weaponTags>
 										<li>CE_FlareLauncher</li>
@@ -121,8 +121,8 @@
 								<li>
 									<generateChance>0.075</generateChance>
 									<sidearmMoney>
-										<min>10</min>
-										<max>100</max>
+										<min>80</min>
+										<max>160</max>
 									</sidearmMoney>
 									<weaponTags>
 										<li>CE_FlareLauncher</li>
@@ -211,8 +211,8 @@
 								<li>
 									<generateChance>0.075</generateChance>
 									<sidearmMoney>
-										<min>10</min>
-										<max>100</max>
+										<min>80</min>
+										<max>160</max>
 									</sidearmMoney>
 									<weaponTags>
 										<li>CE_FlareLauncher</li>

--- a/Royalty/Patches/PawnKindDefs_Royalty/PawnKinds_Royalty.xml
+++ b/Royalty/Patches/PawnKindDefs_Royalty/PawnKinds_Royalty.xml
@@ -51,8 +51,8 @@
 					<li>
 						<generateChance>0.175</generateChance>
 						<sidearmMoney>
-							<min>10</min>
-							<max>100</max>
+							<min>80</min>
+							<max>160</max>
 						</sidearmMoney>
 						<weaponTags>
 							<li>CE_FlareLauncher</li>
@@ -123,8 +123,8 @@
 					<li>
 						<generateChance>0.125</generateChance>
 						<sidearmMoney>
-							<min>10</min>
-							<max>100</max>
+							<min>80</min>
+							<max>160</max>
 						</sidearmMoney>
 						<weaponTags>
 							<li>CE_FlareLauncher</li>
@@ -235,8 +235,8 @@
 					<li>
 						<generateChance>0.1</generateChance>
 						<sidearmMoney>
-							<min>10</min>
-							<max>100</max>
+							<min>80</min>
+							<max>160</max>
 						</sidearmMoney>
 						<weaponTags>
 							<li>CE_FlareLauncher</li>
@@ -296,8 +296,8 @@
 					<li>
 						<generateChance>0.1</generateChance>
 						<sidearmMoney>
-							<min>10</min>
-							<max>100</max>
+							<min>80</min>
+							<max>160</max>
 						</sidearmMoney>
 						<weaponTags>
 							<li>CE_FlareLauncher</li>


### PR DESCRIPTION
## Changes

- Increased the budget for flare guns in pawn loadouts.

## Reasoning

- https://discord.com/channels/278818534069501953/303988654492090370/1216773608479916052
    tl;dr NPC pawns don't have enough budget to have flare guns when spawned.

## Alternatives

- No flare guns on NPCs?

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (it works)
