### PR TITLE
Mini and Medium turret adjustments

### DIFF
--- a/Defs/ThingDefs_Misc/Weapons_Turrets.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Turrets.xml
@@ -131,13 +131,13 @@
 		<statBases>
 			<SightsEfficiency>1</SightsEfficiency>
 			<ShotSpread>0.05</ShotSpread>
-			<SwayFactor>0.94</SwayFactor>
+			<SwayFactor>0.84</SwayFactor>
 			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-			<Mass>15</Mass>
+			<Mass>10</Mass>
 		</statBases>
 		<verbs>
 			<li Class="CombatExtended.VerbPropertiesCE">
-				<recoilAmount>0.77</recoilAmount>
+				<recoilAmount>0.95</recoilAmount>
 				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 				<hasStandardCommand>true</hasStandardCommand>
 				<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>

--- a/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
@@ -84,7 +84,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_MiniTurret"]/costList/ComponentIndustrial</xpath>
 		<value>
-			<ComponentIndustrial>6</ComponentIndustrial>
+			<ComponentIndustrial>5</ComponentIndustrial>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
@@ -54,13 +54,20 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_MiniTurret"]/statBases/Mass</xpath>
 		<value>
-			<Mass>25</Mass>
-			<Bulk>15</Bulk>
+			<Mass>20</Mass>
+			<Bulk>20</Bulk>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Turret_MiniTurret"]/comps/li[@Class="CompProperties_Explosive"]</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Turret_MiniTurret"]/comps/li[@Class="CompProperties_Power"]/basePowerConsumption</xpath>
+		<value>
+			<basePowerConsumption>100</basePowerConsumption>
+		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationRemove">
@@ -70,7 +77,14 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_MiniTurret"]/fillPercent</xpath>
 		<value>
-			<fillPercent>0.85</fillPercent>
+			<fillPercent>0.8</fillPercent>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Turret_MiniTurret"]/costList/ComponentIndustrial</xpath>
+		<value>
+			<ComponentIndustrial>6</ComponentIndustrial>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
@@ -77,7 +77,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_MiniTurret"]/fillPercent</xpath>
 		<value>
-			<fillPercent>0.8</fillPercent>
+			<fillPercent>0.85</fillPercent>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -834,10 +834,11 @@
 			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 			<SightsEfficiency>1</SightsEfficiency>
 			<ShotSpread>0.07</ShotSpread>
-			<SwayFactor>0.69</SwayFactor>
+			<SwayFactor>0.67</SwayFactor>
+			<Mass>4</Mass>
 		</statBases>
 		<Properties>
-			<recoilAmount>0.91</recoilAmount>
+			<recoilAmount>1.02</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>


### PR DESCRIPTION
## Changes

- Slight adjustments to the vanilla mini-turret and CE's medium turret. Changed the components in the mini-turret building recipe from 3 to 6 and power consumption from 80 to 100. Minor mass adjustments to increase the recoil on the both turret guns. Made the mini-turret slightly shorter and less bulkier.

## References

- https://docs.google.com/spreadsheets/d/1lbT0zzagCRPDJG4GctkeeoTsFCt3lYfM4SRnWt8ql-k/edit#gid=1573763037

## Reasoning

- The mini-turret in vanilla is truly garbage and its recipe and power requirements fit it perfectly, but it's a decently potent turret and slightly overtuned in CE as it fires a not-so-weak cartridge pretty accurately at close range, it also has access to advanced ammo and is very cheap to build and power. The slight increase in power consumption and the components in its recipe remedies that and also makes it close to what the spreadsheet outputs its building recipe. It's still a full-auto turret with an AI on top so 6 comps instead of 8 fits the bill if it's considered to be a simple blowback gun as it's unlocked at that stage. These changes keep it pretty balanced compared to the medium turret and makes it less absurdly spammable. The mass decrease is meant to make the turrets less accurate in long bursts and not a laser pointer.
- The only vanilla turret not adjusted for CE.

## Alternatives

- Keep as is?

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
