### PR TITLE
Projectile position fix

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompFragments.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompFragments.cs
@@ -96,7 +96,7 @@ namespace CombatExtended
                 FloatRange fragXZAngleRange;
                 if (parent is ProjectileCE projCE)
                 {
-                    height = projCE.Height;
+                    height = projCE.ExactPosition.y;
                     fragXZAngleRange = new FloatRange(projCE.shotRotation + PropsCE.fragXZAngleRange.min, projCE.shotRotation + PropsCE.fragXZAngleRange.max);
                 }
                 else

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using RimWorld;
 using UnityEngine;
 using Verse;

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -222,13 +222,13 @@ namespace CombatExtended
         {
             get
             {
-                var w = (Destination - origin);
+                Vector2 w = (Destination - origin);
 
-                var vx = w.x / StartingTicksToImpact;
+                var vx = w.x / startingTicksToImpact;
 
-                var vy = (w.y - shotHeight) / StartingTicksToImpact
+                var vy = (w.y - shotHeight) / startingTicksToImpact
                          + shotSpeed * Mathf.Sin(shotAngle) / GenTicks.TicksPerRealSecond
-                         - (GravityFactor * fTicks) / (GenTicks.TicksPerRealSecond * GenTicks.TicksPerRealSecond);
+                         - (GravityFactor * FlightTicks) / (GenTicks.TicksPerRealSecond * GenTicks.TicksPerRealSecond);
 
                 return Quaternion.AngleAxis(
                            Mathf.Rad2Deg * Mathf.Atan2(-vy, vx) + 90f

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -132,42 +132,7 @@ namespace CombatExtended
         #endregion
 
         #region Ticks/Seconds
-        protected float startingTicksToImpactInt = -1f;
-        public float StartingTicksToImpact
-        {
-            get
-            {
-                if (!lerpPosition)
-                {
-                    return float.MaxValue;
-                }
-                if (startingTicksToImpactInt < 0f)
-                {
-                    // Optimization in case shotHeight is zero (for example for fragments)
-                    if (shotHeight < 0.001f)
-                    {
-                        // Opt-out in case the projectile is to collide instantly
-                        if (shotAngle < 0f)
-                        {
-                            destinationInt = origin;
-                            startingTicksToImpactInt = 0f;
-                            // During drawing in Multiplayer - impact causes issues. Will get handled inside of the `Tick` call.
-                            // In the future, replace this with `!InInterface` call, as it's more fitting here.
-                            if (!global::CombatExtended.Compatibility.Multiplayer.InMultiplayer)
-                            {
-                                ImpactSomething();
-                            }
-                            return 0f;
-                        }
-                        // Multiplied by ticksPerSecond since the calculated time is actually in seconds.
-                        startingTicksToImpactInt = (float)((origin - Destination).magnitude / (Mathf.Cos(shotAngle) * shotSpeed)) * (float)GenTicks.TicksPerRealSecond;
-                        return startingTicksToImpactInt;
-                    }
-                    startingTicksToImpactInt = GetFlightTime() * (float)GenTicks.TicksPerRealSecond;
-                }
-                return startingTicksToImpactInt;
-            }
-        }
+        public float startingTicksToImpact;
 
         int intTicksToImpact = -1;
         /// <summary>
@@ -407,6 +372,7 @@ namespace CombatExtended
             Scribe_References.Look<Thing>(ref launcher, "launcher");
             Scribe_References.Look<Thing>(ref equipment, "equipment");
             Scribe_Values.Look<int>(ref ticksToImpact, "ticksToImpact", 0, true);
+            Scribe_Values.Look<float>(ref startingTicksToImpact, "startingTicksToImpact", 0, true);
             Scribe_Defs.Look<ThingDef>(ref equipmentDef, "equipmentDef");
             Scribe_Values.Look<bool>(ref landed, "landed");
             //Here be new variables
@@ -638,6 +604,7 @@ namespace CombatExtended
                 var info = SoundInfo.InMap(this, MaintenanceType.PerTick);
                 ambientSustainer = def.projectile.soundAmbient.TrySpawnSustainer(info);
             }
+            this.startingTicksToImpact = GetFlightTime() * GenTicks.TicksPerRealSecond;
             this.ExactPosition = this.LastPos = new Vector3(origin.x, shotHeight, origin.y);
 
         }

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -246,7 +246,8 @@ namespace CombatExtended
             return Vector2.Lerp(origin, Destination, ticks / StartingTicksToImpact);
         }
 
