### PR TITLE
Short Barrel 7.62 Soviet ammoset

### DIFF
--- a/Defs/Ammo/Rifle/762x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/762x39mmSoviet.xml
@@ -24,6 +24,20 @@
 		<similarTo>AmmoSet_RifleIntermediate</similarTo>
 	</CombatExtended.AmmoSetDef>
 
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_762x39mmSoviet_SB</defName>
+		<label>7.62x39 Soviet</label>
+		<ammoTypes>
+			<Ammo_762x39mmSoviet_FMJ>Bullet_762x39mmSoviet_FMJ_SB</Ammo_762x39mmSoviet_FMJ>
+			<Ammo_762x39mmSoviet_AP>Bullet_762x39mmSoviet_AP_SB</Ammo_762x39mmSoviet_AP>
+			<Ammo_762x39mmSoviet_HP>Bullet_762x39mmSoviet_HP_SB</Ammo_762x39mmSoviet_HP>
+			<Ammo_762x39mmSoviet_Incendiary>Bullet_762x39mmSoviet_Incendiary_SB</Ammo_762x39mmSoviet_Incendiary>
+			<Ammo_762x39mmSoviet_HE>Bullet_762x39mmSoviet_HE_SB</Ammo_762x39mmSoviet_HE>
+			<Ammo_762x39mmSoviet_Sabot>Bullet_762x39mmSoviet_Sabot_SB</Ammo_762x39mmSoviet_Sabot>
+		</ammoTypes>
+		<similarTo>AmmoSet_RifleIntermediate</similarTo>
+	</CombatExtended.AmmoSetDef>
+
 	<!-- ==================== Ammo ========================== -->
 
 	<ThingDef Class="CombatExtended.AmmoDef" Name="762x39mmSovietBase" ParentName="SmallAmmoBase" Abstract="True">
@@ -212,6 +226,86 @@
 			<armorPenetrationSharp>19.25</armorPenetrationSharp>
 			<armorPenetrationBlunt>53.36</armorPenetrationBlunt>
 			<speed>189</speed>
+		</projectile>
+	</ThingDef>
+
+	<!-- Short barrel -->
+
+	<ThingDef ParentName="Base762x39mmSovietBullet">
+		<defName>Bullet_762x39mmSoviet_FMJ_SB</defName>
+		<label>7.62mm Soviet bullet (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>15</damageAmountBase>
+			<armorPenetrationSharp>4.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>29.56</armorPenetrationBlunt>
+			<speed>123</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base762x39mmSovietBullet">
+		<defName>Bullet_762x39mmSoviet_AP_SB</defName>
+		<label>7.62mm Soviet bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>9</damageAmountBase>
+			<armorPenetrationSharp>9</armorPenetrationSharp>
+			<armorPenetrationBlunt>29.56</armorPenetrationBlunt>
+			<speed>123</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base762x39mmSovietBullet">
+		<defName>Bullet_762x39mmSoviet_HP_SB</defName>
+		<label>7.62mm Soviet bullet (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>19</damageAmountBase>
+			<armorPenetrationSharp>2.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>29.56</armorPenetrationBlunt>
+			<speed>123</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base762x39mmSovietBullet">
+		<defName>Bullet_762x39mmSoviet_Incendiary_SB</defName>
+		<label>7.62mm Soviet bullet (AP-I)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>9</damageAmountBase>
+			<armorPenetrationSharp>9</armorPenetrationSharp>
+			<armorPenetrationBlunt>29.56</armorPenetrationBlunt>
+			<speed>123</speed>
+			<secondaryDamage>
+				<li>
+					<def>Flame_Secondary</def>
+					<amount>6</amount>
+				</li>
+			</secondaryDamage>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base762x39mmSovietBullet">
+		<defName>Bullet_762x39mmSoviet_HE_SB</defName>
+		<label>7.62mm Soviet bullet (AP-HE)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>15</damageAmountBase>
+			<armorPenetrationSharp>4.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>29.56</armorPenetrationBlunt>
+			<speed>123</speed>
+			<secondaryDamage>
+				<li>
+					<def>Bomb_Secondary</def>
+					<amount>9</amount>
+				</li>
+			</secondaryDamage>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base762x39mmSovietBullet">
+		<defName>Bullet_762x39mmSoviet_Sabot_SB</defName>
+		<label>7.62mm Soviet bullet (Sabot)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>7</damageAmountBase>
+			<armorPenetrationSharp>15.75</armorPenetrationSharp>
+			<armorPenetrationBlunt>38.34</armorPenetrationBlunt>
+			<speed>167</speed>
 		</projectile>
 	</ThingDef>
 


### PR DESCRIPTION
## Changes

- Added the Short Barrel ammoset for the 7.62x39mm ammo.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070

## Reasoning

- AKMS-U in Guns requires it.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
