### PR TITLE
Rimsenal Spacer 1.5 Mech update.

### DIFF
--- a/ModPatches/Rimsenal - Spacer Faction Pack/Patches/Rimsenal - Spacer Faction Pack/Mechs_Smart_CE.xml
+++ b/ModPatches/Rimsenal - Spacer Faction Pack/Patches/Rimsenal - Spacer Faction Pack/Mechs_Smart_CE.xml
@@ -5,14 +5,19 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="BaseMechanoidTagma"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
-			<ArmorRating_Sharp>7</ArmorRating_Sharp>
+			<ArmorRating_Sharp>11</ArmorRating_Sharp>
+			<AimingAccuracy>1.3</AimingAccuracy>
+			<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
+			<MeleeDodgeChance>0.15</MeleeDodgeChance>
+			<MeleeCritChance>0.20</MeleeCritChance>
+			<MeleeParryChance>0.50</MeleeParryChance>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="BaseMechanoidTagma"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
-			<ArmorRating_Blunt>15</ArmorRating_Blunt>
+			<ArmorRating_Blunt>22</ArmorRating_Blunt>
 		</value>
 	</Operation>
 
@@ -41,6 +46,94 @@
 					<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
 					<armorPenetrationBlunt>1.75</armorPenetrationBlunt>
 					<chanceFactor>0.1</chanceFactor>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>6</power>
+					<cooldownTime>1.85</cooldownTime>
+					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					<chanceFactor>0.1</chanceFactor>
+					<armorPenetrationBlunt>0.7</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[@Name="BaseMechanoidTagma"]</xpath>
+		<value>
+			<comps>
+				<li Class="CombatExtended.CompProperties_ArmorDurability">
+					<Durability>1160</Durability>
+					<Regenerates>true</Regenerates>
+					<RegenInterval>1250</RegenInterval>
+					<RegenValue>5</RegenValue>
+					<Repairable>true</Repairable>
+					<RepairIngredients>
+						<Steel>5</Steel>
+						<Plasteel>5</Plasteel>
+					</RepairIngredients>
+					<RepairTime>300</RepairTime>
+					<RepairValue>200</RepairValue>
+					<CanOverHeal>true</CanOverHeal>
+					<MaxOverHeal>116</MaxOverHeal>
+					<MinArmorPct>0.50</MinArmorPct>
+					<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
+					<MinArmorValueBlunt>22</MinArmorValueBlunt>
+					<MinArmorValueHeat>0.2</MinArmorValueHeat>
+					<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
+				</li>
+			</comps>
+		</value>
+	</Operation>
+	
+	<!-- ========== Skutaton =========== -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Mech_Skutaton"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>14</ArmorRating_Sharp>
+			<MeleeDodgeChance>0.15</MeleeDodgeChance>
+			<MeleeCritChance>0.40</MeleeCritChance>
+			<MeleeParryChance>0.70</MeleeParryChance>
+			<MeleeHitChance>6</MeleeHitChance>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Mech_Skutaton"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>28</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Mech_Skutaton"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>left hammer fist</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>15</power>
+					<cooldownTime>1.50</cooldownTime>
+					<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+					<armorPenetrationBlunt>17.5</armorPenetrationBlunt>
+					<chanceFactor>3</chanceFactor>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>right hammer fist</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>15</power>
+					<cooldownTime>1.50</cooldownTime>
+					<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+					<armorPenetrationBlunt>17.5</armorPenetrationBlunt>
+					<chanceFactor>3</chanceFactor>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>head</label>
@@ -110,6 +203,34 @@
 			</tools>
 		</value>
 	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[@Name="RSMechanoid"]</xpath>
+		<value>
+			<comps>
+				<li Class="CombatExtended.CompProperties_ArmorDurability">
+					<Durability>860</Durability>
+					<Regenerates>true</Regenerates>
+					<RegenInterval>1250</RegenInterval>
+					<RegenValue>5</RegenValue>
+					<Repairable>true</Repairable>
+					<RepairIngredients>
+						<Steel>5</Steel>
+						<Plasteel>5</Plasteel>
+					</RepairIngredients>
+					<RepairTime>300</RepairTime>
+					<RepairValue>200</RepairValue>
+					<CanOverHeal>true</CanOverHeal>
+					<MaxOverHeal>86</MaxOverHeal>
+					<MinArmorPct>0.75</MinArmorPct>
+					<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
+					<MinArmorValueBlunt>22</MinArmorValueBlunt>
+					<MinArmorValueHeat>0.2</MinArmorValueHeat>
+					<MinArmorValueElectric>0.1</MinArmorValueElectric> -->
+				</li>
+			</comps>
+		</value>
+	</Operation>
 
 	<!-- ========== Borer =========== -->
 	<Operation Class="PatchOperationReplace">
@@ -145,5 +266,5 @@
 			<ArmorRating_Blunt>6</ArmorRating_Blunt>
 		</value>
 	</Operation>
-
+	
 </Patch>

--- a/ModPatches/Rimsenal - Spacer Faction Pack/Patches/Rimsenal - Spacer Faction Pack/Weapons_Smart_CE.xml
+++ b/ModPatches/Rimsenal - Spacer Faction Pack/Patches/Rimsenal - Spacer Faction Pack/Weapons_Smart_CE.xml
@@ -679,7 +679,7 @@
 			<muzzleFlashScale>9</muzzleFlashScale>
 		</Properties>
 		<AmmoUser>
-			<magazineSize>24</magazineSize>
+			<magazineSize>72</magazineSize>
 			<reloadTime>4</reloadTime>
 			<ammoSet>AmmoSet_5x100mmCaseless_LV</ammoSet>
 		</AmmoUser>
@@ -705,8 +705,8 @@
 					</capacities>
 					<power>18</power>
 					<cooldownTime>1.38</cooldownTime>
-					<armorPenetrationBlunt>1.15</armorPenetrationBlunt>
-					<armorPenetrationSharp>2.50</armorPenetrationSharp>
+					<armorPenetrationBlunt>5</armorPenetrationBlunt>
+					<armorPenetrationSharp>6.5</armorPenetrationSharp>
 					<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 				</li>
 			</tools>


### PR DESCRIPTION
Buffed tagmaton gun
Added patch for new skulaton
partial armor patch for rimsenal mechs
suicide drone works fine

## Additions

Added patch for new skulaton
Degrading armor added for rimsenal mechs
The bomb mech doesn't need a patch since its inheritance is all good, though depending on balance may need to nerf the bomb damage perhaps.

## Changes

Increased Tagmaton needler melee damage. Increased clip size as Vanilla version is actually 4 shot assault rifle which indicates its probably high capacity, so that is now reflected. 

Increased armor on tagmaton .

## Reasoning

3 bandwidth cost, and large size means they're (tag and skul) bulletcatchers. Both have close to pede armor in vanilla and tech wise you get them at the same time as gunnerpedes, so buffed accordingly to hopefully make them a bit meatier in combat. Armor degredation should let intermediate eventauly pen them and full power should still start by penetrating and wear them down fairly quickly.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