-        private Vector3? exactPosition = null;
+        private Vector3 exactPosition;
+
         /// <summary>
         /// Exact x,y,z (x,height,y) position in terms of Vec2Position.x, .y (lerped origin to Destination) and Height.
         /// </summary>
@@ -254,24 +255,12 @@ namespace CombatExtended
         {
             set
             {
-                exactPosition = new Vector3(value.x, value.y, value.z);
+                exactPosition = value;
                 Position = ((Vector3)exactPosition).ToIntVec3();
             }
             get
             {
-                if (exactPosition == null)
-                {
-                    exactPosition = new Vector3(origin.x, shotHeight, origin.y);
-                }
-                return ((Vector3)exactPosition);
-            }
-        }
-
-        public virtual Vector2 DrawPosV2
-        {
-            get
-            {
-                return new Vector2(ExactPosition.x, ExactPosition.z);
+                return exactPosition;
             }
         }
 
@@ -464,7 +453,7 @@ namespace CombatExtended
         #region Throw
         public virtual void Throw(Thing launcher, Vector3 origin, Vector3 heading, Thing equipment = null)
         {
-            this.ExactPosition = origin;
+            this.ExactPosition = LastPos = origin;
             this.shotHeight = origin.y;
             this.origin = new Vector2(origin.x, origin.z);
             this.shotSpeed = Math.Max(heading.magnitude, def.projectile.speed);
@@ -667,6 +656,8 @@ namespace CombatExtended
                 var info = SoundInfo.InMap(this, MaintenanceType.PerTick);
                 ambientSustainer = def.projectile.soundAmbient.TrySpawnSustainer(info);
             }
+            this.ExactPosition = this.LastPos = new Vector3(origin.x, shotHeight, origin.y);
+
         }
         #endregion
 

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -42,18 +42,7 @@ namespace CombatExtended
 
         public Vector2 origin;
 
-        private IntVec3 originInt = new IntVec3(0, -1000, 0);
-        public IntVec3 OriginIV3
-        {
-            get
-            {
-                if (originInt.y < 0)
-                {
-                    originInt = new IntVec3(origin);
-                }
-                return originInt;
-            }
-        }
+        public IntVec3 OriginIV3;
 
         public Vector3 destinationInt = new Vector3(0f, 0f, -1f);
         /// <summary>
@@ -446,6 +435,7 @@ namespace CombatExtended
             //To fix landed grenades sl problem
             Scribe_Values.Look(ref exactPosition, "exactPosition");
 	    Scribe_Values.Look(ref GravityFactor, "gravityFactor", CE_Utility.GravityConst);
+            Scribe_Values.Look(ref OriginIV3, "originIV3", new IntVec3(this.origin));
             // To insure saves don't get affected..
         }
         #endregion
@@ -456,6 +446,7 @@ namespace CombatExtended
             this.ExactPosition = LastPos = origin;
             this.shotHeight = origin.y;
             this.origin = new Vector2(origin.x, origin.z);
+            this.OriginIV3 = new IntVec3(this.origin);
             this.shotSpeed = Math.Max(heading.magnitude, def.projectile.speed);
             var projectileProperties = def.projectile as ProjectilePropertiesCE;
             this.castShadow = projectileProperties.castShadow;
@@ -647,6 +638,7 @@ namespace CombatExtended
         {
             this.launcher = launcher;
             this.origin = origin;
+            this.OriginIV3 = new IntVec3(origin);
             this.equipment = equipment;
             //For explosives/bullets, equipmentDef is important
             equipmentDef = (equipment != null) ? equipment.def : null;
@@ -1269,7 +1261,7 @@ namespace CombatExtended
                     }
                 }
             }
