### PR TITLE
Revert "80mm fuel cells and inferno cannons readjusted and fixed (#3029 reopened)"

### DIFF
--- a/Defs/Ammo/Advanced/80x256mmFuelCell.xml
+++ b/Defs/Ammo/Advanced/80x256mmFuelCell.xml
@@ -24,7 +24,7 @@
 	<ThingDef Class="CombatExtended.AmmoDef" Name="80x256mmFuelBase" ParentName="SpacerMediumAmmoBase" Abstract="True">
 		<description>Large fuel container for incendiary shot cannons.</description>
 		<statBases>
-			<Mass>2.0</Mass>
+			<Mass>0.85</Mass>
 			<Bulk>3.87</Bulk>
 		</statBases>
 		<thingCategories>
@@ -45,14 +45,14 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>14.03</MarketValue><!-- value intentionally decreased to help reduce wealth bloat/free silver -->
+			<MarketValue>10.38</MarketValue><!-- value intentionally decreased to help reduce wealth bloat/free silver -->
 		</statBases>
 		<ammoClass>GrenadeIncendiary</ammoClass>
 		<detonateProjectile>Bullet_80x256mmFuel_Incendiary</detonateProjectile>
 		<comps>
 			<li Class="CompProperties_Explosive">
-				<explosiveRadius>2.0</explosiveRadius>
-				<damageAmountBase>7</damageAmountBase>
+				<explosiveRadius>1.9</explosiveRadius>
+				<damageAmountBase>5</damageAmountBase>
 				<explosiveDamageType>PrometheumFlame</explosiveDamageType>
 				<explosiveExpandPerStackcount>0.10</explosiveExpandPerStackcount>
 				<startWickHitPointsPercent>0.33</startWickHitPointsPercent>
@@ -75,10 +75,10 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>PrometheumFlame</damageDef>
-			<damageAmountBase>13</damageAmountBase>
+			<damageAmountBase>9</damageAmountBase>
 			<speed>73</speed>
 			<flyOverhead>false</flyOverhead>
-			<explosionRadius>7.5</explosionRadius>
+			<explosionRadius>5.9</explosionRadius>
 			<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
 			<preExplosionSpawnChance>0.5</preExplosionSpawnChance>
 			<soundExplode>MortarIncendiary_Explode</soundExplode>
@@ -95,9 +95,9 @@
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>200</damageAmountBase>
+				<damageAmountBase>150</damageAmountBase>
 				<explosiveDamageType>Thermobaric</explosiveDamageType>
-				<explosiveRadius>2.5</explosiveRadius>
+				<explosiveRadius>1.9</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 			</li>
 		</comps>
@@ -117,7 +117,7 @@
 						<li>Prometheum</li>
 					</thingDefs>
 				</filter>
-				<count>5</count>
+				<count>3</count>
 			</li>
 			<li>
 				<filter>
@@ -125,7 +125,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>22</count>
+				<count>10</count>
 			</li>
 			<li>
 				<filter>
@@ -149,7 +149,7 @@
 		<skillRequirements>
 			<Crafting>8</Crafting>
 		</skillRequirements>
-		<workAmount>5950</workAmount><!-- 10% more work -->
+		<workAmount>3730</workAmount><!-- 10% more work -->
 	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Generic/Mech.xml
+++ b/Defs/Ammo/Generic/Mech.xml
@@ -81,9 +81,9 @@
 	<ThingDef Class="CombatExtended.AmmoDef" Name="MechShellAmmo" ParentName="SpacerMediumAmmoBase" Abstract="True">
 		<description>Large shell used by mechanoid cannons and heavy weapons.</description>
 		<statBases>
-			<Mass>2.0</Mass>
+			<Mass>0.85</Mass>
 			<Bulk>3.87</Bulk>
-			<MarketValue>14.03</MarketValue>
+			<MarketValue>10.38</MarketValue>
 		</statBases>
 		<tradeTags>
 			<li>CE_AutoEnableTrade_Sellable</li>
@@ -106,8 +106,8 @@
 		<detonateProjectile>Bullet_80x256mmFuel_Incendiary</detonateProjectile>
 		<comps>
 			<li Class="CompProperties_Explosive">
