### PR TITLE
80mm fuel cells and inferno cannons readjusted and fixed (#3029 reopened)

### DIFF
--- a/Defs/Ammo/Advanced/80x256mmFuelCell.xml
+++ b/Defs/Ammo/Advanced/80x256mmFuelCell.xml
@@ -24,7 +24,7 @@
 	<ThingDef Class="CombatExtended.AmmoDef" Name="80x256mmFuelBase" ParentName="SpacerMediumAmmoBase" Abstract="True">
 		<description>Large fuel container for incendiary shot cannons.</description>
 		<statBases>
-			<Mass>0.85</Mass>
+			<Mass>2.5</Mass>
 			<Bulk>3.87</Bulk>
 		</statBases>
 		<thingCategories>
@@ -45,14 +45,14 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>10.38</MarketValue><!-- value intentionally decreased to help reduce wealth bloat/free silver -->
+			<MarketValue>14.82</MarketValue><!-- value intentionally decreased to help reduce wealth bloat/free silver -->
 		</statBases>
 		<ammoClass>GrenadeIncendiary</ammoClass>
 		<detonateProjectile>Bullet_80x256mmFuel_Incendiary</detonateProjectile>
 		<comps>
 			<li Class="CompProperties_Explosive">
-				<explosiveRadius>1.9</explosiveRadius>
-				<damageAmountBase>5</damageAmountBase>
+				<explosiveRadius>2.0</explosiveRadius>
+				<damageAmountBase>7</damageAmountBase>
 				<explosiveDamageType>PrometheumFlame</explosiveDamageType>
 				<explosiveExpandPerStackcount>0.10</explosiveExpandPerStackcount>
 				<startWickHitPointsPercent>0.33</startWickHitPointsPercent>
@@ -75,10 +75,10 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>PrometheumFlame</damageDef>
-			<damageAmountBase>9</damageAmountBase>
+			<damageAmountBase>13</damageAmountBase>
 			<speed>73</speed>
 			<flyOverhead>false</flyOverhead>
-			<explosionRadius>5.9</explosionRadius>
+			<explosionRadius>7.5</explosionRadius>
 			<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
 			<preExplosionSpawnChance>0.5</preExplosionSpawnChance>
 			<soundExplode>MortarIncendiary_Explode</soundExplode>
@@ -95,9 +95,9 @@
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>150</damageAmountBase>
+				<damageAmountBase>200</damageAmountBase>
 				<explosiveDamageType>Thermobaric</explosiveDamageType>
-				<explosiveRadius>1.9</explosiveRadius>
+				<explosiveRadius>2.5</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 			</li>
 		</comps>
@@ -117,7 +117,7 @@
 						<li>Prometheum</li>
 					</thingDefs>
 				</filter>
-				<count>3</count>
+				<count>5</count>
 			</li>
 			<li>
 				<filter>
@@ -125,7 +125,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>10</count>
+				<count>26</count>
 			</li>
 			<li>
 				<filter>
@@ -149,7 +149,7 @@
 		<skillRequirements>
 			<Crafting>8</Crafting>
 		</skillRequirements>
-		<workAmount>3730</workAmount><!-- 10% more work -->
+		<workAmount>6380</workAmount><!-- 10% more work -->
 	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Advanced/80x256mmFuelCell.xml
+++ b/Defs/Ammo/Advanced/80x256mmFuelCell.xml
@@ -24,7 +24,7 @@
 	<ThingDef Class="CombatExtended.AmmoDef" Name="80x256mmFuelBase" ParentName="SpacerMediumAmmoBase" Abstract="True">
 		<description>Large fuel container for incendiary shot cannons.</description>
 		<statBases>
-			<Mass>2.5</Mass>
+			<Mass>4.5</Mass>
 			<Bulk>3.87</Bulk>
 		</statBases>
 		<thingCategories>
@@ -45,7 +45,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>14.82</MarketValue><!-- value intentionally decreased to help reduce wealth bloat/free silver -->
+			<MarketValue>18.79</MarketValue><!-- value intentionally decreased to help reduce wealth bloat/free silver -->
 		</statBases>
 		<ammoClass>GrenadeIncendiary</ammoClass>
 		<detonateProjectile>Bullet_80x256mmFuel_Incendiary</detonateProjectile>
@@ -125,7 +125,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>26</count>
+				<count>46</count>
 			</li>
 			<li>
 				<filter>
@@ -149,7 +149,7 @@
 		<skillRequirements>
 			<Crafting>8</Crafting>
 		</skillRequirements>
-		<workAmount>6380</workAmount><!-- 10% more work -->
+		<workAmount>8580</workAmount><!-- 10% more work -->
 	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Advanced/80x256mmFuelCell.xml
+++ b/Defs/Ammo/Advanced/80x256mmFuelCell.xml
@@ -24,7 +24,7 @@
 	<ThingDef Class="CombatExtended.AmmoDef" Name="80x256mmFuelBase" ParentName="SpacerMediumAmmoBase" Abstract="True">
 		<description>Large fuel container for incendiary shot cannons.</description>
 		<statBases>
-			<Mass>4.5</Mass>
+			<Mass>2.0</Mass>
 			<Bulk>3.87</Bulk>
 		</statBases>
 		<thingCategories>
@@ -45,7 +45,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>18.79</MarketValue><!-- value intentionally decreased to help reduce wealth bloat/free silver -->
+			<MarketValue>14.03</MarketValue><!-- value intentionally decreased to help reduce wealth bloat/free silver -->
 		</statBases>
 		<ammoClass>GrenadeIncendiary</ammoClass>
 		<detonateProjectile>Bullet_80x256mmFuel_Incendiary</detonateProjectile>
@@ -125,7 +125,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>46</count>
+				<count>22</count>
 			</li>
 			<li>
 				<filter>
@@ -149,7 +149,7 @@
 		<skillRequirements>
 			<Crafting>8</Crafting>
 		</skillRequirements>
-		<workAmount>8580</workAmount><!-- 10% more work -->
+		<workAmount>5950</workAmount><!-- 10% more work -->
 	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Generic/Mech.xml
+++ b/Defs/Ammo/Generic/Mech.xml
@@ -81,9 +81,9 @@
 	<ThingDef Class="CombatExtended.AmmoDef" Name="MechShellAmmo" ParentName="SpacerMediumAmmoBase" Abstract="True">
 		<description>Large shell used by mechanoid cannons and heavy weapons.</description>
 		<statBases>
-			<Mass>0.85</Mass>
+			<Mass>2.0</Mass>
 			<Bulk>3.87</Bulk>
-			<MarketValue>10.38</MarketValue>
+			<MarketValue>14.03</MarketValue>
 		</statBases>
 		<tradeTags>
 			<li>CE_AutoEnableTrade_Sellable</li>
@@ -106,8 +106,8 @@
 		<detonateProjectile>Bullet_80x256mmFuel_Incendiary</detonateProjectile>
 		<comps>
 			<li Class="CompProperties_Explosive">
-				<explosiveRadius>1.9</explosiveRadius>
-				<damageAmountBase>5</damageAmountBase>
+				<explosiveRadius>2.0</explosiveRadius>
+				<damageAmountBase>7</damageAmountBase>
 				<explosiveDamageType>PrometheumFlame</explosiveDamageType>
 				<explosiveExpandPerStackcount>0.10</explosiveExpandPerStackcount>
 				<startWickHitPointsPercent>0.33</startWickHitPointsPercent>
@@ -205,7 +205,7 @@
 						<li>Prometheum</li>
 					</thingDefs>
 				</filter>
-				<count>3</count>
+				<count>5</count>
 			</li>
 			<li>
 				<filter>
@@ -213,7 +213,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>10</count>
+				<count>22</count>
 			</li>
 			<li>
 				<filter>
@@ -237,7 +237,7 @@
 		<skillRequirements>
 			<Crafting>8</Crafting>
 		</skillRequirements>
-		<workAmount>3730</workAmount><!-- 10% more work -->
+		<workAmount>5950</workAmount><!-- 10% more work -->
 	</RecipeDef>
 
 	<RecipeDef ParentName="ChargeAmmoRecipeBase" MayRequire="Ludeon.RimWorld.Biotech">
@@ -252,7 +252,7 @@
 						<li>FSX</li>
 					</thingDefs>
 				</filter>
-				<count>3</count>
+				<count>5</count>
 			</li>
 			<li>
 				<filter>
@@ -260,7 +260,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>10</count>
+				<count>16</count>
 			</li>
 			<li>
 				<filter>
@@ -268,7 +268,7 @@
 						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
-				<count>2</count>
+				<count>4</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -284,7 +284,7 @@
 		<skillRequirements>
 			<Crafting>8</Crafting>
 		</skillRequirements>
-		<workAmount>3730</workAmount><!-- 10% more work -->
+		<workAmount>6600</workAmount><!-- 10% more work -->
 	</RecipeDef>
 
 </Defs>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -1219,18 +1219,18 @@
 		<defName>Gun_InfernoCannon</defName>
 		<statBases>
 			<Mass>50.00</Mass>
-			<RangedWeapon_Cooldown>2.54</RangedWeapon_Cooldown>
+			<RangedWeapon_Cooldown>2.59</RangedWeapon_Cooldown>
 			<SightsEfficiency>1</SightsEfficiency>
 			<ShotSpread>0.01</ShotSpread>
 			<SwayFactor>0.14</SwayFactor>
 			<Bulk>20.00</Bulk>
 		</statBases>
 		<Properties>
-			<recoilAmount>2.01</recoilAmount>
+			<recoilAmount>3.18</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>
-			<warmupTime>3.5</warmupTime> <!-- Intentionally decreased from 4.3s -->
+			<warmupTime>4.3</warmupTime>
 			<range>86</range>
 			<burstShotCount>1</burstShotCount>
 			<soundCast>InfernoCannon_Fire</soundCast>
@@ -1243,7 +1243,7 @@
 		<AmmoUser>
 			<magazineSize>1</magazineSize>
 			<AmmoGenPerMagOverride>2</AmmoGenPerMagOverride>
-			<reloadTime>9.8</reloadTime>
+			<reloadTime>1.6</reloadTime>
 			<ammoSet>AmmoSet_80x256mmFuel</ammoSet>
 		</AmmoUser>
 		<FireModes>

--- a/Patches/MechanoidsExtraordinaire/ThingDefs_Misc/Weapons_Guns_MechanoidsExtraordinaire.xml
+++ b/Patches/MechanoidsExtraordinaire/ThingDefs_Misc/Weapons_Guns_MechanoidsExtraordinaire.xml
@@ -10,17 +10,18 @@
 					<defName>Gun_InfernoCannonChimeraME</defName>
 					<statBases>
 						<Mass>300.00</Mass>
-						<RangedWeapon_Cooldown>2.53</RangedWeapon_Cooldown>
+						<RangedWeapon_Cooldown>2.52</RangedWeapon_Cooldown>
 						<SightsEfficiency>1</SightsEfficiency>
 						<ShotSpread>0.01</ShotSpread>
 						<SwayFactor>0.82</SwayFactor>
 						<Bulk>20.00</Bulk>
 					</statBases>
 					<Properties>
+						<recoilAmount>1.3</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>
-						<warmupTime>4.1</warmupTime>
+						<warmupTime>4.3</warmupTime>
 						<range>86</range>
 						<burstShotCount>1</burstShotCount>
 						<soundCast>InfernoCannon_Fire</soundCast>
@@ -30,7 +31,7 @@
 					<AmmoUser>
 						<magazineSize>1</magazineSize>
 						<AmmoGenPerMagOverride>2</AmmoGenPerMagOverride>
-						<reloadTime>9.8</reloadTime>
+						<reloadTime>1.6</reloadTime>
 						<ammoSet>AmmoSet_80x256mmFuel</ammoSet>
 					</AmmoUser>
 					<FireModes>

--- a/Patches/Reinforced Mechanoid 2/ThingDefs_Misc/RM_MechWeaponry.xml
+++ b/Patches/Reinforced Mechanoid 2/ThingDefs_Misc/RM_MechWeaponry.xml
@@ -81,6 +81,7 @@
 						<Bulk>18.00</Bulk>
 					</statBases>
 					<Properties>
+						<recoilAmount>3.18</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>
@@ -95,7 +96,7 @@
 					</Properties>
 					<AmmoUser>
 						<magazineSize>1</magazineSize>
-						<reloadTime>13.7</reloadTime>
+						<reloadTime>4.0</reloadTime>
 						<ammoSet>AmmoSet_80x256mmFuel</ammoSet>
 					</AmmoUser>
 					<FireModes>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/CombinationDefs/CombinationDefs.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/CombinationDefs/CombinationDefs.xml
@@ -609,7 +609,7 @@
 								<li>ComponentIndustrial</li>
 							</thirdItems>
 							<amount>
-								<li>26</li>
+								<li>46</li>
 								<li>5</li>
 								<li>2</li>
 							</amount>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/CombinationDefs/CombinationDefs.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/CombinationDefs/CombinationDefs.xml
@@ -609,8 +609,8 @@
 								<li>ComponentIndustrial</li>
 							</thirdItems>
 							<amount>
-								<li>10</li>
-								<li>3</li>
+								<li>26</li>
+								<li>5</li>
 								<li>2</li>
 							</amount>
 							<outputLimitControlled>true</outputLimitControlled>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/CombinationDefs/CombinationDefs.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/CombinationDefs/CombinationDefs.xml
@@ -609,7 +609,7 @@
 								<li>ComponentIndustrial</li>
 							</thirdItems>
 							<amount>
-								<li>46</li>
+								<li>22</li>
 								<li>5</li>
 								<li>2</li>
 							</amount>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Mech.xml
@@ -213,13 +213,13 @@
 					<defName>VFE_Gun_InfernoArtillery</defName>
 					<statBases>
 						<Mass>300.00</Mass>
-						<RangedWeapon_Cooldown>2.51</RangedWeapon_Cooldown>
+						<RangedWeapon_Cooldown>2.52</RangedWeapon_Cooldown>
 						<SightsEfficiency>1</SightsEfficiency>
 						<ShotSpread>0.01</ShotSpread>
 						<SwayFactor>0.82</SwayFactor>
 					</statBases>
 					<Properties>
-						<recoilAmount>0.82</recoilAmount>
+						<recoilAmount>1.3</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Security_Turrets.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Security_Turrets.xml
@@ -229,7 +229,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VFE_Turret_AutoInfernoCannon"]/building/turretBurstCooldownTime</xpath>
 					<value>
-						<turretBurstCooldownTime>2.5</turretBurstCooldownTime>
+						<turretBurstCooldownTime>2.59</turretBurstCooldownTime>
 					</value>
 				</li>
 
@@ -277,18 +277,18 @@
 					<defName>VFE_Gun_AutoInfernoCannon</defName>
 					<statBases>
 						<Mass>50.00</Mass>
-						<RangedWeapon_Cooldown>2.54</RangedWeapon_Cooldown>
+						<RangedWeapon_Cooldown>2.59</RangedWeapon_Cooldown>
 						<SightsEfficiency>1</SightsEfficiency>
 						<ShotSpread>0.01</ShotSpread>
 						<SwayFactor>0.14</SwayFactor>
 						<Bulk>20.00</Bulk>
 					</statBases>
 					<Properties>
-						<recoilAmount>2.01</recoilAmount>
+						<recoilAmount>3.18</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>
-						<warmupTime>3.5</warmupTime>
+						<warmupTime>4.3</warmupTime>
 						<range>86</range>
 						<burstShotCount>1</burstShotCount>
 						<soundCast>InfernoCannon_Fire</soundCast>
@@ -300,7 +300,7 @@
 					</Properties>
 					<AmmoUser>
 						<magazineSize>5</magazineSize>
-						<reloadTime>9.8</reloadTime>
+						<reloadTime>8.0</reloadTime>
 						<ammoSet>AmmoSet_80x256mmFuel</ammoSet>
 					</AmmoUser>
 					<FireModes>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
@@ -663,18 +663,18 @@
 					<defName>VFE_Gun_AdvancedInfernoCannon</defName>
 					<statBases>
 						<Mass>75.00</Mass>
-						<RangedWeapon_Cooldown>2.52</RangedWeapon_Cooldown>
+						<RangedWeapon_Cooldown>2.56</RangedWeapon_Cooldown>
 						<SightsEfficiency>1</SightsEfficiency>
 						<ShotSpread>0.01</ShotSpread>
 						<SwayFactor>0.21</SwayFactor>
 						<Bulk>20.00</Bulk>
 					</statBases>
 					<Properties>
-						<recoilAmount>1.90</recoilAmount>
+						<recoilAmount>2.60</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>
-						<warmupTime>3.0</warmupTime>
+						<warmupTime>4.0</warmupTime>
 						<range>86</range>
 						<burstShotCount>1</burstShotCount>
 						<soundCast>InfernoCannon_Fire</soundCast>
@@ -686,7 +686,7 @@
 					</Properties>
 					<AmmoUser>
 						<magazineSize>3</magazineSize>
-						<reloadTime>9.8</reloadTime>
+						<reloadTime>4.8</reloadTime>
 						<ammoSet>AmmoSet_80x256mmFuel</ammoSet>
 					</AmmoUser>
 					<FireModes>

--- a/Royalty/Defs/ThingDefs_Buildings/Weapons_Turrets.xml
+++ b/Royalty/Defs/ThingDefs_Buildings/Weapons_Turrets.xml
@@ -104,18 +104,18 @@
 		</graphicData>
 		<statBases>
 			<Mass>200.00</Mass>
-			<RangedWeapon_Cooldown>2.5</RangedWeapon_Cooldown>
+			<RangedWeapon_Cooldown>2.52</RangedWeapon_Cooldown>
 			<SightsEfficiency>1</SightsEfficiency>
 			<ShotSpread>0.01</ShotSpread>
 			<SwayFactor>0.82</SwayFactor>
 		</statBases>
 		<verbs>
 			<li Class="CombatExtended.VerbPropertiesCE">
-				<recoilAmount>1.01</recoilAmount>
+				<recoilAmount>1.59</recoilAmount>
 				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 				<hasStandardCommand>true</hasStandardCommand>
 				<defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>
-				<warmupTime>3.5</warmupTime><!-- Intentionally decreased from 4.3s -->
+				<warmupTime>4.3</warmupTime>
 				<range>86</range>
 				<burstShotCount>1</burstShotCount>
 				<soundCast>InfernoCannon_Fire</soundCast>
@@ -128,7 +128,7 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_AmmoUser" Inherit="False">
 				<magazineSize>5</magazineSize>
-				<reloadTime>9.8</reloadTime>
+				<reloadTime>8.0</reloadTime>
 				<ammoSet>AmmoSet_80x256mmFuel</ammoSet>
 			</li>
 			<li Class="CombatExtended.CompProperties_FireModes">

--- a/Royalty/Patches/ThingDefs_Buildings/Buildings_Mechanoid.xml
+++ b/Royalty/Patches/ThingDefs_Buildings/Buildings_Mechanoid.xml
@@ -213,7 +213,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_AutoInferno"]/building/turretBurstCooldownTime</xpath>
 		<value>
-			<turretBurstCooldownTime>2.5</turretBurstCooldownTime><!-- Intentionally increased from 1.0s of CE auto turrets-->
+			<turretBurstCooldownTime>2.52</turretBurstCooldownTime><!-- Intentionally increased from 1.0s of CE auto turrets-->
 		</value>
 	</Operation>
 


### PR DESCRIPTION
## Changes

Same as #3029, my fork got borked and had to delete it.

- Increased the projectile and casing mass of the 80x256mm fuel cell ammo and also increased the filling amount from 0.5 to 1kg of incendiary agents.
- Make the appropriate changes to the inferno cannons to accommodate for the changes to the ammo.
- Decreased the reload time of the inferno cannon to a single shot weapon's 1.6s and reverted the warmup time to the accurate 4.3s.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070
- https://docs.google.com/spreadsheets/d/1lbT0zzagCRPDJG4GctkeeoTsFCt3lYfM4SRnWt8ql-k/edit#gid=1573763037

## Reasoning

- The cells were extremely light to the point that the projectile was 5/6th made up of filling contrary to conventional incendiary shells being a lot heavier with a much lower filler to shell mass ratio. Increased the projectile mass to 1.5kg to make the ammo have a more sensible total mass of not a measly 0.85kg for what it does for a cannon. The cell has been always light so I did not went too far in terms of the total mass.
- Increased the filling amount to 1kg to make it more consistent with other incendiary shells, it was slightly undertuned after being converted to an incendiary shell in #1686. It deals more direct damage now, both incendiary and thermobaric and also in a larger radius.
- Inferno cannons shoot decently quick for a cannon but the reload time is what makes them fall short in comparison to other heavy mech weapons, the reload time reduction means that they shoot more frequently. It does not make much sense that a weapon hooked to a mech without hands takes 10 seconds to reload like a conventional breach-loaded cannon, it's internally loaded.

## Alternatives

- Give the inferno cannon a 5 round magazine?

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
