### PR TITLE
VVE Tier 3 - Fix broken recoil on Burya

### DIFF
--- a/ModPatches/Vanilla Vehicles Expanded - Tier 3/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Burya.xml
+++ b/ModPatches/Vanilla Vehicles Expanded - Tier 3/Patches/Vanilla Vehicles Expanded - Tier 3/VehicleDefs/Burya.xml
@@ -32,6 +32,7 @@
 				<speed>160</speed> <!-- Temporarily set artifically high, as it fires on a flat trajectory. -->
 				<sway>0.82</sway>
 				<spread>0.15</spread>
+				<recoil>0</recoil> 
 			</li>
 		</value>
 	</Operation>


### PR DESCRIPTION
## Changes

- Added recoil of 0 to the "Vehicles.CETurretDataDefModExtension" for the Burya

## References

- Requires #3122 or similar fix for testing

## Reasoning

- The recoil for the Burya was broken and incrementing by -1 after each shot causing it to shoot randomly all around the place and even at itself
![image](https://github.com/CombatExtended-Continued/CombatExtended/assets/66878914/683a99c1-8ab9-4e40-b65c-87505ed7aac9)
- Recoil of 0 replicates behaviour of other vehicles when using CE (all other vehicles seem to have 0 recoil by default)

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony - used devtest to shoot burya at different targets
https://gyazo.com/88a60be30e81e9099ae881fcb45316cb