-				<explosiveRadius>2.0</explosiveRadius>
-				<damageAmountBase>7</damageAmountBase>
+				<explosiveRadius>1.9</explosiveRadius>
+				<damageAmountBase>5</damageAmountBase>
 				<explosiveDamageType>PrometheumFlame</explosiveDamageType>
 				<explosiveExpandPerStackcount>0.10</explosiveExpandPerStackcount>
 				<startWickHitPointsPercent>0.33</startWickHitPointsPercent>
@@ -205,7 +205,7 @@
 						<li>Prometheum</li>
 					</thingDefs>
 				</filter>
-				<count>5</count>
+				<count>3</count>
 			</li>
 			<li>
 				<filter>
@@ -213,7 +213,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>22</count>
+				<count>10</count>
 			</li>
 			<li>
 				<filter>
@@ -237,7 +237,7 @@
 		<skillRequirements>
 			<Crafting>8</Crafting>
 		</skillRequirements>
-		<workAmount>5950</workAmount><!-- 10% more work -->
+		<workAmount>3730</workAmount><!-- 10% more work -->
 	</RecipeDef>
 
 	<RecipeDef ParentName="ChargeAmmoRecipeBase" MayRequire="Ludeon.RimWorld.Biotech">
@@ -252,7 +252,7 @@
 						<li>FSX</li>
 					</thingDefs>
 				</filter>
-				<count>5</count>
+				<count>3</count>
 			</li>
 			<li>
 				<filter>
@@ -260,7 +260,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>16</count>
+				<count>10</count>
 			</li>
 			<li>
 				<filter>
@@ -268,7 +268,7 @@
 						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
-				<count>4</count>
+				<count>2</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -284,7 +284,7 @@
 		<skillRequirements>
 			<Crafting>8</Crafting>
 		</skillRequirements>
-		<workAmount>6600</workAmount><!-- 10% more work -->
+		<workAmount>3730</workAmount><!-- 10% more work -->
 	</RecipeDef>
 
 </Defs>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -1228,18 +1228,18 @@
 		<defName>Gun_InfernoCannon</defName>
 		<statBases>
 			<Mass>50.00</Mass>
-			<RangedWeapon_Cooldown>2.59</RangedWeapon_Cooldown>
+			<RangedWeapon_Cooldown>2.54</RangedWeapon_Cooldown>
 			<SightsEfficiency>1</SightsEfficiency>
 			<ShotSpread>0.01</ShotSpread>
 			<SwayFactor>0.14</SwayFactor>
 			<Bulk>20.00</Bulk>
 		</statBases>
 		<Properties>
-			<recoilAmount>3.18</recoilAmount>
+			<recoilAmount>2.01</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>
-			<warmupTime>4.3</warmupTime>
+			<warmupTime>3.5</warmupTime> <!-- Intentionally decreased from 4.3s -->
 			<range>86</range>
 			<burstShotCount>1</burstShotCount>
 			<soundCast>InfernoCannon_Fire</soundCast>
@@ -1252,7 +1252,7 @@
 		<AmmoUser>
 			<magazineSize>1</magazineSize>
 			<AmmoGenPerMagOverride>2</AmmoGenPerMagOverride>
-			<reloadTime>1.6</reloadTime>
+			<reloadTime>9.8</reloadTime>
 			<ammoSet>AmmoSet_80x256mmFuel</ammoSet>
 		</AmmoUser>
 		<FireModes>

--- a/Patches/MechanoidsExtraordinaire/ThingDefs_Misc/Weapons_Guns_MechanoidsExtraordinaire.xml
+++ b/Patches/MechanoidsExtraordinaire/ThingDefs_Misc/Weapons_Guns_MechanoidsExtraordinaire.xml
@@ -10,18 +10,17 @@
 					<defName>Gun_InfernoCannonChimeraME</defName>
 					<statBases>
 						<Mass>300.00</Mass>
-						<RangedWeapon_Cooldown>2.52</RangedWeapon_Cooldown>
+						<RangedWeapon_Cooldown>2.53</RangedWeapon_Cooldown>
 						<SightsEfficiency>1</SightsEfficiency>
 						<ShotSpread>0.01</ShotSpread>
 						<SwayFactor>0.82</SwayFactor>
 						<Bulk>20.00</Bulk>
 					</statBases>
 					<Properties>
