### PR TITLE
Fix 'CE_Laser' ParentName Typo

### DIFF
--- a/Defs/DamageDefs/Damages_LocalInjury.xml
+++ b/Defs/DamageDefs/Damages_LocalInjury.xml
@@ -150,7 +150,7 @@
 		<hediff>Flashbanged</hediff>
 	</DamageDef>
 	
-  <DamageDef Name="Bullet">
+  <DamageDef ParentName="Bullet">
 		<defName>CE_Laser</defName>
 		<label>laser</label>
     <workerClass>DamageWorker_AddInjury</workerClass>

--- a/Defs/DamageDefs/Damages_LocalInjury.xml
+++ b/Defs/DamageDefs/Damages_LocalInjury.xml
@@ -153,21 +153,13 @@
   <DamageDef ParentName="Bullet">
 		<defName>CE_Laser</defName>
 		<label>laser</label>
-    <workerClass>DamageWorker_AddInjury</workerClass>
-    <externalViolence>true</externalViolence>
 		<deathMessage>{0} has been scorched to death.</deathMessage>
 		<hediff>BurnSecondary</hediff>
-    <harmAllLayersUntilOutside>true</harmAllLayersUntilOutside>
-    <hasForcefulImpact>false</hasForcefulImpact>
-    <impactSoundType>Bullet</impactSoundType>
-    <armorCategory>Sharp</armorCategory>
-    <overkillPctToDestroyPart>0~0.7</overkillPctToDestroyPart>
-    <isRanged>true</isRanged>
-    <makesAnimalsFlee>true</makesAnimalsFlee>
+    	<hasForcefulImpact>false</hasForcefulImpact>
 		<minDamageToFragment>99999</minDamageToFragment>
-    <defaultDamage>1</defaultDamage>
-    <defaultArmorPenetration>0</defaultArmorPenetration>
-		<buildingDamageFactor>0.100</buildingDamageFactor>
+    	<defaultDamage>1</defaultDamage>
+    	<defaultArmorPenetration>0</defaultArmorPenetration>
+		<buildingDamageFactor>0.1</buildingDamageFactor>
 		<plantDamageFactor>2</plantDamageFactor>
   </DamageDef>
 	


### PR DESCRIPTION
## Changes
- Fix an error with `CE_Laser` having a `Name` instead of a `ParentName`. 
- Trim out some excess lines that are already present in `Bullet` an so aren't needed.

## Reasoning
- It's a typo.

## Alternatives
Suffer.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
