### PR TITLE
Smoke grenade rework

### DIFF
--- a/Defs/Effects/Effecter.xml
+++ b/Defs/Effects/Effecter.xml
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+	<EffecterDef>
+		<defName>WhiteSmokeReleasing</defName>
+		<children>
+		  <li>
+			<subEffecterClass>SubEffecter_Sustainer</subEffecterClass>
+			<soundDef>GasReleasing</soundDef>
+		  </li>
+		  <li>
+			<subEffecterClass>SubEffecter_SprayerChance</subEffecterClass>
+			<positionRadius>0.3</positionRadius>
+			<fleckDef>Fleck_WhiteSmokeSmall</fleckDef>
+			<chancePerTick>0.1</chancePerTick>
+			<scale>0.5~1</scale>
+			<spawnLocType>OnSource</spawnLocType>
+		  </li>	  
+		</children>
+	</EffecterDef>	
+
+</Defs>

--- a/Defs/Effects/Flecks.xml
+++ b/Defs/Effects/Flecks.xml
@@ -165,6 +165,23 @@
 		<collide>true</collide>
 	</FleckDef>
 
+	<!--=============== For Smoke Grenades ==============-->
+
+	<FleckDef ParentName="FleckBase_Thrown">
+		<defName>Fleck_WhiteSmokeSmall</defName>
+		<altitudeLayer>MoteOverhead</altitudeLayer>
+		<fadeInTime>0.3</fadeInTime>
+		<solidTime>0</solidTime>
+		<fadeOutTime>0.3</fadeOutTime>
+		<growthRate>0.8</growthRate>
+		<acceleration>(0, 0, 2)</acceleration>
+		<graphicData>
+		  <texPath>Things/Gas/GasCloudThickA</texPath>
+		  <shaderType>TransparentPostLight</shaderType>
+		  <color>(255, 255, 255, 64)</color>
+		</graphicData>
+	</FleckDef>
+
 	<!--=============== For 40k Ammo ==============-->
 
 	<!-- === Casings === -->

--- a/Defs/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Grenades.xml
@@ -321,8 +321,11 @@
 			<casingMoteDefname>Fleck_GrenadePin</casingMoteDefname>
 			<casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname> 
 			<postExplosionSpawnThingDef>Grenade_Smoke_Releasing</postExplosionSpawnThingDef>
+			<soundExplode>Interact_BeatFire</soundExplode>
 			<speed>12</speed>
+			<explosionDelay>60</explosionDelay>
 			<screenShakeFactor>0</screenShakeFactor>
+			<doExplosionVFX>false</doExplosionVFX>
 		</projectile>
 	</ThingDef>
 
@@ -333,7 +336,7 @@
 			<texPath>Things/Projectile/Grenades/Smoke</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 			<shaderType>Transparent</shaderType>
-			<onGroundRandomRotateAngle>45</onGroundRandomRotateAngle>
+			<onGroundRandomRotateAngle>15</onGroundRandomRotateAngle>
 		</graphicData>
 		<comps Inherit="false">
 		<li Class="CompProperties_ReleaseGas">

--- a/Defs/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Grenades.xml
@@ -313,14 +313,13 @@
 			<texPath>Things/Projectile/Grenades/Smoke</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
-	<!--	<thingClass>CombatExtended.ProjectileCE_SpawnsThing</thingClass>	-->	
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<dangerFactor>0.0</dangerFactor>
 			<explosionRadius>0.1</explosionRadius>
 			<damageDef>Smoke</damageDef>
 			<dropsCasings>true</dropsCasings>
 			<casingMoteDefname>Fleck_GrenadePin</casingMoteDefname>
-			<casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
+			<casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname> 
 			<postExplosionSpawnThingDef>Grenade_Smoke_Releasing</postExplosionSpawnThingDef>
 			<speed>12</speed>
 			<screenShakeFactor>0</screenShakeFactor>
