### PR TITLE
Give Ammo Float Menu Typo Fix

### DIFF
--- a/Languages/ChineseSimplified/Keyed/Misc_Gameplay.xml
+++ b/Languages/ChineseSimplified/Keyed/Misc_Gameplay.xml
@@ -5,7 +5,7 @@
 	<CE_MeleeTargetting_CurHeight>近战攻击部位</CE_MeleeTargetting_CurHeight>
 	<CE_NoBP>未启用</CE_NoBP>
 	<CE_Yes>是</CE_Yes>
-	<CE_GiveAmmoToThing>将弹药交给</CE_GiveAmmoToThing>
+	<CE_GiveAmmoToThing>将弹药交给{0}</CE_GiveAmmoToThing>
 	<CE_Give>交给</CE_Give>
 	<CE_NoAmmoToGive>没有合适的弹药</CE_NoAmmoToGive>
 	<CE_AmmoAmount>交给的弹药数量：</CE_AmmoAmount>

--- a/Languages/English/Keyed/Misc_Gameplay.xml
+++ b/Languages/English/Keyed/Misc_Gameplay.xml
@@ -7,7 +7,7 @@
 	<CE_NoBP>None</CE_NoBP>
 	<CE_Yes>Yes</CE_Yes>
 	<CE_No>No</CE_No>
-	<CE_GiveAmmoToThing>Give ammo to</CE_GiveAmmoToThing>
+	<CE_GiveAmmoToThing>Give ammo to {0}</CE_GiveAmmoToThing>
 	<CE_Give>Give</CE_Give>
 	<CE_NoAmmoToGive>No compatible ammo</CE_NoAmmoToGive>
 	<CE_AmmoAmount>Amount of ammo to give:</CE_AmmoAmount>

--- a/Languages/PortugueseBrazilian/Keyed/Misc_Gameplay.xml
+++ b/Languages/PortugueseBrazilian/Keyed/Misc_Gameplay.xml
@@ -7,7 +7,7 @@
 	<CE_NoBP>Nenhuma</CE_NoBP>
 	<CE_Yes>Sim</CE_Yes>
 	<CE_No>Não</CE_No>
-	<CE_GiveAmmoToThing>Dar munição para</CE_GiveAmmoToThing>
+	<CE_GiveAmmoToThing>Dar munição para {0}</CE_GiveAmmoToThing>
 	<CE_Give>Dar</CE_Give>
 	<CE_NoAmmoToGive>Sem munição compatível</CE_NoAmmoToGive>
 	<CE_AmmoAmount>Quantidade de munição a dar:</CE_AmmoAmount>

--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoGiver.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoGiver.cs
@@ -30,7 +30,7 @@ namespace CombatExtended
                             selPawn.inventory.innerContainer.Where(x => x is AmmoThing).Any(x => ((AmmoDef)x.def).AmmoSetDefs.Contains(user.Props.ammoSet))
                        )
                     {
-                        yield return new FloatMenuOption("CE_GiveAmmoToThing".Translate() + (dad.Name?.ToStringShort ?? dad.def.label),
+                        yield return new FloatMenuOption("CE_GiveAmmoToThing".Translate(dad.Name?.ToStringShort ?? dad.def.label),
                                                          delegate
                         {
                             List<FloatMenuOption> options = new List<FloatMenuOption>();


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Changes code to allow translations to use {0} in place of subject
- Update existing English, Chinese Simplified, and Portuguese translations to utilize correctly

## Reasoning

Why did you choose to implement things this way, e.g.
- Allows translations that do not follow same sentence structure as English to have proper translation

## Alternatives

Describe alternative implementations you have considered, e.g.
- Add a space directly in the C# code
  - Not as flexible as using {0} for the subject
- Leave typo of "Give Ammo to{SUBJECT]" on float menu

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] Playtested a colony (specify how long)
