### PR TITLE
Fix and rewrite weapon toughness autopatcher

### DIFF
--- a/Source/CombatExtended/Compatibility/WeaponToughnessAutoPatcher.cs
+++ b/Source/CombatExtended/Compatibility/WeaponToughnessAutoPatcher.cs
@@ -18,95 +18,115 @@ namespace CombatExtended.Compatibility
             {
                 return;
             }
+
+            StatDef SHARP_ARMOR_STUFF_POWER = StatDefOf.ArmorRating_Sharp.GetStatPart<StatPart_Stuff>().stuffPowerStat;
+
             foreach (var def in DefDatabase<ThingDef>.AllDefs.Where(x => x.IsWeapon && !x.IsApparel))
             {
                 try
                 {
-                    if (!def.statBases.Any(x => x.stat == CE_StatDefOf.StuffEffectMultiplierToughness || x.stat == CE_StatDefOf.ToughnessRating))
+                    // Check if toughness is already defined
+                    if (def.statBases?
+                            .Any(x => x.stat == CE_StatDefOf.StuffEffectMultiplierToughness
+                                || x.stat == CE_StatDefOf.ToughnessRating)
+                            ?? true)
                     {
-                        // Approximate weapon thickness via the bulk of the weapon. Longswords get about 2.83mm, knives get 1mm, spears get about 3.162mm
-                        float weaponThickness = Mathf.Sqrt(def.statBases?.Find(statMod => statMod.stat.defName == CE_StatDefOf.Bulk.defName)?.value ?? 0f);
-
-                        if (weaponThickness == 0f)
-                        {
-                            continue;
-                        }
-
-                        // Tech level improves toughness
-                        switch (def.techLevel)
-                        {
-                            //Plasteel
-                            case (TechLevel.Spacer):
-                                weaponThickness *= 2f;
-                                break;
-                            case (TechLevel.Ultra):
-                                weaponThickness *= 4f;
-                                break;
-                            case (TechLevel.Archotech):
-                                weaponThickness *= 8f;
-                                break;
-                        }
-
-                        // Blunt weapons get double thickness because edges are easier to damage. Note that ranged weapons are excluded
-                        if (!def.IsRangedWeapon
-                                && (!def.tools?
-                                    .Any(tool => tool.capacities?
-                                        .Any(capacityDef => DefDatabase<DamageDef>.defsList
-                                            .Any(damageDef => damageDef.armorCategory == DamageArmorCategoryDefOf.Sharp && capacityDef.defName == damageDef.defName))
-                                        ?? false)
-                                    ?? false))
-                        {
-                            weaponThickness *= 2f;
-                        }
-
-                        // Stuffable weapons get the multiplier stat
-                        if (def.MadeFromStuff)
-                        {
-                            def.statBases.Add(new StatModifier { stat = CE_StatDefOf.StuffEffectMultiplierToughness, value = weaponThickness });
-                        }
-                        // Non-stuffable weapons get the rating value
-                        else
-                        {
-                            // Search for a fitting recipe
-                            RecipeDef firstRecipeDef = DefDatabase<RecipeDef>.AllDefs
-                                .FirstOrDefault(recipeDef => recipeDef.products?
-                                        .Any(productDef => productDef.thingDef?.defName == def.defName) ?? false);
-
-                            IngredientCount biggestIngredientCount = firstRecipeDef?.ingredients?
-                                .MaxBy(ingredientCount => ingredientCount.count);
-
-                            float strongestIngredientSharpArmor = 0f;
-
-                            // Recipe does exist and has a fixed ingredient
-                            if (biggestIngredientCount?.IsFixedIngredient ?? false)
-                            {
-                                strongestIngredientSharpArmor = biggestIngredientCount.FixedIngredient.statBases?
-                                    .Find(statMod => statMod.stat.defName == StatDefOf.ArmorRating_Sharp.GetStatPart<StatPart_Stuff>().stuffPowerStat.defName)?
-                                    .value * (biggestIngredientCount.FixedIngredient.GetModExtension<StuffToughnessMultiplierExtensionCE>()?.toughnessMultiplier ?? 1f) ?? 0f;
-                            }
-                            // Recipe may or may not exist
-                            else
-                            {
-                                // Becomes null if the recipe doesn't exist or doesn't have any ingredients
-                                float? nullableSharpArmor = biggestIngredientCount?.filter?.thingDefs?
-                                    .Max(thingDef => thingDef.statBases?
-                                            .Find(statMod => statMod.stat.defName == StatDefOf.ArmorRating_Sharp.GetStatPart<StatPart_Stuff>().stuffPowerStat.defName)?
-                                            .value * (thingDef.GetModExtension<StuffToughnessMultiplierExtensionCE>()?.toughnessMultiplier ?? 1f) ?? 0f);
-
-                                // Fallback to tech level; above industrial is assumed to have items made out of plasteel (hardcoded)
-                                strongestIngredientSharpArmor = nullableSharpArmor ?? (def.techLevel > TechLevel.Industrial ? 2f : 1f);
-                            }
-
-                            def.statBases.Add(new StatModifier { stat = CE_StatDefOf.ToughnessRating, value = weaponThickness * strongestIngredientSharpArmor });
-                        }
+                        continue;
                     }
+
+                    // Approximate weapon thickness with the bulk of the weapon.
+                    // Longswords get about 2.83mm, knives get 1mm, spears get about 3.162mm
+                    float weaponThickness = def.statBases
+                        .Find(statMod => statMod.stat == CE_StatDefOf.Bulk)?.value
+                        ?? 0f;
+                    if (weaponThickness == 0f)
+                    {
+                        continue;
+                    }
+                    weaponThickness = Mathf.Sqrt(weaponThickness);
+
+                    // Tech level improves toughness
+                    switch (def.techLevel)
+                    {
+                        //Plasteel
+                        case (TechLevel.Spacer):
+                            weaponThickness *= 2f;
+                            break;
+                        case (TechLevel.Ultra):
+                            weaponThickness *= 4f;
+                            break;
+                        case (TechLevel.Archotech):
+                            weaponThickness *= 8f;
+                            break;
+                    }
+
+                    // Blunt-only weapons get additional weapon thickness. Ranged weapons excluded
+                    if (!def.IsRangedWeapon
+                            && (!def.tools?
+                                .Any(tool => tool.VerbsProperties
+                                    .Any(property => property.meleeDamageDef
+                                        .armorCategory == DamageArmorCategoryDefOf.Sharp))
+                                ?? false))
+                    {
+                        weaponThickness *= 2f;
+                    }
+
+                    // Stuffable weapons receive the multiplier stat
+                    if (def.MadeFromStuff)
+                    {
+                        def.statBases.Add(new StatModifier
+                        {
+                            stat = CE_StatDefOf.StuffEffectMultiplierToughness,
+                            value = weaponThickness
+                        });
+                        continue;
+                    }
+
+                    // Non-stuffable weapons get the rating value
+                    // Search for a fitting recipe
+                    RecipeDef firstRecipeDef = DefDatabase<RecipeDef>.AllDefs
+                        .FirstOrDefault(recipeDef => recipeDef.products?
+                                .Any(productDef => productDef.thingDef == def) ?? false);
+
+                    IngredientCount biggestIngredientCount = null;
+                    if (!firstRecipeDef?.ingredients?.Empty() ?? false)
+                    {
+                        biggestIngredientCount = firstRecipeDef.ingredients
+                            .MaxBy(ingredientCount => ingredientCount.count);
+                    }
+
+                    float strongestIngredientSharpArmor = 1f;
+
+                    // Recipe does exist and has a fixed ingredient
+                    if (biggestIngredientCount?.IsFixedIngredient ?? false)
+                    {
+                        strongestIngredientSharpArmor = biggestIngredientCount.FixedIngredient.statBases
+                            .Find(statMod => statMod.stat == SHARP_ARMOR_STUFF_POWER)?.value
+                            ?? 0f;
+                        strongestIngredientSharpArmor *= biggestIngredientCount.FixedIngredient
+                            .GetModExtension<StuffToughnessMultiplierExtensionCE>()?.toughnessMultiplier
+                            ?? 1f;
+                    }
+                    // Recipe may or may not exist
+                    else
+                    {
+                        strongestIngredientSharpArmor = biggestIngredientCount?.filter?.thingDefs?
+                            .Max(thingDef => (thingDef.statBases?.Find(statMod => statMod.stat == SHARP_ARMOR_STUFF_POWER)?.value ?? 0f)
+                                    * (thingDef.GetModExtension<StuffToughnessMultiplierExtensionCE>()?.toughnessMultiplier ?? 1f))
+                            ?? 1f;
+                    }
+
+                    def.statBases.Add(new StatModifier
+                    {
+                        stat = CE_StatDefOf.ToughnessRating,
+                        value = weaponThickness * strongestIngredientSharpArmor
+                    });
                 }
                 catch (Exception e)
                 {
-                    Log.Error($"Failed to patch {def} with error {e}");
+                    Log.Error($"[CE] Failed to autopatch toughness for {def} with error {e}");
                 }
             }
-
         }
     }
 }


### PR DESCRIPTION
## Changes

- Fixes the autopatcher when encountering weapons with a defined, but empty ingredients list;
- Rewrote and reformatted the autopatcher.

## References

- Fixes an error encountered by #3139 which was caused by the autopatcher;
- Should look slightly cleaner.

## Testing

- [x] Compiles without warnings;
- [x] Game runs without errors;
- [ ] Playtested a colony (specify how long).
- Ran #3139 with the changed assembly and did not encounter the error.
