### PR TITLE
Loadout manager window performance fixes

### DIFF
--- a/Source/CombatExtended/CombatExtended/Loadouts/Dialog_ManageLoadouts.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/Dialog_ManageLoadouts.cs
@@ -85,13 +85,13 @@ namespace CombatExtended
             _allSuitableDefs = DefDatabase<ThingDef>.AllDefs.Where(td => !td.IsMenuHidden() && IsSuitableThingDef(td)).ToList();
             _allDefsGeneric = DefDatabase<LoadoutGenericDef>.AllDefs.OrderBy(g => g.label).ToList();
             _selectableItems = new List<SelectableItem>();
-            List<ThingDef> mapSuitableDefs = Find.CurrentMap.listerThings.AllThings.Where((Thing thing) => !thing.PositionHeld.Fogged(thing.MapHeld) && !thing.GetInnerIfMinified().def.Minifiable).Select((Thing thing) => thing.def).Distinct().Intersect(_allSuitableDefs).ToList();
+            List<ThingDef> suitableMapDefs = Find.CurrentMap.listerThings.AllThings.Where((Thing thing) => !thing.PositionHeld.Fogged(thing.MapHeld) && !thing.GetInnerIfMinified().def.Minifiable).Select((Thing thing) => thing.def).Distinct().Intersect(_allSuitableDefs).ToList();
             foreach (var td in _allSuitableDefs)
             {
                 _selectableItems.Add(new SelectableItem()
                 {
                     thingDef = td,
-                    isGreyedOut = (mapSuitableDefs.Find((ThingDef def) => def == td) == null)
+                    isGreyedOut = (suitableMapDefs.Find((ThingDef def) => def == td) == null)
                 });
             }
             SetSource(SourceSelection.Ranged);

--- a/Source/CombatExtended/CombatExtended/Loadouts/Dialog_ManageLoadouts.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/Dialog_ManageLoadouts.cs
@@ -1046,15 +1046,16 @@ namespace CombatExtended
         {
             int tick = GenTicks.TicksAbs;
             int position = 1;
-            foreach (LoadoutGenericDef def in _sourceGeneric)
+            List<ThingDef> mapDefs = Find.CurrentMap.listerThings.AllThings.Where((Thing thing) => !thing.PositionHeld.Fogged(thing.MapHeld) && !thing.GetInnerIfMinified().def.Minifiable).Select((Thing thing) => thing.def).Distinct().ToList();
+            foreach (LoadoutGenericDef loadoutDef in _sourceGeneric)
             {
-                if (!genericVisibility.ContainsKey(def))
+                if (!genericVisibility.ContainsKey(loadoutDef))
                 {
-                    genericVisibility.Add(def, new VisibilityCache());
+                    genericVisibility.Add(loadoutDef, new VisibilityCache());
                 }
-                genericVisibility[def].ticksToRecheck = tick;
-                genericVisibility[def].check = Find.CurrentMap.listerThings.AllThings.Find(x => def.lambda(x.GetInnerIfMinified().def) && !x.def.Minifiable) == null;
-                genericVisibility[def].position = position;
+                genericVisibility[loadoutDef].ticksToRecheck = tick;
+                genericVisibility[loadoutDef].check = mapDefs.Find((ThingDef def) => loadoutDef.lambda(def)) == null;
+                genericVisibility[loadoutDef].position = position;
                 position++;
                 tick += advanceTicks;
             }

--- a/Source/CombatExtended/CombatExtended/Loadouts/Dialog_ManageLoadouts.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/Dialog_ManageLoadouts.cs
@@ -85,13 +85,13 @@ namespace CombatExtended
             _allSuitableDefs = DefDatabase<ThingDef>.AllDefs.Where(td => !td.IsMenuHidden() && IsSuitableThingDef(td)).ToList();
             _allDefsGeneric = DefDatabase<LoadoutGenericDef>.AllDefs.OrderBy(g => g.label).ToList();
             _selectableItems = new List<SelectableItem>();
+            List<ThingDef> mapSuitableDefs = Find.CurrentMap.listerThings.AllThings.Where((Thing thing) => !thing.PositionHeld.Fogged(thing.MapHeld) && !thing.GetInnerIfMinified().def.Minifiable).Select((Thing thing) => thing.def).Distinct().Intersect(_allSuitableDefs).ToList();
             foreach (var td in _allSuitableDefs)
             {
                 _selectableItems.Add(new SelectableItem()
                 {
                     thingDef = td,
-                    isGreyedOut = (Find.CurrentMap.listerThings.AllThings.Find(thing => thing.GetInnerIfMinified().def == td && !thing.def.Minifiable) == null)
-                    //!thing.PositionHeld.Fogged(thing.MapHeld) //check Thing is visible on map. CPU expensive!
+                    isGreyedOut = (mapSuitableDefs.Find((ThingDef def) => def == td) == null)
                 });
             }
             SetSource(SourceSelection.Ranged);


### PR DESCRIPTION
## Changes

- Improved the time it takes to open the loadout editor window on a 400x400 map from 5 seconds to pretty much instant
- Similarly improved the performance of the generic tab
- Re-added the visibility check for greying out items
- Other logic _should_ be unchanged

## Reasoning

The previous implementation searches through every selectable thing on the map for every item in the list. That's a lot, especially for big and mountanous maps. Now it's only done once each time you open the window or the generic tab. The rest of the lookups go through a distinct list of defs found, which is much, much smaller. 
That frees up a lot of performance to reimplement the visibility check that was deemed "CPU expensive!" before.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
