### PR TITLE
Imperial Cataphract minGenerationAge

### DIFF
--- a/Royalty/Patches/PawnKindDefs_Royalty/PawnKinds_Royalty.xml
+++ b/Royalty/Patches/PawnKindDefs_Royalty/PawnKinds_Royalty.xml
@@ -29,13 +29,6 @@
 
 	<!-- ========== Fighters ========== -->
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/PawnKindDef[@Name="ImperialFighterBase"]</xpath>
-		<value>
-			<minGenerationAge>18</minGenerationAge>
-		</value>
-	</Operation>
-
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="Empire_Fighter_Trooper"]</xpath>
 		<value>
@@ -191,6 +184,13 @@
 					<stuff>Plasteel</stuff>
 				</li>
 			</specificApparelRequirements>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/PawnKindDef[@Name="CataphractBase"]</xpath>
+		<value>
+			<minGenerationAge>18</minGenerationAge>
 		</value>
 	</Operation>
 

--- a/Royalty/Patches/PawnKindDefs_Royalty/PawnKinds_Royalty.xml
+++ b/Royalty/Patches/PawnKindDefs_Royalty/PawnKinds_Royalty.xml
@@ -29,6 +29,13 @@
 
 	<!-- ========== Fighters ========== -->
 
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/PawnKindDef[@Name="ImperialFighterBase"]</xpath>
+		<value>
+			<minGenerationAge>18</minGenerationAge>
+		</value>
+	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="Empire_Fighter_Trooper"]</xpath>
 		<value>


### PR DESCRIPTION
## Changes

- Made sure imperial Cataphract+ pawnKinds spawn older than 18 years old.

## Reasoning

- Imperial Cataphracts spawn with ages lower than 18 and tend to have inventory cap issues, cataphract armor is heavy by itself and requires full inventory capacity values instead of the 80% that 13-18 y/o pawns get.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
