### PR TITLE
VFE- Pirate crypto cannon damage fix.

### DIFF
--- a/ModPatches/Vanilla Factions Expanded - Pirates/Defs/Vanilla Factions Expanded - Pirates/Ammo/DamageDefs.xml
+++ b/ModPatches/Vanilla Factions Expanded - Pirates/Defs/Vanilla Factions Expanded - Pirates/Ammo/DamageDefs.xml
@@ -1,16 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
 
-	<!--
-	While these Defs are only used conditionally with other mods active,
-	they don't actually do anything by themselves, so there's no harm loading them.
-	 -->
+	<!-- While these Defs are only used conditionally with other mods active, they don't actually do anything by themselves, so there's no harm loading them. -->
 
-	<DamageDef ParentName="Bullet">
+	<DamageDef ParentName="Frostbite">
 		<defName>CE_Cryptofuel</defName>
 		<label>Crypto Burn</label>
 		<hediff>Frostbite</hediff>
 		<workerClass>DamageWorker_AddInjury</workerClass>
+		<additionalHediffs>
+			<li>
+				<hediff>Hypothermia</hediff>
+				<severityPerDamageDealt>0.01</severityPerDamageDealt>
+			</li>
+		</additionalHediffs>
 		<hasForcefulImpact>true</hasForcefulImpact>
 		<makesBlood>false</makesBlood>
 		<canInterruptJobs>true</canInterruptJobs>
@@ -18,7 +21,7 @@
 		<deathMessage>{0} has been frozen to death.</deathMessage>
 		<armorCategory>Heat</armorCategory>
 		<minDamageToFragment>15</minDamageToFragment>
-		<defaultArmorPenetration>0</defaultArmorPenetration>
+		<defaultArmorPenetration>0.5</defaultArmorPenetration>
 		<explosionHeatEnergyPerCell>-20</explosionHeatEnergyPerCell>
 		<soundExplosion>Explosion_Stun</soundExplosion>
 		<combatLogRules>Damage_Flame</combatLogRules>
@@ -26,5 +29,5 @@
 		<explosionColorCenter>(0,1,1,1)</explosionColorCenter>
 		<explosionColorEdge>(0,0.70,1,1)</explosionColorEdge>
 	</DamageDef>
-	
+
 </Defs>


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
Fix crypto cannon's damage not applying hypothermia and changed parent def to Frostbite.

## Changes

Describe adjustments to existing features made in this merge, e.g.

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