-						<recoilAmount>1.3</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>
-						<warmupTime>4.3</warmupTime>
+						<warmupTime>4.1</warmupTime>
 						<range>86</range>
 						<burstShotCount>1</burstShotCount>
 						<soundCast>InfernoCannon_Fire</soundCast>
@@ -31,7 +30,7 @@
 					<AmmoUser>
 						<magazineSize>1</magazineSize>
 						<AmmoGenPerMagOverride>2</AmmoGenPerMagOverride>
-						<reloadTime>1.6</reloadTime>
+						<reloadTime>9.8</reloadTime>
 						<ammoSet>AmmoSet_80x256mmFuel</ammoSet>
 					</AmmoUser>
 					<FireModes>

--- a/Patches/Reinforced Mechanoid 2/ThingDefs_Misc/RM_MechWeaponry.xml
+++ b/Patches/Reinforced Mechanoid 2/ThingDefs_Misc/RM_MechWeaponry.xml
@@ -81,7 +81,6 @@
 						<Bulk>18.00</Bulk>
 					</statBases>
 					<Properties>
-						<recoilAmount>3.18</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>
@@ -96,7 +95,7 @@
 					</Properties>
 					<AmmoUser>
 						<magazineSize>1</magazineSize>
-						<reloadTime>4.0</reloadTime>
+						<reloadTime>13.7</reloadTime>
 						<ammoSet>AmmoSet_80x256mmFuel</ammoSet>
 					</AmmoUser>
 					<FireModes>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/CombinationDefs/CombinationDefs.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/CombinationDefs/CombinationDefs.xml
@@ -609,8 +609,8 @@
 								<li>ComponentIndustrial</li>
 							</thirdItems>
 							<amount>
-								<li>22</li>
-								<li>5</li>
+								<li>10</li>
+								<li>3</li>
 								<li>2</li>
 							</amount>
 							<outputLimitControlled>true</outputLimitControlled>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Mech.xml
@@ -213,13 +213,13 @@
 					<defName>VFE_Gun_InfernoArtillery</defName>
 					<statBases>
 						<Mass>300.00</Mass>
-						<RangedWeapon_Cooldown>2.52</RangedWeapon_Cooldown>
+						<RangedWeapon_Cooldown>2.51</RangedWeapon_Cooldown>
 						<SightsEfficiency>1</SightsEfficiency>
 						<ShotSpread>0.01</ShotSpread>
 						<SwayFactor>0.82</SwayFactor>
 					</statBases>
 					<Properties>
-						<recoilAmount>1.3</recoilAmount>
+						<recoilAmount>0.82</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Security_Turrets.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Security_Turrets.xml
@@ -229,7 +229,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VFE_Turret_AutoInfernoCannon"]/building/turretBurstCooldownTime</xpath>
 					<value>
-						<turretBurstCooldownTime>2.59</turretBurstCooldownTime>
+						<turretBurstCooldownTime>2.5</turretBurstCooldownTime>
 					</value>
 				</li>
 
@@ -277,18 +277,18 @@
 					<defName>VFE_Gun_AutoInfernoCannon</defName>
 					<statBases>
 						<Mass>50.00</Mass>
-						<RangedWeapon_Cooldown>2.59</RangedWeapon_Cooldown>
+						<RangedWeapon_Cooldown>2.54</RangedWeapon_Cooldown>
 						<SightsEfficiency>1</SightsEfficiency>
 						<ShotSpread>0.01</ShotSpread>
 						<SwayFactor>0.14</SwayFactor>
 						<Bulk>20.00</Bulk>
 					</statBases>
 					<Properties>
-						<recoilAmount>3.18</recoilAmount>
+						<recoilAmount>2.01</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>
-						<warmupTime>4.3</warmupTime>
+						<warmupTime>3.5</warmupTime>
 						<range>86</range>
 						<burstShotCount>1</burstShotCount>
 						<soundCast>InfernoCannon_Fire</soundCast>
