### PR TITLE
5x35mm Charged reworked

### DIFF
--- a/Defs/Ammo/Advanced/5x35mmCharged.xml
+++ b/Defs/Ammo/Advanced/5x35mmCharged.xml
@@ -45,9 +45,9 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.36</MarketValue>
+			<MarketValue>0.36</MarketValue><!-- value intentionally decreased to help reduce wealth bloat/free silver -->
 		</statBases>
-		<ammoClass>ChargedAP</ammoClass>
+		<ammoClass>Ionized</ammoClass>
 	</ThingDef>
 
 	<!-- ================== Projectiles ================== -->
@@ -66,11 +66,11 @@
 			<speed>178</speed>
 			<secondaryDamage>
 				<li>
-					<def>Bomb_Secondary</def>
-					<amount>2</amount>
+					<def>EMP</def>
+					<amount>8</amount>
 				</li>
 			</secondaryDamage>
-			<armorPenetrationSharp>30</armorPenetrationSharp>
+			<armorPenetrationSharp>26</armorPenetrationSharp>
 			<armorPenetrationBlunt>60</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Advanced/5x35mmCharged.xml
+++ b/Defs/Ammo/Advanced/5x35mmCharged.xml
@@ -72,6 +72,7 @@
 			</secondaryDamage>
 			<armorPenetrationSharp>26</armorPenetrationSharp>
 			<armorPenetrationBlunt>60</armorPenetrationBlunt>
+			<empShieldBreakChance>0.66</empShieldBreakChance>
 		</projectile>
 	</ThingDef>
 

--- a/Patches/Forsakens/Forsakens_CE_Patch_Ammo_ProjReskin.xml
+++ b/Patches/Forsakens/Forsakens_CE_Patch_Ammo_ProjReskin.xml
@@ -198,6 +198,7 @@
 								</secondaryDamage>
 								<armorPenetrationSharp>26</armorPenetrationSharp>
 								<armorPenetrationBlunt>60</armorPenetrationBlunt>
+								<empShieldBreakChance>0.66</empShieldBreakChance>
 							</projectile>
 						</ThingDef>
 

--- a/Patches/Forsakens/Forsakens_CE_Patch_Ammo_ProjReskin.xml
+++ b/Patches/Forsakens/Forsakens_CE_Patch_Ammo_ProjReskin.xml
@@ -189,15 +189,15 @@
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
 								<damageDef>Bullet</damageDef>
 								<damageAmountBase>13</damageAmountBase>
-								<speed>200</speed>
+								<speed>178</speed>
 								<secondaryDamage>
 									<li>
-										<def>Bomb_Secondary</def>
-										<amount>2</amount>
+										<def>EMP</def>
+										<amount>8</amount>
 									</li>
 								</secondaryDamage>
-								<armorPenetrationSharp>30</armorPenetrationSharp>
-								<armorPenetrationBlunt>40</armorPenetrationBlunt>
+								<armorPenetrationSharp>26</armorPenetrationSharp>
+								<armorPenetrationBlunt>60</armorPenetrationBlunt>
 							</projectile>
 						</ThingDef>
 

--- a/Patches/Reinforced Mechanoid 2/ThingDefs_Misc/RM_Ammo_Spacer.xml
+++ b/Patches/Reinforced Mechanoid 2/ThingDefs_Misc/RM_Ammo_Spacer.xml
@@ -213,6 +213,7 @@
 								</secondaryDamage>
 								<armorPenetrationSharp>21</armorPenetrationSharp>
 								<armorPenetrationBlunt>38.4</armorPenetrationBlunt>
+								<empShieldBreakChance>0.5</empShieldBreakChance>
 							</projectile>
 						</ThingDef>
 
@@ -238,6 +239,7 @@
 								</secondaryDamage>
 								<armorPenetrationSharp>31</armorPenetrationSharp>
 								<armorPenetrationBlunt>86.4</armorPenetrationBlunt>
+								<empShieldBreakChance>0.75</empShieldBreakChance>
 							</projectile>
 						</ThingDef>
 

--- a/Patches/Reinforced Mechanoid 2/ThingDefs_Misc/RM_Ammo_Spacer.xml
+++ b/Patches/Reinforced Mechanoid 2/ThingDefs_Misc/RM_Ammo_Spacer.xml
@@ -204,14 +204,14 @@
 							<projectile Class="CombatExtended.ProjectilePropertiesCE" Inherit="False">
 								<damageDef>Bullet</damageDef>
 								<damageAmountBase>11</damageAmountBase>
-								<speed>151</speed>
+								<speed>178</speed>
 								<secondaryDamage>
 									<li>
-										<def>Bomb_Secondary</def>
-										<amount>2</amount>
+										<def>EMP</def>
+										<amount>7</amount>
 									</li>
 								</secondaryDamage>
-								<armorPenetrationSharp>27</armorPenetrationSharp>
+								<armorPenetrationSharp>21</armorPenetrationSharp>
 								<armorPenetrationBlunt>38.4</armorPenetrationBlunt>
 							</projectile>
 						</ThingDef>
@@ -232,11 +232,11 @@
 								<speed>204</speed>
 								<secondaryDamage>
 									<li>
-										<def>Bomb_Secondary</def>
-										<amount>2</amount>
+										<def>EMP</def>
+										<amount>9</amount>
 									</li>
 								</secondaryDamage>
