### PR TITLE
Various mech-related tweaks (#3034 reopened)

### DIFF
--- a/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Light.xml
+++ b/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Light.xml
@@ -165,7 +165,7 @@
 			<ArmorRating_Blunt>4</ArmorRating_Blunt>
 			<ArmorRating_Sharp>2.5</ArmorRating_Sharp>
 			<AimingAccuracy>1.0</AimingAccuracy>
-			<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
+			<ShootingAccuracyPawn>1.0</ShootingAccuracyPawn>
 			<MeleeDodgeChance>0.13</MeleeDodgeChance>
 			<MeleeCritChance>0.05</MeleeCritChance>
 			<MeleeParryChance>0.05</MeleeParryChance>
@@ -335,8 +335,8 @@
 		<value>
 			<ArmorRating_Blunt>4</ArmorRating_Blunt>
 			<ArmorRating_Sharp>2.5</ArmorRating_Sharp>
-			<AimingAccuracy>1.0</AimingAccuracy>
-			<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
+			<AimingAccuracy>1.3</AimingAccuracy>
+			<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
 			<MeleeDodgeChance>0.14</MeleeDodgeChance>
 			<MeleeCritChance>0.06</MeleeCritChance>
 			<MeleeParryChance>0.05</MeleeParryChance>

--- a/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Medium.xml
+++ b/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Medium.xml
@@ -1,15 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 
-	<!-- ========== Cover-Seeking Behavior ========== -->
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/PawnKindDef[defName="Mech_Tesseron" or defName="Mech_Apocriton"]</xpath>
-		<value>
-			<aiAvoidCover>false</aiAvoidCover>
-		</value>
-	</Operation>
-
 	<!-- ========== Adjust combatPower ========== -->
 
 	<Operation Class="PatchOperationReplace">
@@ -88,7 +79,7 @@
 		<xpath>Defs/ThingDef[defName="Mech_Legionary"]/statBases</xpath>
 		<value>
 			<CarryWeight>75</CarryWeight>
-			<CarryBulk>40</CarryBulk>
+			<CarryBulk>60</CarryBulk>
 			<MeleeDodgeChance>0.12</MeleeDodgeChance>
 			<MeleeCritChance>0.11</MeleeCritChance>
 			<MeleeParryChance>0.09</MeleeParryChance>
@@ -266,7 +257,7 @@
 		<value>
 			<ArmorRating_Heat>0.5</ArmorRating_Heat>
 			<CarryWeight>75</CarryWeight>
-			<CarryBulk>30</CarryBulk>
+			<CarryBulk>40</CarryBulk>
 			<MeleeDodgeChance>0.07</MeleeDodgeChance>
 			<MeleeCritChance>0.13</MeleeCritChance>
 			<MeleeParryChance>0.13</MeleeParryChance>

--- a/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_SuperHeavy.xml
+++ b/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_SuperHeavy.xml
@@ -70,7 +70,7 @@
 			<CarryWeight>50</CarryWeight>
 			<CarryBulk>50</CarryBulk>
 			<AimingAccuracy>1.0</AimingAccuracy>
-			<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+			<ShootingAccuracyPawn>1.0</ShootingAccuracyPawn>
 			<MeleeDodgeChance>0.02</MeleeDodgeChance>
 			<MeleeCritChance>0.20</MeleeCritChance>
 			<MeleeParryChance>0.57</MeleeParryChance>
@@ -170,7 +170,7 @@
 			<CarryWeight>75</CarryWeight>
 			<CarryBulk>50</CarryBulk>
 			<AimingAccuracy>1.0</AimingAccuracy>
-			<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+			<ShootingAccuracyPawn>1.0</ShootingAccuracyPawn>
 			<MeleeDodgeChance>0.02</MeleeDodgeChance>
 			<MeleeCritChance>0.22</MeleeCritChance>
 			<MeleeParryChance>0.64</MeleeParryChance>
@@ -249,12 +249,11 @@
 			<ArmorRating_Heat>0.5</ArmorRating_Heat>
 			<CarryWeight>75</CarryWeight>
 			<CarryBulk>60</CarryBulk>
-			<AimingAccuracy>1.0</AimingAccuracy>
-			<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
+			<AimingAccuracy>1.3</AimingAccuracy>
+			<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
 			<MeleeDodgeChance>0.03</MeleeDodgeChance>
 			<MeleeCritChance>0.42</MeleeCritChance>
 			<MeleeParryChance>0.64</MeleeParryChance>
-			<AimingDelayFactor>1.25</AimingDelayFactor>
 			<MaxHitPoints>600</MaxHitPoints>
 		</value>
 	</Operation>

--- a/Defs/Ammo/Advanced/66mmThermalBolt.xml
+++ b/Defs/Ammo/Advanced/66mmThermalBolt.xml
@@ -28,8 +28,8 @@
 		</graphicData>
 		<statBases>
 			<MaxHitPoints>200</MaxHitPoints>
-			<Mass>2.0</Mass>
-			<Bulk>3.08</Bulk>
+			<Mass>1.5</Mass>
+			<Bulk>2.57</Bulk>
 		</statBases>
 		<thingCategories>
 			<li>Ammo66mmThermalBolts</li>
@@ -51,7 +51,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>12.13</MarketValue><!-- value intentionally decreased to help reduce wealth bloat/free silver -->
+			<MarketValue>11.34</MarketValue><!-- value intentionally decreased to help reduce wealth bloat/free silver -->
 		</statBases>
 		<ammoClass>GrenadeIncendiary</ammoClass>
 		<detonateProjectile>Bullet_66mmThermalBolt_Incendiary</detonateProjectile>
@@ -128,7 +128,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>22</count>
+				<count>18</count>
 			</li>
 			<li>
 				<filter>
@@ -152,7 +152,7 @@
 		<skillRequirements>
 			<Crafting>8</Crafting>
 		</skillRequirements>
-		<workAmount>4620</workAmount><!-- 10% more work -->
+		<workAmount>4180</workAmount><!-- 10% more work -->
 	</RecipeDef>
 
 </Defs>

--- a/Defs/ThingDefs_Misc/Weapons_Ranged.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Ranged.xml
@@ -322,7 +322,7 @@
 			<SwayFactor>1.00</SwayFactor>
 			<Bulk>7.5</Bulk>
 			<Mass>10.00</Mass>
-			<RangedWeapon_Cooldown>3</RangedWeapon_Cooldown>
+			<RangedWeapon_Cooldown>2</RangedWeapon_Cooldown>
 			<MarketValue>1400</MarketValue>
 		</statBases>
 		<techLevel>Spacer</techLevel>
@@ -336,8 +336,7 @@
 				<defaultProjectile>Bullet_66mmThermalBolt_Incendiary</defaultProjectile>
 				<warmupTime>4</warmupTime>
 				<minRange>10</minRange>
-				<range>55</range>
-				<burstShotCount>1</burstShotCount>
+				<range>62</range>
 				<soundCast>Mortar_LaunchA</soundCast>
 				<muzzleFlashScale>16</muzzleFlashScale>
 				<circularError>3</circularError>
@@ -358,7 +357,8 @@
 			</li>
 			<li Class="CombatExtended.CompProperties_AmmoUser">
 				<magazineSize>3</magazineSize>
-				<reloadTime>12</reloadTime>
+				<reloadOneAtATime>true</reloadOneAtATime>
+				<reloadTime>3</reloadTime>
 				<ammoSet>AmmoSet_66mmThermalBolt</ammoSet>
 			</li>
 			<li Class="CombatExtended.CompProperties_FireModes">

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Misc/Weapons.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Misc/Weapons.xml
@@ -198,10 +198,10 @@
 							<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 							<hasStandardCommand>true</hasStandardCommand>
 							<defaultProjectile>Bullet_12x64mmHyper</defaultProjectile>
-							<warmupTime>2.3</warmupTime>
+							<warmupTime>1.3</warmupTime>
 							<range>75</range>
 							<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
-							<burstShotCount>25</burstShotCount>
+							<burstShotCount>15</burstShotCount>
 							<soundCast>AM_Shot_ChargeBlaster_Red</soundCast>
 							<soundCastTail>GunTail_Heavy</soundCastTail>
 							<muzzleFlashScale>9</muzzleFlashScale>
@@ -213,7 +213,7 @@
 						</AmmoUser>
 						<FireModes>
 							<aimedBurstShotCount>10</aimedBurstShotCount>
-							<aiAimMode>Snapshot</aiAimMode>
+							<aiAimMode>AimedShot</aiAimMode>
 						</FireModes>
 						<weaponTags>
 							<li>CE_AI_Suppressive</li>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Apoptosis.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Apoptosis.xml
@@ -28,7 +28,7 @@
 						<value>
 							<ArmorRating_Heat>0.75</ArmorRating_Heat>
 							<CarryWeight>75</CarryWeight>
-							<CarryBulk>30</CarryBulk>
+							<CarryBulk>40</CarryBulk>
 							<MeleeDodgeChance>0.1</MeleeDodgeChance>
 							<MeleeCritChance>0.13</MeleeCritChance>
 							<MeleeParryChance>0.13</MeleeParryChance>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Bellicor.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Bellicor.xml
@@ -28,7 +28,7 @@
 						<value>
 							<CarryWeight>50</CarryWeight>
 							<CarryBulk>20</CarryBulk>
-							<AimingAccuracy>1.0</AimingAccuracy>
+							<AimingAccuracy>1.3</AimingAccuracy>
 							<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
 							<MeleeDodgeChance>0.13</MeleeDodgeChance>
 							<MeleeCritChance>0.12</MeleeCritChance>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Bellicor_Mortar.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Bellicor_Mortar.xml
@@ -28,7 +28,7 @@
 						<value>
 							<CarryWeight>50</CarryWeight>
 							<CarryBulk>20</CarryBulk>
-							<AimingAccuracy>1.0</AimingAccuracy>
+							<AimingAccuracy>1.3</AimingAccuracy>
 							<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
 							<MeleeDodgeChance>0.09</MeleeDodgeChance>
 							<MeleeCritChance>0.12</MeleeCritChance>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Infernus.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Infernus.xml
@@ -29,12 +29,11 @@
 							<ArmorRating_Heat>0.75</ArmorRating_Heat>
 							<CarryWeight>75</CarryWeight>
 							<CarryBulk>60</CarryBulk>
-							<AimingAccuracy>1.0</AimingAccuracy>
+							<AimingAccuracy>1.7</AimingAccuracy>
 							<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 							<MeleeDodgeChance>0.1</MeleeDodgeChance>
 							<MeleeCritChance>0.42</MeleeCritChance>
 							<MeleeParryChance>0.64</MeleeParryChance>
-							<AimingDelayFactor>1.25</AimingDelayFactor>
 							<MaxHitPoints>600</MaxHitPoints>
 						</value>
 					</li>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Legate.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Legate.xml
@@ -43,8 +43,8 @@
 							<ArmorRating_Heat>0.5</ArmorRating_Heat>
 							<CarryWeight>100</CarryWeight>
 							<CarryBulk>75</CarryBulk>
-							<AimingAccuracy>1.0</AimingAccuracy>
-							<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+							<AimingAccuracy>1.3</AimingAccuracy>
+							<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
 							<MeleeDodgeChance>0.02</MeleeDodgeChance>
 							<MeleeCritChance>0.20</MeleeCritChance>
 							<MeleeParryChance>0.57</MeleeParryChance>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Siegemelter.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Siegemelter.xml
@@ -42,8 +42,8 @@
 							<ArmorRating_Heat>0.5</ArmorRating_Heat>
 							<CarryWeight>200</CarryWeight>
 							<CarryBulk>150</CarryBulk>
-							<AimingAccuracy>1.0</AimingAccuracy>
-							<ShootingAccuracyPawn>1.0</ShootingAccuracyPawn>
+							<AimingAccuracy>1.3</AimingAccuracy>
+							<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
 							<MeleeDodgeChance>0.01</MeleeDodgeChance>
 							<MeleeCritChance>0.07</MeleeCritChance>
 							<MeleeParryChance>0.24</MeleeParryChance>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Starfire.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Starfire.xml
@@ -42,8 +42,8 @@
 							<ArmorRating_Heat>0.5</ArmorRating_Heat>
 							<CarryWeight>200</CarryWeight>
 							<CarryBulk>150</CarryBulk>
-							<AimingAccuracy>1.0</AimingAccuracy>
-							<ShootingAccuracyPawn>1.0</ShootingAccuracyPawn>
+							<AimingAccuracy>1.3</AimingAccuracy>
+							<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
 							<MeleeDodgeChance>0.01</MeleeDodgeChance>
 							<MeleeCritChance>0.07</MeleeCritChance>
 							<MeleeParryChance>0.24</MeleeParryChance>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_WarEmpress.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_WarEmpress.xml
@@ -43,8 +43,8 @@
 							<ArmorRating_Heat>0.75</ArmorRating_Heat>
 							<CarryWeight>75</CarryWeight>
 							<CarryBulk>50</CarryBulk>
-							<AimingAccuracy>1.0</AimingAccuracy>
-							<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+							<AimingAccuracy>1.3</AimingAccuracy>
+							<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
 							<MeleeDodgeChance>0.02</MeleeDodgeChance>
 							<MeleeCritChance>0.22</MeleeCritChance>
 							<MeleeParryChance>0.64</MeleeParryChance>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvFireworm.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvFireworm.xml
@@ -41,8 +41,8 @@
 						<xpath>Defs/ThingDef[defName="VFE_Mech_Advanced_Fireworm"]/statBases</xpath>
 						<value>
 							<ArmorRating_Heat>1.0</ArmorRating_Heat>
-							<AimingAccuracy>1.0</AimingAccuracy>
-							<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+							<AimingAccuracy>1.7</AimingAccuracy>
+							<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 							<MeleeDodgeChance>0.01</MeleeDodgeChance>
 							<MeleeCritChance>0.19</MeleeCritChance>
 							<MeleeParryChance>0.19</MeleeParryChance>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvGoliath.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvGoliath.xml
@@ -43,8 +43,8 @@
 							<ArmorRating_Heat>0.75</ArmorRating_Heat>
 							<CarryWeight>200</CarryWeight>
 							<CarryBulk>100</CarryBulk>
-							<AimingAccuracy>1.0</AimingAccuracy>
-							<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
+							<AimingAccuracy>1.7</AimingAccuracy>
+							<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 							<MeleeDodgeChance>0.05</MeleeDodgeChance>
 							<MeleeCritChance>0.75</MeleeCritChance>
 							<MeleeParryChance>0.2</MeleeParryChance>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvPhalanx.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvPhalanx.xml
@@ -41,8 +41,8 @@
 						<xpath>Defs/ThingDef[defName="VFE_Mech_Advanced_Phalanx"]/statBases</xpath>
 						<value>
 							<ArmorRating_Heat>1.0</ArmorRating_Heat>
-							<AimingAccuracy>1.0</AimingAccuracy>
-							<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+							<AimingAccuracy>1.7</AimingAccuracy>
+							<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 							<MeleeDodgeChance>0.01</MeleeDodgeChance>
 							<MeleeCritChance>0.56</MeleeCritChance>
 							<MeleeParryChance>0.44</MeleeParryChance>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvSiegebreaker.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvSiegebreaker.xml
@@ -43,8 +43,8 @@
 							<ArmorRating_Heat>0.75</ArmorRating_Heat>
 							<CarryWeight>200</CarryWeight>
 							<CarryBulk>200</CarryBulk>
-							<AimingAccuracy>1.0</AimingAccuracy>
-							<ShootingAccuracyPawn>1.0</ShootingAccuracyPawn>
+							<AimingAccuracy>1.7</AimingAccuracy>
+							<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 							<MeleeDodgeChance>0.01</MeleeDodgeChance>
 							<MeleeCritChance>0.07</MeleeCritChance>
 							<MeleeParryChance>0.24</MeleeParryChance>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEFireworm.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEFireworm.xml
@@ -40,8 +40,8 @@
 						<xpath>Defs/ThingDef[defName="VFE_Mech_Fireworm"]/statBases</xpath>
 						<value>
 							<ArmorRating_Heat>0.5</ArmorRating_Heat>
-							<AimingAccuracy>1.0</AimingAccuracy>
-							<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+							<AimingAccuracy>1.3</AimingAccuracy>
+							<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
 							<MeleeDodgeChance>0.01</MeleeDodgeChance>
 							<MeleeCritChance>0.19</MeleeCritChance>
 							<MeleeParryChance>0.19</MeleeParryChance>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEGoliath.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEGoliath.xml
@@ -42,8 +42,8 @@
 							<ArmorRating_Heat>0.25</ArmorRating_Heat>
 							<CarryWeight>200</CarryWeight>
 							<CarryBulk>100</CarryBulk>
-							<AimingAccuracy>1.0</AimingAccuracy>
-							<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
+							<AimingAccuracy>1.7</AimingAccuracy>
+							<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 							<MeleeDodgeChance>0.05</MeleeDodgeChance>
 							<MeleeCritChance>0.75</MeleeCritChance>
 							<MeleeParryChance>0.2</MeleeParryChance>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEPhalanx.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEPhalanx.xml
@@ -39,8 +39,8 @@
 						<xpath>Defs/ThingDef[defName="VFE_Mech_Phalanx"]/statBases</xpath>
 						<value>
 							<ArmorRating_Heat>0.5</ArmorRating_Heat>
-							<AimingAccuracy>1.0</AimingAccuracy>
-							<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+							<AimingAccuracy>1.3</AimingAccuracy>
+							<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
 							<MeleeDodgeChance>0.01</MeleeDodgeChance>
 							<MeleeCritChance>0.56</MeleeCritChance>
 							<MeleeParryChance>0.44</MeleeParryChance>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFESiegebreaker.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFESiegebreaker.xml
@@ -42,8 +42,8 @@
 							<ArmorRating_Heat>0.25</ArmorRating_Heat>
 							<CarryWeight>200</CarryWeight>
 							<CarryBulk>150</CarryBulk>
-							<AimingAccuracy>1.0</AimingAccuracy>
-							<ShootingAccuracyPawn>1.0</ShootingAccuracyPawn>
+							<AimingAccuracy>1.3</AimingAccuracy>
+							<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
 							<MeleeDodgeChance>0.01</MeleeDodgeChance>
 							<MeleeCritChance>0.07</MeleeCritChance>
 							<MeleeParryChance>0.24</MeleeParryChance>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Fireworm.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Fireworm.xml
@@ -46,8 +46,8 @@
 							<xpath>Defs/ThingDef[defName="VFE_Mech_Advanced_Fireworm_PlayerControlled"]/statBases</xpath>
 							<value>
 								<ArmorRating_Heat>1.0</ArmorRating_Heat>
-								<AimingAccuracy>1.0</AimingAccuracy>
-								<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+								<AimingAccuracy>1.7</AimingAccuracy>
+								<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 								<MeleeDodgeChance>0.01</MeleeDodgeChance>
 								<MeleeCritChance>0.19</MeleeCritChance>
 								<MeleeParryChance>0.19</MeleeParryChance>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Goliath.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Goliath.xml
@@ -48,8 +48,8 @@
 								<ArmorRating_Heat>0.75</ArmorRating_Heat>
 								<CarryWeight>400</CarryWeight>
 								<CarryBulk>200</CarryBulk>
-								<AimingAccuracy>1.0</AimingAccuracy>
-								<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
+								<AimingAccuracy>1.7</AimingAccuracy>
+								<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 								<MeleeDodgeChance>0.05</MeleeDodgeChance>
 								<MeleeCritChance>0.75</MeleeCritChance>
 								<MeleeParryChance>0.2</MeleeParryChance>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Phalanx.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Phalanx.xml
@@ -45,8 +45,8 @@
 							<xpath>Defs/ThingDef[defName="VFE_Mech_Advanced_Phalanx_PlayerControlled"]/statBases</xpath>
 							<value>
 								<ArmorRating_Heat>1.0</ArmorRating_Heat>
-								<AimingAccuracy>1.0</AimingAccuracy>
-								<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+								<AimingAccuracy>1.7</AimingAccuracy>
+								<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 								<MeleeDodgeChance>0.01</MeleeDodgeChance>
 								<MeleeCritChance>0.56</MeleeCritChance>
 								<MeleeParryChance>0.44</MeleeParryChance>

--- a/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Siegebreaker.xml
+++ b/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Siegebreaker.xml
@@ -48,8 +48,8 @@
 								<ArmorRating_Heat>0.75</ArmorRating_Heat>
 								<CarryWeight>200</CarryWeight>
 								<CarryBulk>300</CarryBulk>
-								<AimingAccuracy>1.0</AimingAccuracy>
-								<ShootingAccuracyPawn>1.0</ShootingAccuracyPawn>
+								<AimingAccuracy>1.7</AimingAccuracy>
+								<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 								<MeleeDodgeChance>0.01</MeleeDodgeChance>
 								<MeleeCritChance>0.07</MeleeCritChance>
 								<MeleeParryChance>0.24</MeleeParryChance>

--- a/Patches/Alpha Mechs/ThingDefs_Misc/AlphaMechs_RangedMechanoid.xml
+++ b/Patches/Alpha Mechs/ThingDefs_Misc/AlphaMechs_RangedMechanoid.xml
@@ -258,7 +258,7 @@
 					<AmmoUser>
 						<magazineSize>1</magazineSize>
 						<AmmoGenPerMagOverride>2</AmmoGenPerMagOverride>
-						<reloadTime>8</reloadTime>
+						<reloadTime>1.6</reloadTime>
 						<ammoSet>AmmoSet_90mmCannonShell</ammoSet>
 					</AmmoUser>
 					<FireModes>

--- a/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Demolisher.xml
+++ b/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Demolisher.xml
@@ -38,8 +38,8 @@
 						<ArmorRating_Heat>0.25</ArmorRating_Heat>
 						<CarryWeight>50</CarryWeight>
 						<CarryBulk>100</CarryBulk>
-						<AimingAccuracy>1.0</AimingAccuracy>
-						<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+						<AimingAccuracy>1.3</AimingAccuracy>
+						<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
 						<MeleeDodgeChance>0.01</MeleeDodgeChance>
 						<MeleeCritChance>0.72</MeleeCritChance>
 						<MeleeParryChance>0.33</MeleeParryChance>

--- a/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Fireworm.xml
+++ b/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Fireworm.xml
@@ -36,8 +36,8 @@
 					<xpath>Defs/ThingDef[defName="AM_Fireworm"]/statBases</xpath>
 					<value>
 						<ArmorRating_Heat>0.5</ArmorRating_Heat>
-						<AimingAccuracy>1.0</AimingAccuracy>
-						<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+						<AimingAccuracy>1.3</AimingAccuracy>
+						<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
 						<MeleeDodgeChance>0.01</MeleeDodgeChance>
 						<MeleeCritChance>0.19</MeleeCritChance>
 						<MeleeParryChance>0.19</MeleeParryChance>

--- a/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Goliath.xml
+++ b/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Goliath.xml
@@ -38,8 +38,8 @@
 						<ArmorRating_Heat>0.25</ArmorRating_Heat>
 						<CarryWeight>200</CarryWeight>
 						<CarryBulk>100</CarryBulk>
-						<AimingAccuracy>1.0</AimingAccuracy>
-						<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
+						<AimingAccuracy>1.7</AimingAccuracy>
+						<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 						<MeleeDodgeChance>0.05</MeleeDodgeChance>
 						<MeleeCritChance>0.75</MeleeCritChance>
 						<MeleeParryChance>0.2</MeleeParryChance>

--- a/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Phalanx.xml
+++ b/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Phalanx.xml
@@ -35,8 +35,8 @@
 					<xpath>Defs/ThingDef[defName="AM_Phalanx"]/statBases</xpath>
 					<value>
 						<ArmorRating_Heat>0.5</ArmorRating_Heat>
-						<AimingAccuracy>1.0</AimingAccuracy>
-						<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+						<AimingAccuracy>1.3</AimingAccuracy>
+						<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
 						<MeleeDodgeChance>0.01</MeleeDodgeChance>
 						<MeleeCritChance>0.56</MeleeCritChance>
 						<MeleeParryChance>0.44</MeleeParryChance>

--- a/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Siegebreaker.xml
+++ b/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Siegebreaker.xml
@@ -37,8 +37,8 @@
 						<ArmorRating_Heat>0.25</ArmorRating_Heat>
 						<CarryWeight>200</CarryWeight>
 						<CarryBulk>150</CarryBulk>
-						<AimingAccuracy>1.0</AimingAccuracy>
-						<ShootingAccuracyPawn>1.0</ShootingAccuracyPawn>
+						<AimingAccuracy>1.3</AimingAccuracy>
+						<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
 						<MeleeDodgeChance>0.01</MeleeDodgeChance>
 						<MeleeCritChance>0.07</MeleeCritChance>
 						<MeleeParryChance>0.24</MeleeParryChance>

--- a/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
@@ -141,12 +141,11 @@
 			<ArmorRating_Heat>0.25</ArmorRating_Heat>
 			<CarryWeight>150</CarryWeight>
 			<CarryBulk>60</CarryBulk>
-			<AimingAccuracy>1.0</AimingAccuracy>
-			<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+			<AimingAccuracy>1.3</AimingAccuracy>
+			<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
 			<MeleeDodgeChance>0.03</MeleeDodgeChance>
 			<MeleeCritChance>0.26</MeleeCritChance>
 			<MeleeParryChance>0.52</MeleeParryChance>
-			<AimingDelayFactor>1.25</AimingDelayFactor>
 			<MaxHitPoints>500</MaxHitPoints>
 		</value>
 	</Operation>
@@ -250,7 +249,7 @@
 		<value>
 			<CarryWeight>50</CarryWeight>
 			<CarryBulk>20</CarryBulk>
-			<AimingAccuracy>1.0</AimingAccuracy>
+			<AimingAccuracy>1.7</AimingAccuracy>
 			<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 			<MeleeDodgeChance>0.13</MeleeDodgeChance>
 			<MeleeCritChance>0.12</MeleeCritChance>
@@ -592,12 +591,11 @@
 			<ArmorRating_Heat>0.25</ArmorRating_Heat>
 			<CarryWeight>150</CarryWeight>
 			<CarryBulk>60</CarryBulk>
-			<AimingAccuracy>1.0</AimingAccuracy>
-			<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+			<AimingAccuracy>1.3</AimingAccuracy>
+			<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
 			<MeleeDodgeChance>0.04</MeleeDodgeChance>
 			<MeleeCritChance>0.14</MeleeCritChance>
 			<MeleeParryChance>0.24</MeleeParryChance>
-			<AimingDelayFactor>1.25</AimingDelayFactor>
 			<MaxHitPoints>350</MaxHitPoints>
 		</value>
 	</Operation>

--- a/Patches/MechanoidsExtraordinaire/ThingDefs_Races/Races_Mechanoid_MechanoidsExtraordinaire.xml
+++ b/Patches/MechanoidsExtraordinaire/ThingDefs_Races/Races_Mechanoid_MechanoidsExtraordinaire.xml
@@ -21,7 +21,7 @@
 					<value>
 						<CarryWeight>55</CarryWeight>
 						<CarryBulk>22</CarryBulk>
-						<AimingAccuracy>1.0</AimingAccuracy>
+						<AimingAccuracy>1.7</AimingAccuracy>
 						<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 						<MeleeDodgeChance>0.25</MeleeDodgeChance>
 						<MeleeCritChance>0.25</MeleeCritChance>
@@ -82,8 +82,8 @@
 					<value>
 						<CarryWeight>200</CarryWeight>
 						<CarryBulk>100</CarryBulk>
-						<AimingAccuracy>0.8</AimingAccuracy>
-						<ShootingAccuracyPawn>0.8</ShootingAccuracyPawn>
+						<AimingAccuracy>1.0</AimingAccuracy>
+						<ShootingAccuracyPawn>1.0</ShootingAccuracyPawn>
 						<MeleeDodgeChance>0.05</MeleeDodgeChance>
 						<MeleeCritChance>0.15</MeleeCritChance>
 					</value>
@@ -143,7 +143,7 @@
 					<value>
 						<CarryWeight>200</CarryWeight>
 						<CarryBulk>120</CarryBulk>
-						<AimingAccuracy>1.0</AimingAccuracy>
+						<AimingAccuracy>1.3</AimingAccuracy>
 						<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
 						<MeleeDodgeChance>0.10</MeleeDodgeChance>
 						<MeleeCritChance>0.15</MeleeCritChance>
@@ -204,8 +204,8 @@
 					<value>
 						<CarryWeight>150</CarryWeight>
 						<CarryBulk>40</CarryBulk>
-						<AimingAccuracy>0.8</AimingAccuracy>
-						<ShootingAccuracyPawn>0.8</ShootingAccuracyPawn>
+						<AimingAccuracy>1.0</AimingAccuracy>
+						<ShootingAccuracyPawn>1.0</ShootingAccuracyPawn>
 						<MeleeDodgeChance>0.15</MeleeDodgeChance>
 						<MeleeCritChance>0.50</MeleeCritChance>
 					</value>
@@ -265,7 +265,7 @@
 					<value>
 						<CarryWeight>200</CarryWeight>
 						<CarryBulk>150</CarryBulk>
-						<AimingAccuracy>1.0</AimingAccuracy>
+						<AimingAccuracy>1.3</AimingAccuracy>
 						<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
 						<MeleeDodgeChance>0.15</MeleeDodgeChance>
 						<MeleeCritChance>0.40</MeleeCritChance>

--- a/Patches/MoreMechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/MoreMechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -460,7 +460,7 @@
 						<ArmorRating_Heat>0.25</ArmorRating_Heat>
 						<CarryWeight>50</CarryWeight>
 						<CarryBulk>40</CarryBulk>
-						<AimingAccuracy>1.0</AimingAccuracy>
+						<AimingAccuracy>1.7</AimingAccuracy>
 						<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 						<MeleeDodgeChance>0.12</MeleeDodgeChance>
 						<MeleeCritChance>0.16</MeleeCritChance>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/CombinationDefs/CombinationDefs.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/CombinationDefs/CombinationDefs.xml
@@ -729,7 +729,7 @@
 								<li>ComponentIndustrial</li>
 							</thirdItems>
 							<amount>
-								<li>22</li>
+								<li>18</li>
 								<li>2</li>
 								<li>2</li>
 							</amount>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
@@ -70,12 +70,11 @@
 						<ArmorRating_Heat>0.75</ArmorRating_Heat>
 						<CarryWeight>160</CarryWeight>
 						<CarryBulk>70</CarryBulk>
-						<AimingAccuracy>1.05</AimingAccuracy>
-						<ShootingAccuracyPawn>1.05</ShootingAccuracyPawn>
+						<AimingAccuracy>1.7</AimingAccuracy>
+						<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 						<MeleeDodgeChance>0.03</MeleeDodgeChance>
 						<MeleeCritChance>0.30</MeleeCritChance>
 						<MeleeParryChance>0.52</MeleeParryChance>
-						<AimingDelayFactor>1.20</AimingDelayFactor>
 						<MaxHitPoints>500</MaxHitPoints>
 					</value>
 				</li>
@@ -91,13 +90,6 @@
 					<xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedCentipede"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>22</ArmorRating_Sharp>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedCentipede"]/race/baseBodySize</xpath>
