### PR TITLE
Barbed Wire research prerequisite

### DIFF
--- a/Defs/ThingDefs_Buildings/Buildings_Defenses.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Defenses.xml
@@ -54,6 +54,9 @@
 		<terrainAffordanceNeeded>Light</terrainAffordanceNeeded>
 		<designationCategory>Security</designationCategory>
 		<staticSunShadowHeight>0.0</staticSunShadowHeight>
+		<researchPrerequisites>
+			<li>Smithing</li>
+		</researchPrerequisites>
 	</ThingDef>
 
 	<!--========================= Embrasures =============================-->
@@ -117,7 +120,7 @@
 		<designationCategory>Structure</designationCategory>
 		<staticSunShadowHeight>1</staticSunShadowHeight>
 		<blockLight>false</blockLight>
-    <disableImpassableShotOverConfigError>true</disableImpassableShotOverConfigError>
+		<disableImpassableShotOverConfigError>true</disableImpassableShotOverConfigError>
 		<stuffCategories>
 			<li>Metallic</li>
 			<li>Woody</li>


### PR DESCRIPTION
## Changes

- Added the Smithing research as barbed wire's research prerequisite.

## Reasoning

- Making the wires being metalworking and all that.

## Alternatives

- Could set the prerequisite to machining but that'd be too ~~evil~~ late.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
