### PR TITLE
Minor turret research project location tweaks

### DIFF
--- a/Defs/ResearchProjectDefs/ResearchProjects_Turrets.xml
+++ b/Defs/ResearchProjectDefs/ResearchProjects_Turrets.xml
@@ -42,7 +42,7 @@
 			<li>MultiAnalyzer</li>
 		</requiredResearchFacilities>
 		<researchViewX>11</researchViewX>
-		<researchViewY>3.2</researchViewY>
+		<researchViewY>3.1</researchViewY>
 		<generalRules>
 			<rulesStrings>
 				<li>subject->heavy autoturrets</li>

--- a/Patches/Core/ResearchProjectDefs/ResearchProjects.xml
+++ b/Patches/Core/ResearchProjectDefs/ResearchProjects.xml
@@ -44,13 +44,6 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ResearchProjectDef[defName="HeavyTurrets"]/researchViewY</xpath>
-		<value>
-			<researchViewY>3.1</researchViewY>
-		</value>
-	</Operation>
-
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ResearchProjectDef[defName="HeavyTurrets"]/prerequisites</xpath>
 		<value>


### PR DESCRIPTION
## Changes

- Moved CE's heavy auto turret research project slightly up to be on the same Y level as the vanilla autocannon turret.
- Removed the Y axis patch of the vanilla autocannon turret.

## Reasoning

- Alignment issues. CE's heavy auto turret tech now sits besides vanilla's AC turret tech and does not stick to the precision rifling project. AC turret tech now has the 3.1 Y coordinate by default making the patch redundant.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