-					<value>
-						<baseBodySize>3.0</baseBodySize>
 					</value>
 				</li>
 
@@ -171,7 +163,7 @@
 					<value>
 						<CarryWeight>50</CarryWeight>
 						<CarryBulk>20</CarryBulk>
-						<AimingAccuracy>1.1</AimingAccuracy>
+						<AimingAccuracy>1.8</AimingAccuracy>
 						<ShootingAccuracyPawn>1.6</ShootingAccuracyPawn>
 						<MeleeDodgeChance>0.15</MeleeDodgeChance>
 						<MeleeCritChance>0.14</MeleeCritChance>
@@ -489,6 +481,8 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedKnight"]/statBases</xpath>
 					<value>
+						<AimingAccuracy>1.8</AimingAccuracy>
+						<ShootingAccuracyPawn>1.6</ShootingAccuracyPawn>
 						<CarryWeight>50</CarryWeight>
 						<CarryBulk>20</CarryBulk>
 						<MeleeDodgeChance>0.13</MeleeDodgeChance>
@@ -605,8 +599,8 @@
 						<ArmorRating_Heat>1.0</ArmorRating_Heat>
 						<CarryWeight>50</CarryWeight>
 						<CarryBulk>50</CarryBulk>
-						<AimingAccuracy>1.0</AimingAccuracy>
-						<ShootingAccuracyPawn>1.1</ShootingAccuracyPawn>
+						<AimingAccuracy>1.7</AimingAccuracy>
+						<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 						<MeleeDodgeChance>0.07</MeleeDodgeChance>
 						<MeleeCritChance>0.04</MeleeCritChance>
 						<MeleeParryChance>0.09</MeleeParryChance>
