### PR TITLE
Hotfix to restore ABI compatibility with CE < 1.4.5.7

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompFragments.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompFragments.cs
@@ -30,6 +30,10 @@ namespace CombatExtended
 
         public static IEnumerator FragRoutine(Vector3 pos, Map map, float height, Thing instigator, ThingDefCountClass frag, float fragSpeedFactor, float fragShadowChance, FloatRange fragAngleRange, FloatRange fragXZAngleRange, float minCollisionDistance = 0f, bool canTargetSelf = true)
         {
+            if (height < 0.001f)
+            {
+                height = 0.001f;
+            }
             var cell = pos.ToIntVec3();
             var exactOrigin = new Vector2(pos.x, pos.z);
 

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -207,7 +207,10 @@ namespace CombatExtended
             set
             {
                 exactPosition = value;
-                Position = ((Vector3)exactPosition).ToIntVec3();
+                if (value != null)
+                {
+                    Position = ((Vector3)exactPosition).ToIntVec3();
+                }
             }
             get
             {

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -224,7 +224,7 @@ namespace CombatExtended
             }
         }
 
-	//TODO 1.5: Make this a cached field updated by setting ExactPosition
+        //TODO 1.5: Make this a cached field updated by setting ExactPosition
         public override Vector3 DrawPos
         {
             get

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -43,6 +43,10 @@ namespace CombatExtended
         public Vector2 origin;
 
         public IntVec3 OriginIV3;
+        public IntVec3 get_OriginIV3()
+        {
+            return OriginIV3;
+        }
 
         /// <summary>
         /// Calculates the destination (zero height) reached with a projectile of speed <i>shotSpeed</i> fired at <i>shotAngle</i> from height <i>shotHeight</i> starting from <i>origin</i>. Does not take into account air resistance.

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -229,7 +229,7 @@ namespace CombatExtended
         {
             get
             {
-                var sh = Mathf.Max(0f, ExactPosition.y);
+                var sh = Mathf.Max(0f, (ExactPosition.y) * 0.84f);
                 return new Vector3(ExactPosition.x, def.Altitude, ExactPosition.z + sh);
             }
         }
@@ -1258,7 +1258,7 @@ namespace CombatExtended
                     //TODO : EXPERIMENTAL Add edifice height
                     var shadowPos = new Vector3(ExactPosition.x,
                                                 def.Altitude - 0.001f,
-                                                ExactPosition.z - Mathf.Max(0f, ExactPosition.y));
+                                                ExactPosition.z);
                     //EXPERIMENTAL: + (new CollisionVertical(ExactPosition.ToIntVec3().GetEdifice(Map))).Max);
 
                     //TODO : Vary ShadowMat plane

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -48,6 +48,10 @@ namespace CombatExtended
         /// Calculates the destination (zero height) reached with a projectile of speed <i>shotSpeed</i> fired at <i>shotAngle</i> from height <i>shotHeight</i> starting from <i>origin</i>. Does not take into account air resistance.
         /// </summary>
         public Vector2 Destination;
+        public Vector2 get_Destination()
+        {
+            return Destination;
+        }
         #endregion
 
         /// <summary>
@@ -114,18 +118,15 @@ namespace CombatExtended
         public bool landed;
         // TODO: // Remove in 1.5
         public int intTicksToImpact;
-        public int ticksToImpact
+        public int ticksToImpact;
+        public int get_ticksToImpact()
         {
-            get
-            {
-                return intTicksToImpact;
-            }
-            set
-            {
-                intTicksToImpact = value;
-            }
+            return intTicksToImpact;
         }
-
+        public void set_ticksToImpact(int value)
+        {
+            intTicksToImpact = value;
+        }
 
         protected Sustainer ambientSustainer;
 
@@ -140,6 +141,7 @@ namespace CombatExtended
         {
             get
             {
+                Log.ErrorOnce("ProjectileCE.Height is deprecated and will be removed in 1.5", 50023);
                 return ExactPosition.y;
             }
         }
@@ -149,6 +151,11 @@ namespace CombatExtended
         public float startingTicksToImpact;
 
         public int FlightTicks = 0;
