### PR TITLE
Verb_LaunchProjectileStaticOneUse and tactical turret patch

### DIFF
--- a/Anomaly/Patches/ThingDefs_Buildings/Buildings_Misc.xml
+++ b/Anomaly/Patches/ThingDefs_Buildings/Buildings_Misc.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- ========== Mini-turret ========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Turret_TacticalTurret"]/description</xpath>
+		<value>
+			<description>A portable automatic turret. Its dumb AI brain can't be directly controlled, so beware of friendly fire.</description>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Turret_TacticalTurret"]/thingClass</xpath>
+		<value>
+			<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Turret_TacticalTurret"]/statBases</xpath>
+		<value>
+			<AimingAccuracy>0.25</AimingAccuracy>
+		</value>
+	</Operation>
+
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Turret_TacticalTurret"]/statBases/ShootingAccuracyTurret</xpath>
+		<value>
+			<ShootingAccuracyTurret>0.5</ShootingAccuracyTurret>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Turret_TacticalTurret"]/statBases/Mass</xpath>
+		<value>
+			<Mass>25</Mass>
+			<Bulk>15</Bulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Turret_TacticalTurret"]/comps/li[@Class="CompProperties_Explosive"]</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Turret_TacticalTurret"]/fillPercent</xpath>
+		<value>
+			<fillPercent>0.85</fillPercent>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Turret_TacticalTurret"]/building/turretBurstCooldownTime</xpath>
+		<value>
+			<turretBurstCooldownTime>1.0</turretBurstCooldownTime>
+		</value>
+	</Operation>
+
+	<!-- Add trade tags -->
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="Turret_TacticalTurret"]/tradeTags</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Turret_TacticalTurret"]</xpath>
+			<value>
+				<tradeTags />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Turret_TacticalTurret"]/tradeTags</xpath>
+		<value>
+			<li>CE_Turret</li>
+		</value>
+	</Operation>
+
+
+</Patch>

--- a/Anomaly/Patches/ThingDefs_Buildings/Buildings_Misc.xml
+++ b/Anomaly/Patches/ThingDefs_Buildings/Buildings_Misc.xml
@@ -24,7 +24,6 @@
 		</value>
 	</Operation>
 
-
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_TacticalTurret"]/statBases/ShootingAccuracyTurret</xpath>
 		<value>
@@ -76,6 +75,5 @@
 			<li>CE_Turret</li>
 		</value>
 	</Operation>
-
 
 </Patch>

--- a/Anomaly/Patches/ThingDefs_Misc/Apparel_Packs.xml
+++ b/Anomaly/Patches/ThingDefs_Misc/Apparel_Packs.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 
+  <!--DisruptorFlarePack-->
   <!--Apparel-->
   
 	<Operation Class="PatchOperationReplace">
@@ -63,4 +64,34 @@
     </value>
   </Operation>
 
+
+  <!--PackTurret-->
+  <!--Apparel-->
+  <Operation Class="PatchOperationAttributeSet">
+    <xpath>Defs/ThingDef[defName="Apparel_PackTurret"]/verbs/li[label="deploy turret"]</xpath>
+    <attribute>Class</attribute>
+    <value>CombatExtended.VerbPropertiesCE</value>
+  </Operation>
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Apparel_PackTurret"]/verbs/li[label="deploy turret"]/verbClass</xpath>
+    <value>
+      <verbClass>CombatExtended.Verb_ShootCEOneUseStatic</verbClass>
+    </value>
+  </Operation>
+
+  <!--Projectile-->
+
+  <Operation Class="PatchOperationAttributeSet">
+    <xpath>Defs/ThingDef[defName="Grenade_TurretPack"]/projectile</xpath>
+    <attribute>Class</attribute>
+    <value>CombatExtended.ProjectilePropertiesCE</value>
+  </Operation>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Grenade_TurretPack"]/thingClass</xpath>
+    <value>
+      <thingClass>CombatExtended.ProjectileCE_SpawnsThing</thingClass>
+    </value>
+  </Operation>
+  
 </Patch>