@@ -816,12 +810,11 @@
 							<ArmorRating_Heat>0.75</ArmorRating_Heat>
 							<CarryWeight>150</CarryWeight>
 							<CarryBulk>60</CarryBulk>
-							<AimingAccuracy>1.0</AimingAccuracy>
-							<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+							<AimingAccuracy>1.7</AimingAccuracy>
+							<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 							<MeleeDodgeChance>0.04</MeleeDodgeChance>
 							<MeleeCritChance>0.16</MeleeCritChance>
 							<MeleeParryChance>0.24</MeleeParryChance>
-							<AimingDelayFactor>1.25</AimingDelayFactor>
 							<MaxHitPoints>400</MaxHitPoints>
 						</statBases>
 					</value>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid_PlayerControlled.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid_PlayerControlled.xml
@@ -30,12 +30,11 @@
 							<ArmorRating_Heat>0.75</ArmorRating_Heat>
 							<CarryWeight>160</CarryWeight>
 							<CarryBulk>70</CarryBulk>
-							<AimingAccuracy>1.05</AimingAccuracy>
-							<ShootingAccuracyPawn>1.05</ShootingAccuracyPawn>
+							<AimingAccuracy>1.7</AimingAccuracy>
+							<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 							<MeleeDodgeChance>0.03</MeleeDodgeChance>
 							<MeleeCritChance>0.30</MeleeCritChance>
 							<MeleeParryChance>0.52</MeleeParryChance>