-            float distToOrigin = originInt.DistanceTo(positionInt);
+            float distToOrigin = OriginIV3.DistanceTo(positionInt);
             float dangerFactor = (def.projectile as ProjectilePropertiesCE).dangerFactor;
             if (dangerFactor > 0f && nextPosition.y < CollisionVertical.WallCollisionHeight && distToOrigin > 3)
             {

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -112,9 +112,9 @@ namespace CombatExtended
 
         #region Vanilla
         public bool landed;
-	// TODO: // Remove in 1.5
+        // TODO: // Remove in 1.5
         public int intTicksToImpact;
-	public int ticksToImpact
+        public int ticksToImpact
         {
             get
             {
@@ -153,14 +153,14 @@ namespace CombatExtended
         #endregion
 
         #region Position
-	protected virtual Vector2 Vec2Position(float ticks = -1f)
-	{
+        protected virtual Vector2 Vec2Position(float ticks = -1f)
+        {
             Log.ErrorOnce("Vec2Position(float) is deprecated and will be removed in 1.5", 50021);
-	    if (ticks < 0)
-	    {
+            if (ticks < 0)
+            {
                 return Vec2Position();
             }
-	    return Vector2.Lerp(origin, Destination, ticks / startingTicksToImpact);
+            return Vector2.Lerp(origin, Destination, ticks / startingTicksToImpact);
         }
         protected virtual Vector2 Vec2Position()
         {
@@ -185,14 +185,14 @@ namespace CombatExtended
             }
         }
 
-	public Vector3 ExactMinusLastPos
-	{
-	    get
-	    {
+        public Vector3 ExactMinusLastPos
+        {
+            get
+            {
                 Log.ErrorOnce("ExactMinusLastPos is deprecated and will be removed in 1.5", 50022);
                 return (ExactPosition - LastPos);
-	    }
-	}
+            }
+        }
 
         public override Vector3 DrawPos
         {
@@ -350,11 +350,11 @@ namespace CombatExtended
 
             //To fix landed grenades sl problem
             Scribe_Values.Look(ref exactPosition, "exactPosition");
-	    Scribe_Values.Look(ref GravityFactor, "gravityFactor", CE_Utility.GravityConst);
+            Scribe_Values.Look(ref GravityFactor, "gravityFactor", CE_Utility.GravityConst);
             Scribe_Values.Look(ref LastPos, "lastPosition");
             Scribe_Values.Look(ref FlightTicks, "flightTicks");
             Scribe_Values.Look(ref OriginIV3, "originIV3", new IntVec3(this.origin));
-	    Scribe_Values.Look(ref Destination, "destination", this.origin + Vector2.up.RotatedBy(shotRotation) * DistanceTraveled);
+            Scribe_Values.Look(ref Destination, "destination", this.origin + Vector2.up.RotatedBy(shotRotation) * DistanceTraveled);
             // To insure saves don't get affected..
         }
         #endregion

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -112,7 +112,21 @@ namespace CombatExtended
 
         #region Vanilla
         public bool landed;
-        public int ticksToImpact;
+	// TODO: // Remove in 1.5
+        public int intTicksToImpact;
+	public int ticksToImpact
+        {
+            get
+            {
+                return intTicksToImpact;
+            }
+            set
+            {
+                intTicksToImpact = value;
+            }
+        }
+
+
         protected Sustainer ambientSustainer;
 
         #endregion
@@ -320,7 +334,7 @@ namespace CombatExtended
             Scribe_Values.Look<Vector2>(ref origin, "origin", default(Vector2), true);
             Scribe_References.Look<Thing>(ref launcher, "launcher");
             Scribe_References.Look<Thing>(ref equipment, "equipment");
-            Scribe_Values.Look<int>(ref ticksToImpact, "ticksToImpact", 0, true);
+            Scribe_Values.Look<int>(ref intTicksToImpact, "ticksToImpact", 0, true);
             Scribe_Values.Look<float>(ref startingTicksToImpact, "startingTicksToImpact", 0, true);
             Scribe_Defs.Look<ThingDef>(ref equipmentDef, "equipmentDef");
             Scribe_Values.Look<bool>(ref landed, "landed");

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -134,25 +134,7 @@ namespace CombatExtended
         #region Ticks/Seconds
         public float startingTicksToImpact;
 
-        int intTicksToImpact = -1;
-        /// <summary>
-        /// An integer ceil value of StartingTicksToImpact. intTicksToImpact is equal to -1 when not initialized.
-        /// </summary>
-        public int IntTicksToImpact
-        {
-            get
-            {
-                if (!lerpPosition)
-                {
-                    return 1;
-                }
-                if (intTicksToImpact < 0)
-                {
-                    intTicksToImpact = Mathf.CeilToInt(StartingTicksToImpact);
-                }
-                return intTicksToImpact;
-            }
-        }
+        public int FlightTicks = 0;
 
         private int flightTicks;
         /// <summary>
@@ -586,7 +568,6 @@ namespace CombatExtended
                 this.GravityFactor = props.Gravity;
             }
             Launch(launcher, origin, equipment);
-            this.ticksToImpact = IntTicksToImpact;
         }
 
         public virtual void Launch(Thing launcher, Vector2 origin, Thing equipment = null)
@@ -605,6 +586,7 @@ namespace CombatExtended
                 ambientSustainer = def.projectile.soundAmbient.TrySpawnSustainer(info);
             }
             this.startingTicksToImpact = GetFlightTime() * GenTicks.TicksPerRealSecond;
+            this.ticksToImpact = Mathf.CeilToInt(this.startingTicksToImpact);
             this.ExactPosition = this.LastPos = new Vector3(origin.x, shotHeight, origin.y);
 
         }

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -382,28 +382,10 @@ namespace CombatExtended
         /// </summary>
         public float shotSpeed = -1f;
 
