### PR TITLE
Fix Remote Bombardment Cannot Target Ambush Map

### DIFF
--- a/Languages/English/Keyed/Keys.xml
+++ b/Languages/English/Keyed/Keys.xml
@@ -56,6 +56,7 @@
 	<CE_ArtilleryTargetLabel>Attack world tile</CE_ArtilleryTargetLabel>
 	<CE_ArtilleryTargetDesc>Attack a world tile. If the selected tile contains a map, you can select the attack target within that map.</CE_ArtilleryTargetDesc>
 	<CE_ArtilleryTarget_AlreadyDestroyed>Selected target already destroyed</CE_ArtilleryTarget_AlreadyDestroyed>
+	<CE_ArtilleryTarget_MustTargetMark>Can only target artillery mark</CE_ArtilleryTarget_MustTargetMark>
 
 	<!-- Marking -->
 	<CE_MarkingUnavailableReason>Pawn cannot mark targets for artillery because they are on a map with no local artillery and they need a radio pack to communicate with the artillery crew.\n\nMarking targets is disabled when no artillery is available in local map and the pawn doesn't have access to long range radios.</CE_MarkingUnavailableReason>

--- a/Source/CombatExtended/CombatExtended/Gizmos/Command_ArtilleryTarget.cs
+++ b/Source/CombatExtended/CombatExtended/Gizmos/Command_ArtilleryTarget.cs
@@ -178,7 +178,7 @@ namespace CombatExtended
             }, canSelectTarget: (targetInfo) =>
             {
                 if (!targetInfo.HasWorldObject || targetInfo.Tile == turretTile ||
-                        !(targetInfo.WorldObject.def == WorldObjectDefOf.Ambush) &&
+                        (targetInfo.WorldObject as MapParent)?.Map == null &&
                         targetInfo.WorldObject.GetComponent<WorldObjects.HealthComp>() == null)
                 {
                     return false;

--- a/Source/CombatExtended/CombatExtended/Gizmos/Command_ArtilleryTarget.cs
+++ b/Source/CombatExtended/CombatExtended/Gizmos/Command_ArtilleryTarget.cs
@@ -74,9 +74,9 @@ namespace CombatExtended
                     }, targetValidator: (target) =>
                     {
                         RoofDef roof = map.roofGrid.RoofAt(target.Cell);
-                        if ((roof == null || roof == RoofDefOf.RoofConstructed) && 
+                        if ((roof == null || roof == RoofDefOf.RoofConstructed) &&
                                 target.Cell.GetFirstThing<ArtilleryMarker>(map) != null)
-                        {   
+                        {
                             return true;
                         }
                         else

--- a/Source/CombatExtended/CombatExtended/Gizmos/Command_ArtilleryTarget.cs
+++ b/Source/CombatExtended/CombatExtended/Gizmos/Command_ArtilleryTarget.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
@@ -44,17 +44,14 @@ namespace CombatExtended
                 Log.Error("Command_ArtilleryTarget selected turrets collection is invalid");
                 return;
             }
-            int tile = turret.Map.Tile;
+            int turretTile = turret.Map.Tile;
             int radius = (int)turret.MaxWorldRange;
             Find.WorldTargeter.BeginTargeting((targetInfo) =>
             {
-                if (!targetInfo.HasWorldObject || targetInfo.Tile == tile || targetInfo.WorldObject.GetComponent<WorldObjects.HealthComp>() == null)
-                {
-                    return false;
-                }
                 IEnumerable<Building_TurretGunCE> turrets = SelectedTurrets;
                 Map map = Find.World.worldObjects.MapParentAt(targetInfo.Tile)?.Map ?? null;
-                if (map != null)
+                // We only want player to target world object when there's no colonist in the map
+                if (map != null && map.mapPawns.AnyPawnBlockingMapRemoval)
                 {
                     IntVec3 selectedCell = IntVec3.Invalid;
                     Find.WorldTargeter.StopTargeting();
@@ -69,7 +66,7 @@ namespace CombatExtended
                         targetInfo.mapInt = map;
                         targetInfo.tileInt = map.Tile;
                         targetInfo.cellInt = target.cellInt;
-                        targetInfo.thingInt = target.thingInt;
+                        //targetInfo.thingInt = target.thingInt;
                         TryAttack(turrets, targetInfo, target);
                     }, highlightAction: (target) =>
                     {
@@ -77,7 +74,16 @@ namespace CombatExtended
                     }, targetValidator: (target) =>
                     {
                         RoofDef roof = map.roofGrid.RoofAt(target.Cell);
-                        return roof == null || roof == RoofDefOf.RoofConstructed;
+                        if ((roof == null || roof == RoofDefOf.RoofConstructed) && 
+                                target.Cell.GetFirstThing<ArtilleryMarker>(map) != null)
+                        {   
+                            return true;
+                        }
+                        else
+                        {
+                            Messages.Message("CE_ArtilleryTarget_MustTargetMark".Translate(), MessageTypeDefOf.RejectInput);
+                            return false;
+                        }
                     });
                     return false;
                 }
@@ -122,14 +128,14 @@ namespace CombatExtended
                     {
                         if (t.MaxWorldRange != radius)
                         {
-                            GenDraw.DrawWorldRadiusRing(tile, (int)t.MaxWorldRange);
+                            GenDraw.DrawWorldRadiusRing(turretTile, (int)t.MaxWorldRange);
                         }
                     }
                 }
-                GenDraw.DrawWorldRadiusRing(tile, radius);
+                GenDraw.DrawWorldRadiusRing(turretTile, radius);
             }, extraLabelGetter: (targetInfo) =>
             {
-                int distanceToTarget = Find.WorldGrid.TraversalDistanceBetween(tile, targetInfo.Tile, true);
+                int distanceToTarget = Find.WorldGrid.TraversalDistanceBetween(turretTile, targetInfo.Tile, true);
                 string distanceMessage = null;
                 if (others != null)
                 {
@@ -169,6 +175,15 @@ namespace CombatExtended
                     }
                 }
                 return distanceMessage + "\n" + "CE_ArtilleryTarget_ClickToOrderAttack".Translate() + extra;
+            }, canSelectTarget: (targetInfo) =>
+            {
+                if (!targetInfo.HasWorldObject || targetInfo.Tile == turretTile ||
+                        !(targetInfo.WorldObject.def == WorldObjectDefOf.Ambush) &&
+                        targetInfo.WorldObject.GetComponent<WorldObjects.HealthComp>() == null)
+                {
+                    return false;
+                }
+                return true;
             });
             base.ProcessInput(ev);
         }


### PR DESCRIPTION
## Additions

Remote bombardment can target ambush map now

## Changes

- Player can no longer target the world object itself when there's player pawn on the map.
- Cross-map bombardment can only be performed on artillery markers.

## References

https://discord.com/channels/278818534069501953/324222101550661663/1241442741221720317

## Alternatives

- Or make it possible as long as there's any player faction pawn on target map (or have equipped radio pack, or more...)

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Bombardment works as claimed