-							<AimingDelayFactor>1.20</AimingDelayFactor>
 							<MaxHitPoints>500</MaxHitPoints>
 						</value>
 					</li>
@@ -51,13 +50,6 @@
 						<xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedCentipede_PlayerControlled"]/statBases/ArmorRating_Sharp</xpath>
 						<value>
 							<ArmorRating_Sharp>22</ArmorRating_Sharp>
-						</value>
-					</li>
-
-					<li Class="PatchOperationReplace">
-						<xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedCentipede_PlayerControlled"]/race/baseBodySize</xpath>
-						<value>
-							<baseBodySize>3.0</baseBodySize>
 						</value>
 					</li>
 
@@ -122,7 +114,7 @@
 						<value>
 							<CarryWeight>50</CarryWeight>
 							<CarryBulk>20</CarryBulk>
-							<AimingAccuracy>1.1</AimingAccuracy>
+							<AimingAccuracy>1.8</AimingAccuracy>
 							<ShootingAccuracyPawn>1.6</ShootingAccuracyPawn>
 							<MeleeDodgeChance>0.15</MeleeDodgeChance>
 							<MeleeCritChance>0.14</MeleeCritChance>
@@ -460,7 +452,7 @@
 					<li Class="PatchOperationAdd">
 						<xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedKnight_PlayerControlled"]/statBases</xpath>
 						<value>
