### PR TITLE
Add CE patches for ghoul and shambler weapon

### DIFF
--- a/Anomaly/Patches/Misc/Mutants.xml
+++ b/Anomaly/Patches/Misc/Mutants.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+  <!-- ========== Shambler ========== -->
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/MutantDef[defName="Shambler"]/tools</xpath>
+    <value>
+      <tools>
+        <li Class="CombatExtended.ToolCE">
+          <label>teeth</label>
+          <capacities>
+            <li>Bite</li>
+          </capacities>
+          <power>8.2</power>
+          <cooldownTime>2</cooldownTime>
+          <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+          <chanceFactor>1</chanceFactor>
+          <soundMeleeHit>Pawn_Melee_HumanBite_Hit</soundMeleeHit>
+          <soundMeleeMiss>Pawn_Melee_HumanBite_Miss</soundMeleeMiss>
+          <armorPenetrationSharp>0.15</armorPenetrationSharp>
+          <armorPenetrationBlunt>1.0</armorPenetrationBlunt>
+        </li>
+        <li Class="CombatExtended.ToolCE">
+          <label>left hand</label>
+          <capacities>
+            <li>Scratch</li>
+          </capacities>
+          <power>7</power>
+          <cooldownTime>2</cooldownTime>
+          <linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+          <chanceFactor>1.5</chanceFactor>
+          <armorPenetrationBlunt>1.2</armorPenetrationBlunt>
+          <armorPenetrationSharp>0.6</armorPenetrationSharp>
+          <alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+        </li>
+        <li Class="CombatExtended.ToolCE">
+          <label>right hand</label>
+          <capacities>
+            <li>Scratch</li>
+          </capacities>
+          <power>7</power>
+          <cooldownTime>2</cooldownTime>
+          <linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+          <chanceFactor>1.5</chanceFactor>
+          <armorPenetrationBlunt>1.2</armorPenetrationBlunt>
+          <armorPenetrationSharp>0.6</armorPenetrationSharp>
+          <alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+        </li>
+      </tools>
+    </value>
+  </Operation>
+
+  <!-- ========== Ghoul ========== -->
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/MutantDef[defName="Ghoul"]/tools</xpath>
+    <value>
+      <tools>
+        <li Class="CombatExtended.ToolCE">
+          <label>teeth</label>
+          <capacities>
+            <li>Bite</li>
+          </capacities>
+          <power>8.2</power>
+          <cooldownTime>2</cooldownTime>
+          <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+          <chanceFactor>0.5</chanceFactor>
+          <soundMeleeHit>Pawn_Melee_HumanBite_Hit</soundMeleeHit>
+          <soundMeleeMiss>Pawn_Melee_HumanBite_Miss</soundMeleeMiss>
+          <armorPenetrationSharp>0.15</armorPenetrationSharp>
+          <armorPenetrationBlunt>1.0</armorPenetrationBlunt>
+        </li>
+        <li Class="CombatExtended.ToolCE">
+          <label>left claw</label>
+          <capacities>
+            <li>Scratch</li>
+          </capacities>
+          <power>7</power>
+          <cooldownTime>2</cooldownTime>
+          <linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+          <chanceFactor>1.5</chanceFactor>
+          <armorPenetrationBlunt>1.2</armorPenetrationBlunt>
+          <armorPenetrationSharp>0.6</armorPenetrationSharp>
+          <alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+          <soundMeleeHit>Pawn_Ghoul_Scratch</soundMeleeHit>
+          <soundMeleeMiss>Pawn_Melee_SmallScratch_Miss</soundMeleeMiss>
+        </li>
+        <li Class="CombatExtended.ToolCE">
+          <label>right claw</label>
+          <capacities>
+            <li>Scratch</li>
+          </capacities>
+          <power>7</power>
+          <cooldownTime>2</cooldownTime>
+          <linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+          <chanceFactor>1.5</chanceFactor>
+          <armorPenetrationBlunt>1.2</armorPenetrationBlunt>
+          <armorPenetrationSharp>0.6</armorPenetrationSharp>
+          <alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+          <soundMeleeHit>Pawn_Ghoul_Scratch</soundMeleeHit>
+          <soundMeleeMiss>Pawn_Melee_SmallScratch_Miss</soundMeleeMiss>
+        </li>
+      </tools>
+    </value>
+  </Operation>
+
+</Patch>


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Patch the melee weapon attacks for Anomaly's Ghouls and Shamblers

