### PR TITLE
Fix airburst positioning

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_HeightFuse.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_HeightFuse.cs
@@ -54,7 +54,6 @@ namespace CombatExtended
         void HeightFuseAirBurst()
         {
             float f = (LastPos.y - detonationHeight) / (LastPos.y - ExactPosition.y);
-            ExactPosition = f * (LastPos - ExactPosition);
             ExactPosition += f * (LastPos - ExactPosition);
             if (!ExactPosition.ToIntVec3().IsValid)
             {


### PR DESCRIPTION
## Reasoning

The ExactPosition line should be relative.  In trying to fix it the first go around, I added the new line withotu committing the removal of the old line.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
