### PR TITLE
Railgun ammo rebalanced

### DIFF
--- a/Defs/Ammo/Advanced/12mmRailgun.xml
+++ b/Defs/Ammo/Advanced/12mmRailgun.xml
@@ -25,9 +25,9 @@
 		<label>12mm Railgun (Sabot)</label>
 		<description>Fin-stabilized tungsten carbide penetrator with discarding sabot, designed for large-caliber railgun weapons.</description>
 		<statBases>
-			<Mass>0.051</Mass>
-			<Bulk>0.04</Bulk>
-			<MarketValue>0.33</MarketValue>
+			<Mass>0.078</Mass>
+			<Bulk>0.03</Bulk>
+			<MarketValue>0.67</MarketValue>
 		</statBases>
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
@@ -38,7 +38,6 @@
 		<thingCategories>
 			<li>Ammo12mmRailgun</li>
 		</thingCategories>
-		<stackLimit>200</stackLimit>
 		<graphicData>
 			<texPath>Things/Ammo/Railgun/HighCaliber</texPath>
 			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
@@ -57,10 +56,10 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<damageAmountBase>73</damageAmountBase>
-			<armorPenetrationSharp>130</armorPenetrationSharp>
-			<armorPenetrationBlunt>7250</armorPenetrationBlunt>
-			<speed>354</speed>
+			<damageAmountBase>49</damageAmountBase>
+			<armorPenetrationSharp>80</armorPenetrationSharp>
+			<armorPenetrationBlunt>2332.8</armorPenetrationBlunt>
+			<speed>277</speed>
 		</projectile>
 	</ThingDef>
 
@@ -71,7 +70,7 @@
 		<label>make 12mm Railgun cartridge (Sabot) x200</label>
 		<description>Craft 200 12mm Railgun (Sabot) cartridges.</description>
 		<jobString>Making 12mm Railgun (Sabot) cartridges.</jobString>
-		<workAmount>2200</workAmount>
+		<workAmount>8200</workAmount>
 		<ingredients>
 			<li>
 				<filter>
@@ -79,7 +78,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>2</count>
+				<count>4</count>
 			</li>
 			<li>
 				<filter>
@@ -87,13 +86,22 @@
 						<li>Uranium</li>
 					</thingDefs>
 				</filter>
-				<count>10</count>
+				<count>15</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Chemfuel</li>
+					</thingDefs>
+				</filter>
+				<count>12</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
 			<thingDefs>
 				<li>Steel</li>
 				<li>Uranium</li>
+				<li>Chemfuel</li>
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>

--- a/Defs/Ammo/Advanced/6mmRailgun.xml
+++ b/Defs/Ammo/Advanced/6mmRailgun.xml
@@ -25,9 +25,9 @@
 		<label>6mm Railgun (Sabot)</label>
 		<description>Fin-stabilized tungsten carbide penetrator with discarding sabot, designed for railgun rifles.</description>
 		<statBases>
-			<Mass>0.01</Mass>
-			<Bulk>0.008</Bulk>
-			<MarketValue>0.06</MarketValue>
+			<Mass>0.009</Mass>
+			<Bulk>0.01</Bulk>
+			<MarketValue>0.09</MarketValue>
 		</statBases>
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
@@ -56,10 +56,10 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<damageAmountBase>19</damageAmountBase>
-			<armorPenetrationSharp>59</armorPenetrationSharp>
-			<armorPenetrationBlunt>290.80</armorPenetrationBlunt>
-			<speed>300</speed>
+			<damageAmountBase>13</damageAmountBase>
+			<armorPenetrationSharp>20</armorPenetrationSharp>
+			<armorPenetrationBlunt>101.4</armorPenetrationBlunt>
+			<speed>217</speed>
 		</projectile>
 	</ThingDef>
 
@@ -70,7 +70,7 @@
 		<label>make 6mm Railgun cartridge (Sabot) x500</label>
 		<description>Craft 500 6mm Railgun (Sabot) cartridges.</description>
 		<jobString>Making 6mm Railgun (Sabot) cartridges.</jobString>
-		<workAmount>1000</workAmount>
+		<workAmount>3400</workAmount>
 		<ingredients>
 			<li>
 				<filter>
@@ -78,7 +78,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>2</count>
+				<count>4</count>
 			</li>
 			<li>
 				<filter>
@@ -86,13 +86,22 @@
 						<li>Uranium</li>
 					</thingDefs>
 				</filter>
-				<count>4</count>
+				<count>3</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Chemfuel</li>
+					</thingDefs>
+				</filter>
+				<count>6</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
 			<thingDefs>
 				<li>Steel</li>
 				<li>Uranium</li>
