### PR TITLE
VBGE packageId fix and RW version update

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -9,7 +9,7 @@
 	</supportedVersions>
 	<packageId>CETeam.CombatExtended</packageId>
 	<description>Version: 15.6.0.0\n\nExtends combat mechanics to make them deeper and more tactical.</description>
-	<modIconPath>UI/Icons/CE_ModIcon_JustHat</modIconPath>
+	<modIconPath IgnoreIfNoMatchingField="True">UI/Icons/CE_ModIcon_JustHat</modIconPath>
 	<modDependencies>
 		<li>
 			<packageId>brrainz.harmony</packageId>

--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <loadFolders>
-	<v1.4>
+	<v1.5>
 		<!-- Core Files -->
 		<li>/</li>
 		<!-- DLC -->
@@ -414,7 +414,7 @@
 		<li IfModActive="VanillaExpanded.VAPPE">ModPatches/Vanilla Apparel Expanded</li>
 		<li IfModActive="VanillaExpanded.VAEAccessories">ModPatches/Vanilla Apparel Expanded - Accessories</li>
 		<li IfModActive="VanillaExpanded.VARME">ModPatches/Vanilla Armour Expanded</li>
-		<li IfModActive="VanillaExpanded.BaseGeneration">ModPatches/Vanilla Base Generation Expanded</li>
+		<li IfModActive="VanillaExpanded.BaseGenerationExpanded">ModPatches/Vanilla Base Generation Expanded</li>
 		<li IfModActive="VanillaExpanded.VBrewE">ModPatches/Vanilla Brewing Expanded</li>
 		<li IfModActive="VanillaExpanded.VChemfuelE">ModPatches/Vanilla Chemfuel Expanded</li>
 		<li IfModActive="VanillaExpanded.VFEA">ModPatches/Vanilla Factions Expanded - Ancients</li>
@@ -590,5 +590,5 @@
 		<li IfModActive="840.Tach.GWarCasket">ModPatches/WarCasket Barbatos Gundam Addon</li>
 		<li IfModActive="Mlie.XennRace">ModPatches/Xenn</li>
 		<li IfModActive="Neronix17.OuterRim.DroidDepot">ModPatches/Outer Rim - Droid Depot</li>
-	</v1.4>
+	</v1.5>
 </loadFolders>


### PR DESCRIPTION
## Changes

- Updated and fixed the package ID of the Vanilla Base Generation Expanded mod.
- Updated the RW version in the LoadFolders file from v1.4 to v1.5.

## Alternatives

- Suffer.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (Works, no errors)
