### PR TITLE
Cherry pick draw fixes from 1.4 backports

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompFragments.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompFragments.cs
@@ -30,6 +30,10 @@ namespace CombatExtended
 
         public static IEnumerator FragRoutine(Vector3 pos, Map map, float height, Thing instigator, ThingDefCountClass frag, float fragSpeedFactor, float fragShadowChance, FloatRange fragAngleRange, FloatRange fragXZAngleRange, float minCollisionDistance = 0f, bool canTargetSelf = true)
         {
+            if (height < 0.001f)
+            {
+                height = 0.001f;
+            }
             var cell = pos.ToIntVec3();
             var exactOrigin = new Vector2(pos.x, pos.z);
 

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -1225,12 +1225,8 @@ namespace CombatExtended
                 {
                     //TODO : EXPERIMENTAL Add edifice height
                     var shadowPos = new Vector3(ExactPosition.x,
-<<<<<<< HEAD
-                                                0,
-=======
                                                 def.Altitude - 0.001f,
->>>>>>> d452ab850 (Use a 40 degree projection for projectile drawing)
-                                                ExactPosition.z);
+                                                ExactPosition.z - Mathf.Max(0f, ExactPosition.y));
                     //EXPERIMENTAL: + (new CollisionVertical(ExactPosition.ToIntVec3().GetEdifice(Map))).Max);
 
                     //TODO : Vary ShadowMat plane

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -198,7 +198,8 @@ namespace CombatExtended
         {
             get
             {
-                return ExactPosition + new Vector3(0, 0, ExactPosition.y - shotHeight);
+                var sh = Mathf.Max(0f, (ExactPosition.y) * 0.84f);
+                return new Vector3(ExactPosition.x, def.Altitude, ExactPosition.z + sh);
             }
         }
 
@@ -1224,7 +1225,11 @@ namespace CombatExtended
                 {
                     //TODO : EXPERIMENTAL Add edifice height
                     var shadowPos = new Vector3(ExactPosition.x,
+<<<<<<< HEAD
                                                 0,
+=======
+                                                def.Altitude - 0.001f,
+>>>>>>> d452ab850 (Use a 40 degree projection for projectile drawing)
                                                 ExactPosition.z);
                     //EXPERIMENTAL: + (new CollisionVertical(ExactPosition.ToIntVec3().GetEdifice(Map))).Max);
 


### PR DESCRIPTION
## Changes

The shadow and draw position fixes from the 1.4 branch need to be applied to Dev

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #3096 
- Based on #3052 

## Reasoning
Rim World uses a pseudo 3d rendering space.  The y-coord only affects draw order, which determines what renders last (and what shows when things collide).  So all the rendering calls need to provide a y-height that matches the relative rendering order specified by `def.Altitude`.  (This is related to zIndex in css/html land, but RW uses the Y-axis).  For shadows, we want them to render above nearly everything else, at least above everything the projectile renders above, but *below* the projectile itself.  So we set the y-index on the projectile render call to the same as the y-order of the projectile, minus a small adjustment.  

We then emulate the virtual height by adjusting the z location of the drawing, currently based on the camera being 40 degrees off the vertical.  *No* value is correct for this, so this is a compromise between the perspectives on different things (pawns facing left/right vs up/down, doors, et cetera).  If we want to sell this illusion better, we would need to rescale the projectile draw size based on height relative to our fictitious camera.

## Alternatives

We assume the light is directly above the projectile, so the shadow's x/z position is exactly correct.  We could add a mod option to use the same code as the tree shadows use to adjust the projectile shadow, and again we could sell the illusion better by scaling and fuzzing the shadow with height.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
