### PR TITLE
Damage Application Rework

### DIFF
--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -330,12 +330,14 @@ namespace CombatExtended
                 info.dinfo.SetIgnoreArmor(true);
                 info.dinfo.weaponInt = null;
                 info.dinfo.SetAmount(info.penAmount * info.dmgPerPenAmount);
+                info.dinfo.armorPenetrationInt = info.penAmount;
                 Log.Warning($"GetAfterArmorDamage additional damage {info.dinfo}");
                 dworker.Apply(info.dinfo, pawn);
             }
 
             Log.Warning($"GetAfterArmorDamage return {ainfo.dinfo}");
             ainfo.dinfo.SetAmount(ainfo.penAmount * ainfo.dmgPerPenAmount);
+            ainfo.dinfo.armorPenetrationInt = ainfo.penAmount;
             return ainfo.dinfo;
         }
 
@@ -439,6 +441,7 @@ namespace CombatExtended
                 dinfo.SetIgnoreArmor(true);
                 dinfo.weaponInt = null;
                 dinfo.SetAmount(newPenAmount * ainfo.dmgPerPenAmount);
+                dinfo.armorPenetrationInt = newPenAmount;
                 Log.Warning($"PenetrateBodyPart additional damage {dinfo}");
                 dworker.Apply(dinfo, pawn);
             }

--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -241,7 +241,7 @@ namespace CombatExtended
                         continue;
                     }
 