While playtesting Anomaly, having my starting ghoul melee and land an attack would give this error:
```
Exception in JobDriver tick for pawn Speedy driver=JobDriver_AttackMelee (toilIndex=2) driver.job=(AttackMelee (Job_3735) A = Thing_Hare49152 Giver = ThinkNode_QueuedJob [workGiverDef: null])
System.NullReferenceException: Object reference not set to an instance of an object
[Ref 23AC53EF]
 at CombatExtended.Verb_MeleeAttackCE+<DamageInfosToApply>d__33.MoveNext () [0x00627] in <114f8ba2cb5445278852f48ffa8a3138>:0 
 at CombatExtended.Verb_MeleeAttackCE.ApplyMeleeDamageToTarget (Verse.LocalTargetInfo target) [0x0007d] in <114f8ba2cb5445278852f48ffa8a3138>:0 
 at CombatExtended.Verb_MeleeAttackCE.TryCastShot () [0x00485] in <114f8ba2cb5445278852f48ffa8a3138>:0 
 at Verse.Verb.TryCastNextBurstShot () [0x00012] in <869ae09cd42e4958ad76d610931cb571>:0 
     - TRANSPILER CombatExtended.HarmonyCE: IEnumerable`1 CombatExtended.HarmonyCE.Harmony_Verb_TryCastNextBurstShot:Transpiler(IEnumerable`1 instructions, ILGenerator generator)
 at Verse.Verb.WarmupComplete () [0x00013] in <869ae09cd42e4958ad76d610931cb571>:0 
 at CombatExtended.Verb_MeleeAttackCE.WarmupComplete () [0x00008] in <114f8ba2cb5445278852f48ffa8a3138>:0 
 at Verse.Verb.TryStartCastOn (Verse.LocalTargetInfo castTarg, Verse.LocalTargetInfo destTarg, System.Boolean surpriseAttack, System.Boolean canHitNonTargetPawns, System.Boolean preventFriendlyFire, System.Boolean nonInterruptingSelfCast) [0x001e7] in <869ae09cd42e4958ad76d610931cb571>:0 
     - TRANSPILER CombatExtended.HarmonyCE: IEnumerable`1 CombatExtended.HarmonyCE.Harmony_Verb_TryStartCastOn:Transpiler(IEnumerable`1 instructions, ILGenerator generator)
     - PREFIX com.ogliss.rimworld.mod.VanillaWeaponsExpandedLaser: Void VanillaWeaponsExpandedLaser.HarmonyPatches.VWEL_Verb_Shoot_TryStartCastOn_RapidFire_Patch:TryStartCastOn_RapidFire_Prefix(Verb& __instance, LocalTargetInfo castTarg)
     - POSTFIX com.ogliss.rimworld.mod.VanillaWeaponsExpandedLaser: Void VanillaWeaponsExpandedLaser.HarmonyPatches.VWEL_Verb_Shoot_TryStartCastOn_RapidFire_Patch:TryStartCastOn_RapidFire_Postfix(Verb& __instance, LocalTargetInfo castTarg, Single __state)
 at Verse.Verb.TryStartCastOn (Verse.LocalTargetInfo castTarg, System.Boolean surpriseAttack, System.Boolean canHitNonTargetPawns, System.Boolean preventFriendlyFire, System.Boolean nonInterruptingSelfCast) [0x00007] in <869ae09cd42e4958ad76d610931cb571>:0 
 at RimWorld.Pawn_MeleeVerbs.TryMeleeAttack (Verse.Thing target, Verse.Verb verbToUse, System.Boolean surpriseAttack) [0x0009f] in <869ae09cd42e4958ad76d610931cb571>:0 
 at Verse.AI.JobDriver_AttackMelee.<MakeNewToils>b__4_2 () [0x0003d] in <869ae09cd42e4958ad76d610931cb571>:0 
 at Verse.AI.Toils_Combat+<>c__DisplayClass6_0.<FollowAndMeleeAttack>b__0 () [0x000e9] in <869ae09cd42e4958ad76d610931cb571>:0 
 at Verse.AI.JobDriver.DriverTick () [0x00163] in <869ae09cd42e4958ad76d610931cb571>:0  
(Filename: ./Runtime/Export/Debug/Debug.bindings.h Line: 39)
```

So adding the CE patches / tags for the `Anomaly/Defs/Misc/Mutants.xml` fixes this issue.

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Create `Anomaly/Patches/Misc/Mutants.xml` with CE patches

## References

Links to the associated issues or other related pull requests, e.g.
- Closes: N/A
- Contributes towards [#[3024]](https://github.com/CombatExtended-Continued/CombatExtended/issues/3024)

## Reasoning

Why did you choose to implement things this way, e.g.
- I looked at what the `Anomaly/Patches/ThingDefs_Races/Races_Entities_Misc.xml` is already doing in terms of patching the "tools" for the new entities.
- I just copied the damage values from the vanilla game
- the base game's `Mutants.xml` also has "AwokenCorpse" defined, but it doesn't define any new tools so i didn't add anything for that

## Alternatives

Describe alternative implementations you have considered, e.g.
- idk

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [X] (For compatibility patches) ...with and without patched mod loaded
  - testing with only Harmony and CE (and dlc's)
- [X] Playtested a colony (specify how long)
  - A few min from the dev quickstart
  - Loading an existing save and checking that the melee error is gone