-							<AimingAccuracy>1.1</AimingAccuracy>
+							<AimingAccuracy>1.8</AimingAccuracy>
 							<ShootingAccuracyPawn>1.6</ShootingAccuracyPawn>
 							<CarryWeight>50</CarryWeight>
 							<CarryBulk>20</CarryBulk>
@@ -578,8 +570,8 @@
 							<ArmorRating_Heat>1.0</ArmorRating_Heat>
 							<CarryWeight>50</CarryWeight>
 							<CarryBulk>50</CarryBulk>
-							<AimingAccuracy>1.0</AimingAccuracy>
-							<ShootingAccuracyPawn>1.1</ShootingAccuracyPawn>
+							<AimingAccuracy>1.7</AimingAccuracy>
+							<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 							<MeleeDodgeChance>0.07</MeleeDodgeChance>
 							<MeleeCritChance>0.04</MeleeCritChance>
 							<MeleeParryChance>0.09</MeleeParryChance>
@@ -696,12 +688,11 @@
 							<ArmorRating_Heat>0.75</ArmorRating_Heat>
 							<CarryWeight>150</CarryWeight>
 							<CarryBulk>60</CarryBulk>
-							<AimingAccuracy>1.0</AimingAccuracy>
-							<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+							<AimingAccuracy>1.7</AimingAccuracy>
+							<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 							<MeleeDodgeChance>0.04</MeleeDodgeChance>
 							<MeleeCritChance>0.16</MeleeCritChance>
 							<MeleeParryChance>0.24</MeleeParryChance>
