### PR TITLE
Turn compat assembly building back on

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,9 +26,9 @@ jobs:
       run: |
         TEMP=${{ runner.temp }}/ python Make.py --csproj Source/CombatExtended/CombatExtended.csproj --output Assemblies/CombatExtended.dll --download-libs --all-libs --publicizer $PWD/AssemblyPublicizer
         
-    #- name: build compat
-    #  run: |
-    #    TEMP=${{ runner.temp }}/ python BuildCompat.py
+    - name: build compat
+      run: |
+        TEMP=${{ runner.temp }}/ python BuildCompat.py
         
     - name: package
       run: |

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -39,9 +39,9 @@ jobs:
       run: |
         TEMP=${{ runner.temp }}/ python Make.py --csproj Source/CombatExtended/CombatExtended.csproj --output Assemblies/CombatExtended.dll --download-libs --all-libs --publicizer $PWD/AssemblyPublicizer
 
-    #- name: build compat
-    #  run: |
-    #    TEMP=${{ runner.temp }}/ python BuildCompat.py
+    - name: build compat
+      run: |
+        TEMP=${{ runner.temp }}/ python BuildCompat.py
         
     - name: package
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,9 @@ jobs:
     - name: build core
       run: |
         TEMP=${{ runner.temp }}/ python Make.py --csproj Source/CombatExtended/CombatExtended.csproj --output Assemblies/CombatExtended.dll --download-libs --all-libs --publicizer $PWD/AssemblyPublicizer
-    #- name: build compat
-    #  run: |
-    #    TEMP=${{ runner.temp }}/ python BuildCompat.py
+    - name: build compat
+      run: |
+        TEMP=${{ runner.temp }}/ python BuildCompat.py
     - name: package
       run: |
         mkdir CombatExtended


### PR DESCRIPTION
## Changes

- Turn compat assembly building back on by uncommenting it in the workflows

## Reasoning

- Makes testing fixes to the compat patches way easier and allows people to test the patches for bugs on 1.5 as you don't have to build locally
- None of the compat patches give errors on startup when building locally unless they are outdated and their specific mod is enabled, so theres no real reason to keep them disabled
