### PR TITLE
Minor Patch Fixes

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -27,7 +27,7 @@
 		<li IfModActive="aa.warcaskets.rw">ModPatches/Ancient Arsenal Warcaskets</li>
 		<li IfModActive="bbbbilly.ancientbladecyborg">ModPatches/Ancient Blade Cyborg</li>
 		<li IfModActive="zal.easternarmory">ModPatches/Ancient Eastern Armory</li>
-		<li IfModActive="Fallout.Armory.Geminingen">ModPatches/Ancient Fallout Armory</li>
+		<li IfModActive="biowreck.ancientfalloutarmory">ModPatches/Ancient Fallout Armory</li>
 		<li IfModActive="bbbbilly.ancienthuman">ModPatches/Ancient Human</li>
 		<li IfModActive="Mlie.AndroidTiersTXSeries">ModPatches/Android Tiers - TX Series</li>
 		<li IfModActive="Killathon.AndroidTiersReforged">ModPatches/Android Tiers Reforged</li>

--- a/ModPatches/Revia Race — biotech/Defs/Revia Race — biotech/Recipes_Revia.xml
+++ b/ModPatches/Revia Race — biotech/Defs/Revia Race — biotech/Recipes_Revia.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
 


### PR DESCRIPTION
## Changes
- Delete leading whitespace in Revia patch that's causing a parse error.
- Change Ancient Armory - Fallout packageID from 1.3 to updated version.

## Reasoning
- It just works.

## Alternatives
- It just doesn't work.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