+				<li>Chemfuel</li>
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>

--- a/Defs/Ammo/Advanced/8mmRailgun.xml
+++ b/Defs/Ammo/Advanced/8mmRailgun.xml
@@ -25,9 +25,9 @@
 		<label>8mm Railgun (Sabot)</label>
 		<description>Fin-stabilized tungsten carbide penetrator with discarding sabot, designed for railgun pistols.</description>
 		<statBases>
-			<Mass>0.009</Mass>
+			<Mass>0.018</Mass>
 			<Bulk>0.01</Bulk>
-			<MarketValue>0.06</MarketValue>
+			<MarketValue>0.15</MarketValue>
 		</statBases>
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
@@ -56,10 +56,10 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<damageAmountBase>20</damageAmountBase>
-			<armorPenetrationSharp>55</armorPenetrationSharp>
-			<armorPenetrationBlunt>252.720</armorPenetrationBlunt>
-			<speed>277</speed>
+			<damageAmountBase>21</damageAmountBase>
+			<armorPenetrationSharp>32</armorPenetrationSharp>
+			<armorPenetrationBlunt>303.76</armorPenetrationBlunt>
+			<speed>242</speed>
 		</projectile>
 	</ThingDef>
 
@@ -70,7 +70,7 @@
 		<label>make 8mm Railgun cartridge (Sabot) x500</label>
 		<description>Craft 500 8mm Railgun (Sabot) cartridges.</description>
 		<jobString>Making 8mm Railgun (Sabot) cartridges.</jobString>
-		<workAmount>1000</workAmount>
+		<workAmount>5000</workAmount>
 		<ingredients>
 			<li>
 				<filter>
@@ -78,7 +78,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>2</count>
+				<count>4</count>
 			</li>
 			<li>
 				<filter>
@@ -86,13 +86,22 @@
 						<li>Uranium</li>
 					</thingDefs>
 				</filter>
-				<count>4</count>
+				<count>7</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Chemfuel</li>
+					</thingDefs>
+				</filter>
+				<count>8</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
 			<thingDefs>
 				<li>Steel</li>
 				<li>Uranium</li>
+				<li>Chemfuel</li>
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Misc/Weapons.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Misc/Weapons.xml
@@ -56,8 +56,8 @@
 									<damageFalloff>False</damageFalloff>
 									<damageDef>Bullet</damageDef>
 									<damageAmountBase>21</damageAmountBase>
-									<armorPenetrationSharp>46.4</armorPenetrationSharp>
-									<armorPenetrationBlunt>312</armorPenetrationBlunt>
+									<armorPenetrationSharp>32</armorPenetrationSharp>
+									<armorPenetrationBlunt>303.76</armorPenetrationBlunt>
 								</projectile>
 							</ThingDef>
 
@@ -726,22 +726,22 @@
 					<!-- Add back the important stuff it still needed. Clunky, but it works. -->
 					<li Class="PatchOperationAdd">
 						<xpath>Defs/ThingDef[defName="AM_MechanoidGunRotaryNeedle"]</xpath>
-						<value>					
-						    <techLevel>Spacer</techLevel>
+						<value>
+							<techLevel>Spacer</techLevel>
 							<tradeability>None</tradeability>
 							<destroyOnDrop>true</destroyOnDrop>
 							<relicChance>0</relicChance>
 							<weaponClasses>
 								<li>RangedHeavy</li>
 								<li>LongShots</li>
-							</weaponClasses>							
+							</weaponClasses>
 						</value>
 					</li>
 
 					<li Class="PatchOperationAdd">
 						<xpath>Defs/ThingDef[defName="AM_MechanoidGunRotaryNeedle"]/graphicData</xpath>
 						<value>
-							<graphicClass>Graphic_Single</graphicClass>						
+							<graphicClass>Graphic_Single</graphicClass>
 						</value>
 					</li>
 
@@ -781,7 +781,7 @@
 						<FireModes>
 							<aiAimMode>AimedShot</aiAimMode>
 							<noSnapshot>true</noSnapshot>
-						</FireModes>						
+						</FireModes>
 					</li>
 
 					<li Class="PatchOperationAdd">

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VWECRangedWarcasket.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VWECRangedWarcasket.xml
@@ -57,7 +57,7 @@
 						<AmmoUser>
 							<magazineSize>15</magazineSize>
 							<reloadTime>5.2</reloadTime>
-							<ammoSet>AmmoSet_8mmRailgun_GaussLance</ammoSet>
+							<ammoSet>AmmoSet_12mmRailgun_GaussLance</ammoSet>
 						</AmmoUser>
 						<FireModes>
 							<aiUseBurstMode>true</aiUseBurstMode>