+        public int get_FlightTicks()
+        {
+            Log.ErrorOnce("ProjectileCE.get_FlightTicks() is deprecated and will be removed in 1.5", 50022);
+            return FlightTicks;
+        }
 
         #endregion
 

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -57,11 +57,6 @@ namespace CombatExtended
         public Vector2 Destination;
         public Vector2 get_Destination()
         {
-            if (destinationInt.z < 0)
-            {
-                destinationInt.z = 0f;
-                Destination = origin + Vector2.up.RotatedBy(shotRotation) * DistanceTraveled;
-            }
             return Destination;
         }
         #endregion
@@ -187,7 +182,7 @@ namespace CombatExtended
         #endregion
 
         #region Position
-        protected virtual Vector2 Vec2Position(float ticks = -1f)
+        public virtual Vector2 Vec2Position(float ticks = -1f)
         {
             Log.ErrorOnce("Vec2Position(float) is deprecated and will be removed in 1.5", 50021);
             if (ticks < 0)
@@ -196,7 +191,7 @@ namespace CombatExtended
             }
             return Vector2.Lerp(origin, Destination, ticks / startingTicksToImpact);
         }
-        protected virtual Vector2 Vec2Position()
+        public virtual Vector2 Vec2Position()
         {
             return Vector2.Lerp(origin, Destination, FlightTicks / startingTicksToImpact);
         }
@@ -1143,6 +1138,11 @@ namespace CombatExtended
             {
                 return;
             }
+	    if (destinationInt.z < 0)
+            {
+                destinationInt.z = 0f;
+                Destination = origin + Vector2.up.RotatedBy(shotRotation) * DistanceTraveled;
+            }
             LastPos = ExactPosition;
             lastExactPos = LastPos;
             ticksToImpact--;
@@ -1504,7 +1504,7 @@ namespace CombatExtended
         /// </summary>
         /// <param name="ticks">Integer ticks, since the only time value which is not an integer (accessed by StartingTicksToImpact) has height zero by definition.</param>
         /// <returns>Projectile height at time ticks in ticks.</returns>
-        private float GetHeightAtTicks(int ticks)
+        public float GetHeightAtTicks(int ticks)
         {
             var seconds = ((float)ticks) / GenTicks.TicksPerRealSecond;
             return (float)Math.Round(shotHeight + shotSpeed * Mathf.Sin(shotAngle) * seconds - (GravityFactor * seconds * seconds) / 2f, 3);

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -1138,7 +1138,7 @@ namespace CombatExtended
             {
                 return;
             }
-	    if (destinationInt.z < 0)
+            if (destinationInt.z < 0)
             {
                 destinationInt.z = 0f;
                 Destination = origin + Vector2.up.RotatedBy(shotRotation) * DistanceTraveled;

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -365,7 +365,7 @@ namespace CombatExtended
             Scribe_Values.Look<Vector2>(ref origin, "origin", default(Vector2), true);
             Scribe_References.Look<Thing>(ref launcher, "launcher");
             Scribe_References.Look<Thing>(ref equipment, "equipment");
-            Scribe_Values.Look<int>(ref intTicksToImpact, "ticksToImpact", 0, true);
+            Scribe_Values.Look<int>(ref ticksToImpact, "ticksToImpact", 0, true);
             Scribe_Values.Look<float>(ref startingTicksToImpact, "startingTicksToImpact", 0, true);
             startingTicksToImpactInt = startingTicksToImpact;
             Scribe_Defs.Look<ThingDef>(ref equipmentDef, "equipmentDef");

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -224,6 +224,7 @@ namespace CombatExtended
             }
         }
 