-        private float _gravityFactor = -1;
-
         /// <summary>
         /// Gravity factor in meters(cells) per second squared
         /// </summary>
-        private float GravityFactor
-        {
-            get
-            {
-                if (_gravityFactor < 0)
-                {
-                    _gravityFactor = CE_Utility.GravityConst;
-                    if (def.projectile is ProjectilePropertiesCE props)
-                    {
-                        _gravityFactor = props.Gravity;
-                    }
-                }
-                return _gravityFactor;
-            }
-        }
-
-
+        private float GravityFactor = CE_Utility.GravityConst;
 
         protected Material[] shadowMaterial;
         protected Material ShadowMaterial
@@ -474,6 +456,7 @@ namespace CombatExtended
 
             //To fix landed grenades sl problem
             Scribe_Values.Look(ref exactPosition, "exactPosition");
+	    Scribe_Values.Look(ref GravityFactor, "gravityFactor", CE_Utility.GravityConst);
             // To insure saves don't get affected..
         }
         #endregion
@@ -665,6 +648,7 @@ namespace CombatExtended
             {
                 this.castShadow = props.castShadow;
                 this.lerpPosition = props.lerpPosition;
+                this.GravityFactor = props.Gravity;
             }
             Launch(launcher, origin, equipment);
             this.ticksToImpact = IntTicksToImpact;

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -350,7 +350,6 @@ namespace CombatExtended
             Scribe_TargetInfo.Look(ref intendedTarget, "intendedTarget");
 
             Scribe_Values.Look<Vector2>(ref origin, "origin", default(Vector2), true);
