### PR TITLE
30mm fuel cells and T-9 launcher fixed and tweaks (#3030 reopened)

### DIFF
--- a/Defs/Ammo/Advanced/30x64mmFuelCell.xml
+++ b/Defs/Ammo/Advanced/30x64mmFuelCell.xml
@@ -25,7 +25,7 @@
 	<ThingDef Class="CombatExtended.AmmoDef" Name="30x64mmFuelBase" ParentName="SpacerMediumAmmoBase" Abstract="True">
 		<description>Container holding fuel for incendiary shot firearms.</description>
 		<statBases>
-			<Mass>0.08</Mass>
+			<Mass>0.4</Mass>
 			<Bulk>0.14</Bulk>
 		</statBases>
 		<tradeTags>
@@ -46,7 +46,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>3.4</MarketValue>
+			<MarketValue>4.66</MarketValue>
 		</statBases>
 		<ammoClass>IncendiaryFuel</ammoClass>
 	</ThingDef>
@@ -59,7 +59,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>4.91</MarketValue>
+			<MarketValue>6.18</MarketValue>
 		</statBases>
 		<ammoClass>ThermobaricFuel</ammoClass>
 	</ThingDef>
@@ -72,7 +72,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>3.66</MarketValue>
+			<MarketValue>4.93</MarketValue>
 		</statBases>
 		<ammoClass>FoamFuel</ammoClass>
 		<generateAllowChance>0</generateAllowChance>
@@ -149,7 +149,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>8</count>
+				<count>40</count>
 			</li>
 			<li>
 				<filter>
@@ -178,7 +178,7 @@
 		<products>
 			<Ammo_30x64mmFuel_Incendiary>50</Ammo_30x64mmFuel_Incendiary>
 		</products>
-		<workAmount>7600</workAmount>
+		<workAmount>10800</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="LauncherAmmoRecipeBase">
@@ -194,7 +194,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>8</count>
+				<count>40</count>
 			</li>
 			<li>
 				<filter>
@@ -222,7 +222,7 @@
 		<products>
 			<Ammo_30x64mmFuel_Thermobaric>50</Ammo_30x64mmFuel_Thermobaric>
 		</products>
-		<workAmount>10400</workAmount>
+		<workAmount>13600</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="LauncherAmmoRecipeBase">
@@ -242,7 +242,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>8</count>
+				<count>40</count>
 			</li>
 			<li>
 				<filter>
@@ -273,7 +273,7 @@
 		<products>
 			<Ammo_30x64mmFuel_Foam>50</Ammo_30x64mmFuel_Foam>
 		</products>
-		<workAmount>11400</workAmount>
+		<workAmount>14600</workAmount>
 	</RecipeDef>
 
 </Defs>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -640,36 +640,37 @@
 		<statBases>
 			<Mass>8</Mass>
 			<RangedWeapon_Cooldown>0.43</RangedWeapon_Cooldown>
-			<SightsEfficiency>1</SightsEfficiency>
+			<SightsEfficiency>1.1</SightsEfficiency>
 			<ShotSpread>0.15</ShotSpread>
 			<SwayFactor>1.8</SwayFactor>
 			<Bulk>10</Bulk>
-			<WorkToMake>39500</WorkToMake>
+			<WorkToMake>35500</WorkToMake>
 		</statBases>
 		<costList>
 			<Steel>65</Steel>
 			<Plasteel>30</Plasteel>
-			<ComponentIndustrial>7</ComponentIndustrial>
+			<ComponentIndustrial>1</ComponentIndustrial>
+			<ComponentSpacer>1</ComponentSpacer>
 			<Chemfuel>10</Chemfuel>
 		</costList>
 		<Properties>
-			<recoilAmount>1.0</recoilAmount>
+			<recoilAmount>3.87</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_30x64mmFuel_Incendiary</defaultProjectile>
-			<warmupTime>1.1</warmupTime>
+			<warmupTime>1.0</warmupTime>
 			<range>40</range>
-			<burstShotCount>0</burstShotCount>
 			<soundCast>Shot_IncendiaryLauncher</soundCast>
 			<soundCastTail>GunTail_Medium</soundCastTail>
-			<muzzleFlashScale>14</muzzleFlashScale>
+			<muzzleFlashScale>9</muzzleFlashScale>
 			<targetParams>
 				<canTargetLocations>true</canTargetLocations>
 			</targetParams>
 		</Properties>
 		<AmmoUser>
 			<magazineSize>5</magazineSize>
-			<reloadTime>4</reloadTime>
+			<reloadOneAtATime>true</reloadOneAtATime>
+			<reloadTime>0.85</reloadTime>
 			<ammoSet>AmmoSet_30x64mmFuel</ammoSet>
 		</AmmoUser>
 		<FireModes>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -685,6 +685,13 @@
 		<AllowWithRunAndGun>false</AllowWithRunAndGun>
 	</Operation>
 
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Gun_IncendiaryLauncher"]</xpath>
+		<value>
+			<techLevel>Spacer</techLevel>
+		</value>
+	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="Gun_IncendiaryLauncher"]</xpath>
 		<value>


### PR DESCRIPTION
## Changes

Same as #3030, my fork got borked and had to delete it.

- Similar to the changes in #3057, adjusted the stats on the 30mm fuel cells.
- Fixed the stats on the T-9 incendiary launcher and added the proper Spacer TechLevel to it.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070
- https://docs.google.com/spreadsheets/d/1lbT0zzagCRPDJG4GctkeeoTsFCt3lYfM4SRnWt8ql-k/edit#gid=1573763037

## Reasoning

- The aforementioned cells were extremely light for something with 270 grams of filler.
- The T-9 lacked the reflex sights and the advanced component in its recipe.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