-								<armorPenetrationSharp>33</armorPenetrationSharp>
+								<armorPenetrationSharp>31</armorPenetrationSharp>
 								<armorPenetrationBlunt>86.4</armorPenetrationBlunt>
 							</projectile>
 						</ThingDef>

--- a/Patches/Royal Arsenal/Ammo/Ammo_5x35RoyalCharged.xml
+++ b/Patches/Royal Arsenal/Ammo/Ammo_5x35RoyalCharged.xml
@@ -42,6 +42,7 @@
 						</secondaryDamage>
 						<armorPenetrationSharp>31</armorPenetrationSharp>
 						<armorPenetrationBlunt>86.4</armorPenetrationBlunt>
+						<empShieldBreakChance>0.75</empShieldBreakChance>
 					</projectile>
 				</ThingDef>
 

--- a/Patches/Royal Arsenal/Ammo/Ammo_5x35RoyalCharged.xml
+++ b/Patches/Royal Arsenal/Ammo/Ammo_5x35RoyalCharged.xml
@@ -32,16 +32,16 @@
 					</graphicData>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
 						<damageDef>Bullet</damageDef>
-						<damageAmountBase>16</damageAmountBase>
-						<speed>200</speed>
+						<damageAmountBase>14</damageAmountBase>
+						<speed>204</speed>
 						<secondaryDamage>
 							<li>
-								<def>Bomb_Secondary</def>
-								<amount>5</amount>
+								<def>EMP</def>
+								<amount>9</amount>
 							</li>
 						</secondaryDamage>
-						<armorPenetrationSharp>40</armorPenetrationSharp>
-						<armorPenetrationBlunt>70</armorPenetrationBlunt>
+						<armorPenetrationSharp>31</armorPenetrationSharp>
+						<armorPenetrationBlunt>86.4</armorPenetrationBlunt>
 					</projectile>
 				</ThingDef>
 

--- a/Patches/SYR Naga/Patch_Ammo_Naga.xml
+++ b/Patches/SYR Naga/Patch_Ammo_Naga.xml
@@ -104,6 +104,7 @@
 								</secondaryDamage>
 								<armorPenetrationSharp>26</armorPenetrationSharp>
 								<armorPenetrationBlunt>60</armorPenetrationBlunt>
+								<empShieldBreakChance>0.66</empShieldBreakChance>
 							</projectile>
 						</ThingDef>
 

--- a/Patches/SYR Naga/Patch_Ammo_Naga.xml
+++ b/Patches/SYR Naga/Patch_Ammo_Naga.xml
@@ -95,14 +95,14 @@
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
 								<damageDef>Bullet</damageDef>
 								<damageAmountBase>13</damageAmountBase>
-								<speed>200</speed>
+								<speed>178</speed>
 								<secondaryDamage>
 									<li>
-										<def>Bomb_Secondary</def>
-										<amount>2</amount>
+										<def>EMP</def>
+										<amount>8</amount>
 									</li>
 								</secondaryDamage>
-								<armorPenetrationSharp>30</armorPenetrationSharp>
+								<armorPenetrationSharp>26</armorPenetrationSharp>
 								<armorPenetrationBlunt>60</armorPenetrationBlunt>
 							</projectile>
 						</ThingDef>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Ammo_Mechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Ammo_Mechanoid.xml
@@ -38,6 +38,7 @@
 								</secondaryDamage>
 								<armorPenetrationSharp>32</armorPenetrationSharp>
 								<armorPenetrationBlunt>117.6</armorPenetrationBlunt>
+								<empShieldBreakChance>1.0</empShieldBreakChance>
 							</projectile>
 						</ThingDef>
 

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Ammo_Mechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Ammo_Mechanoid.xml
@@ -32,11 +32,11 @@
 								<speed>229</speed>
 								<secondaryDamage>
 									<li>
-										<def>Bomb_Secondary</def>
-										<amount>2</amount>
+										<def>EMP</def>
+										<amount>10</amount>
 									</li>
 								</secondaryDamage>
-								<armorPenetrationSharp>36</armorPenetrationSharp>
+								<armorPenetrationSharp>32</armorPenetrationSharp>
 								<armorPenetrationBlunt>117.6</armorPenetrationBlunt>
 							</projectile>
 						</ThingDef>


### PR DESCRIPTION
## Changes

- Switched 5x35mm charged from Concentrated to Ion.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070

## Reasoning

- Mechs already have pretty much every ammo type in their arsenal from various industrial cartridges (one fixed sabot round and another potential sabot round inside the 7.62 nato ammoset) to mortar shells and high caliber guns and cannons, the only thing missing was a weapon with Ion rounds.
- Ion rounds help both the player and hostile mechs to deal more raw damage and deal with shielded enemies, turrets and bionic pawns more reliably. The base 8 EMP damage is dealt more reliably to both meatbags and mechs even after the emp damage reduction for meatbags which still brings it down to 2 emp damage (2 bomb damage has the potential to be completely negated by armor) with the benefit of dealing more pain resulting in pawns getting downed quicker, all of the aforementioned points make hostile mechs a bigger threat to colonists in general and buffs Lancers a decent amount.
- The base Conc. ammo type had an inappropriate sharp AP considering its muzzle velocity and energy so decided to correct that to around 17mm base being close to 8x35mm and use 26mm sharp AP for the ion round which keeps it close to the old 30mm RHA.

## Alternatives

- Keep as is.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] Playtested a colony (specify how long)