--- a/Patches/Vanilla Weapons Expanded - Coilguns/Ammo.xml
+++ b/Patches/Vanilla Weapons Expanded - Coilguns/Ammo.xml
@@ -29,18 +29,18 @@
 						</CombatExtended.AmmoSetDef>
 
 						<CombatExtended.AmmoSetDef>
-							<defName>AmmoSet_6mmRailgun_GaussMagnum</defName>
-							<label>6mm Railgun</label>
+							<defName>AmmoSet_8mmRailgun_GaussMagnum</defName>
+							<label>8mm Railgun</label>
 							<ammoTypes>
-								<Ammo_6mmRailgun_Sabot>Bullet_CoilGun_Magnum</Ammo_6mmRailgun_Sabot>
+								<Ammo_8mmRailgun_Sabot>Bullet_CoilGun_Magnum</Ammo_8mmRailgun_Sabot>
 							</ammoTypes>
 						</CombatExtended.AmmoSetDef>
 
 						<CombatExtended.AmmoSetDef>
-							<defName>AmmoSet_8mmRailgun_GaussLance</defName>
-							<label>8mm Railgun</label>
+							<defName>AmmoSet_12mmRailgun_GaussLance</defName>
+							<label>12mm Railgun</label>
 							<ammoTypes>
-								<Ammo_8mmRailgun_Sabot>Bullet_CoilGun_Lance</Ammo_8mmRailgun_Sabot>
+								<Ammo_12mmRailgun_Sabot>Bullet_CoilGun_Lance</Ammo_12mmRailgun_Sabot>
 							</ammoTypes>
 						</CombatExtended.AmmoSetDef>
 
@@ -53,9 +53,9 @@
 								<isInstant>true</isInstant>
 								<damageFalloff>False</damageFalloff>
 								<damageDef>Bullet</damageDef>
-								<damageAmountBase>15</damageAmountBase>
-								<armorPenetrationSharp>23</armorPenetrationSharp>
-								<armorPenetrationBlunt>142.5</armorPenetrationBlunt>
+								<damageAmountBase>21</damageAmountBase>
+								<armorPenetrationSharp>32</armorPenetrationSharp>
+								<armorPenetrationBlunt>303.76</armorPenetrationBlunt>
 							</projectile>
 						</ThingDef>
 
@@ -66,9 +66,9 @@
 								<isInstant>true</isInstant>
 								<damageFalloff>False</damageFalloff>
 								<damageDef>Bullet</damageDef>
-								<damageAmountBase>16</damageAmountBase>
-								<armorPenetrationSharp>36.5</armorPenetrationSharp>
-								<armorPenetrationBlunt>235.5</armorPenetrationBlunt>
+								<damageAmountBase>13</damageAmountBase>
+								<armorPenetrationSharp>20</armorPenetrationSharp>
+								<armorPenetrationBlunt>101.4</armorPenetrationBlunt>
 							</projectile>
 						</ThingDef>
 
@@ -79,9 +79,9 @@
 								<isInstant>true</isInstant>
 								<damageFalloff>False</damageFalloff>
 								<damageDef>Bullet</damageDef>
-								<damageAmountBase>21</damageAmountBase>
-								<armorPenetrationSharp>46.4</armorPenetrationSharp>
-								<armorPenetrationBlunt>312</armorPenetrationBlunt>
+								<damageAmountBase>49</damageAmountBase>
+								<armorPenetrationSharp>80</armorPenetrationSharp>
+								<armorPenetrationBlunt>2332.8</armorPenetrationBlunt>
 							</projectile>
 						</ThingDef>
 

--- a/Patches/Vanilla Weapons Expanded - Coilguns/RangedSpacer.xml
+++ b/Patches/Vanilla Weapons Expanded - Coilguns/RangedSpacer.xml
@@ -9,9 +9,9 @@
 			<operations>
 
 				<!-- === 
-      Compared to conventional weapons, coilguns have longer
-      warmups, but higher rates of fire and large magazines.
-      === -->
+				Compared to conventional weapons, coilguns have longer
+				warmups, but higher rates of fire and large magazines.
+				=== -->
 
 				<!-- === Tools === -->
 
@@ -125,8 +125,9 @@
 					</Properties>
 					<AmmoUser>
 						<magazineSize>8</magazineSize>
-						<reloadTime>4</reloadTime>
-						<ammoSet>AmmoSet_6mmRailgun_GaussMagnum</ammoSet>
+						<reloadOneAtATime>true</reloadOneAtATime>
+						<reloadTime>0.85</reloadTime>
+						<ammoSet>AmmoSet_8mmRailgun_GaussMagnum</ammoSet>
 					</AmmoUser>
 					<FireModes>
 						<aiAimMode>AimedShot</aiAimMode>
