### PR TITLE
Fix NRE when selecting Corpse

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompMeleeTargettingGizmo.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompMeleeTargettingGizmo.cs
@@ -171,7 +171,8 @@ namespace CombatExtended
         public override IEnumerable<Gizmo> CompGetGizmosExtra()
         {
             // Don't let people control melee targeting for non-colonist pawns or colonists in a mental state
-            if (!PawnParent.IsColonist || PawnParent.InAggroMentalState)
+            // Corpses are also auto-assigned this comp, but clearly they are not typeof(Pawn)
+            if (parent is Corpse || !PawnParent.IsColonist || PawnParent.InAggroMentalState)
             {
                 yield break;
             }


### PR DESCRIPTION
## Changes

Fix NRE when selecting Corpse

```
System.InvalidCastException: Specified cast is not valid.
[Ref B0D7E200]
 at CombatExtended.CompMeleeTargettingGizmo+<CompGetGizmosExtra>d__14.MoveNext () [0x00029] in <132a6d48a02a4daca8de5c85a98fad9a>:0 
 at Verse.ThingWithComps+<GetGizmos>d__35.MoveNext () [0x000f3] in <957a20e0be784a65bc32cf449445b937>:0 
 at Verse.Corpse+<GetGizmos>d__55.MoveNext () [0x0007a] in <957a20e0be784a65bc32cf449445b937>:0 
 at System.Collections.Generic.List`1[T]..ctor (System.Collections.Generic.IEnumerable`1[T] collection) [0x00077] in <eae584ce26bc40229c1b1aa476bfa589>:0 
 at System.Linq.Enumerable.ToList[TSource] (System.Collections.Generic.IEnumerable`1[T] source) [0x00018] in <351e49e2a5bf4fd6beabb458ce2255f3>:0 
 at PerformanceOptimizer.Optimization_InspectGizmoGrid_DrawInspectGizmoGridFor.GetGizmosFast (Verse.ISelectable selectable) [0x00015] in <5e8f6256eaf94cb4b7e74584595b5bd8>:0 
 at (wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition.RimWorld.InspectGizmoGrid.DrawInspectGizmoGridFor_Patch0(System.Collections.Generic.IEnumerable`1<object>,Verse.Gizmo&) currentSelectable: null
UnityEngine.StackTraceUtility:ExtractStackTrace ()
(wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition:Verse.Log.Error_Patch7 (string)
Verse.Log:ErrorOnce (string,int)
(wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition:RimWorld.InspectGizmoGrid.DrawInspectGizmoGridFor_Patch0 (System.Collections.Generic.IEnumerable`1<object>,Verse.Gizmo&)
RimWorld.MainTabWindow_Inspect:DrawInspectGizmos ()
RimWorld.InspectPaneUtility:ExtraOnGUI (RimWorld.IInspectPane)
RimWorld.MainTabWindow_Inspect:ExtraOnGUI ()
Verse.WindowStack:WindowStackOnGUI ()
(wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition:RimWorld.UIRoot_Play.UIRootOnGUI_Patch3 (RimWorld.UIRoot_Play)
(wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition:Verse.Root.OnGUI_Patch2 (Verse.Root)
```
## Reasoning

Not sure why, but starts from 1.5 Corpses are also auto-assigned with CompMeleeTargettingGizmo

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
