### PR TITLE
Disable building compat libraries add ModPatches/

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,14 +26,14 @@ jobs:
       run: |
         TEMP=${{ runner.temp }}/ python Make.py --csproj Source/CombatExtended/CombatExtended.csproj --output Assemblies/CombatExtended.dll --download-libs --all-libs --publicizer $PWD/AssemblyPublicizer
         
-    - name: build compat
-      run: |
-        TEMP=${{ runner.temp }}/ python BuildCompat.py
+    #- name: build compat
+    #  run: |
+    #    TEMP=${{ runner.temp }}/ python BuildCompat.py
         
     - name: package
       run: |
         mkdir CombatExtended
-        cp -r Source/ Assemblies/ AssembliesCore/ AssembliesCompat/ About/ Defs/ Languages/ Patches/ Royalty/ Ideology/ Biotech/ Sounds/ Textures/ LoadFolders.xml README.md SupportedThirdPartyMods.md CombatExtended
+        cp -r Source/ Assemblies/ AssembliesCore/ AssembliesCompat/ About/ Defs/ Languages/ Patches/ Royalty/ Ideology/ Biotech/ Sounds/ Textures/ ModPatches/ LoadFolders.xml README.md SupportedThirdPartyMods.md CombatExtended
         zip -9 -r build.zip CombatExtended
     - name: Upload to DO
       run: |

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -39,14 +39,14 @@ jobs:
       run: |
         TEMP=${{ runner.temp }}/ python Make.py --csproj Source/CombatExtended/CombatExtended.csproj --output Assemblies/CombatExtended.dll --download-libs --all-libs --publicizer $PWD/AssemblyPublicizer
 
-    - name: build compat
-      run: |
-        TEMP=${{ runner.temp }}/ python BuildCompat.py
+    #- name: build compat
+    #  run: |
+    #    TEMP=${{ runner.temp }}/ python BuildCompat.py
         
     - name: package
       run: |
         mkdir CombatExtended
-        cp -r Source/ Assemblies/ AssembliesCompat/ AssembliesCore/ About/ Defs/ Languages/ Patches/ Royalty/ Ideology/ Biotech/ Sounds/ Textures/ LoadFolders.xml README.md SupportedThirdPartyMods.md CombatExtended
+        cp -r Source/ Assemblies/ AssembliesCompat/ AssembliesCore/ About/ Defs/ Languages/ Patches/ Royalty/ Ideology/ Biotech/ Sounds/ Textures/ ModPatches/ LoadFolders.xml README.md SupportedThirdPartyMods.md CombatExtended
         zip -9 -r build.zip CombatExtended
     - name: Upload to DO
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,13 +26,13 @@ jobs:
     - name: build core
       run: |
         TEMP=${{ runner.temp }}/ python Make.py --csproj Source/CombatExtended/CombatExtended.csproj --output Assemblies/CombatExtended.dll --download-libs --all-libs --publicizer $PWD/AssemblyPublicizer
-    - name: build compat
-      run: |
-        TEMP=${{ runner.temp }}/ python BuildCompat.py
+    #- name: build compat
+    #  run: |
+    #    TEMP=${{ runner.temp }}/ python BuildCompat.py
     - name: package
       run: |
         mkdir CombatExtended
-        cp -r Assemblies/ AssembliesCore/ AssembliesCompat/ About/ Defs/ Languages/ Patches/ Royalty/ Ideology/ Biotech/ Sounds/ Textures/ LoadFolders.xml README.md SupportedThirdPartyMods.md CombatExtended
+        cp -r Assemblies/ AssembliesCore/ AssembliesCompat/ About/ Defs/ Languages/ Patches/ Royalty/ Ideology/ Biotech/ Sounds/ Textures/ ModPatches/ LoadFolders.xml README.md SupportedThirdPartyMods.md CombatExtended
         zip -9 -r CombatExtended.zip CombatExtended
     - name: Upload Package
       id: upload-package

--- a/Source/BetterTurretsCompat/BetterTurretsCompat.csproj
+++ b/Source/BetterTurretsCompat/BetterTurretsCompat.csproj
@@ -54,7 +54,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Krafs.Rimworld.Ref" Version="1.4.3704" GeneratePathProperty="true" />
-		<PackageReference Include="Lib.Harmony" Version="2.2.2" ExcludeAssets="runtime" />
+		<PackageReference Include="Krafs.Rimworld.Ref" Version="1.5.4061" GeneratePathProperty="true" />
+		<PackageReference Include="Lib.Harmony" Version="2.3.3" ExcludeAssets="runtime" />
 	</ItemGroup>
 </Project>