-            Scribe_Values.Look<int>(ref ticksToImpact, "ticksToImpact", 0, true);
             Scribe_References.Look<Thing>(ref launcher, "launcher");
             Scribe_References.Look<Thing>(ref equipment, "equipment");
             Scribe_Values.Look<int>(ref ticksToImpact, "ticksToImpact", 0, true);

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -13,7 +13,6 @@ using CombatExtended.Utilities;
 
 namespace CombatExtended
 {
-    [StaticConstructorOnStartup]
     public abstract class ProjectileCE : ThingWithComps
     {
         #region ClassVariables

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -44,23 +44,10 @@ namespace CombatExtended
 
         public IntVec3 OriginIV3;
 
-        public Vector3 destinationInt = new Vector3(0f, 0f, -1f);
         /// <summary>
         /// Calculates the destination (zero height) reached with a projectile of speed <i>shotSpeed</i> fired at <i>shotAngle</i> from height <i>shotHeight</i> starting from <i>origin</i>. Does not take into account air resistance.
         /// </summary>
-        public Vector2 Destination
-        {
-            get
-            {
-                if (destinationInt.z < 0)
-                {
-                    destinationInt = origin + Vector2.up.RotatedBy(shotRotation) * DistanceTraveled;
-                    destinationInt.z = 0f;
-                }
-                // Since returning as a Vector2 yields Vector2(Vector3.x, Vector3.y)!
-                return destinationInt;
-            }
-        }
+        public Vector2 Destination;
         #endregion
 
         /// <summary>
@@ -436,6 +423,7 @@ namespace CombatExtended
             Scribe_Values.Look(ref exactPosition, "exactPosition");
 	    Scribe_Values.Look(ref GravityFactor, "gravityFactor", CE_Utility.GravityConst);
             Scribe_Values.Look(ref OriginIV3, "originIV3", new IntVec3(this.origin));
+	    Scribe_Values.Look(ref Destination, "destination", this.origin + Vector2.up.RotatedBy(shotRotation) * DistanceTraveled);
             // To insure saves don't get affected..
         }
         #endregion
@@ -447,6 +435,7 @@ namespace CombatExtended
             this.shotHeight = origin.y;
             this.origin = new Vector2(origin.x, origin.z);
             this.OriginIV3 = new IntVec3(this.origin);
+            this.Destination = this.origin + Vector2.up.RotatedBy(shotRotation) * DistanceTraveled;
             this.shotSpeed = Math.Max(heading.magnitude, def.projectile.speed);
             var projectileProperties = def.projectile as ProjectilePropertiesCE;
             this.castShadow = projectileProperties.castShadow;
@@ -639,6 +628,7 @@ namespace CombatExtended
             this.launcher = launcher;
             this.origin = origin;
             this.OriginIV3 = new IntVec3(origin);
+            this.Destination = origin + Vector2.up.RotatedBy(shotRotation) * DistanceTraveled;
             this.equipment = equipment;
             //For explosives/bullets, equipmentDef is important
             equipmentDef = (equipment != null) ? equipment.def : null;

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -613,11 +613,11 @@ namespace CombatExtended
             {
                 return false;
             }
-            if (!interceptorComp.Props.interceptOutgoingProjectiles && (shieldPosition - lastExactPos).sqrMagnitude <= radius * radius)
+            if (!interceptorComp.Props.interceptOutgoingProjectiles && (shieldPosition - LastPos).sqrMagnitude <= radius * radius)
             {
                 return false;
             }
-            if (CE_Utility.IntersectionPoint(lastExactPos, newExactPos, shieldPosition, radius, out Vector3[] sect))
+            if (CE_Utility.IntersectionPoint(LastPos, newExactPos, shieldPosition, radius, out Vector3[] sect))
             {
                 ExactPosition = newExactPos = sect.OrderBy(x => (OriginIV3.ToVector3() - x).sqrMagnitude).First();
                 landed = true;
@@ -626,7 +626,7 @@ namespace CombatExtended
             {
                 return false;
             }
-            interceptorComp.lastInterceptAngle = lastExactPos.AngleToFlat(interceptorThing.TrueCenter());
+            interceptorComp.lastInterceptAngle = LastPos.AngleToFlat(interceptorThing.TrueCenter());
             interceptorComp.lastInterceptTicks = Find.TickManager.TicksGame;
 
             var projectileProperties = def.projectile as ProjectilePropertiesCE;

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -1212,8 +1212,8 @@ namespace CombatExtended
                 {
                     //TODO : EXPERIMENTAL Add edifice height
                     var shadowPos = new Vector3(ExactPosition.x,
-                                                def.Altitude - 0.01f,
-                                                ExactPosition.z - Mathf.Lerp(shotHeight, 0f, fTicks / StartingTicksToImpact));
+                                                0,
+                                                ExactPosition.z);
                     //EXPERIMENTAL: + (new CollisionVertical(ExactPosition.ToIntVec3().GetEdifice(Map))).Max);
 
                     //TODO : Vary ShadowMat plane

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -1110,7 +1110,7 @@ namespace CombatExtended
             if (lerpPosition)
             {
                 var v = Vec2Position();
-                nextPosition = new Vector3(v.x, Height, v.y);
+                nextPosition = new Vector3(v.x, GetHeightAtTicks(FlightTicks), v.y);
             }
             else
             {

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -139,13 +139,18 @@ namespace CombatExtended
         #endregion
 
         #region Position
-        protected virtual Vector2 Vec2Position(float ticks = -1f)
-        {
-            if (ticks < 0)
-            {
-                ticks = fTicks;
+	protected virtual Vector2 Vec2Position(float ticks = -1f)
+	{
+            Log.ErrorOnce("Vec2Position(float) is deprecated and will be removed in 1.5", 50021);
+	    if (ticks < 0)
+	    {
+                return Vec2Position();
             }
-            return Vector2.Lerp(origin, Destination, ticks / StartingTicksToImpact);
+	    return Vector2.Lerp(origin, Destination, ticks / startingTicksToImpact);
+        }
+        protected virtual Vector2 Vec2Position()
+        {
+            return Vector2.Lerp(origin, Destination, FlightTicks / startingTicksToImpact);
         }
 
         private Vector3 exactPosition;

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -184,32 +184,11 @@ namespace CombatExtended
         {
             get
             {
-                return ExactPosition;
-            }
-        }
-
-        private Vector3 lastExactPos = new Vector3(-1000, 0, 0);
-        public Vector3 LastPos
-        {
-            protected set
-            {
-                lastExactPos = value;
-            }
-            get
-            {
-                if (lastExactPos.x < -999)
-                {
-                    var lastPos = Vec2Position(FlightTicks - 1);
-                    lastExactPos = new Vector3(lastPos.x, GetHeightAtTicks(FlightTicks - 1), lastPos.y);
-                }
-                return lastExactPos;
-            }
-        }
-
                 return ExactPosition + new Vector3(0, 0, ExactPosition.y - shotHeight);
             }
         }
 
+        public Vector3 LastPos;
         protected DangerTracker _dangerTracker = null;
         protected DangerTracker DangerTracker
         {
@@ -358,6 +337,7 @@ namespace CombatExtended
             //To fix landed grenades sl problem
             Scribe_Values.Look(ref exactPosition, "exactPosition");
 	    Scribe_Values.Look(ref GravityFactor, "gravityFactor", CE_Utility.GravityConst);
+            Scribe_Values.Look(ref LastPos, "lastPosition");
             Scribe_Values.Look(ref FlightTicks, "flightTicks");
             Scribe_Values.Look(ref OriginIV3, "originIV3", new IntVec3(this.origin));
 	    Scribe_Values.Look(ref Destination, "destination", this.origin + Vector2.up.RotatedBy(shotRotation) * DistanceTraveled);

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -171,6 +171,15 @@ namespace CombatExtended
             }
         }
 
+	public Vector3 ExactMinusLastPos
+	{
+	    get
+	    {
+                Log.ErrorOnce("ExactMinusLastPos is deprecated and will be removed in 1.5", 50022);
+                return (ExactPosition - LastPos);
+	    }
+	}
+
         public override Vector3 DrawPos
         {
             get
@@ -197,11 +206,7 @@ namespace CombatExtended
             }
         }
 
-        public Vector3 ExactMinusLastPos
-        {
-            get
-            {
-                return (ExactPosition - LastPos);
+                return ExactPosition + new Vector3(0, 0, ExactPosition.y - shotHeight);
             }
         }
 
@@ -222,7 +227,7 @@ namespace CombatExtended
             {
                 if (lastShotLine != FlightTicks)
                 {
-                    shotLine = new Ray(LastPos, ExactMinusLastPos);
+                    shotLine = new Ray(LastPos, ExactPosition - LastPos);
                     lastShotLine = FlightTicks;
                 }
                 return shotLine;
@@ -879,7 +884,7 @@ namespace CombatExtended
             {
                 return false;
             }
-            if (dist * dist > ExactMinusLastPos.sqrMagnitude)
+            if (dist * dist > (ExactPosition - LastPos).sqrMagnitude)
             {
                 return false;
             }
@@ -913,7 +918,7 @@ namespace CombatExtended
             {
                 return false;
             }
-            if (dist * dist > ExactMinusLastPos.sqrMagnitude)
+            if (dist * dist > (ExactPosition - LastPos).sqrMagnitude)
             {
                 return false;
             }

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -136,27 +136,6 @@ namespace CombatExtended
 
         public int FlightTicks = 0;
 
-        private int flightTicks;
-        /// <summary>
-        /// The amount of integer ticks this projectile has remained in the air for, ignoring impact.
-        /// </summary>
-        public int FlightTicks
-        {
-            get
-            {
-                return flightTicks;
-            }
-        }
-        /// <summary>
-        /// The amount of float ticks the projectile has remained in the air for, including impact.
-        /// </summary>
-        public float fTicks
-        {
-            get
-            {
-                return (ticksToImpact == 0 ? StartingTicksToImpact : (float)FlightTicks);
-            }
-        }
         #endregion
 
         #region Position
@@ -369,6 +348,7 @@ namespace CombatExtended
             //To fix landed grenades sl problem
             Scribe_Values.Look(ref exactPosition, "exactPosition");
 	    Scribe_Values.Look(ref GravityFactor, "gravityFactor", CE_Utility.GravityConst);
+            Scribe_Values.Look(ref FlightTicks, "flightTicks");
             Scribe_Values.Look(ref OriginIV3, "originIV3", new IntVec3(this.origin));
 	    Scribe_Values.Look(ref Destination, "destination", this.origin + Vector2.up.RotatedBy(shotRotation) * DistanceTraveled);
             // To insure saves don't get affected..
@@ -1120,7 +1100,7 @@ namespace CombatExtended
             }
             LastPos = ExactPosition;
             ticksToImpact--;
-            flightTicks++;
+            FlightTicks++;
             Vector3 nextPosition;
             if (lerpPosition)
             {

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_Bursting.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_Bursting.cs
@@ -56,7 +56,6 @@ namespace CombatExtended
             this.shotRotation = shotRotation;
             this.shotSpeed = Math.Max(shotSpeed, def.projectile.speed);
             Launch(launcher, origin, equipment);
-            this.ticksToImpact = IntTicksToImpact;
         }
 
         public override void Tick()

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_Flare.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_Flare.cs
@@ -36,7 +36,7 @@ namespace CombatExtended
             base.Tick();
             if (decentStarted)
             {
-                if (Height <= FLYOVER_FLARING_HEIGHT && Rand.Chance(FLYOVER_FLARING_CHANCE))
+                if (ExactPosition.y <= FLYOVER_FLARING_HEIGHT && Rand.Chance(FLYOVER_FLARING_CHANCE))
                 {
                     Impact(null);
                 }
@@ -53,7 +53,7 @@ namespace CombatExtended
             Flare flare;
             flare = (Flare)ThingMaker.MakeThing(CE_ThingDefOf.Flare, null);
             flare.DrawMode = Flare.FlareDrawMode.FlyOver;
-            flare.StartingAltitude = Height;
+            flare.StartingAltitude = ExactPosition.y;
             flare.Position = Position;
             flare.SpawnSetup(Map, false);
             base.Impact(null);

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_HeightFuse.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_HeightFuse.cs
@@ -32,7 +32,7 @@ namespace CombatExtended
             {
                 armed = true;
             }
-            if (armed && Height <= detonationHeight)
+            if (armed && ExactPosition.y <= detonationHeight)
             {
                 HeightFuseAirBurst();
             }
@@ -41,7 +41,7 @@ namespace CombatExtended
         public override void Impact(Thing hitThing)
         {
             //intercept impact if it hit something after where height fuse should have triggered
-            if (armed && Height <= detonationHeight)
+            if (armed && ExactPosition.y <= detonationHeight)
             {
                 HeightFuseAirBurst();
             }
@@ -53,7 +53,7 @@ namespace CombatExtended
 
         void HeightFuseAirBurst()
         {
-            float f = (LastPos.y - detonationHeight) / (LastPos.y - Height);
+            float f = (LastPos.y - detonationHeight) / (LastPos.y - ExactPosition.y);
             ExactPosition = f * (LastPos - ExactPosition);
             if (!ExactPosition.ToIntVec3().IsValid)
             {


### PR DESCRIPTION
## Changes

Projectiles cache most values instead of recalculating on the fly.

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Recalculating values on the fly is incredibly expensive, doing it multiple times per projectile per tick is incredibly expensive.
Tracking position and other properties lets other mods modify projectile trajectory on the fly.

## Alternatives

Roll back position changes

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (hour)
