### PR TITLE
Adds hand coverage to trooper armor from "Vanilla Armour Expanded"

### DIFF
--- a/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -116,7 +116,7 @@
 						</weaponTags>
 					</li>
 					<li>
-						<generateChance>0.075</generateChance>
+						<generateChance>0.1</generateChance>
 						<sidearmMoney>
 							<min>10</min>
 							<max>100</max>
@@ -302,6 +302,20 @@
 							<li>CE_Sidearm_Melee</li>
 						</weaponTags>
 					</li>
+					<li>
+						<generateChance>0.1</generateChance>
+						<sidearmMoney>
+							<min>80</min>
+							<max>160</max>
+						</sidearmMoney>
+						<weaponTags>
+							<li>CE_FlareLauncher</li>
+						</weaponTags>
+						<magazineCount>
+							<min>1</min>
+							<max>3</max>
+						</magazineCount>
+					</li>					
 				</sidearms>
 			</li>
 		</value>
@@ -352,6 +366,20 @@
 							<li>CE_Sidearm_Melee</li>
 						</weaponTags>
 					</li>
+					<li>
+						<generateChance>0.1</generateChance>
+						<sidearmMoney>
+							<min>80</min>
+							<max>160</max>
+						</sidearmMoney>
+						<weaponTags>
+							<li>CE_FlareLauncher</li>
+						</weaponTags>
+						<magazineCount>
+							<min>1</min>
+							<max>3</max>
+						</magazineCount>
+					</li>					
 				</sidearms>
 			</li>
 		</value>

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Spacer.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Spacer.xml
@@ -199,7 +199,7 @@
 									<parts>
 										<li>Arm</li>
 									</parts>
-								</li>						
+								</li>
 							</stats>
 						</li>
 					</value>

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Spacer.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Spacer.xml
@@ -145,6 +145,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="VAE_Apparel_TrooperArmor" or defName="VAE_Apparel_RoyalTrooperArmor"]/apparel/bodyPartGroups</xpath>
 					<value>
+						<li>Hands</li>
 						<li>Feet</li>
 					</value>
 				</li>
@@ -165,12 +166,14 @@
 									<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
 									<parts>
 										<li>Neck</li>
+										<li>Hand</li>
 									</parts>
 								</li>
 								<li>
 									<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
 									<parts>
 										<li>Neck</li>
+										<li>Hand</li>
 									</parts>
 								</li>
 								<li>
@@ -196,7 +199,7 @@
 									<parts>
 										<li>Arm</li>
 									</parts>
-								</li>
+								</li>						
 							</stats>
 						</li>
 					</value>


### PR DESCRIPTION
## Additions

## Changes

- Added hand coverage to the trooper armor from "Vanilla Armour Expanded"



## Reasoning

- All power armors cover the hands, so it was weird that this armor covered the whole body except the hands

## Alternatives

Describe alternative implementations you have considered, e.g.
- None
## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (10 minutes)
