### PR TITLE
StunHandler 1.5 patch

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_StunHandler.cs
+++ b/Source/CombatExtended/Harmony/Harmony_StunHandler.cs
@@ -46,7 +46,7 @@ namespace CombatExtended.HarmonyCE
                 {
                     float stunResistChance = ((float)adaptedTicksLeft / (float)newStunAdaptedTicks) * 15;
 
-                    if (Rand.Value > stunResistChance)
+                    if (Rand.Value * 100 > stunResistChance)
                     {
                         ___adaptationTicksLeft[dinfo.Def] += newStunAdaptedTicks;
 

--- a/Source/CombatExtended/Harmony/Harmony_StunHandler.cs
+++ b/Source/CombatExtended/Harmony/Harmony_StunHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -9,14 +9,19 @@ using HarmonyLib;
 
 namespace CombatExtended.HarmonyCE
 {
-    //TODO 1.5:  StunHandler.adaptationTicksLeft : Dictionary<DamageDef, int> mapping damage type to duration
-    /*    [HarmonyPatch(typeof(StunHandler), nameof(StunHandler.Notify_DamageApplied))]
+    [HarmonyPatch(typeof(StunHandler), nameof(StunHandler.Notify_DamageApplied))]
     public static class Harmony_StunHandler_Notify_DamageApplied
     {
-        public static bool Prefix(StunHandler __instance, DamageInfo dinfo, ref int ___EMPAdaptedTicksLeft, ref int ___stunTicksLeft, ref bool ___stunFromEMP)
+        public static bool Prefix(StunHandler __instance, DamageInfo dinfo, ref int ___stunTicksLeft, ref bool ___stunFromEMP, ref Dictionary<DamageDef, int> ___adaptationTicksLeft)
         {
+            if (!__instance.CanBeStunnedByDamage(dinfo.Def))
+            {
+                return false;
+            }
+
             Pawn pawn = __instance.parent as Pawn;
             float bodySize = 1.0f;
+            float resistance = 1f;
             if (pawn != null)
             {
                 if (pawn.Downed || pawn.Dead)
@@ -24,70 +29,61 @@ namespace CombatExtended.HarmonyCE
                     return false;
                 }
                 bodySize = pawn.BodySize;
-            }
-
-            if (dinfo.Def == DamageDefOf.EMP)
-            {
-                if (__instance.parent.TryGetComp<CompPower>() == null && __instance.parent.TryGetComp<CompMannable>() != null)
+                if (!dinfo.Def.stunResistStat?.Worker.IsDisabledFor(pawn) ?? false)
                 {
-                    return false;
+                    resistance = pawn.GetStatValue(dinfo.Def.stunResistStat);
                 }
-                if (pawn != null && !(pawn.RaceProps?.IsFlesh ?? false))
+            }
+            float stunTicks = dinfo.Def.constantStunDurationTicks ?? dinfo.Amount * 30f;
+            // Makes the adapted tick and stun tick scales with bodysize
+            // And add a chance of resisting new stun when adaptation ticks are not 0
+            if (__instance.CanAdaptToDamage(dinfo.Def))
+            {
+                int newStunAdaptedTicks = Mathf.RoundToInt(dinfo.Amount * 45 * bodySize);
+                int newStunTicks = Mathf.RoundToInt(stunTicks * Mathf.Clamp01(1f - resistance));
+                // remember value is of value type, not reference type
+                if (___adaptationTicksLeft.TryGetValue(dinfo.Def, out int adaptedTicksLeft) && adaptedTicksLeft > 0)
                 {
-                    if (___EMPAdaptedTicksLeft > 0)
+                    float stunResistChance = ((float)adaptedTicksLeft / (float)newStunAdaptedTicks) * 15;
+
+                    if (Rand.Value > stunResistChance)
                     {
-                        int newStunAdaptedTicks = Mathf.RoundToInt(dinfo.Amount * 45 * bodySize);
-                        int newStunTicks = Mathf.RoundToInt(dinfo.Amount * 30);
+                        ___adaptationTicksLeft[dinfo.Def] += newStunAdaptedTicks;
 
-                        float stunResistChance = ((float)___EMPAdaptedTicksLeft / (float)newStunAdaptedTicks) * 15;
+                        ___stunFromEMP = dinfo.Def == DamageDefOf.EMP;
+                        // StunFor already uses Mathf.Max(stunTicksLeft, ticks) for ___stunTicksLeft
+                        __instance.StunFor(newStunTicks, dinfo.Instigator, true, true);
+                        return false;
+                    }
+                    else // Adapted
+                    {
+                        MoteMakerCE.ThrowText(new Vector3((float)__instance.parent.Position.x + 1f, (float)__instance.parent.Position.y, (float)__instance.parent.Position.z + 1f), __instance.parent.Map, "Adapted".Translate(), Color.white, -1f);
+                        int adaptationReduction = Mathf.RoundToInt(Mathf.Sqrt(dinfo.Amount * 45));
 
-                        if (Rand.Value > stunResistChance)
+                        if (adaptationReduction < adaptedTicksLeft)
                         {
-                            ___EMPAdaptedTicksLeft += Mathf.RoundToInt(dinfo.Amount * 45 * bodySize);
-
-                            if (___stunTicksLeft > 0 && newStunTicks > ___stunTicksLeft)
-                            {
-                                ___stunTicksLeft = newStunTicks;
-                            }
-                            else
-                            {
-                                __instance.StunFor(newStunTicks, dinfo.Instigator, true, true);
-                            }
+                            ___adaptationTicksLeft[dinfo.Def] -= adaptationReduction;
                         }
                         else
                         {
-                            MoteMakerCE.ThrowText(new Vector3((float)__instance.parent.Position.x + 1f, (float)__instance.parent.Position.y, (float)__instance.parent.Position.z + 1f), __instance.parent.Map, "Adapted".Translate(), Color.white, -1f);
-                            int adaptationReduction = Mathf.RoundToInt(Mathf.Sqrt(dinfo.Amount * 45));
+                            float adaptationReductionRatio = (adaptationReduction - adaptedTicksLeft) / adaptationReduction;
+                            ___adaptationTicksLeft[dinfo.Def] = Mathf.RoundToInt(newStunAdaptedTicks * adaptationReductionRatio);
+                            newStunTicks = Mathf.RoundToInt(newStunTicks * adaptationReductionRatio);
 
-                            if (adaptationReduction < ___EMPAdaptedTicksLeft)
-                            {
-                                ___EMPAdaptedTicksLeft -= adaptationReduction;
-                            }
-                            else
-                            {
-                                float adaptationReductionRatio = (adaptationReduction - ___EMPAdaptedTicksLeft) / adaptationReduction;
-                                newStunAdaptedTicks = Mathf.RoundToInt(newStunAdaptedTicks * adaptationReductionRatio);
-                                newStunTicks = Mathf.RoundToInt(newStunTicks * adaptationReductionRatio);
-
-                                if (___stunTicksLeft > 0 && newStunTicks > ___stunTicksLeft)
-                                {
-                                    ___stunTicksLeft = newStunTicks;
-                                }
-                                else
-                                {
-                                    __instance.StunFor(newStunTicks, dinfo.Instigator, true, true);
-                                }
-                            }
+                            // StunFor already uses Mathf.Max(stunTicksLeft, ticks) for ___stunTicksLeft
+                            ___stunFromEMP = dinfo.Def == DamageDefOf.EMP;
+                            __instance.StunFor(newStunTicks, dinfo.Instigator, true, true);
                         }
-
+                        return false;
                     }
-                    else
-                    {
-                        __instance.StunFor(Mathf.RoundToInt(dinfo.Amount * 30f), dinfo.Instigator, true, true);
-                        ___EMPAdaptedTicksLeft = Mathf.RoundToInt(dinfo.Amount * 45 * bodySize);
-                        ___stunFromEMP = true;
 
-                    }
+                }
+                else // no adaptation ticks, full stun
+                {
+                    ___stunFromEMP = dinfo.Def == DamageDefOf.EMP;
+                    __instance.StunFor(newStunTicks, dinfo.Instigator, true, true);
+                    ___adaptationTicksLeft.SetOrAdd(dinfo.Def, newStunAdaptedTicks);
+                    return false;
                 }
             }
             return true;
@@ -106,5 +102,5 @@ namespace CombatExtended.HarmonyCE
                 __instance.parent.TakeDamage(newDinfo);
             }
         }
-        }*/
+    }
 }

--- a/Source/CombatExtended/Harmony/Harmony_StunHandler.cs
+++ b/Source/CombatExtended/Harmony/Harmony_StunHandler.cs
@@ -21,7 +21,7 @@ namespace CombatExtended.HarmonyCE
 
             Pawn pawn = __instance.parent as Pawn;
             float bodySize = 1.0f;
-            float resistance = 1f;
+            float resistance = 0f;
             if (pawn != null)
             {
                 if (pawn.Downed || pawn.Dead)


### PR DESCRIPTION
## Additions

StunHandler patch for 1.5.

## Changes

Besides all changes that makes it works in 1.5:
- Add reduction from `DamageDef.stunResistStat` if it exists;
- Make the prefix only returns true when the calculation is not redirected
- Fix a bug where the chance of resist another stun is always 100% (`Rand.Value` returns 0~1, but `stunResistChance` is not a percentage)

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Mentioned bug fixed
