### PR TITLE
Fix Vanilla Leather Patch

### DIFF
--- a/Patches/Core/ThingDefs_Items/Items_Resource_Stuff_Leather.xml
+++ b/Patches/Core/ThingDefs_Items/Items_Resource_Stuff_Leather.xml
@@ -56,8 +56,8 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Leather_Wolf" or defName="Leather_Panthera"]/statBases/StuffPower_Armor_Blunt</xpath>
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Leather_Wolf" or defName="Leather_Panthera"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.056</StuffPower_Armor_Blunt>
 		</value>


### PR DESCRIPTION
## Changes
- Swap a 'Replace' operation with an 'Add' instead.

## Reasoning
- Patch operation failing.

## Alternatives
Suffer.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
