### PR TITLE
Alpha Animals ADS patch commented out

### DIFF
--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Misc/Alpha_Hediffs.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Misc/Alpha_Hediffs.xml
@@ -96,17 +96,17 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationFindMod">
+	<!-- <Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>A Dog Said... Animal Prosthetics</li>
 		</mods>
 
 		<match Class="PatchOperationSequence">
-			<operations>
+			<operations> -->
 
-				<!--=============== Non-ranged implants ====================-->
+	<!--=============== Non-ranged implants ====================-->
 
-				<li Class="PatchOperationReplace">
+	<!-- <li Class="PatchOperationReplace">
 					<xpath>Defs/HediffDef[defName="AA_ProstheticTentacle"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
 					<value>
 						<tools>
@@ -240,11 +240,11 @@
 							</li>
 						</tools>
 					</value>
-				</li>
+				</li> -->
 
-				<!--=============== Ranged implants ====================-->
+	<!--=============== Ranged implants ====================-->
 
-				<li Class="PatchOperationReplace">
+	<!-- <li Class="PatchOperationReplace">
 					<xpath>Defs/HediffDef[defName="AA_RangedSpinneretImplant"]/comps/li[@Class="MVCF.Comps.HediffCompProperties_ExtendedVerbGiver"]/verbs</xpath>
 					<value>
 						<verbs>
@@ -418,6 +418,6 @@
 
 			</operations>
 		</match>
-	</Operation>
+	</Operation> -->
 
 </Patch>


### PR DESCRIPTION
## Changes

- What it says on the tin.

## Reasoning

- The A Dog Said mod patches were disabled in the AA mod for 1.5 in favor of a possible future mod so the CE patches were commented out for time being in case they come back in another shape or form.

## Alternatives

- Remove the patches completely? There'd be no point in that.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
