### PR TITLE
Mech sight sensor partial armor tweaked

### DIFF
--- a/ModPatches/Metal Gear Rimworld-Gekko/Patches/Metal Gear Rimworld-Gekko/ThingDefs_Races/Races_Mechanoid.xml
+++ b/ModPatches/Metal Gear Rimworld-Gekko/Patches/Metal Gear Rimworld-Gekko/ThingDefs_Races/Races_Mechanoid.xml
@@ -72,7 +72,7 @@
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="MGR_Mech_Gekko"]</xpath>
 			<value>
-				<comps/>
+				<comps />
 			</value>
 		</nomatch>
 	</Operation>
@@ -100,14 +100,14 @@
 				<stats>
 					<li>
 						<useStatic>false</useStatic>
-						<ArmorRating_Sharp>0.1</ArmorRating_Sharp>
+						<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
 						<parts>
 							<li>SightSensor</li>
 						</parts>
 					</li>
 					<li>
 						<useStatic>false</useStatic>
-						<ArmorRating_Blunt>0.1</ArmorRating_Blunt>
+						<ArmorRating_Blunt>0.25</ArmorRating_Blunt>
 						<parts>
 							<li>SightSensor</li>
 						</parts>

--- a/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Machines.xml
+++ b/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Machines.xml
@@ -32,14 +32,14 @@
 				<stats>
 					<li>
 						<useStatic>false</useStatic>
-						<ArmorRating_Sharp>0.1</ArmorRating_Sharp>
+						<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
 						<parts>
 							<li>SightSensor</li>
 						</parts>
 					</li>
 					<li>
 						<useStatic>false</useStatic>
-						<ArmorRating_Blunt>0.1</ArmorRating_Blunt>
+						<ArmorRating_Blunt>0.25</ArmorRating_Blunt>
 						<parts>
 							<li>SightSensor</li>
 						</parts>

--- a/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -34,14 +34,14 @@
 				<stats>
 					<li>
 						<useStatic>false</useStatic>
-						<ArmorRating_Sharp>0.1</ArmorRating_Sharp>
+						<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
 						<parts>
 							<li>SightSensor</li>
 						</parts>
 					</li>
 					<li>
 						<useStatic>false</useStatic>
-						<ArmorRating_Blunt>0.1</ArmorRating_Blunt>
+						<ArmorRating_Blunt>0.25</ArmorRating_Blunt>
 						<parts>
 							<li>SightSensor</li>
 						</parts>

--- a/ModPatches/pphhyy Expanded Scythers/Patches/pphhyy Expanded Scythers/MechKind_CE.xml
+++ b/ModPatches/pphhyy Expanded Scythers/Patches/pphhyy Expanded Scythers/MechKind_CE.xml
@@ -133,7 +133,7 @@
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedArch"]</xpath>
 			<value>
-				<comps/>
+				<comps />
 			</value>
 		</nomatch>
 	</Operation>
@@ -230,7 +230,7 @@
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedTank"]</xpath>
 			<value>
-				<comps/>
+				<comps />
 			</value>
 		</nomatch>
 	</Operation>
@@ -268,14 +268,14 @@
 					<stats>
 						<li>
 							<useStatic>false</useStatic>
-							<ArmorRating_Sharp>0.1</ArmorRating_Sharp>
+							<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
 							<parts>
 								<li>SightSensor</li>
 							</parts>
 						</li>
 						<li>
 							<useStatic>false</useStatic>
-							<ArmorRating_Blunt>0.1</ArmorRating_Blunt>
+							<ArmorRating_Blunt>0.25</ArmorRating_Blunt>
 							<parts>
 								<li>SightSensor</li>
 							</parts>
@@ -414,7 +414,7 @@
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedMono"]</xpath>
 			<value>
-				<comps/>
+				<comps />
 			</value>
 		</nomatch>
 	</Operation>
@@ -570,7 +570,7 @@
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedSearing"]</xpath>
 			<value>
-				<comps/>
+				<comps />
 			</value>
 		</nomatch>
 	</Operation>
@@ -699,7 +699,7 @@
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="pphhyy_ScytherExpandedPrestige"]</xpath>
 			<value>
-				<comps/>
+				<comps />
 			</value>
 		</nomatch>
 	</Operation>

--- a/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
@@ -100,14 +100,14 @@
 				<stats>
 					<li>
 						<useStatic>false</useStatic>
-						<ArmorRating_Sharp>0.1</ArmorRating_Sharp>
+						<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
 						<parts>
 							<li>SightSensor</li>
 						</parts>
 					</li>
 					<li>
 						<useStatic>false</useStatic>
-						<ArmorRating_Blunt>0.1</ArmorRating_Blunt>
+						<ArmorRating_Blunt>0.25</ArmorRating_Blunt>
 						<parts>
 							<li>SightSensor</li>
 						</parts>


### PR DESCRIPTION
## Changes

- Increased the partial armor on mech eyes from x0.1 to x0.25

## Reasoning

- Mechs are getting brained through their eyes. With the outside squishy bodyparts working for mechs and degradable armor we can afford to have higher armor values on their eyes to lower the instant kill chances by destroying their brains.

## Alternatives

- Even more armor on their eyes?

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