-							<AimingDelayFactor>1.25</AimingDelayFactor>
 							<MaxHitPoints>400</MaxHitPoints>
 						</value>
 					</li>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Machines.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Machines.xml
@@ -128,7 +128,7 @@
 					<value>
 						<CarryWeight>100</CarryWeight>
 						<CarryBulk>50</CarryBulk>
-						<AimingAccuracy>1.0</AimingAccuracy>
+						<AimingAccuracy>1.3</AimingAccuracy>
 						<ShootingAccuracyPawn>2.6</ShootingAccuracyPawn>
 						<ReloadSpeed>1</ReloadSpeed>
 						<MeleeDodgeChance>0</MeleeDodgeChance>
@@ -249,7 +249,7 @@
 					<value>
 						<CarryWeight>50</CarryWeight>
 						<CarryBulk>30</CarryBulk>
-						<AimingAccuracy>1.0</AimingAccuracy>
+						<AimingAccuracy>1.3</AimingAccuracy>
 						<ShootingAccuracyPawn>2.6</ShootingAccuracyPawn>
 						<ReloadSpeed>1</ReloadSpeed>
 						<MeleeDodgeChance>0.19</MeleeDodgeChance>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -94,12 +94,11 @@
 						<ArmorRating_Heat>0.25</ArmorRating_Heat>
 						<CarryWeight>150</CarryWeight>
 						<CarryBulk>60</CarryBulk>
