### PR TITLE
.300 WM vanilla sniper rifle

### DIFF
--- a/ModPatches/Combat Enthusiast's Collection/Patches/Combat Enthusiast's Collection/ThingDefs_Weapons.xml
+++ b/ModPatches/Combat Enthusiast's Collection/Patches/Combat Enthusiast's Collection/ThingDefs_Weapons.xml
@@ -800,7 +800,7 @@
 		<Properties>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
+			<defaultProjectile>Bullet_300WinchesterMagnum_FMJ</defaultProjectile>
 			<warmupTime>1.60</warmupTime>
 			<range>75</range>
 			<soundCast>CEC_WA2000Shot</soundCast>
@@ -808,9 +808,9 @@
 			<muzzleFlashScale>9</muzzleFlashScale>
 		</Properties>
 		<AmmoUser>
-			<magazineSize>6</magazineSize>
+			<magazineSize>5</magazineSize>
 			<reloadTime>4.5</reloadTime>
-			<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
+			<ammoSet>AmmoSet_300WinchesterMagnum</ammoSet>
 		</AmmoUser>
 		<FireModes>
 			<aiUseBurstMode>FALSE</aiUseBurstMode>

--- a/ModPatches/RH2 Rimmu-Nation² - Weapons/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_DMR.xml
+++ b/ModPatches/RH2 Rimmu-Nation² - Weapons/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_DMR.xml
@@ -594,7 +594,7 @@
 		</Properties>
 
 		<AmmoUser>
-			<magazineSize>6</magazineSize>
+			<magazineSize>5</magazineSize>
 			<reloadTime>4</reloadTime>
 			<ammoSet>AmmoSet_300WinchesterMagnum</ammoSet>
 		</AmmoUser>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -463,24 +463,24 @@
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>Gun_SniperRifle</defName>
 		<statBases>
-			<Mass>7.30</Mass>
-			<RangedWeapon_Cooldown>1.36</RangedWeapon_Cooldown>
+			<Mass>6.80</Mass>
+			<RangedWeapon_Cooldown>1.37</RangedWeapon_Cooldown>
 			<SightsEfficiency>2.6</SightsEfficiency>
 			<ShotSpread>0.05</ShotSpread>
-			<SwayFactor>1.35</SwayFactor>
+			<SwayFactor>1.31</SwayFactor>
 			<Bulk>11.92</Bulk>
-			<WorkToMake>30000</WorkToMake>
+			<WorkToMake>30500</WorkToMake>
 		</statBases>
 		<costList>
-			<Steel>60</Steel>
+			<Steel>65</Steel>
 			<ComponentIndustrial>5</ComponentIndustrial>
 			<Chemfuel>15</Chemfuel>
 		</costList>
 		<Properties>
-			<recoilAmount>1.50</recoilAmount>
+			<recoilAmount>1.75</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
+			<defaultProjectile>Bullet_300WinchesterMagnum_FMJ</defaultProjectile>
 			<warmupTime>1.8</warmupTime>
 			<range>75</range>
 			<soundCast>Shot_SniperRifle</soundCast>
@@ -490,7 +490,7 @@
 		<AmmoUser>
 			<magazineSize>5</magazineSize>
 			<reloadTime>4</reloadTime>
-			<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
+			<ammoSet>AmmoSet_300WinchesterMagnum</ammoSet>
 		</AmmoUser>
 		<FireModes>
 			<aiAimMode>AimedShot</aiAimMode>


### PR DESCRIPTION
## Changes

- Rechambered the vanilla sniper rifle to .300 Winchester Magnum.
- Some consistency checks on some inaccurate stats in comparison to the spreadsheet.
- Rechambered the odd modded .300WM snipers that are chambered in 7.62 NATO.

## References

- https://docs.google.com/spreadsheets/d/1lbT0zzagCRPDJG4GctkeeoTsFCt3lYfM4SRnWt8ql-k/edit#gid=1573763037

## Reasoning

- There is a lack of proper long range firepower in the vanilla weapon line-up and 7.62 NATO does not do the weapon justice as it deals a lot more damage in vanilla than a hypothetical BR, I'd say let's disregard the ammo commonality in this case.

## Alternatives

- Keep as is and suffer.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