@@ -331,16 +330,17 @@
 		<defName>Grenade_Smoke_Releasing</defName>
 		<label>smoke grenade</label>	
 		<graphicData>
-		<texPath>Things/Projectile/Grenades/Smoke</texPath>
-		<graphicClass>Graphic_Single</graphicClass>
-		<shaderType>Transparent</shaderType>
+			<texPath>Things/Projectile/Grenades/Smoke</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<shaderType>Transparent</shaderType>
+			<onGroundRandomRotateAngle>45</onGroundRandomRotateAngle>
 		</graphicData>
 		<comps Inherit="false">
 		<li Class="CompProperties_ReleaseGas">
 			<gasType>BlindSmoke</gasType>
-			<cellsToFill>16</cellsToFill>
+			<cellsToFill>20</cellsToFill>
 			<durationSeconds>30</durationSeconds>
-			<effecterReleasing>ToxGasReleasing</effecterReleasing>
+			<effecterReleasing>WhiteSmokeReleasing</effecterReleasing>
 		</li>
 		<li Class="CompProperties_DestroyAfterDelay">
 			<delayTicks>30000</delayTicks><!-- 1/2 day -->

--- a/Defs/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Grenades.xml
@@ -313,20 +313,39 @@
 			<texPath>Things/Projectile/Grenades/Smoke</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
+	<!--	<thingClass>CombatExtended.ProjectileCE_SpawnsThing</thingClass>	-->	
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<explosionRadius>4</explosionRadius>
-			<damageDef>Smoke</damageDef>
-			<suppressionFactor>0.0</suppressionFactor>
 			<dangerFactor>0.0</dangerFactor>
-			<explosionDelay>30</explosionDelay>
+			<explosionRadius>0.1</explosionRadius>
+			<damageDef>Smoke</damageDef>
 			<dropsCasings>true</dropsCasings>
 			<casingMoteDefname>Fleck_GrenadePin</casingMoteDefname>
 			<casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
-			<postExplosionGasType>BlindSmoke</postExplosionGasType>
-			<preExplosionSpawnChance>1</preExplosionSpawnChance>
+			<postExplosionSpawnThingDef>Grenade_Smoke_Releasing</postExplosionSpawnThingDef>
 			<speed>12</speed>
 			<screenShakeFactor>0</screenShakeFactor>
 		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Shell_Toxic_Releasing_Base">
+		<defName>Grenade_Smoke_Releasing</defName>
+		<label>smoke grenade</label>	
+		<graphicData>
+		<texPath>Things/Projectile/Grenades/Smoke</texPath>
+		<graphicClass>Graphic_Single</graphicClass>
+		<shaderType>Transparent</shaderType>
+		</graphicData>
+		<comps Inherit="false">
+		<li Class="CompProperties_ReleaseGas">
+			<gasType>BlindSmoke</gasType>
+			<cellsToFill>16</cellsToFill>
+			<durationSeconds>30</durationSeconds>
+			<effecterReleasing>ToxGasReleasing</effecterReleasing>
+		</li>
+		<li Class="CompProperties_DestroyAfterDelay">
+			<delayTicks>30000</delayTicks><!-- 1/2 day -->
+		</li>
+		</comps>	
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseGrenadeEquipment">


### PR DESCRIPTION
## Additions
- New white smoke flecks, based off the vanilla tox smoke.
- New effecter for smoke grenade, which spews white smoke and makes an appropriate sound.

## Changes
- Rather than exploding in cloud of smoke, the smoke grenade now lands on the ground and begins to spew a cloud of smoke, similar to the Biotech tox mortar shell.

## Reasoning
- While it has less immediate dispersion, the smoke cloud lasts considerably longer with this implementation and still covers a similar-sized area. This makes it a bit better for providing screening, and potentially more appealing for the player to use. 

## Alternatives
- Could leave it as-is.
- Could convert other smoke grenades over to this format, but most--such as launched grenades--have a much smaller payload.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