-						<AimingAccuracy>1.0</AimingAccuracy>
-						<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+						<AimingAccuracy>1.3</AimingAccuracy>
+						<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
 						<MeleeDodgeChance>0.03</MeleeDodgeChance>
 						<MeleeCritChance>0.26</MeleeCritChance>
 						<MeleeParryChance>0.52</MeleeParryChance>
-						<AimingDelayFactor>1.25</AimingDelayFactor>
 						<MaxHitPoints>500</MaxHitPoints>
 					</value>
 				</li>
@@ -115,13 +114,6 @@
 					<xpath>Defs/ThingDef[defName="VFE_Mech_Centipede"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>20</ArmorRating_Sharp>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VFE_Mech_Centipede"]/race/baseBodySize</xpath>
-					<value>
-						<baseBodySize>3.0</baseBodySize>
 					</value>
 				</li>
 
@@ -195,7 +187,7 @@
 					<value>
 						<CarryWeight>50</CarryWeight>
 						<CarryBulk>20</CarryBulk>
-						<AimingAccuracy>1.0</AimingAccuracy>
+						<AimingAccuracy>1.7</AimingAccuracy>
 						<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 						<MeleeDodgeChance>0.13</MeleeDodgeChance>
 						<MeleeCritChance>0.12</MeleeCritChance>
@@ -515,8 +507,8 @@
 					<value>
 						<CarryWeight>50</CarryWeight>
 						<CarryBulk>20</CarryBulk>
-						<AimingAccuracy>1.0</AimingAccuracy>
-						<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
+						<AimingAccuracy>1.7</AimingAccuracy>
+						<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 						<MeleeDodgeChance>0.13</MeleeDodgeChance>
 						<MeleeCritChance>0.11</MeleeCritChance>
 						<MeleeParryChance>0.09</MeleeParryChance>
@@ -631,8 +623,8 @@
 						<ArmorRating_Heat>0.5</ArmorRating_Heat>
 						<CarryWeight>50</CarryWeight>
 						<CarryBulk>50</CarryBulk>
-						<AimingAccuracy>1.0</AimingAccuracy>
-						<ShootingAccuracyPawn>1.0</ShootingAccuracyPawn>
+						<AimingAccuracy>1.3</AimingAccuracy>
+						<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
 						<MeleeDodgeChance>0.06</MeleeDodgeChance>
 						<MeleeCritChance>0.03</MeleeCritChance>
 						<MeleeParryChance>0.09</MeleeParryChance>
@@ -851,12 +843,11 @@
 						<ArmorRating_Heat>0.25</ArmorRating_Heat>
 						<CarryWeight>150</CarryWeight>
 						<CarryBulk>60</CarryBulk>
-						<AimingAccuracy>1.0</AimingAccuracy>
-						<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+						<AimingAccuracy>1.3</AimingAccuracy>
+						<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
 						<MeleeDodgeChance>0.04</MeleeDodgeChance>
 						<MeleeCritChance>0.14</MeleeCritChance>
 						<MeleeParryChance>0.24</MeleeParryChance>
-						<AimingDelayFactor>1.25</AimingDelayFactor>
 						<MaxHitPoints>350</MaxHitPoints>
 					</value>
 				</li>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid_PlayerControlled.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid_PlayerControlled.xml
@@ -29,12 +29,11 @@
 							<ArmorRating_Heat>0.25</ArmorRating_Heat>
 							<CarryWeight>150</CarryWeight>
 							<CarryBulk>60</CarryBulk>
-							<AimingAccuracy>1.0</AimingAccuracy>
-							<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+							<AimingAccuracy>1.3</AimingAccuracy>
+							<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
 							<MeleeDodgeChance>0.04</MeleeDodgeChance>
 							<MeleeCritChance>0.14</MeleeCritChance>
 							<MeleeParryChance>0.24</MeleeParryChance>
-							<AimingDelayFactor>1.25</AimingDelayFactor>
 							<MaxHitPoints>350</MaxHitPoints>
 						</value>
 					</li>
@@ -122,8 +121,8 @@
 						<value>
 							<CarryWeight>50</CarryWeight>
 							<CarryBulk>20</CarryBulk>
-							<AimingAccuracy>1.0</AimingAccuracy>
-							<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
+							<AimingAccuracy>1.7</AimingAccuracy>
+							<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 							<MeleeDodgeChance>0.13</MeleeDodgeChance>
 							<MeleeCritChance>0.11</MeleeCritChance>
 							<MeleeParryChance>0.09</MeleeParryChance>
@@ -238,8 +237,8 @@
 							<ArmorRating_Heat>0.5</ArmorRating_Heat>
 							<CarryWeight>50</CarryWeight>
 							<CarryBulk>50</CarryBulk>
-							<AimingAccuracy>1.0</AimingAccuracy>
-							<ShootingAccuracyPawn>1.0</ShootingAccuracyPawn>
+							<AimingAccuracy>1.3</AimingAccuracy>
+							<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
 							<MeleeDodgeChance>0.06</MeleeDodgeChance>
 							<MeleeCritChance>0.03</MeleeCritChance>
 							<MeleeParryChance>0.09</MeleeParryChance>


### PR DESCRIPTION
## Changes

Same as #3034, my fork got borked and had to delete it.

- Implemented proper aiming accuracy stats for mechs and ran a consistency check on their shooting.
- Removed the AimingDelayFactor from Thermites and Centipedes.
- Adjusted the bulk and mass value of the 66mm thermal bolts.
- Adjusted the bulk capacity of the legionary and Apocriton mechs to be slightly higher to enable them to carry more ammo.
- Removed the cover-seeking behavior from the Tesseron and Apocriton.
- Removed various somehow leftover body size patches for centipedes.
- Tweaked the thermal bolt projector to fire and reload slightly quicker and have more range to make the mech able to stay with its allies.
- Tweaked the Siegebreaker mech's weapon reload time similar to inferno cannons in #3057.
- Consistency check on the the Super HCB's aim mode and warmup time similar to normal HCBs.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070

## Reasoning

- The mech weapon handling stats go 8 shooting (1.0 shooting accuracy stat) for light mechs, 11 shooting (1.25 shooting accuracy stat) for heavy and super heavy ones and 15 (1.5 shooting accuracy stat) for medium mechs like Lancers and Pikemen. Relative to that, their aiming accuracy was adjusted to be 1.0, 1.3 and 1.7 respectively to reflect the shooting skills which was a key point in some mechs' accuracy problems. Light mechs are simple hence the low skill, medium ones are kept accurate and heavy ones deserve to be more accurate with their shots.
- Thermites and Centipedes already have weapons that take a long time to fire, there is no need for an arbitrary nerf to their DPS.
- 66mm thermal bolts did not need to be as heavy and bulky considering the changes made to the 80mm fuel cells.
- The Tesseron tends to have issues with its weapon hitting the cover when standing directly behind a solid structure and the Apocriton has the mech resurrection ai that conflicts with cover-seeking.

## Alternatives

- Leave things be?
- I'm considering increasing the HP scaling of Lancers to 1.0, they too flimsy for their bandwidth cost or their DPS in raids. The bandwidth changes are out of the question for CE so this seems a decent method of making them more threatening.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
