### PR TITLE
30x29mm HEDP grenades and housekeeping

### DIFF
--- a/Defs/Ammo/Grenade/30x29mmGrenade.xml
+++ b/Defs/Ammo/Grenade/30x29mmGrenade.xml
@@ -16,6 +16,7 @@
 		<ammoTypes>
 			<Ammo_30x29mmGrenade_HE>Bullet_30x29mmGrenade_HE</Ammo_30x29mmGrenade_HE>
 			<Ammo_30x29mmGrenade_HE_TFuzed>Bullet_30x29mmGrenade_HE_TFuzed</Ammo_30x29mmGrenade_HE_TFuzed>
+			<Ammo_30x29mmGrenade_HEDP>Bullet_30x29mmGrenade_HEDP</Ammo_30x29mmGrenade_HEDP>
 			<Ammo_30x29mmGrenade_EMP>Bullet_30x29mmGrenade_EMP</Ammo_30x29mmGrenade_EMP>
 			<Ammo_30x29mmGrenade_Smoke>Bullet_30x29mmGrenade_Smoke</Ammo_30x29mmGrenade_Smoke>
 		</ammoTypes>
@@ -67,6 +68,20 @@
 		</statBases>
 		<ammoClass>GrenadeHETF</ammoClass>
 		<detonateProjectile>Bullet_30x29mmGrenade_HE</detonateProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="30x29mmGrenadeBase">
+		<defName>Ammo_30x29mmGrenade_HEDP</defName>
+		<label>30x29mm grenade (HEDP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/GrenadeLauncher/DP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>2.59</MarketValue>
+		</statBases>
+		<ammoClass>GrenadeHEDP</ammoClass>
+		<detonateProjectile>Bullet_30x29mmGrenade_HEDP</detonateProjectile>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="30x29mmGrenadeBase">
@@ -150,6 +165,31 @@
 					<Fragment_Small>28</Fragment_Small>
 				</fragments>
 				<fragAngleRange>-89~-5</fragAngleRange>
+			</li>
+		</comps>
+	</ThingDef>
+
+	<ThingDef ParentName="Base30x29mmGrenadeBullet">
+		<defName>Bullet_30x29mmGrenade_HEDP</defName>
+		<thingClass>CombatExtended.BulletCE</thingClass>
+		<label>30x29mm grenade (HEDP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<damageAmountBase>35</damageAmountBase>
+			<armorPenetrationSharp>45</armorPenetrationSharp>
+			<armorPenetrationBlunt>5.569</armorPenetrationBlunt>
+		</projectile>
+		<comps>
+			<li Class="CombatExtended.CompProperties_ExplosiveCE">
+				<damageAmountBase>19</damageAmountBase>
+				<explosiveDamageType>Bomb</explosiveDamageType>
+				<explosiveRadius>0.5</explosiveRadius>
+				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			</li>
+			<li Class="CombatExtended.CompProperties_Fragments">
+				<fragments>
+					<Fragment_Small>14</Fragment_Small>
+				</fragments>
 			</li>
 		</comps>
 	</ThingDef>
@@ -265,6 +305,50 @@
 			<Ammo_30x29mmGrenade_HE_TFuzed>100</Ammo_30x29mmGrenade_HE_TFuzed>
 		</products>
 		<workAmount>13600</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="LauncherAmmoRecipeBase">
+		<defName>MakeAmmo_30x29mmGrenade_HEDP</defName>
+		<label>make 30x29mm HEDP grenades x100</label>
+		<description>Craft 100 30x29mm HEDP grenades.</description>
+		<jobString>Making 30x29mm HEDP grenades.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>74</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>FSX</li>
+					</thingDefs>
+				</filter>
+				<count>6</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>2</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>FSX</li>
+				<li>ComponentIndustrial</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_30x29mmGrenade_HEDP>100</Ammo_30x29mmGrenade_HEDP>
+		</products>
+		<workAmount>11000</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="LauncherAmmoRecipeBase">

--- a/Defs/Ammo/Grenade/35x32mmSRGrenade.xml
+++ b/Defs/Ammo/Grenade/35x32mmSRGrenade.xml
@@ -139,7 +139,7 @@
 			<damageDef>Bullet</damageDef>
 			<damageAmountBase>31</damageAmountBase>
 			<armorPenetrationSharp>55</armorPenetrationSharp>
-			<armorPenetrationBlunt>5.552</armorPenetrationBlunt>
+			<armorPenetrationBlunt>4.961</armorPenetrationBlunt>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">

--- a/Defs/Ammo/Grenade/40x46mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x46mmGrenade.xml
@@ -194,7 +194,7 @@
 			<damageDef>Bullet</damageDef>
 			<damageAmountBase>35</damageAmountBase>
 			<armorPenetrationSharp>63</armorPenetrationSharp>
-			<armorPenetrationBlunt>5.942</armorPenetrationBlunt>
+			<armorPenetrationBlunt>5.543</armorPenetrationBlunt>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">

--- a/Defs/Ammo/Grenade/40x53mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmGrenade.xml
@@ -179,7 +179,7 @@
 			<damageDef>Bullet</damageDef>
 			<damageAmountBase>36</damageAmountBase>
 			<armorPenetrationSharp>76</armorPenetrationSharp>
-			<armorPenetrationBlunt>5.942</armorPenetrationBlunt>
+			<armorPenetrationBlunt>5.768</armorPenetrationBlunt>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">


### PR DESCRIPTION
## Additions

- Added 30x29mm HEDP grenades.

## Changes

- Minor blunt AP housekeeping on a couple other HEDP nades.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
