### PR TITLE
Resolve armor value error for some clothing.

### DIFF
--- a/Biotech/Patches/ThingDefs_Misc/Apparel_BiotechHeadgear.xml
+++ b/Biotech/Patches/ThingDefs_Misc/Apparel_BiotechHeadgear.xml
@@ -130,6 +130,8 @@
 				<Bulk>3</Bulk>
 				<WornBulk>1</WornBulk>
 				<EquipDelay>0.5</EquipDelay>
+				<ArmorRating_Sharp>0.01</ArmorRating_Sharp> <!-- A little bit of armor to prevent triggering a warning when shot. -->
+				<ArmorRating_Blunt>0.01</ArmorRating_Blunt>						
 			</statBases>
 		</value>
 	</Operation>

--- a/Defs/ThingDefs_Misc/Apparel_Headgear.xml
+++ b/Defs/ThingDefs_Misc/Apparel_Headgear.xml
@@ -109,6 +109,8 @@
 			<Bulk>3</Bulk>
 			<WornBulk>1</WornBulk>
 			<EquipDelay>0.5</EquipDelay>
+			<ArmorRating_Sharp>0.01</ArmorRating_Sharp> <!-- A little bit of armor to prevent triggering a warning when shot. -->
+			<ArmorRating_Blunt>0.01</ArmorRating_Blunt>
 		</statBases>
 		<equippedStatOffsets>
 			<ToxicEnvironmentResistance>0.8</ToxicEnvironmentResistance>
@@ -174,6 +176,8 @@
 			<Bulk>3</Bulk>
 			<WornBulk>1</WornBulk>
 			<EquipDelay>1</EquipDelay>
+			<ArmorRating_Sharp>0.01</ArmorRating_Sharp> <!-- A little bit of armor to prevent triggering a warning when shot. -->
+			<ArmorRating_Blunt>0.01</ArmorRating_Blunt>			
 		</statBases>
 		<equippedStatOffsets>
 			<ToxicEnvironmentResistance>0.5</ToxicEnvironmentResistance>
@@ -239,6 +243,8 @@
 			<WornBulk>1</WornBulk>
 			<EquipDelay>0.5</EquipDelay>
 			<NightVisionEfficiency_Apparel>0.4</NightVisionEfficiency_Apparel>
+			<ArmorRating_Sharp>0.03</ArmorRating_Sharp>
+			<ArmorRating_Blunt>0.01</ArmorRating_Blunt>			
 		</statBases>
 		<apparel>
 			<countsAsClothingForNudity>false</countsAsClothingForNudity>
@@ -301,6 +307,8 @@
 			<WornBulk>1</WornBulk>
 			<EquipDelay>0.5</EquipDelay>
 			<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
+			<ArmorRating_Sharp>0.04</ArmorRating_Sharp> <!-- A little bit of armor to prevent triggering a warning when shot. -->
+			<ArmorRating_Blunt>0.01</ArmorRating_Blunt>			
 		</statBases>
 		<apparel>
 			<countsAsClothingForNudity>false</countsAsClothingForNudity>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -371,6 +371,7 @@ Opossum Friends |
 Orassans	|
 Ordo Tempestus - Tempestus Scions   |
 Outer Rim - Core	|
+Outer Rim - Droid Depot	|
 Outer Rim - Galactic Empire	|
 Outer Rim - Galactic Republic	|
 Outer Rim - Mandalore	|


### PR DESCRIPTION
## Additions
- Add a small amount of armor to a few pieces of apparel that don't otherwise have it.

## Changes
- Update SupportedModList with one that was forgotten.

## Reasoning
CE currently reports an error the first time apparel without any armor value is struck by a projectile (ErrorOnce). This error is harmless, but can be annoying/alarming for players seeing it. The easiest way to remedy it is simply to give the affects pieces of apparel a tiny amount of armor.

## Alternatives
- Could rework the error/warning message.
- Could ignore.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