+	//TODO 1.5: Make this a cached field updated by setting ExactPosition
         public override Vector3 DrawPos
         {
             get

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -47,6 +47,9 @@ namespace CombatExtended
         /// <summary>
         /// Calculates the destination (zero height) reached with a projectile of speed <i>shotSpeed</i> fired at <i>shotAngle</i> from height <i>shotHeight</i> starting from <i>origin</i>. Does not take into account air resistance.
         /// </summary>
+
+        public Vector3 destinationInt = new Vector3(0f, 0f, -1f);
+
         public Vector2 Destination;
         public Vector2 get_Destination()
         {
@@ -149,6 +152,7 @@ namespace CombatExtended
 
         #region Ticks/Seconds
         public float startingTicksToImpact;
+        float startingTicksToImpactInt = -1f;
 
         public int FlightTicks = 0;
         public int get_FlightTicks()
@@ -349,6 +353,7 @@ namespace CombatExtended
             Scribe_References.Look<Thing>(ref equipment, "equipment");
             Scribe_Values.Look<int>(ref intTicksToImpact, "ticksToImpact", 0, true);
             Scribe_Values.Look<float>(ref startingTicksToImpact, "startingTicksToImpact", 0, true);
+            startingTicksToImpactInt = startingTicksToImpact;
             Scribe_Defs.Look<ThingDef>(ref equipmentDef, "equipmentDef");
             Scribe_Values.Look<bool>(ref landed, "landed");
             //Here be new variables
@@ -585,6 +590,7 @@ namespace CombatExtended
                 ambientSustainer = def.projectile.soundAmbient.TrySpawnSustainer(info);
             }
             this.startingTicksToImpact = GetFlightTime() * GenTicks.TicksPerRealSecond;
+            this.startingTicksToImpactInt = startingTicksToImpact;
             this.ticksToImpact = Mathf.CeilToInt(this.startingTicksToImpact);
             this.ExactPosition = this.LastPos = new Vector3(origin.x, shotHeight, origin.y);
             this.lastExactPos = LastPos;

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -48,11 +48,16 @@ namespace CombatExtended
         /// Calculates the destination (zero height) reached with a projectile of speed <i>shotSpeed</i> fired at <i>shotAngle</i> from height <i>shotHeight</i> starting from <i>origin</i>. Does not take into account air resistance.
         /// </summary>
 
-        public Vector3 destinationInt = new Vector3(0f, 0f, -1f);
+        public Vector3 destinationInt = new Vector3(0f, 0f, 0f);
 
         public Vector2 Destination;
         public Vector2 get_Destination()
         {
+            if (destinationInt.z < 0)
+            {
+                destinationInt.z = 0f;
+                Destination = origin + Vector2.up.RotatedBy(shotRotation) * DistanceTraveled;
+            }
             return Destination;
         }
         #endregion

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -1256,8 +1256,8 @@ namespace CombatExtended
                 {
                     //TODO : EXPERIMENTAL Add edifice height
                     var shadowPos = new Vector3(ExactPosition.x,
-                                                0,
-                                                ExactPosition.z);
+                                                def.Altitude - 0.001f,
+                                                ExactPosition.z - Mathf.Max(0f, ExactPosition.y));
                     //EXPERIMENTAL: + (new CollisionVertical(ExactPosition.ToIntVec3().GetEdifice(Map))).Max);
 
                     //TODO : Vary ShadowMat plane

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -228,7 +228,8 @@ namespace CombatExtended
         {
             get
             {
-                return ExactPosition + new Vector3(0, 0, ExactPosition.y - shotHeight);
+                var sh = Mathf.Max(0f, ExactPosition.y);
+                return new Vector3(ExactPosition.x, def.Altitude, ExactPosition.z + sh);
             }
         }
 

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -158,6 +158,15 @@ namespace CombatExtended
         #region Ticks/Seconds
         public float startingTicksToImpact;
         float startingTicksToImpactInt = -1f;
+        public float get_StartingTicksToImpact()
+        {
+            return startingTicksToImpact;
+        }
+
+        public void set_StartingTicksToImpact(float value)
+        {
+            startingTicksToImpact = value;
+        }
 
         public int FlightTicks = 0;
         public int get_FlightTicks()

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -128,11 +128,12 @@ namespace CombatExtended
         public int ticksToImpact;
         public int get_ticksToImpact()
         {
-            return intTicksToImpact;
+            return ticksToImpact;
         }
         public void set_ticksToImpact(int value)
         {
             intTicksToImpact = value;
+            ticksToImpact = value;
         }
 
         protected Sustainer ambientSustainer;
@@ -1146,6 +1147,7 @@ namespace CombatExtended
             LastPos = ExactPosition;
             lastExactPos = LastPos;
             ticksToImpact--;
+            intTicksToImpact = ticksToImpact;
             FlightTicks++;
             Vector3 nextPosition;
             if (lerpPosition)

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -157,9 +157,9 @@ namespace CombatExtended
             return FlightTicks;
         }
 
