### PR TITLE
Alpha Biomes material patch fix

### DIFF
--- a/ModPatches/Alpha Biomes/Patches/Alpha Biomes/Items_Resource_Stuff.xml
+++ b/ModPatches/Alpha Biomes/Patches/Alpha Biomes/Items_Resource_Stuff.xml
@@ -9,6 +9,14 @@
 		</value>
 	</Operation>
 
+	<!-- ======== Propane Fuel Tank ======== -->
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="AB_Propane"]/statBases</xpath>
+		<value>
+			<Bulk>0.05</Bulk>
+		</value>
+	</Operation>
+
 	<!-- ======== Alcyonite Chunk ======== -->
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="AB_AlcyoniteChunk"]/statBases</xpath>
@@ -57,7 +65,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]</xpath>
+		<xpath>Defs/ThingDef[defName="AB_MushroomWoodLog" or defName="AB_CrystalWood" or defName="GU_RedWood"]</xpath>
 		<value>
 			<li Class="CombatExtended.StuffToughnessMultiplierExtensionCE">
 				<toughnessMultiplier>4</toughnessMultiplier>
@@ -77,7 +85,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/StuffPower_Armor_Sharp</xpath>
+		<xpath>Defs/ThingDef[defName="AB_MushroomWoodLog" or defName="AB_CrystalWood" or defName="GU_RedWood"]/statBases/StuffPower_Armor_Sharp</xpath>
 		<value>
 			<Bulk>0.07</Bulk>
 			<MeleeCounterParryBonus>1.33</MeleeCounterParryBonus>

--- a/ModPatches/Alpha Biomes/Patches/Alpha Biomes/Items_Resource_Stuff.xml
+++ b/ModPatches/Alpha Biomes/Patches/Alpha Biomes/Items_Resource_Stuff.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
+
 	<!-- ======== Psychotropic Fungus ======== -->
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="AB_PsychotropicFungus"]/statBases</xpath>
@@ -64,77 +65,38 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationFindMod">
-		<mods>
-			<li>Alpha Animals</li>
-		</mods>
-		<match Class="PatchOperationSequence">
-			<operations>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/equippedStatOffsets</xpath>
-					<value>
-						<equippedStatOffsets>
-							<MeleeCritChance>0.2</MeleeCritChance>
-							<MeleeParryChance>1</MeleeParryChance>
-							<MeleeDodgeChance>0.13</MeleeDodgeChance>
-						</equippedStatOffsets>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/StuffPower_Armor_Sharp</xpath>
-					<value>
-						<Bulk>0.07</Bulk>
-						<MeleeCounterParryBonus>1.33</MeleeCounterParryBonus>
-						<StuffPower_Armor_Sharp>0.1</StuffPower_Armor_Sharp>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/StuffPower_Armor_Blunt</xpath>
-					<value>
-						<StuffPower_Armor_Blunt>0.2</StuffPower_Armor_Blunt>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/StuffPower_Armor_Heat</xpath>
-					<value>
-						<StuffPower_Armor_Heat>0.025</StuffPower_Armor_Heat>
-					</value>
-				</li>
-
-			</operations>
-		</match>
-
-		<nomatch Class="PatchOperationSequence">
-			<operations>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/StuffPower_Armor_Sharp</xpath>
-					<value>
-						<Bulk>0.07</Bulk>
-						<MeleeCounterParryBonus>1.33</MeleeCounterParryBonus>
-						<StuffPower_Armor_Sharp>0.1</StuffPower_Armor_Sharp>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/StuffPower_Armor_Blunt</xpath>
-					<value>
-						<StuffPower_Armor_Blunt>0.2</StuffPower_Armor_Blunt>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/StuffPower_Armor_Heat</xpath>
-					<value>
-						<StuffPower_Armor_Heat>0.025</StuffPower_Armor_Heat>
-					</value>
-				</li>
-
-			</operations>
-		</nomatch>
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]</xpath>
+		<value>
+			<equippedStatOffsets>
+				<MeleeCritChance>0.2</MeleeCritChance>
+				<MeleeParryChance>1</MeleeParryChance>
+				<MeleeDodgeChance>0.13</MeleeDodgeChance>
+			</equippedStatOffsets>
+		</value>
 	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/StuffPower_Armor_Sharp</xpath>
+		<value>
+			<Bulk>0.07</Bulk>
+			<MeleeCounterParryBonus>1.33</MeleeCounterParryBonus>
+			<StuffPower_Armor_Sharp>0.1</StuffPower_Armor_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/StuffPower_Armor_Blunt</xpath>
+		<value>
+			<StuffPower_Armor_Blunt>0.2</StuffPower_Armor_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/StuffPower_Armor_Heat</xpath>
+		<value>
+			<StuffPower_Armor_Heat>0.025</StuffPower_Armor_Heat>
+		</value>
+	</Operation>
+
 </Patch>


### PR DESCRIPTION
## Changes

- Fixed a couple patches regarding the woody materials added by Alpha Biomes, the Alpha Animals check and equippedStatOffsets patch were unnecessary and broken.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (Works)
