### PR TITLE
Frags adjusted and minor housekeeping

### DIFF
--- a/Defs/Ammo/Projectiles_Fragments.xml
+++ b/Defs/Ammo/Projectiles_Fragments.xml
@@ -10,10 +10,10 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Fragment</damageDef>
-			<damageAmountBase>27</damageAmountBase>
+			<damageAmountBase>34</damageAmountBase>
 			<speed>60</speed>
 			<armorPenetrationSharp>4.5</armorPenetrationSharp>
-			<armorPenetrationBlunt>62.5</armorPenetrationBlunt>
+			<armorPenetrationBlunt>122.5</armorPenetrationBlunt>
 			<gravityFactor>5</gravityFactor>
 		</projectile>
 	</ThingDef>
@@ -27,10 +27,10 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Fragment</damageDef>
-			<damageAmountBase>18</damageAmountBase>
+			<damageAmountBase>23</damageAmountBase>
 			<speed>50</speed>
 			<armorPenetrationSharp>3</armorPenetrationSharp>
-			<armorPenetrationBlunt>30.4</armorPenetrationBlunt>
+			<armorPenetrationBlunt>63.38</armorPenetrationBlunt>
 			<gravityFactor>5</gravityFactor>
 		</projectile>
 	</ThingDef>
@@ -44,10 +44,10 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Fragment</damageDef>
-			<damageAmountBase>9</damageAmountBase>
+			<damageAmountBase>12</damageAmountBase>
 			<speed>40</speed>
 			<armorPenetrationSharp>2</armorPenetrationSharp>
-			<armorPenetrationBlunt>6.4</armorPenetrationBlunt>
+			<armorPenetrationBlunt>14.4</armorPenetrationBlunt>
 			<gravityFactor>5</gravityFactor>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Rifle/277Fury.xml
+++ b/Defs/Ammo/Rifle/277Fury.xml
@@ -135,7 +135,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>166</speed>
+			<speed>167</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -146,7 +146,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>19</damageAmountBase>
 			<armorPenetrationSharp>7.5</armorPenetrationSharp>
-			<armorPenetrationBlunt>72.46</armorPenetrationBlunt>
+			<armorPenetrationBlunt>73.1</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -156,7 +156,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>12</damageAmountBase>
 			<armorPenetrationSharp>15</armorPenetrationSharp>
-			<armorPenetrationBlunt>72.46</armorPenetrationBlunt>
+			<armorPenetrationBlunt>73.1</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -166,7 +166,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>25</damageAmountBase>
 			<armorPenetrationSharp>4</armorPenetrationSharp>
-			<armorPenetrationBlunt>72.46</armorPenetrationBlunt>
+			<armorPenetrationBlunt>73.1</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -176,7 +176,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>12</damageAmountBase>
 			<armorPenetrationSharp>15</armorPenetrationSharp>
-			<armorPenetrationBlunt>72.46</armorPenetrationBlunt>
+			<armorPenetrationBlunt>73.1</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
@@ -192,7 +192,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>19</damageAmountBase>
 			<armorPenetrationSharp>7.5</armorPenetrationSharp>
-			<armorPenetrationBlunt>72.46</armorPenetrationBlunt>
+			<armorPenetrationBlunt>73.1</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
@@ -208,8 +208,8 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>10</damageAmountBase>
 			<armorPenetrationSharp>26.25</armorPenetrationSharp>
-			<armorPenetrationBlunt>93.16</armorPenetrationBlunt>
-			<speed>225</speed>
+			<armorPenetrationBlunt>93.98</armorPenetrationBlunt>
+			<speed>226</speed>
 		</projectile>
 	</ThingDef>
 


### PR DESCRIPTION
## Changes

- Increased the spreadsheet velocities of frags from 400, 450 and 500 to a more realistic 600, 650 and 700m/s.
- Accuracy check on .277 Fury's muzzle velocity.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070

## Reasoning

- The usual argument around frags being underperforming. According to here (https://en.wikipedia.org/wiki/F-1_grenade_(Russia)) grenade fragments fly at 700m/s away from the explosion which is pretty accurate to the velocity numbers shown in videos by Ballistic High Speed youtube channel. This increase helps both damage and the blunt AP of fragments considering fragment damage type already make the initial projectile to fragment and deal multiple smaller instances of damage.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
