### PR TITLE
Patch Charge Enfield Mod

### DIFF
--- a/Patches/Charge-Loading Lee-Enfield/ThingDefs_Weapons.xml
+++ b/Patches/Charge-Loading Lee-Enfield/ThingDefs_Weapons.xml
@@ -1,0 +1,157 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Charge-Loading Lee-Enfield 1.4 Fork</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- Melee Tools -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Gun_ChargeEnfield" or defName="Gun_ChargeLewis"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>stock</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
+							<chanceFactor>1.5</chanceFactor>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>barrel</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>5</power>
+							<cooldownTime>2.02</cooldownTime>
+							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>muzzle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<!-- Charge Enfield -->
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>Gun_ChargeEnfield</defName>
+				<statBases>
+					<Mass>4.19</Mass>
+					<RangedWeapon_Cooldown>1.17</RangedWeapon_Cooldown>
+					<SightsEfficiency>1</SightsEfficiency>
+					<ShotSpread>0.02</ShotSpread>
+					<SwayFactor>1.68</SwayFactor>
+					<Bulk>12.60</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>1.75</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_8x35mmCharged</defaultProjectile>
+					<warmupTime>1.1</warmupTime>
+					<range>55</range>
+					<soundCast>Shot_ChargeEnfield</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>10</magazineSize>
+					<reloadTime>4.3</reloadTime>
+					<ammoSet>AmmoSet_8x35mmCharged</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+				<weaponTags>
+					<li>CE_AI_SR</li>
+				</weaponTags>
+				<AllowWithRunAndGun>false</AllowWithRunAndGun>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="Gun_ChargeEnfield"]</xpath>
+				<value>
+					<li Class="CombatExtended.GunDrawExtension">
+						<DrawSize>1.15,1.15</DrawSize>
+						<DrawOffset>0.02,0.04</DrawOffset>
+						<CasingOffset>-0.1,0.1</CasingOffset>
+					</li>
+				</value>
+			</li>
+
+			<!-- Charge Lewis Gun -->
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>Gun_ChargeLewis</defName>
+				<statBases>
+					<Mass>8.7</Mass>
+					<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
+					<SightsEfficiency>1</SightsEfficiency>
+					<ShotSpread>0.05</ShotSpread>
+					<SwayFactor>1.37</SwayFactor>
+					<Bulk>12.9</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>1.17</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_8x35mmCharged</defaultProjectile>
+					<warmupTime>1.3</warmupTime>
+					<range>62</range>
+					<ticksBetweenBurstShots>7</ticksBetweenBurstShots>
+					<burstShotCount>10</burstShotCount>
+					<soundCast>Shot_ChargeBlaster</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+					<recoilPattern>Mounted</recoilPattern>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>50</magazineSize>
+					<reloadTime>4.9</reloadTime>
+					<ammoSet>AmmoSet_8x35mmCharged</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aimedBurstShotCount>5</aimedBurstShotCount>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>SuppressFire</aiAimMode>
+				</FireModes>
+				<weaponTags>
+					<li>CE_MachineGun</li>
+					<li>CE_AI_LMG</li>
+					<li>Bipod_LMG</li>
+				</weaponTags>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="Gun_ChargeLewis"]</xpath>
+				<value>
+					<li Class="CombatExtended.GunDrawExtension">
+						<DrawSize>1.2,1.14</DrawSize>
+						<DrawOffset>0.08,-0.03</DrawOffset>
+					</li>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -154,6 +154,7 @@ Call of Duty: Pack A Punch |
 Call of Duty: Wonder Weapons |
 Carbon	|
 Censored Armory  |
+Charge-Loading Lee-Enfield  |
 Civilization Beyond Earth Armor Sets    |
 Clay Soldier Race |
 Colony Leadership   |


### PR DESCRIPTION
## Additions
- Patch for the Charge Enfield Mod
  - Charge Enfield uses same base stats as the vanilla bolt action.
  - Charge Lewis Gun uses the same base stats as the vanilla LMG. (We patch this as a Bren instead of a Lewis, but it's close enough for our purposes.)

## References
Close #2882 

## Reasoning
Weapons are essentially spacer versions of the regular guns, firing 8x35mm Charged instead of .303 British. The recoil has been adjusted accordingly.

## Alternatives
Could use a different charge caliber or make a new one, I suppose.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