@@ -162,14 +163,14 @@
 						<muzzleFlashScale>9</muzzleFlashScale>
 					</Properties>
 					<AmmoUser>
-						<magazineSize>40</magazineSize>
+						<magazineSize>30</magazineSize>
 						<reloadTime>4</reloadTime>
 						<ammoSet>AmmoSet_6mmRailgun_GaussRifle</ammoSet>
 					</AmmoUser>
 					<FireModes>
 						<aiAimMode>AimedShot</aiAimMode>
 						<aiUseBurstMode>True</aiUseBurstMode>
-						<aimedBurstShotCount>4</aimedBurstShotCount>
+						<aimedBurstShotCount>2</aimedBurstShotCount>
 					</FireModes>
 					<weaponTags>
 						<li>SpacerGun</li>
@@ -189,12 +190,12 @@
 						<RangedWeapon_Cooldown>0.86</RangedWeapon_Cooldown>
 					</statBases>
 					<Properties>
-						<recoilAmount>2.0</recoilAmount>
+						<recoilAmount>3.0</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>True</hasStandardCommand>
 						<defaultProjectile>Bullet_CoilGun_Lance</defaultProjectile>
 						<warmupTime>2.4</warmupTime>
-						<range>62</range>
+						<range>75</range>
 						<soundCast>VWE_Shot_GaussLance</soundCast>
 						<soundCastTail>GunTail_Heavy</soundCastTail>
 						<muzzleFlashScale>9</muzzleFlashScale>
@@ -203,7 +204,7 @@
 					<AmmoUser>
 						<magazineSize>10</magazineSize>
 						<reloadTime>5.2</reloadTime>
-						<ammoSet>AmmoSet_8mmRailgun_GaussLance</ammoSet>
+						<ammoSet>AmmoSet_12mmRailgun_GaussLance</ammoSet>
 					</AmmoUser>
 					<FireModes>
 						<aiAimMode>AimedShot</aiAimMode>

--- a/Patches/Vanilla Weapons Expanded - Frontier/Patch_HighRoller_AddonAmmo.xml
+++ b/Patches/Vanilla Weapons Expanded - Frontier/Patch_HighRoller_AddonAmmo.xml
@@ -147,7 +147,7 @@
 									<damageFalloff>False</damageFalloff>
 									<damageDef>Bullet</damageDef>
 									<damageAmountBase>16</damageAmountBase>
-									<armorPenetrationSharp>35.1</armorPenetrationSharp>
+									<armorPenetrationSharp>25.1</armorPenetrationSharp>
 									<armorPenetrationBlunt>190.8</armorPenetrationBlunt>
 									<secondaryDamage>
 										<li>
@@ -203,7 +203,7 @@
 
 							<ThingDef Class="CombatExtended.Lasers.LaserBeamDefCE" ParentName="LaserBulletGreen">
 								<defName>Bullet_Laser_SalvagedLaserRevolver_HR</defName>
-                <label>laser beam</label>
+								<label>laser beam</label>
 								<projectile Class="CombatExtended.ProjectilePropertiesCE">
 									<damageDef>Bullet</damageDef>
 									<damageAmountBase>12</damageAmountBase>
@@ -221,7 +221,7 @@
 
 							<ThingDef Class="CombatExtended.Lasers.LaserBeamDefCE" ParentName="LaserBulletGreen">
 								<defName>Bullet_Laser_SalvagedLaserRepeater_HR</defName>
-                <label>laser beam</label>
+								<label>laser beam</label>
 								<projectile Class="CombatExtended.ProjectilePropertiesCE">
 									<damageDef>Bullet</damageDef>
 									<damageAmountBase>20</damageAmountBase>
@@ -239,7 +239,7 @@
 
 							<ThingDef Class="CombatExtended.Lasers.LaserBeamDefCE" ParentName="LaserBulletGreen">
 								<defName>Bullet_Laser_SalvagedLaserHuntingRifle_HR</defName>
-                <label>laser beam</label>
+								<label>laser beam</label>
 								<projectile Class="CombatExtended.ProjectilePropertiesCE">
 									<damageDef>Bullet</damageDef>
 									<damageAmountBase>24</damageAmountBase>


### PR DESCRIPTION
## Changes

- What it says on the tin, made the ammo more useable in handheld weapons.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070

## Reasoning

- 6mm ammo for pistol and SMGs, 8mm ammo for rifles and 12mm ammo for AMRs and bigger weapons.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
