### PR TITLE
Patches for Edge of Descension - Hovercraft

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -105,6 +105,7 @@
 		<li IfModActive="Dubwise.Rimatomics">ModPatches/Dubs Rimatomics</li>
 		<li IfModActive="Dumbs.DumbsDachshunds">ModPatches/Dumbs&apos; Dachshunds</li>
 		<li IfModActive="Harkon.DF.Dusk">ModPatches/Dusk Armory</li>
+		<li IfModActive="Rabbit.Hovercar">ModPatches/Edge of Descension - Hovercraft</li>
 		<li IfModActive="Rabbit.EdgeOfDescension">ModPatches/Edge of Descension - Monoblades</li>
 		<li IfModActive="Rabbit.EoDVanguard">ModPatches/Edge of Descension - Vanguard</li>
 		<li IfModActive="Nazgul.EisenhansPowerArmor">ModPatches/Eisenhans Power Armor</li>

--- a/ModPatches/Edge of Descension - Hovercraft/Patches/Edge of Descension - Hovercraft/VehicleDefs/ArmoredHovertruck.xml
+++ b/ModPatches/Edge of Descension - Hovercraft/Patches/Edge of Descension - Hovercraft/VehicleDefs/ArmoredHovertruck.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- Turret -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleTurretDef[defName="ArmoredHovertruck_MainTurret"]/projectile</xpath>
+		<value>
+			<projectile>Bullet_8x35mmCharged</projectile>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleTurretDef[defName="ArmoredHovertruck_MainTurret"]/reloadTimer</xpath>
+		<value>
+			<reloadTimer>7.8</reloadTimer>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleTurretDef[defName="ArmoredHovertruck_MainTurret"]/warmUpTimer</xpath>
+		<value>
+			<warmUpTimer>2.3</warmUpTimer>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleTurretDef[defName="ArmoredHovertruck_MainTurret"]/magazineCapacity</xpath>
+		<value>
+			<magazineCapacity>50</magazineCapacity>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleTurretDef[defName="ArmoredHovertruck_MainTurret"]/maxRange</xpath>
+		<value>
+			<maxRange>82</maxRange>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleTurretDef[defName="ArmoredHovertruck_MainTurret"]/fireModes</xpath>
+		<value>
+			<fireModes>
+				<li>
+					<shotsPerBurst>1</shotsPerBurst>
+					<ticksBetweenShots>6</ticksBetweenShots>
+					<ticksBetweenBursts>60</ticksBetweenBursts>
+					<label>Single</label>
+					<texPath>UI/Gizmos/FireRate_Single</texPath>
+				</li>
+				<li>
+					<shotsPerBurst>5</shotsPerBurst>
+					<ticksBetweenShots>6</ticksBetweenShots>
+					<ticksBetweenBursts>60</ticksBetweenBursts>
+					<label>Burst</label>
+					<texPath>UI/Gizmos/FireRate_Burst</texPath>
+				</li>
+			</fireModes>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/Vehicles.VehicleTurretDef[defName="ArmoredHovertruck_MainTurret"]</xpath>
+		<value>
+			<li Class="Vehicles.CETurretDataDefModExtension">
+				<ammoSet>AmmoSet_8x35mmCharged</ammoSet>
+				<shotHeight>2.0</shotHeight>
+				<speed>62</speed>
+				<sway>1.61</sway>
+				<spread>0.15</spread>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- Vehicle -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/Vehicles.VehicleDef[defName="ArmoredHovertruck"]</xpath>
+		<value>
+			<descriptionHyperlinks>
+				<CombatExtended.AmmoSetDef>AmmoSet_8x35mmCharged</CombatExtended.AmmoSetDef>
+			</descriptionHyperlinks>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="ArmoredHovertruck"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>24</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="ArmoredHovertruck"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>12</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="ArmoredHovertruck"]/components/li[key="LeftArmorPlating"]/health</xpath>
+		<value>
+			<health>800</health>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="ArmoredHovertruck"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>28</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="ArmoredHovertruck"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>14</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="ArmoredHovertruck"]/components/li[key="RightArmorPlating"]/health</xpath>
+		<value>
+			<health>800</health>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="ArmoredHovertruck"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>28</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="ArmoredHovertruck"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>14</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="ArmoredHovertruck"]/components/li[key="BackArmorPlating"]/health</xpath>
+		<value>
+			<health>380</health>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="ArmoredHovertruck"]/components/li[key="BackArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>20</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="ArmoredHovertruck"]/components/li[key="BackArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>10</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Edge of Descension - Hovercraft/Patches/Edge of Descension - Hovercraft/VehicleDefs/Hovercar.xml
+++ b/ModPatches/Edge of Descension - Hovercraft/Patches/Edge of Descension - Hovercraft/VehicleDefs/Hovercar.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- Big Rig -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="Hovercar"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>8</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="Hovercar"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>4</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Edge of Descension - Hovercraft/Patches/Edge of Descension - Hovercraft/VehicleDefs/Hovertank.xml
+++ b/ModPatches/Edge of Descension - Hovercraft/Patches/Edge of Descension - Hovercraft/VehicleDefs/Hovertank.xml
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- Main Turret -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleTurretDef[defName="Hovertank_MainTurret"]/projectile</xpath>
+		<value>
+			<projectile>Bullet_105x617mmRCannonShell_HE</projectile>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleTurretDef[defName="Hovertank_MainTurret"]/reloadTimer</xpath>
+		<value>
+			<reloadTimer>8.8</reloadTimer>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleTurretDef[defName="Hovertank_MainTurret"]/warmUpTimer</xpath>
+		<value>
+			<warmUpTimer>3.1</warmUpTimer>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleTurretDef[defName="Hovertank_MainTurret"]/maxRange</xpath>
+		<value>
+			<maxRange>89</maxRange>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/Vehicles.VehicleTurretDef[defName="Hovertank_MainTurret"]</xpath>
+		<value>
+			<li Class="Vehicles.CETurretDataDefModExtension">
+				<ammoSet>AmmoSet_105x617mmRCannonShell</ammoSet>
+				<shotHeight>2.5</shotHeight>
+				<speed>182</speed>
+				<sway>0.82</sway>
+				<spread>0.01</spread>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- Vehicle -->
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/Vehicles.VehicleDef[defName="Hovertank"]</xpath>
+		<value>
+			<descriptionHyperlinks>
+				<CombatExtended.AmmoSetDef>AmmoSet_105x617mmRCannonShell</CombatExtended.AmmoSetDef>
+			</descriptionHyperlinks>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="Hovertank"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>40</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="Hovertank"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>20</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="Hovertank"]/vehicleStats/CargoCapacity</xpath>
+		<value>
+			<CargoCapacity>325</CargoCapacity>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="Hovertank"]/components/li[key="FrontArmorPlating"]/health</xpath>
+		<value>
+			<health>900</health>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="Hovertank"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>48</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="Hovertank"]/components/li[key="FrontArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>24</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="Hovertank"]/components/li[key="LeftArmorPlating"]/health</xpath>
+		<value>
+			<health>1000</health>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="Hovertank"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>56</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="Hovertank"]/components/li[key="LeftArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>28</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="Hovertank"]/components/li[key="RightArmorPlating"]/health</xpath>
+		<value>
+			<health>1000</health>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="Hovertank"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>56</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="Hovertank"]/components/li[key="RightArmorPlating"]/armor/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>28</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="Hovertank"]/components/li[key="BackArmorPlating"]/health</xpath>
+		<value>
+			<health>700</health>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="Hovertank"]/components/li[key="RoofPlating"]/health</xpath>
+		<value>
+			<health>700</health>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="Hovertank"]/components/li[key="RoofPlating"]/armor/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>40</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="Hovertank"]/components/li[key="RoofPlating"]/armor/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>20</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Edge of Descension - Hovercraft/Patches/Edge of Descension - Hovercraft/VehicleDefs/Hovertruck.xml
+++ b/ModPatches/Edge of Descension - Hovercraft/Patches/Edge of Descension - Hovercraft/VehicleDefs/Hovertruck.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- Big Rig -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="Hovertruck"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>8</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="Hovertruck"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>4</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Edge of Descension - Hovercraft/Patches/Edge of Descension - Hovercraft/VehicleDefs/Vehicles_Explosions_Fix.xml
+++ b/ModPatches/Edge of Descension - Hovercraft/Patches/Edge of Descension - Hovercraft/VehicleDefs/Vehicles_Explosions_Fix.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[
+			defName="ArmoredHovertruck" or
+			defName="Hovercar" or
+			defName="Hovertank" or
+			defName="Hovertruck"]/components/li[key="Engine"]/reactors/li[@Class = "Vehicles.Reactor_Explosive"]/damageDef</xpath>
+		<value>
+			<damageDef>Bomb</damageDef>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[
+			defName="ArmoredHovertruck" or
+			defName="Hovercar" or
+			defName="Hovertank" or
+			defName="Hovertruck"]/components/li[key="Engine"]/reactors/li[@Class = "Vehicles.Reactor_Explosive"]/radius</xpath>
+		<value>
+			<radius>1</radius>
+		</value>
+	</Operation>
+
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -178,6 +178,7 @@ Dumbs' Dachshunds   |
 Dusk Armory   |
 Eccentric Militors	|
 ED-Shields	|
+Edge of Descension - Hovercraft  |
 Edge of Descension - Monoblades  |
 Edge of Descension - Vanguard   |
 Eltex Bodysuit  |


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- added patches for Armored Hovertruck and Hovertank.

## Changes
- adjusted armor value for Armored Hovertruck, Hovercar, Hovertruck, and Hovertank.
- adjusted cargo value for Hovertank.
- adjusted internal components explosion range for Armored Hovertruck, Hovercar, Hovertruck, and Hovertank.

## Reasoning

Why did you choose to implement things this way, e.g.
- because Sci-fi vehicles go woosh and Hovertank go boom boom.

## Alternatives

Describe alternative implementations you have considered, e.g.
- electric Tesla vehicles.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