-                    for(var info = ainfo; info != null; info = info.next)
+                    for (var info = ainfo; info != null; info = info.next)
                     {
                         var blockedPenAmount = PenetrateArmor(info, app);
                         if (info.penTransferRate > 0f)
@@ -292,11 +292,11 @@ namespace CombatExtended
 
                 var armorRatingStat = ainfo.dinfo.ArmorRatingStat();
                 var partDensity = 0f;
-                if(armorRatingStat == StatDefOf.ArmorRating_Sharp)
+                if (armorRatingStat == StatDefOf.ArmorRating_Sharp)
                 {
                     partDensity = sharpPartDensity;
                 }
-                else if(armorRatingStat == StatDefOf.ArmorRating_Blunt)
+                else if (armorRatingStat == StatDefOf.ArmorRating_Blunt)
                 {
                     partDensity = bluntPartDensity;
                 }
@@ -605,7 +605,7 @@ namespace CombatExtended
 
             if (parryThing is Apparel app)
             {
-                for(var info = ainfo; info != null; info = info.next)
+                for (var info = ainfo; info != null; info = info.next)
                 {
                     var blockedPenAmount = PenetrateArmor(info, app);
                     if (info.penTransferRate > 0f)
@@ -618,11 +618,11 @@ namespace CombatExtended
 
             if (parryThing.def.IsWeapon)
             {
-                for(var info = ainfo; info != null; info = info.next)
+                for (var info = ainfo; info != null; info = info.next)
                 {
                     var armorRatingStat = info.dinfo.ArmorRatingStat();
                     float armorAmount = 0f;
-                    if(armorRatingStat == StatDefOf.ArmorRating_Sharp)
+                    if (armorRatingStat == StatDefOf.ArmorRating_Sharp)
                     {
                         armorAmount = parryThing.GetStatValue(CE_StatDefOf.ToughnessRating);
                     }

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -437,15 +437,20 @@ namespace CombatExtended
         /// <summary>
         /// Gets the true rating of armor with partial stats taken into account
         /// </summary>
-        public static float PartialStat(this Apparel apparel, StatDef stat, BodyPartRecord part)
+        public static float PartialStat(this Apparel apparel, StatDef stat, BodyPartRecord part,
+                bool ignoreShieldCoverage = false)
         {
             if (!apparel.def.apparel.CoversBodyPart(part))
             {
-                var shieldDef = apparel.def.GetModExtension<ShieldDefExtension>();
-                if(shieldDef == null
-                        || !shieldDef.PartIsCoveredByShield(part, true))
+                if(ignoreShieldCoverage)
                 {
-                    return 0;
+                    return 0f;
+                }
+
+                var shieldDef = apparel.def.GetModExtension<ShieldDefExtension>();
+                if(shieldDef == null || !shieldDef.PartIsCoveredByShield(part, true))
+                {
+                    return 0f;
                 }
             }
 
@@ -477,7 +482,7 @@ namespace CombatExtended
         /// <summary>
         /// Gets the true rating of armor with partial stats taken into account
         /// </summary>
-        public static float PartialStat(this Pawn pawn, StatDef stat, BodyPartRecord part, float damage = 0f, float AP = 0f)
+        public static float PartialStat(this Pawn pawn, StatDef stat, BodyPartRecord part)
         {
             float result = pawn.GetStatValue(stat);
 

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -442,13 +442,13 @@ namespace CombatExtended
         {
             if (!apparel.def.apparel.CoversBodyPart(part))
             {
-                if(ignoreShieldCoverage)
+                if (ignoreShieldCoverage)
                 {
                     return 0f;
                 }
 
                 var shieldDef = apparel.def.GetModExtension<ShieldDefExtension>();
-                if(shieldDef == null || !shieldDef.PartIsCoveredByShield(part, true))
+                if (shieldDef == null || !shieldDef.PartIsCoveredByShield(part, true))
                 {
                     return 0f;
                 }

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -441,7 +441,12 @@ namespace CombatExtended
         {
             if (!apparel.def.apparel.CoversBodyPart(part))
             {
-                return 0;
+                var shieldDef = apparel.def.GetModExtension<ShieldDefExtension>();
+                if(shieldDef == null
+                        || !shieldDef.PartIsCoveredByShield(part, true))
+                {
+                    return 0;
+                }
             }
 
             float result = apparel.GetStatValue(stat);

--- a/Source/CombatExtended/CombatExtended/Defs/ShieldDefExtension.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/ShieldDefExtension.cs
@@ -14,7 +14,7 @@ namespace CombatExtended
         public List<BodyPartGroupDef> crouchCoverage = new List<BodyPartGroupDef>();
         public bool drawAsTall = false;
 
-        public bool PartIsCoveredByShield(BodyPartRecord part, Pawn pawn)
+        public bool PartIsCoveredByShield(BodyPartRecord part, bool isCrouching)
         {
             if (!shieldCoverage.NullOrEmpty())
             {
@@ -26,7 +26,7 @@ namespace CombatExtended
                     }
                 }
             }
-            if (!crouchCoverage.NullOrEmpty() && pawn.IsCrouching())
+            if (!crouchCoverage.NullOrEmpty() && isCrouching)
             {
                 foreach (BodyPartGroupDef group in crouchCoverage)
                 {

--- a/Source/CombatExtended/Harmony/Harmony_DamageWorker_AddInjury.cs
+++ b/Source/CombatExtended/Harmony/Harmony_DamageWorker_AddInjury.cs
@@ -16,7 +16,7 @@ namespace CombatExtended.HarmonyCE
     {
         // Secondary damage debounce boolean
         private static bool _applyingSecondary = false;
-        // Set to false initially and in the prefix, may be set to true in GetAfterArmorDamage
+        // Set to false initially and in postfix, may be set to true in GetAfterArmorDamage
         private static bool _skipSecondary = false;
         // Lines in armor block that need to be nulled out
         private static readonly int[] ArmorBlockNullOps = { 1, 3, 4, 5, 6 };
@@ -99,19 +99,14 @@ namespace CombatExtended.HarmonyCE
             return codes;
         }
 
-        internal static void Prefix()
-        {
-            _skipSecondary = false;
-        }
-
         internal static void Postfix(DamageInfo dinfo, Pawn pawn)
         {
-            if (_skipSecondary)
+            if (_applyingSecondary)
             {
                 return;
             }
 
-            if (!_applyingSecondary
+            if (!_skipSecondary
                     && dinfo.Weapon?.projectile is ProjectilePropertiesCE props
                     && !props.secondaryDamage.NullOrEmpty())
             {
@@ -131,6 +126,7 @@ namespace CombatExtended.HarmonyCE
                 }
                 _applyingSecondary = false;
             }
+            _skipSecondary = false;
         }
     }
 

--- a/Source/CombatExtended/Harmony/Harmony_DamageWorker_AddInjury.cs
+++ b/Source/CombatExtended/Harmony/Harmony_DamageWorker_AddInjury.cs
@@ -14,17 +14,17 @@ namespace CombatExtended.HarmonyCE
     [HarmonyPatch(typeof(DamageWorker_AddInjury), "ApplyDamageToPart")]
     internal static class Harmony_DamageWorker_AddInjury_ApplyDamageToPart
     {
-        // Secondary damage debounce boolean
-        private static bool _applyingSecondary = false;
         // Set to false initially and in postfix, may be set to true in GetAfterArmorDamage
         private static bool _skipSecondary = false;
+        // Secondary damage debounce boolean
+        private static bool _applyingSecondary = false;
         // Lines in armor block that need to be nulled out
         private static readonly int[] ArmorBlockNullOps = { 1, 3, 4, 5, 6 };
 
         private static void ArmorReroute(Pawn pawn, ref DamageInfo dinfo,
                 out bool deflectedByArmor, out bool diminishedByArmor)
         {
-            var newDinfo = ArmorUtilityCE.GetAfterArmorDamage(dinfo, pawn, dinfo.HitPart,
+            var newDinfo = ArmorUtilityCE.GetAfterArmorDamage(dinfo, pawn,
                     out deflectedByArmor, out diminishedByArmor, out _skipSecondary);
             if (dinfo.HitPart != newDinfo.HitPart)
             {


### PR DESCRIPTION
## Changes

- No more code separation between partial penetration and deflection blunt damage - instead sharp damage decays to blunt damage at a rate;
- Use the initial damage worker for all damage applications against pawns;
- Apply body part density to part damage calculations with custom handling of damage propagation of hit internal body parts;
- Partial armor stat system now supports shield coverage from the shield extension.

## Reasoning

- The separation between partial penetration and deflection blunt damage was a band-aid fix to implement partial penetration; that is no longer the case. New class - AttackInfo - is now used for storing information damage info penetration information: current penetration amount, damage per penetration amount, one unit of penetration amount decaying to how much of the next attack info penetration amount and the next damage info; 
- Fixes partial penetrations using the blunt damage worker to apply additional damage to bones;
- Body part density only affected penetration amount, which meant that it could only cause deflections, but not change damage. Vanilla damage propagation was limited - different parts couldn't have different damage amounts, therefore a custom solution was implemented.

## Testing

- [x] Compiles without warnings;
- [x] Game runs without errors;
- [ ] Playtested a colony.

## Additional notes
- Working body part density
![image](https://github.com/CombatExtended-Continued/CombatExtended/assets/34545746/6878cdbc-4a5e-4fba-b551-ee058e309e20)