@@ -300,7 +300,7 @@
 					</Properties>
 					<AmmoUser>
 						<magazineSize>5</magazineSize>
-						<reloadTime>8.0</reloadTime>
+						<reloadTime>9.8</reloadTime>
 						<ammoSet>AmmoSet_80x256mmFuel</ammoSet>
 					</AmmoUser>
 					<FireModes>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
@@ -663,18 +663,18 @@
 					<defName>VFE_Gun_AdvancedInfernoCannon</defName>
 					<statBases>
 						<Mass>75.00</Mass>
-						<RangedWeapon_Cooldown>2.56</RangedWeapon_Cooldown>
+						<RangedWeapon_Cooldown>2.52</RangedWeapon_Cooldown>
 						<SightsEfficiency>1</SightsEfficiency>
 						<ShotSpread>0.01</ShotSpread>
 						<SwayFactor>0.21</SwayFactor>
 						<Bulk>20.00</Bulk>
 					</statBases>
 					<Properties>
-						<recoilAmount>2.60</recoilAmount>
+						<recoilAmount>1.90</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>
-						<warmupTime>4.0</warmupTime>
+						<warmupTime>3.0</warmupTime>
 						<range>86</range>
 						<burstShotCount>1</burstShotCount>
 						<soundCast>InfernoCannon_Fire</soundCast>
@@ -686,7 +686,7 @@
 					</Properties>
 					<AmmoUser>
 						<magazineSize>3</magazineSize>
-						<reloadTime>4.8</reloadTime>
+						<reloadTime>9.8</reloadTime>
 						<ammoSet>AmmoSet_80x256mmFuel</ammoSet>
 					</AmmoUser>
 					<FireModes>

--- a/Royalty/Defs/ThingDefs_Buildings/Weapons_Turrets.xml
+++ b/Royalty/Defs/ThingDefs_Buildings/Weapons_Turrets.xml
@@ -104,18 +104,18 @@
 		</graphicData>
 		<statBases>
 			<Mass>200.00</Mass>
-			<RangedWeapon_Cooldown>2.52</RangedWeapon_Cooldown>
+			<RangedWeapon_Cooldown>2.5</RangedWeapon_Cooldown>
 			<SightsEfficiency>1</SightsEfficiency>
 			<ShotSpread>0.01</ShotSpread>
 			<SwayFactor>0.82</SwayFactor>
 		</statBases>
 		<verbs>
 			<li Class="CombatExtended.VerbPropertiesCE">
-				<recoilAmount>1.59</recoilAmount>
+				<recoilAmount>1.01</recoilAmount>
 				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 				<hasStandardCommand>true</hasStandardCommand>
 				<defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>
-				<warmupTime>4.3</warmupTime>
+				<warmupTime>3.5</warmupTime><!-- Intentionally decreased from 4.3s -->
 				<range>86</range>
 				<burstShotCount>1</burstShotCount>
 				<soundCast>InfernoCannon_Fire</soundCast>
@@ -128,7 +128,7 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_AmmoUser" Inherit="False">
 				<magazineSize>5</magazineSize>
-				<reloadTime>8.0</reloadTime>
+				<reloadTime>9.8</reloadTime>
 				<ammoSet>AmmoSet_80x256mmFuel</ammoSet>
 			</li>
 			<li Class="CombatExtended.CompProperties_FireModes">

--- a/Royalty/Patches/ThingDefs_Buildings/Buildings_Mechanoid.xml
+++ b/Royalty/Patches/ThingDefs_Buildings/Buildings_Mechanoid.xml
@@ -213,7 +213,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_AutoInferno"]/building/turretBurstCooldownTime</xpath>
 		<value>
-			<turretBurstCooldownTime>2.52</turretBurstCooldownTime><!-- Intentionally increased from 1.0s of CE auto turrets-->
+			<turretBurstCooldownTime>2.5</turretBurstCooldownTime><!-- Intentionally increased from 1.0s of CE auto turrets-->
 		</value>
 	</Operation>
 


### PR DESCRIPTION
Reverts CombatExtended-Continued/CombatExtended#3057

Having this PR in `development` would create serious and difficult to resolve conflicts with `loadfolder-migration.`