### PR TITLE
Fix HAR Compat by removing obsolete/broken patch

### DIFF
--- a/Source/CombatExtended/Harmony/Compatibility/Harmony_AlienRace.cs
+++ b/Source/CombatExtended/Harmony/Compatibility/Harmony_AlienRace.cs
@@ -95,37 +95,5 @@ namespace CombatExtended.HarmonyCE.Compatibility
         //
         //<==================================== Example end ====================================>
         //
-
-        private static Type TypeOf_HarmonyPatches
-        {
-            get
-            {
-                return AccessTools.TypeByName("AlienRace.HarmonyPatches");
-            }
-        }
-
-        [HarmonyPatch]
-        public static class Harmony_AlienPartGenerator_GetHumanlikeHeadSetForPawnHelper
-        {
-            public static bool Prepare()
-            {
-                return TypeOf_HarmonyPatches != null;
-            }
-
-            public static MethodBase TargetMethod()
-            {
-                return AccessTools.Method(typeof(Harmony_PawnRenderer), nameof(Harmony_PawnRenderer.GetHumanlikeHeadSetForPawnHelper));
-            }
-
-            public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
-            {
-                // GetHumanlikeHeadSetForPawnHelper() now expects an object rather than a float, so explicitly box lifeStageFactor before forwarding it
-                yield return new CodeInstruction(OpCodes.Ldarg_0);
-                yield return new CodeInstruction(OpCodes.Box, typeof(float));
-                yield return new CodeInstruction(OpCodes.Ldarg_1); // pawn
-                yield return new CodeInstruction(OpCodes.Call, AccessTools.Method(TypeOf_HarmonyPatches, "GetHumanlikeHeadSetForPawnHelper"));
-                yield return new CodeInstruction(OpCodes.Ret);
-            }
-        }
     }
 }


### PR DESCRIPTION
## Changes

- Removed the transpiler GetHumanlikeHeadSetForPawnHelper patch for HAR

## References

- Closes #3111 

## Reasoning

- With 1.5, HAR no longer has a transpiler patch for GetHumanlikeHeadSetForPawnHelper which meant the CE side patch was obsolete and breaking and causing CE to not load properly.

## Alternatives

- Could maybe just delete the whole Harmony_AlienRace.cs file as it seems theres no patching needed but I left it since it has the giant example comment
- Might need to add back some kind of alternate patch if CE further changes the pawn rendering for 1.5

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony - Tested with a couple random HAR mods and equipped them with various armours, rendering seemed to be working properly, had no errors.