--- a/Anomaly/Patches/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Anomaly/Patches/ThingDefs_Misc/Weapons_Guns.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- ========== Tactical turret gun ========== -->
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Gun_TacticalTurret</defName>
+		<statBases>
+			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+			<SightsEfficiency>1</SightsEfficiency>
+			<ShotSpread>0.07</ShotSpread>
+			<SwayFactor>0.69</SwayFactor>
+		</statBases>
+		<Properties>
+			<recoilAmount>0.91</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+			<warmupTime>1.3</warmupTime>
+			<range>20</range>
+			<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+			<burstShotCount>10</burstShotCount>
+			<soundCast>GunShotA</soundCast>
+			<soundCastTail>GunTail_Light</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+			<recoilPattern>Mounted</recoilPattern>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>60</magazineSize>
+			<reloadTime>7.8</reloadTime>
+			<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aiAimMode>AimedShot</aiAimMode>
+			<noSnapshot>true</noSnapshot>
+			<noSingleShot>true</noSingleShot>
+		</FireModes>
+	</Operation>
+
+</Patch>

--- a/Anomaly/Patches/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Anomaly/Patches/ThingDefs_Misc/Weapons_Guns.xml
@@ -8,16 +8,16 @@
 		<statBases>
 			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 			<SightsEfficiency>1</SightsEfficiency>
-			<ShotSpread>0.07</ShotSpread>
-			<SwayFactor>0.69</SwayFactor>
+			<ShotSpread>0.11</ShotSpread>
+			<SwayFactor>0.63</SwayFactor>
 		</statBases>
 		<Properties>
-			<recoilAmount>0.91</recoilAmount>
+			<recoilAmount>1.35</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
 			<warmupTime>1.3</warmupTime>
-			<range>20</range>
+			<range>40</range>
 			<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
 			<burstShotCount>10</burstShotCount>
 			<soundCast>GunShotA</soundCast>

--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -7,6 +7,7 @@
 		<li IfModActive="Ludeon.Rimworld.Royalty">Royalty</li>
 		<li IfModActive="Ludeon.Rimworld.Ideology">Ideology</li>
 		<li IfModActive="Ludeon.Rimworld.Biotech">Biotech</li>
+		<li IfModActive="Ludeon.Rimworld.Anomaly">Anomaly</li>
 		<!-- Mod Patches -->
 		<li IfModActive="Torann.ARimworldOfMagic">ModPatches/A Rimworld of Magic</li>
 		<li IfModActive="ADE.AdvancedTurrets.Mod">ModPatches/ADE Advanced Turrets</li>

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -1364,7 +1364,7 @@ namespace CombatExtended
             }
 
             //If the comp exists, it'll already call CompFragments
-            if (explodingComp != null || def.projectile.explosionRadius > 0f)
+            if (explodingComp != null || (def.projectile.explosionRadius > 0f && def.projectile.damageDef != null))
             {
                 float explosionSuppressionRadius = SuppressionRadius + (def.projectile.applyDamageToExplosionCellsNeighbors ? 1.5f : 0f);
                 //Handle anything explosive

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCEOneUseStatic.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCEOneUseStatic.cs
@@ -1,0 +1,21 @@
+﻿using RimWorld;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Verse;
+using Verse.AI;
+
+namespace CombatExtended
+{
+    public class Verb_ShootCEOneUseStatic : Verb_ShootCEOneUse
+    {
+        public override void OrderForceTarget(LocalTargetInfo target)
+        {
+            Job job = JobMaker.MakeJob(JobDefOf.UseVerbOnThingStaticReserve, target);
+            job.verbToUse = this;
+            this.CasterPawn.jobs.TryTakeOrderedJob(job, new JobTag?(JobTag.Misc), false);
+        }
+    }
+}


### PR DESCRIPTION
## Additions

- Verb_ShootCEOneUseStatic for tactilal turret pack
- Patch for tactical turret (mostly copied from default turret, except range and mag size)

## Changes

- Disabled explosion code if there's no damage def

## Reasoning

- Disabled explosions without damageDef cuz Tynan use explosionRadius to show turret range

## Note

Add Anomaly folder to LoadFolder.xml before test
Also it's better test with #3097 

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