-        public int get_fTicks()
+        public float get_fTicks()
         {
-            return FlightTicks;
+            return FlightTicks / 1.0f;
         }
 
         #endregion

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -157,6 +157,11 @@ namespace CombatExtended
             return FlightTicks;
         }
 
+        public int get_fTicks()
+        {
+            return FlightTicks;
+        }
+
         #endregion
 
         #region Position
@@ -210,6 +215,7 @@ namespace CombatExtended
         }
 
         public Vector3 LastPos;
+        protected Vector3 lastExactPos;
         protected DangerTracker _dangerTracker = null;
         protected DangerTracker DangerTracker
         {
@@ -359,6 +365,7 @@ namespace CombatExtended
             Scribe_Values.Look(ref exactPosition, "exactPosition");
             Scribe_Values.Look(ref GravityFactor, "gravityFactor", CE_Utility.GravityConst);
             Scribe_Values.Look(ref LastPos, "lastPosition");
+            lastExactPos = LastPos;
             Scribe_Values.Look(ref FlightTicks, "flightTicks");
             Scribe_Values.Look(ref OriginIV3, "originIV3", new IntVec3(this.origin));
             Scribe_Values.Look(ref Destination, "destination", this.origin + Vector2.up.RotatedBy(shotRotation) * DistanceTraveled);
@@ -448,6 +455,7 @@ namespace CombatExtended
                     destination = tp;
                     landed = true;
                     LastPos = destination;
+                    lastExactPos = LastPos;
                     Position = ExactPosition.ToIntVec3();
 
                     lbce.SpawnBeam(muzzle, destination);
@@ -490,6 +498,7 @@ namespace CombatExtended
                     destination = tp;
                     landed = true;
                     LastPos = destination;
+                    lastExactPos = LastPos;
                     Position = ExactPosition.ToIntVec3();
 
                     lbce.SpawnBeam(muzzle, destination);
@@ -578,6 +587,7 @@ namespace CombatExtended
             this.startingTicksToImpact = GetFlightTime() * GenTicks.TicksPerRealSecond;
             this.ticksToImpact = Mathf.CeilToInt(this.startingTicksToImpact);
             this.ExactPosition = this.LastPos = new Vector3(origin.x, shotHeight, origin.y);
+            this.lastExactPos = LastPos;
 
         }
         #endregion
@@ -1110,6 +1120,7 @@ namespace CombatExtended
                 return;
             }
             LastPos = ExactPosition;