--- a/Source/CombatExtended/CombatExtended.csproj
+++ b/Source/CombatExtended/CombatExtended.csproj
@@ -128,8 +128,8 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Krafs.Rimworld.Ref" Version="1.4.3704" GeneratePathProperty="true" />
-		<PackageReference Include="Lib.Harmony" Version="2.2.2" ExcludeAssets="runtime" />
+		<PackageReference Include="Krafs.Rimworld.Ref" Version="1.5.4061" GeneratePathProperty="true" />
+		<PackageReference Include="Lib.Harmony" Version="2.3.3" ExcludeAssets="runtime" />
 	</ItemGroup>
 	<ItemGroup>
 		<Publicize Include="Assembly-CSharp" />

--- a/Source/Loader/Loader.csproj
+++ b/Source/Loader/Loader.csproj
@@ -35,7 +35,7 @@
 		<Folder Include="Loader" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Krafs.Rimworld.Ref" Version="1.4.3555" GeneratePathProperty="true" />
-		<PackageReference Include="Lib.Harmony" Version="2.2.2" ExcludeAssets="runtime" />
+		<PackageReference Include="Krafs.Rimworld.Ref" Version="1.5.4061" GeneratePathProperty="true" />
+		<PackageReference Include="Lib.Harmony" Version="2.3.3" ExcludeAssets="runtime" />
 	</ItemGroup>
 </Project>

--- a/Source/MiscTurretsCompat/MiscTurretsCompat.csproj
+++ b/Source/MiscTurretsCompat/MiscTurretsCompat.csproj
@@ -54,7 +54,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Krafs.Rimworld.Ref" Version="1.4.3704" GeneratePathProperty="true" />
-		<PackageReference Include="Lib.Harmony" Version="2.2.2" ExcludeAssets="runtime" />
+		<PackageReference Include="Krafs.Rimworld.Ref" Version="1.5.4061" GeneratePathProperty="true" />
+		<PackageReference Include="Lib.Harmony" Version="2.3.3" ExcludeAssets="runtime" />
 	</ItemGroup>
 </Project>

--- a/Source/MultiplayerCompat/MultiplayerCompat.csproj
+++ b/Source/MultiplayerCompat/MultiplayerCompat.csproj
@@ -46,8 +46,8 @@
 		</ProjectReference>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Krafs.Rimworld.Ref" Version="1.4.3704" GeneratePathProperty="true" />
-		<PackageReference Include="Lib.Harmony" Version="2.2.2" ExcludeAssets="runtime" />
+		<PackageReference Include="Krafs.Rimworld.Ref" Version="1.5.4061" GeneratePathProperty="true" />
+		<PackageReference Include="Lib.Harmony" Version="2.3.3" ExcludeAssets="runtime" />
 		<PackageReference Include="RimWorld.MultiplayerAPI" Version="0.4.0" />
 	</ItemGroup>
 </Project>

--- a/Source/SRTSCompat/SRTSCompat.csproj
+++ b/Source/SRTSCompat/SRTSCompat.csproj
@@ -52,7 +52,7 @@
 	  </Reference>
 	</ItemGroup>
 	<ItemGroup>
-          <PackageReference Include="Krafs.Rimworld.Ref" Version="1.4.3704" GeneratePathProperty="true" />
-          <PackageReference Include="Lib.Harmony" Version="2.2.2" ExcludeAssets="runtime" />
+          <PackageReference Include="Krafs.Rimworld.Ref" Version="1.5.4061" GeneratePathProperty="true" />
+          <PackageReference Include="Lib.Harmony" Version="2.3.3" ExcludeAssets="runtime" />
 	</ItemGroup>
 </Project>

--- a/Source/VehiclesCompat/VehiclesCompat.csproj
+++ b/Source/VehiclesCompat/VehiclesCompat.csproj
@@ -61,8 +61,8 @@
 			  <PrivateAssets>all</PrivateAssets>
 			  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
           </PackageReference>
-          <PackageReference Include="Krafs.Rimworld.Ref" Version="1.4.3704" GeneratePathProperty="true" />
-          <PackageReference Include="Lib.Harmony" Version="2.2.2" ExcludeAssets="runtime" />
+          <PackageReference Include="Krafs.Rimworld.Ref" Version="1.5.4061" GeneratePathProperty="true" />
+          <PackageReference Include="Lib.Harmony" Version="2.3.3" ExcludeAssets="runtime" />
 	</ItemGroup>
 	<ItemGroup>
 		<Publicize Include="Assembly-CSharp" />


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Compatibility patches can't currently build against 1.5, so are disabled
- Mod compatibility uses LoadFolders.xml + ModPatches/ so include them in the zip file

