### PR TITLE
Implement vanilla stunnable comp for auto turrets

### DIFF
--- a/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
@@ -50,6 +50,12 @@
 		<comps>
 			<li Class="CompProperties_Flickable" />
 			<li Class="CompProperties_Breakdownable" />
+			<li Class="CompProperties_Stunnable">
+				<useLargeEMPEffecter>true</useLargeEMPEffecter>
+				<affectedDamageDefs>
+				<li>EMP</li>
+				</affectedDamageDefs>
+			</li>
 		</comps>
 	</ThingDef>
 

--- a/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
@@ -117,10 +117,6 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="Turret_Sniper"]/comps/li[@Class="CompProperties_Stunnable"]/affectedDamageDefs/li[.="Stun"]</xpath>
-	</Operation>
-
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Turret_Sniper"]</xpath>
 		<value>
@@ -190,7 +186,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[@Name="Turret_Autocannon"]/comps/li[@Class="CompProperties_Stunnable"]/affectedDamageDefs/li[.="Stun"]</xpath>
+		<xpath>Defs/ThingDef[@Name="AutocannonTurret"]/comps/li[@Class="CompProperties_Stunnable"]/affectedDamageDefs/li[.="Stun"]</xpath>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">

--- a/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
@@ -553,6 +553,10 @@
 	</Operation>
 
 	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Turret_Mortar"]/comps/li[@Class="CompProperties_Stunnable"]</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Turret_Mortar"]/comps</xpath>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
@@ -19,6 +19,10 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Turret_MiniTurret"]/comps/li[@Class="CompProperties_Stunnable"]/affectedDamageDefs/li[.="Stun"]</xpath>
+	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_MiniTurret"]/thingClass</xpath>
 		<value>
@@ -113,6 +117,10 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Turret_Sniper"]/comps/li[@Class="CompProperties_Stunnable"]/affectedDamageDefs/li[.="Stun"]</xpath>
+	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Turret_Sniper"]</xpath>
 		<value>
@@ -179,6 +187,10 @@
 		<value>
 			<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
 		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[@Name="Turret_Autocannon"]/comps/li[@Class="CompProperties_Stunnable"]/affectedDamageDefs/li[.="Stun"]</xpath>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
@@ -267,6 +279,10 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Turret_FoamTurret"]/comps/li[@Class="CompProperties_Stunnable"]/affectedDamageDefs/li[.="Stun"]</xpath>
+	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_FoamTurret"]/comps/li[@Class="CompProperties_Refuelable"]/fuelFilter/thingDefs/li</xpath>
 		<value>
@@ -304,6 +320,10 @@
 
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Turret_RocketswarmLauncher"]/placeWorkers/li[.="PlaceWorker_ShowTurretRadius"]</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Turret_RocketswarmLauncher"]/comps/li[@Class="CompProperties_Stunnable"]/affectedDamageDefs/li[.="Stun"]</xpath>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">


### PR DESCRIPTION
## Additions
- Add the vanilla `Comp_Stunnable` to CE's auto turrets.

## Changes
- Make it so 'Stun' damage doesn't stun vanilla auto turrets.
- Remove `Comp_Stunnable` from the mortar.

## Reasoning
- The new comp was implemented in 1.5 and allows us to hand-off the EMP-stun behavior to the vanilla comp instead of managing it in our code. Since the comp largely duplicates our functionality, it's preferable to switch over to the vanilla comp, since it's already exposed to xml and we don't have to work about maintaining it ourselves.
- For CE's purposes, we probably don't want flashbangs to be able to do the job of EMP rounds by stunning auto turrets.
- Why could a mortar be stunned...?

## Alternatives
- Could continue to use our coded stun for auto turrets, I suppose.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
