### PR TITLE
Mech generic ammo hotfix

### DIFF
--- a/Defs/Ammo/Advanced/5x35mmCharged.xml
+++ b/Defs/Ammo/Advanced/5x35mmCharged.xml
@@ -47,7 +47,7 @@
 		<statBases>
 			<MarketValue>0.36</MarketValue>
 		</statBases>
-		<ammoClass>ChargedAP</ammoClass>
+		<ammoClass>Charged</ammoClass>
 	</ThingDef>
 
 	<!-- ================== Projectiles ================== -->

--- a/Defs/Ammo/Generic/Mech.xml
+++ b/Defs/Ammo/Generic/Mech.xml
@@ -25,7 +25,7 @@
 		<defName>AmmoSet_MechCharged</defName>
 		<label>mech charged ammo</label>
 		<ammoTypes>
-			<Ammo_Mech_Charged>Bullet_5x35mmCharged</Ammo_Mech_Charged>
+			<Ammo_Mech_Charged>Bullet_12x64mmCharged</Ammo_Mech_Charged>
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
 
@@ -54,7 +54,7 @@
 		<statBases>
 			<Mass>0.058</Mass>
 			<Bulk>0.04</Bulk>
-			<MarketValue>3.39</MarketValue>
+			<MarketValue>1.93</MarketValue>
 		</statBases>
 		<tradeTags>
 			<li>CE_AutoEnableTrade_Sellable</li>
@@ -174,7 +174,7 @@
 						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
-				<count>32</count>
+				<count>14</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -190,7 +190,7 @@
 		<skillRequirements>
 			<Crafting>8</Crafting>
 		</skillRequirements>
-		<workAmount>36080</workAmount><!-- 10% more work -->
+		<workAmount>24200</workAmount><!-- 10% more work -->
 	</RecipeDef>
 
 	<RecipeDef ParentName="ChargeAmmoRecipeBase" MayRequire="Ludeon.RimWorld.Biotech">

--- a/Defs/Ammo/Generic/Mech.xml
+++ b/Defs/Ammo/Generic/Mech.xml
@@ -25,7 +25,7 @@
 		<defName>AmmoSet_MechCharged</defName>
 		<label>mech charged ammo</label>
 		<ammoTypes>
-			<Ammo_Mech_Charged>Bullet_12x64mmCharged</Ammo_Mech_Charged>
+			<Ammo_Mech_Charged>Bullet_8x40mmCharged</Ammo_Mech_Charged>
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
 
@@ -52,9 +52,9 @@
 	<ThingDef Class="CombatExtended.AmmoDef" Name="MechChargedAmmo" ParentName="SpacerAmmoBase" Abstract="True">
 		<description>Charged shot ammo used by mechanoid weaponry.</description>
 		<statBases>
-			<Mass>0.058</Mass>
-			<Bulk>0.04</Bulk>
-			<MarketValue>1.93</MarketValue>
+			<Mass>0.021</Mass>
+			<Bulk>0.01</Bulk>
+			<MarketValue>0.49</MarketValue>
 		</statBases>
 		<tradeTags>
 			<li>CE_AutoEnableTrade_Sellable</li>
@@ -148,8 +148,8 @@
 
 	<RecipeDef ParentName="ChargeAmmoRecipeBase" MayRequire="Ludeon.RimWorld.Biotech">
 		<defName>MakeAmmo_Mech_Charged</defName>
-		<label>make Mech Charged cartridge x200</label>
-		<description>Craft 200 Mech Charged cartridges.</description>
+		<label>make Mech Charged cartridge x500</label>
+		<description>Craft 500 Mech Charged cartridges.</description>
 		<jobString>Making Mech Charged cartridges.</jobString>
 		<ingredients>
 			<li>
@@ -158,7 +158,7 @@
 						<li>Plasteel</li>
 					</thingDefs>
 				</filter>
-				<count>32</count>
+				<count>12</count>
 			</li>
 			<li>
 				<filter>
@@ -166,7 +166,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>8</count>
+				<count>18</count>
 			</li>
 			<li>
 				<filter>
@@ -174,7 +174,7 @@
 						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
-				<count>14</count>
+				<count>9</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -185,12 +185,12 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_Mech_Charged>200</Ammo_Mech_Charged>
+			<Ammo_Mech_Charged>500</Ammo_Mech_Charged>
 		</products>
 		<skillRequirements>
 			<Crafting>8</Crafting>
 		</skillRequirements>
-		<workAmount>24200</workAmount><!-- 10% more work -->
+		<workAmount>15180</workAmount><!-- 10% more work -->
 	</RecipeDef>
 
 	<RecipeDef ParentName="ChargeAmmoRecipeBase" MayRequire="Ludeon.RimWorld.Biotech">


### PR DESCRIPTION
## Changes

- Reverted the 5x35mm charged ammoClass back to Charged.
- Minor housekeeping for the mech generic ammo.

## Reasoning

- The generic ammo lacked AP and Ion ammo types leading to anything that uses the ammo to break in Generic Ammo mode.

## Alternatives

- Add AP and Ion ammo types to the generic mech ammo set.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (It works)
