### PR TITLE
Hip-fire Warcasket Autorifle

### DIFF
--- a/ModPatches/Vanilla Factions Expanded - Pirates/Defs/Vanilla Factions Expanded - Pirates/Ammo/Ammo_Mods.xml
+++ b/ModPatches/Vanilla Factions Expanded - Pirates/Defs/Vanilla Factions Expanded - Pirates/Ammo/Ammo_Mods.xml
@@ -19,7 +19,7 @@
 	<!-- ==================== AmmoSet ========================== -->
 
 	<!-- Vikings -->
-	<CombatExtended.AmmoSetDef>
+	<CombatExtended.AmmoSetDef MayRequire="OskarPotocki.VFE.Vikings">
 		<defName>AmmoSet_CryptoCannon</defName>
 		<label>Crypto Cannon</label>
 		<ammoTypes>
@@ -39,7 +39,7 @@
 	<!-- ================== Projectiles ================== -->
 
 	<!-- Vikings -->
-	<ThingDef ParentName="Base6x24mmChargedBullet">
+	<ThingDef ParentName="Base6x24mmChargedBullet" MayRequire="OskarPotocki.VFE.Vikings">
 		<defName>Bullet_Flamethrower_CryptoCannon</defName>
 		<graphicData>
 			<texPath>Things/Projectile/CryptoBullet</texPath>

--- a/ModPatches/Vanilla Factions Expanded - Pirates/Defs/Vanilla Factions Expanded - Pirates/Ammo/Ammo_Vikings.xml
+++ b/ModPatches/Vanilla Factions Expanded - Pirates/Defs/Vanilla Factions Expanded - Pirates/Ammo/Ammo_Vikings.xml
@@ -3,17 +3,27 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="CryptoAmmoBase" MayRequire="OskarPotocki.VFE.Vikings">
+	<!-- Despite using MayRequire, the Parent still has to exist, so we can't use the Vikings `CryptoAmmoBase`.-->
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="SpacerSmallAmmoBase" MayRequire="OskarPotocki.VFE.Vikings">
 		<defName>Ammo_CryptoCannon</defName>
 		<label>Crypto Cannon Fuel</label>
+		<description>Metal-cored projectiles wrapped in unstable crypto technology contained with an energy field. Capable of dealing both ballistic damage and causing serious hypothermia.</description>
 		<graphicData>
-			<drawSize>0.75</drawSize>
-		</graphicData>
+			<texPath>ThirdParty/VanillaExpanded/Crypto</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+			<drawSize>0.75</drawSize>			
+		</graphicData>	
 		<statBases>
 			<MarketValue>0.7</MarketValue>
 			<Mass>0.01</Mass>
 			<Bulk>0.01</Bulk>
 		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
+		<ammoClass>Crypto</ammoClass>
+		<stackLimit>2500</stackLimit>		
 		<thingCategories>
 			<li>AmmoCryptoCannon</li>
 		</thingCategories>

--- a/ModPatches/Vanilla Factions Expanded - Pirates/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Apparel_Warcaskets.xml
+++ b/ModPatches/Vanilla Factions Expanded - Pirates/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Apparel_Warcaskets.xml
@@ -827,20 +827,20 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Barrage"]/comps/li[@Class="CompProperties_Reloadable"]/ammoDef</xpath>
+		<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Barrage"]/comps/li[@Class="CompProperties_ApparelReloadable"]/ammoDef</xpath>
 		<value>
 			<ammoDef>Ammo_40x53mmGrenade_HE</ammoDef>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Barrage"]/comps/li[@Class="CompProperties_Reloadable"]/ammoCountPerCharge</xpath>
+		<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Barrage"]/comps/li[@Class="CompProperties_ApparelReloadable"]/ammoCountPerCharge</xpath>
 		<value>
 			<ammoCountPerCharge>1</ammoCountPerCharge>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Barrage"]/comps/li[@Class="CompProperties_Reloadable"]/maxCharges</xpath>
+		<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Barrage"]/comps/li[@Class="CompProperties_ApparelReloadable"]/maxCharges</xpath>
 		<value>
 			<maxCharges>8</maxCharges>
 		</value>

--- a/ModPatches/Vanilla Factions Expanded - Pirates/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Ranged_Warcaskets.xml
+++ b/ModPatches/Vanilla Factions Expanded - Pirates/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Ranged_Warcaskets.xml
@@ -71,19 +71,19 @@
 		<defName>VFEP_WarcasketGun_Autorifle</defName>
 		<statBases>
 			<Bulk>25</Bulk>
-			<SwayFactor>1.80</SwayFactor>
-			<ShotSpread>0.08</ShotSpread>
+			<SwayFactor>2.07</SwayFactor>
+			<ShotSpread>0.07</ShotSpread>
 			<SightsEfficiency>1</SightsEfficiency>
 			<RangedWeapon_Cooldown>0.47</RangedWeapon_Cooldown>
 		</statBases>
 		<Properties>
-			<recoilAmount>1.99</recoilAmount>
+			<recoilAmount>2.33</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>True</hasStandardCommand>
 			<defaultProjectile>Bullet_20x82mmMauser_AP</defaultProjectile>
 			<burstShotCount>3</burstShotCount>
 			<ticksBetweenBurstShots>10</ticksBetweenBurstShots>
-			<warmupTime>1.1</warmupTime>
+			<warmupTime>2.1</warmupTime>
 			<range>60</range>
 			<soundCast>Shot_Autocannon</soundCast>
 			<soundCastTail>GunTail_Medium</soundCastTail>


### PR DESCRIPTION
## Changes

- Changed the Warcasket Autorifle into a hip-fire weapon.

## Reasoning

- It lacks a proper stock and overshadows every other warcasket weapon in terms of lethality in quick bursts due to how quick its aim time was.

## Alternatives

- Leave it be?

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
