### PR TITLE
Incorrect projectile draw position fix

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -198,7 +198,7 @@ namespace CombatExtended
         {
             get
             {
-                return ExactPosition + new Vector3(0, 0, ExactPosition.y - shotHeight);
+                return ExactPosition + new Vector3(0, 0, Height);
             }
         }
 
@@ -1206,16 +1206,12 @@ namespace CombatExtended
             }
             else
             {
-                //Projectile
-                //Graphics.DrawMesh(MeshPool.plane10, DrawPos, DrawRotation, def.DrawMatSingle, 0);
-                Graphics.DrawMesh(MeshPool.GridPlane(def.graphicData.drawSize), DrawPos, DrawRotation, def.DrawMatSingle, 0);
-
                 //Shadow
                 if (castShadow)
                 {
                     //TODO : EXPERIMENTAL Add edifice height
                     var shadowPos = new Vector3(ExactPosition.x,
-                                                0,
+                                                -0.5f,
                                                 ExactPosition.z);
                     //EXPERIMENTAL: + (new CollisionVertical(ExactPosition.ToIntVec3().GetEdifice(Map))).Max);
 
@@ -1223,6 +1219,10 @@ namespace CombatExtended
                     //Graphics.DrawMesh(MeshPool.plane08, shadowPos, ExactRotation, ShadowMaterial, 0);
                     Graphics.DrawMesh(MeshPool.GridPlane(def.graphicData.drawSize), shadowPos, ExactRotation, ShadowMaterial, 0);
                 }
+
+                //Projectile
+                //Graphics.DrawMesh(MeshPool.plane10, DrawPos, DrawRotation, def.DrawMatSingle, 0);
+                Graphics.DrawMesh(MeshPool.GridPlane(def.graphicData.drawSize), DrawPos, DrawRotation, def.DrawMatSingle, 0);
 
                 Comps_PostDraw();
             }


### PR DESCRIPTION
## Changes

- Fixed draw positions. Easily to see at landed grenade.
Before
![image](https://github.com/CombatExtended-Continued/CombatExtended/assets/78953324/8e159da9-2c1e-44c1-ae35-3eed4c1bb21a)
after
![image](https://github.com/CombatExtended-Continued/CombatExtended/assets/78953324/56ff89b6-4f7e-424d-9b47-96af169478b0)

## Reasoning

- Projectile draw position really different to ExactPosition
- Shadow of landed grenade is far away from it

## Resolves
#3074 

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (threw few grenades)