+            lastExactPos = LastPos;
             ticksToImpact--;
             FlightTicks++;
             Vector3 nextPosition;

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_HeightFuse.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_HeightFuse.cs
@@ -55,6 +55,7 @@ namespace CombatExtended
         {
             float f = (LastPos.y - detonationHeight) / (LastPos.y - ExactPosition.y);
             ExactPosition = f * (LastPos - ExactPosition);
+            ExactPosition += f * (LastPos - ExactPosition);
             if (!ExactPosition.ToIntVec3().IsValid)
             {
                 Destroy();

--- a/Source/CombatExtended/Harmony/Compatibility/Harmony_BillDoors.cs
+++ b/Source/CombatExtended/Harmony/Compatibility/Harmony_BillDoors.cs
@@ -1,0 +1,81 @@
+using HarmonyLib;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Verse;
+using System.Reflection.Emit;
+using System;
+using RimWorld;
+using Verse.AI;
+using CombatExtended;
+using UnityEngine;
+
+
+namespace CombatExtended.HarmonyCE.Compatibility
+{
+    [HarmonyPatch]
+    class Harmony_Compatibility_BillDoors
+    {
+        static readonly Assembly ass = AppDomain.CurrentDomain.GetAssemblies().
+                                       SingleOrDefault(assembly => assembly.GetName().Name == "BillDoorsFrameworkCE");
+        static MethodBase targetMethod = null;
+
+        internal static bool Prepare()
+        {
+            if (ass == null)
+            {
+                return false;
+            }
+            foreach (var t in ass.GetTypes())
+            {
+                if (t.Name == "DisintegratingProjectileCE")
+                {
+                    targetMethod = t.GetMethod("Tick", BindingFlags.Public | BindingFlags.Instance);
+                }
+            }
+            if (targetMethod == null)
+            {
+                Log.Error($"Failed to find target method while attempting to patch Bill Doors' Framework.");
+                return false;
+            }
+            return true;
+        }
+
+        internal static MethodBase TargetMethod()
+        {
+            return targetMethod;
+        }
+
+        public static bool Prefix(ref BulletCE __instance)
+        {
+	    Vector3 v3Pos = __instance.ExactPosition;
+	    float distance = (__instance.origin - new Vector2(v3Pos.x, v3Pos.z)).magnitude;
+	    float DistancePercent = distance / __instance.equipmentDef.Verbs[0].range;
+	    if (DistancePercent <= 1f)
+            {
+                return true;
+            }
+            if (DistancePercent > (4 / 3f))
+            {
+                return true;
+            }
+            if (!__instance.landed)
+            {
+                __instance.FlightTicks++;
+		var v = __instance.Vec2Position();
+		var nextPosition = new Vector3(v.x, __instance.GetHeightAtTicks(__instance.FlightTicks), v.y);
+                __instance.ExactPosition = nextPosition;
+                if (!__instance.ExactPosition.InBounds(__instance.Map))
+                {
+                    __instance.Destroy();
+                    return false;
+                }
+                if (__instance.ticksToImpact <= 0)
+                {
+                    __instance.Destroy();
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/Source/CombatExtended/Harmony/Compatibility/Harmony_BillDoors.cs
+++ b/Source/CombatExtended/Harmony/Compatibility/Harmony_BillDoors.cs
@@ -48,10 +48,10 @@ namespace CombatExtended.HarmonyCE.Compatibility
 
         public static bool Prefix(ref BulletCE __instance)
         {
-	    Vector3 v3Pos = __instance.ExactPosition;
-	    float distance = (__instance.origin - new Vector2(v3Pos.x, v3Pos.z)).magnitude;
-	    float DistancePercent = distance / __instance.equipmentDef.Verbs[0].range;
-	    if (DistancePercent <= 1f)
+            Vector3 v3Pos = __instance.ExactPosition;
+            float distance = (__instance.origin - new Vector2(v3Pos.x, v3Pos.z)).magnitude;
+            float DistancePercent = distance / __instance.equipmentDef.Verbs[0].range;
+            if (DistancePercent <= 1f)
             {
                 return true;
             }
@@ -62,8 +62,8 @@ namespace CombatExtended.HarmonyCE.Compatibility
             if (!__instance.landed)
             {
                 __instance.FlightTicks++;
-		var v = __instance.Vec2Position();
-		var nextPosition = new Vector3(v.x, __instance.GetHeightAtTicks(__instance.FlightTicks), v.y);
+                var v = __instance.Vec2Position();
+                var nextPosition = new Vector3(v.x, __instance.GetHeightAtTicks(__instance.FlightTicks), v.y);
                 __instance.ExactPosition = nextPosition;
                 if (!__instance.ExactPosition.InBounds(__instance.Map))
                 {


### PR DESCRIPTION
## Changes

Provides explicit getters and caches for mods compiled against the old CE version which cannot easily recompile.

## Reasoning

With 1.5 coming out soon, some mod authors have moved on from 1.4, making recompiling against CE 1.4.5.7 difficult.  So the most common getters and fields that are no longer needed by CE itself should still be provided for these legacy mods.

## Alternatives

Only support mods that can be recompiled against current CE.
Roll back significant performance boosts to our projectiles
Use harmony to monkey patch affected legacy mods

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
