### PR TITLE
Patch the riot gear in VE Armor

### DIFF
--- a/ModPatches/Vanilla Armour Expanded/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Riot.xml
+++ b/ModPatches/Vanilla Armour Expanded/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Riot.xml
@@ -1,0 +1,239 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- === Riot Helmet === -->
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="VAE_Apparel_RiotHelmet"]/statBases</xpath>
+		<value>
+			<Bulk>5</Bulk>
+			<WornBulk>3</WornBulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VAE_Apparel_RiotHelmet"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>3.5</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VAE_Apparel_RiotHelmet"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>28</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VAE_Apparel_RiotHelmet"]/costList/Steel</xpath>
+		<value>
+			<Steel>55</Steel>
+			<DevilstrandCloth>10</DevilstrandCloth>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="VAE_Apparel_RiotHelmet"]/costList/ComponentIndustrial</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="VAE_Apparel_RiotHelmet"]</xpath>
+		<value>
+			<li Class="CombatExtended.PartialArmorExt">
+				<stats>
+					<li>
+						<ArmorRating_Sharp>0.50</ArmorRating_Sharp>
+						<parts>
+							<li>Eye</li>
+							<li>Nose</li>
+							<li>Jaw</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.50</ArmorRating_Blunt>
+						<parts>
+							<li>Eye</li>
+							<li>Nose</li>
+							<li>Jaw</li>
+						</parts>
+					</li>
+				</stats>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- === Riot Armor === -->
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="VAE_Apparel_RiotArmor"]/statBases</xpath>
+		<value>
+			<Bulk>40</Bulk>
+			<WornBulk>15</WornBulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VAE_Apparel_RiotArmor"]/statBases/Mass</xpath>
+		<value>
+			<Mass>20</Mass>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VAE_Apparel_RiotArmor"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>6</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VAE_Apparel_RiotArmor"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>36</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VAE_Apparel_RiotArmor"]/costList/Cloth</xpath>
+		<value>
+			<Cloth>80</Cloth>
+			<DevilstrandCloth>40</DevilstrandCloth>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VAE_Apparel_RiotArmor"]/costList/Steel</xpath>
+		<value>
+			<Steel>80</Steel>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="VAE_Apparel_RiotArmor"]/costList/ComponentIndustrial</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VAE_Apparel_RiotArmor"]/equippedStatOffsets/MoveSpeed</xpath>
+		<value>
+			<MeleeDodgeChance>-0.15</MeleeDodgeChance>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="VAE_Apparel_RiotArmor"]/apparel/bodyPartGroups</xpath>
+		<value>
+			<li>Hands</li>
+			<li>Feet</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="VAE_Apparel_RiotArmor"]</xpath>
+		<value>
+			<li Class="CombatExtended.PartialArmorExt">
+				<stats>
+					<li>
+						<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
+						<parts>
+							<li>Neck</li>
+							<li>Hand</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
+						<parts>
+							<li>Neck</li>
+							<li>Hand</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+						<parts>
+							<li>Leg</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+						<parts>
+							<li>Leg</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+						<parts>
+							<li>Arm</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+						<parts>
+							<li>Arm</li>
+						</parts>
+					</li>
+				</stats>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- === Riot Shield : Replaced as CE type shield === -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VAE_Apparel_Shield_Riot"]</xpath>
+		<value>
+			<ThingDef ParentName="ShieldBase">
+				<defName>VAE_Apparel_Shield_Riot</defName>
+				<label>riot shield</label>
+				<description>An industrial heavy shield made out of reinforced steel. Provides a lot of protection against blunt damage, which makes it ideal for urbworld riot police.</description>
+				<techLevel>Industrial</techLevel>
+				<graphicData>
+					<texPath>Things/Pawn/Humanlike/RiotShield/RiotShield</texPath>
+					<graphicClass>Graphic_Single</graphicClass>
+				</graphicData>
+				<costList>
+					<Steel>60</Steel>
+					<DevilstrandCloth>20</DevilstrandCloth>
+				</costList>
+				<statBases>
+					<WorkToMake>7500</WorkToMake>
+					<MaxHitPoints>125</MaxHitPoints>
+					<ArmorRating_Sharp>3.5</ArmorRating_Sharp>
+					<ArmorRating_Blunt>5.25</ArmorRating_Blunt>
+					<ArmorRating_Heat>0.25</ArmorRating_Heat>
+					<Mass>6</Mass>
+					<Bulk>15</Bulk>
+					<WornBulk>10</WornBulk>
+					<Flammability>0.1</Flammability>
+				</statBases>
+				<equippedStatOffsets>
+					<ReloadSpeed>-0.15</ReloadSpeed>
+					<MeleeHitChance>-2</MeleeHitChance>
+					<ShootingAccuracyPawn>-0.4</ShootingAccuracyPawn>
+					<AimingAccuracy>-0.1</AimingAccuracy>
+					<Suppressability>-0.25</Suppressability>
+					<MeleeCritChance>-0.1</MeleeCritChance>
+					<MeleeParryChance>1.0</MeleeParryChance>
+				</equippedStatOffsets>
+				<apparel>
+					<tags>
+						<li>OutlanderShield</li>
+					</tags>
+				</apparel>
+				<modExtensions>
+					<li Class="CombatExtended.ShieldDefExtension">
+						<shieldCoverage>
+							<li>Hands</li>
+							<li>Arms</li>
+							<li>Shoulders</li>
+							<li>Torso</li>
+							<li>Neck</li>
+							<li>FullHead</li>
+						</shieldCoverage>
+						<crouchCoverage>
+							<li>Legs</li>
+						</crouchCoverage>
+						<drawAsTall>true</drawAsTall>
+					</li>
+				</modExtensions>
+			</ThingDef>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Vanilla Armour Expanded/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Riot.xml
+++ b/ModPatches/Vanilla Armour Expanded/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Riot.xml
@@ -184,7 +184,7 @@
 				<description>An industrial heavy shield made out of reinforced steel. Provides a lot of protection against blunt damage, which makes it ideal for urbworld riot police.</description>
 				<techLevel>Industrial</techLevel>
 				<graphicData>
-					<texPath>Things/Pawn/Humanlike/RiotShield/RiotShield</texPath>
+					<texPath>Things/Apparel/RiotShield/RiotShield</texPath>
 					<graphicClass>Graphic_Single</graphicClass>
 				</graphicData>
 				<costList>


### PR DESCRIPTION
## Changes

- What it says on the tin, the riot gear were moved from VFE-Insectoids to VE Armour.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
