### PR TITLE
Misc. Patch Updates

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -48,6 +48,8 @@
 		<li>miho.fortifiedoutremer</li>
 		<li>co.uk.epicguru.whatsthatmod</li>
 		<li>sarg.alphagenes</li>
+		<li>OskarPotocki.VFE.Classical</li>	
+		<li>OskarPotocki.VFE.Tribals</li>
 	</loadBefore>
 	<loadAfter>
 		<li>brrainz.harmony</li>
@@ -59,7 +61,6 @@
 		<li>HC.GiantRace</li>
 		<li>neronix17.fr.compilation</li>
 		<li>VanillaExpanded.VWEFT</li>
-		<li>oskarpotocki.vfe.mechanoid</li>
 		<li>hlx.ReinforcedMechanoids2</li>
 		<li>oskarpotocki.vanillafactionsexpanded.medievalmodule</li>
 		<li>vanillaexpanded.vwe</li>
@@ -84,7 +85,6 @@
 		<li>Killathon.MechHumanlikes.MechanicalBiomimetics</li>
 		<li>botchjob.divineorder</li>
 		<li>OskarPotocki.VFE.Deserters</li>
-		<li>OskarPotocki.VFE.Tribals</li>
 		<li>Sarg.AlphaMemes</li>
 		<li>K4G.Sultanate</li>
 		<li>Argon.VMEu</li>

--- a/About/About.xml
+++ b/About/About.xml
@@ -88,6 +88,7 @@
 		<li>Sarg.AlphaMemes</li>
 		<li>K4G.Sultanate</li>
 		<li>Argon.VMEu</li>
+		<li>Bonible.rimsenalfactions</li>
 	</loadAfter>
 
 </ModMetaData>

--- a/ModPatches/A Rimworld of Magic/Patches/A Rimworld of Magic/Patch_Apparel.xml
+++ b/ModPatches/A Rimworld of Magic/Patches/A Rimworld of Magic/Patch_Apparel.xml
@@ -271,6 +271,7 @@
 			<Mass>3</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoyalHelm"]/statBases/StuffEffectMultiplierArmor</xpath>
 		<value>
@@ -286,6 +287,7 @@
 			</stuffCategories>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoyalHelm"]/apparel/bodyPartGroups</xpath>
 		<value>
@@ -305,6 +307,7 @@
 			<Mass>4</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="ParagonHelm"]/statBases/StuffEffectMultiplierArmor</xpath>
 		<value>
@@ -320,6 +323,7 @@
 			</stuffCategories>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="ParagonHelm"]/apparel/bodyPartGroups</xpath>
 		<value>

--- a/ModPatches/ADE Advanced Turrets/Patches/ADE Advanced Turrets/Buildings_Security.xml
+++ b/ModPatches/ADE Advanced Turrets/Patches/ADE Advanced Turrets/Buildings_Security.xml
@@ -18,6 +18,7 @@
 			<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="ADE_Turret_HMGT" or
@@ -42,6 +43,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="ADE_Turret_HMGT" or

--- a/ModPatches/ADE Advanced Turrets/Patches/ADE Advanced Turrets/Remove_Mod_Ammo.xml
+++ b/ModPatches/ADE Advanced Turrets/Patches/ADE Advanced Turrets/Remove_Mod_Ammo.xml
@@ -10,6 +10,7 @@
 			defName="Make_Ammo_xx_Grenade_CannonShell"
 			] </xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[
 			defName="HMGT_Ammo" or

--- a/ModPatches/ADE Advanced turrets PLUS/Patches/ADE Advanced turrets PLUS/Buildings_Security.xml
+++ b/ModPatches/ADE Advanced turrets PLUS/Patches/ADE Advanced turrets PLUS/Buildings_Security.xml
@@ -18,6 +18,7 @@
 			<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="ADE_Turret_AHMGT" or
@@ -42,6 +43,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="ADE_Turret_AHMGT" or

--- a/ModPatches/ADE Advanced turrets PLUS/Patches/ADE Advanced turrets PLUS/Remove_Mod_Ammo.xml
+++ b/ModPatches/ADE Advanced turrets PLUS/Patches/ADE Advanced turrets PLUS/Remove_Mod_Ammo.xml
@@ -6,6 +6,7 @@
 			defName="Make_Ammo_xx_AHST_CannonShell"
 			] </xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[
 			defName="AHST_Ammo"

--- a/ModPatches/ADE Pulse Turrets PLUS/Patches/ADE Pulse Turrets PLUS/Buildings_Security.xml
+++ b/ModPatches/ADE Pulse Turrets PLUS/Patches/ADE Pulse Turrets PLUS/Buildings_Security.xml
@@ -53,6 +53,7 @@
 			<basePowerConsumption>1050</basePowerConsumption>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="ZXT_Turret_Advancedrotarypulsemachinegunturret"

--- a/ModPatches/ADE Pulse Turrets PLUS/Patches/ADE Pulse Turrets PLUS/Remove_Mod_Ammo.xml
+++ b/ModPatches/ADE Pulse Turrets PLUS/Patches/ADE Pulse Turrets PLUS/Remove_Mod_Ammo.xml
@@ -6,6 +6,7 @@
 			defName="ZXT_Make_x_Ammo_Mediumpulsebattery"
 			] </xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[
 			defName="ZXT_Ammo_Mediumpulsebattery"

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_Resources_Leathers.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_Resources_Leathers.xml
@@ -4,17 +4,20 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="AA_GallatrossHorn"]/tools</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationAttributeSet">
 		<xpath>Defs/ThingDef[defName="AA_GallatrossHorn"]</xpath>
 		<attribute>ParentName</attribute>
 		<value>ResourceBase</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AA_GallatrossHorn"]/description</xpath>
 		<value>
 			<description>A single horn of the mighty Gallatross. Proof that you're a warrior worthy of the title of Aberration Killer. Traders and collectors might pay a high price for this.</description>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AA_GallatrossHorn"]/statBases/MarketValue</xpath>
 		<value>
@@ -29,6 +32,7 @@
 			<Bulk>0.025</Bulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="AA_SkySteel"]/stuffProps/statFactors</xpath>
 		<value>
@@ -36,9 +40,11 @@
 			<MeleePenetrationFactor>1.10</MeleePenetrationFactor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="AA_SkySteel"]/statBases/SharpDamageMultiplier</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="AA_SkySteel"]/stuffProps/categories</xpath>
 		<value>
@@ -46,18 +52,21 @@
 			<li>Steeled</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AA_SkySteel"]/statBases/StuffPower_Armor_Sharp</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>1.35</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AA_SkySteel"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>2.0</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AA_SkySteel"]/statBases/StuffPower_Armor_Heat</xpath>
 		<value>
@@ -72,6 +81,7 @@
 			<StuffPower_Armor_Sharp>0.5</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="AA_Leather_Behemoth"]/statBases</xpath>
 		<value>
@@ -86,18 +96,21 @@
 			<StuffPower_Armor_Sharp>0.03</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AA_Leather_Aerofleet"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.032</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Leather_Cactus"]/statBases/StuffPower_Armor_Sharp</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>0.05</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Leather_Cactus"]/statBases</xpath>
 		<value>
@@ -112,6 +125,7 @@
 			<StuffPower_Armor_Sharp>0.1</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="AA_ArcticLion_Leather" or defName="AA_SandLion_Leather"]/statBases</xpath>
 		<value>
@@ -126,6 +140,7 @@
 			<StuffPower_Armor_Sharp>0.01</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Leather_Night"]/statBases</xpath>
 		<value>
@@ -140,30 +155,35 @@
 			<StuffPower_Armor_Sharp>0.15</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Leather_BlackChitin"]/statBases/StuffPower_Armor_Sharp</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>0.5</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Leather_BlackChitin"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.16</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Leather_Chitin"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.08</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Leather_RaptorPlates" or defName="Leather_IronChitin"]/statBases/StuffPower_Armor_Sharp</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>0.36</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Leather_RaptorPlates" or defName="Leather_IronChitin"]/statBases</xpath>
 		<value>
@@ -178,6 +198,7 @@
 			<StuffPower_Armor_Sharp>0.9</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Leather_Gallatross"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
@@ -192,30 +213,35 @@
 			<StuffPower_Armor_Sharp>0.06</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="AA_ChameleonYakWoolDesert" or defName="AA_ChameleonYakWoolTemperate"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.05</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AA_ChameleonYakWoolJungle"]/statBases/StuffPower_Armor_Sharp</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>0.12</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="AA_ChameleonYakWoolJungle"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.08</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AA_ChameleonYakWoolWinter"]/statBases/StuffPower_Armor_Sharp</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>0.04</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="AA_ChameleonYakWoolWinter"]/statBases</xpath>
 		<value>
@@ -230,18 +256,21 @@
 			<StuffPower_Armor_Sharp>0.2</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AA_CinderSilk"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.05</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AA_CinderSilk"]/statBases/StuffPower_Armor_Heat</xpath>
 		<value>
 			<StuffPower_Armor_Heat>0.02</StuffPower_Armor_Heat>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="AA_CinderSilk"]/stuffProps/categories</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -267,18 +296,21 @@
 			<StuffPower_Armor_Sharp>0.32</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AA_MothSilk"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.09</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AA_MothSilk"]/statBases/StuffPower_Armor_Heat</xpath>
 		<value>
 			<StuffPower_Armor_Heat>0.015</StuffPower_Armor_Heat>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="AA_MothSilk"]/stuffProps/categories</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -312,12 +344,14 @@
 			<StuffPower_Armor_Sharp>0.04</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AA_NightWool"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.05</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AA_NightWool"]/statBases/StuffPower_Armor_Heat</xpath>
 		<value>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Misc/Alpha_Hediffs.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Misc/Alpha_Hediffs.xml
@@ -9,6 +9,7 @@
 			</statOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="AA_AnoleGrown"]/stages/li/statOffsets</xpath>
 		<value>
@@ -18,6 +19,7 @@
 			</statOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="AA_AnoleGrown"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools/li</xpath>
 		<value>
@@ -35,6 +37,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="AA_EatenACorpse"]/stages/li/statOffsets</xpath>
 		<value>
@@ -53,6 +56,7 @@
 			<CarryBulk>1</CarryBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/HediffDef[defName="AA_CarryWeight2"]/stages/li/statOffsets</xpath>
 		<value>
@@ -60,6 +64,7 @@
 			<CarryBulk>5</CarryBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/HediffDef[defName="AA_CarryWeight3"]/stages/li/statOffsets</xpath>
 		<value>
@@ -67,6 +72,7 @@
 			<CarryBulk>7</CarryBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/HediffDef[defName="AA_CarryWeight4"]/stages/li/statOffsets</xpath>
 		<value>
@@ -74,6 +80,7 @@
 			<CarryBulk>10</CarryBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/HediffDef[defName="AA_CarryWeight5"]/stages/li/statOffsets</xpath>
 		<value>
@@ -81,6 +88,7 @@
 			<CarryBulk>15</CarryBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/HediffDef[defName="AA_CarryWeight6"]/stages/li/statOffsets</xpath>
 		<value>
@@ -88,6 +96,7 @@
 			<CarryBulk>20</CarryBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/HediffDef[defName="AA_CarryWeight7"]/stages/li/statOffsets</xpath>
 		<value>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Agaripawn.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Agaripawn.xml
@@ -15,6 +15,7 @@
 			<ArmorRating_Blunt>20</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AA_Agaripawn"]/statBases/ArmorRating_Sharp</xpath>
 		<value>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Agaripod.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Agaripod.xml
@@ -15,6 +15,7 @@
 			<ArmorRating_Blunt>50</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AA_Agaripod"]/statBases/ArmorRating_Sharp</xpath>
 		<value>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_CrescendoAnole.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_CrescendoAnole.xml
@@ -8,6 +8,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="AA_CrescendoAnole"]/statBases</xpath>
 		<!-- Used CE's formula to calculate these values -->
@@ -18,6 +19,7 @@
 			<MeleeParryChance>0</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AA_CrescendoAnole"]/tools</xpath>
 		<value>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_CrystallineCaracal.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_CrystallineCaracal.xml
@@ -17,6 +17,7 @@
 			<MeleeParryChance>0.06</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AA_CrystallineCaracal"]/tools</xpath>
 		<value>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Dunealisk.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Dunealisk.xml
@@ -130,6 +130,7 @@
 			<ArmorRating_Blunt>8</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AA_DunealiskClutchMother"]/statBases/ArmorRating_Sharp</xpath>
 		<value>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_EmpressButterfly.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_EmpressButterfly.xml
@@ -8,6 +8,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="AA_EmpressButterflyLarva"]/statBases</xpath>
 		<value>
@@ -16,6 +17,7 @@
 			<MeleeParryChance>0.01</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AA_EmpressButterflyLarva"]/tools</xpath>
 		<value>
@@ -34,6 +36,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="AA_EmpressButterfly"]</xpath>
 		<value>
@@ -42,6 +45,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="AA_EmpressButterfly"]/statBases</xpath>
 		<value>
@@ -50,6 +54,7 @@
 			<MeleeParryChance>0.05</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AA_EmpressButterfly"]/tools</xpath>
 		<value>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Erin.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Erin.xml
@@ -19,6 +19,7 @@
 			<MeleeParryChance>0.09</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AA_Erin"]/tools</xpath>
 		<value>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Feralisk.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Feralisk.xml
@@ -130,6 +130,7 @@
 			<ArmorRating_Blunt>8</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AA_FeraliskClutchMother"]/statBases/ArmorRating_Sharp</xpath>
 		<value>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_GreyCoatedMouflon.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_GreyCoatedMouflon.xml
@@ -17,6 +17,7 @@
 			<MeleeParryChance>0.08</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AA_GreyCoatedMouflon"]/tools</xpath>
 		<value>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Overgrown_Colossus.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Overgrown_Colossus.xml
@@ -10,6 +10,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="AA_OvergrownColossus" or
 			defName="AA_AnimaColossus"
@@ -20,6 +21,7 @@
 			<MeleeParryChance>0.40</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AA_OvergrownColossus" or
 			defName="AA_AnimaColossus"

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Pebble_Mit.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Pebble_Mit.xml
@@ -15,6 +15,7 @@
 			<ArmorRating_Blunt>15</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AA_PebbleMit"]/statBases/ArmorRating_Sharp</xpath>
 		<value>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Sand_Squid.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Sand_Squid.xml
@@ -15,6 +15,7 @@
 			<ArmorRating_Blunt>18</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AA_SandSquid"]/statBases/ArmorRating_Sharp</xpath>
 		<value>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Skyeel.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Skyeel.xml
@@ -15,6 +15,7 @@
 			<ArmorRating_Blunt>0.8</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AA_Skyeel"]/statBases/ArmorRating_Sharp</xpath>
 		<value>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Slurrypede.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Slurrypede.xml
@@ -24,6 +24,7 @@
 			<ArmorRating_Blunt>20</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AA_Slurrypede"]/statBases/ArmorRating_Sharp</xpath>
 		<value>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Terramorph.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Terramorph.xml
@@ -16,6 +16,7 @@
 			<ArmorRating_Blunt>12</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AA_Terramorph"]/statBases/ArmorRating_Sharp</xpath>
 		<value>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Thermadon.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Thermadon.xml
@@ -15,6 +15,7 @@
 			<ArmorRating_Blunt>10</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AA_Thermadon"]/statBases/ArmorRating_Sharp</xpath>
 		<value>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Wildpawn.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Wildpawn.xml
@@ -15,6 +15,7 @@
 			<ArmorRating_Blunt>20</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AA_Wildpawn"]/statBases/ArmorRating_Sharp</xpath>
 		<value>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Wildpod.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Wildpod.xml
@@ -15,6 +15,7 @@
 			<ArmorRating_Blunt>48</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AA_Wildpod"]/statBases/ArmorRating_Sharp</xpath>
 		<value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Phalanx.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Phalanx.xml
@@ -16,6 +16,7 @@
 			<ArmorRating_Blunt>27</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AM_Phalanx"]/statBases/ArmorRating_Sharp</xpath>
 		<value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Siegebreaker.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Siegebreaker.xml
@@ -16,6 +16,7 @@
 			<ArmorRating_Blunt>60</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AM_Siegebreaker"]/statBases/ArmorRating_Sharp</xpath>
 		<value>

--- a/ModPatches/Altered Carbon Ultratech Unleashed/Patches/Altered Carbon Ultratech Unleashed/AC_Patches.xml
+++ b/ModPatches/Altered Carbon Ultratech Unleashed/Patches/Altered Carbon Ultratech Unleashed/AC_Patches.xml
@@ -7,6 +7,7 @@
 			<immuneToToxGasExposure>true</immuneToToxGasExposure>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[@Name="AC_HuntersHelmet"]/apparel/layers</xpath>
 		<value>

--- a/ModPatches/Ancient Arsenal Warcaskets/Patches/Ancient Arsenal Warcaskets/AncientWarcaskets.xml
+++ b/ModPatches/Ancient Arsenal Warcaskets/Patches/Ancient Arsenal Warcaskets/AncientWarcaskets.xml
@@ -55,6 +55,7 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Ancient"]/verbs</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Ancient"]/comps/li[@Class="MVCF.Comps.CompProperties_VerbGiver"]</xpath>
 	</Operation>
@@ -170,6 +171,7 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Ancient_Cloak"]/verbs</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Ancient_Cloak"]/comps/li[@Class="MVCF.Comps.CompProperties_VerbGiver"]</xpath>
 	</Operation>
@@ -285,6 +287,7 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Ancient_Penitent"]/verbs</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Ancient_Penitent"]/comps/li[@Class="MVCF.Comps.CompProperties_VerbGiver"]</xpath>
 	</Operation>
@@ -343,6 +346,7 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Ancient_Mechnomancer"]/verbs</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Ancient_Mechnomancer"]/comps/li[@Class="MVCF.Comps.CompProperties_VerbGiver"]</xpath>
 	</Operation>

--- a/ModPatches/Ancient Arsenal Warcaskets/Patches/Ancient Arsenal Warcaskets/RangedWeapons.xml
+++ b/ModPatches/Ancient Arsenal Warcaskets/Patches/Ancient Arsenal Warcaskets/RangedWeapons.xml
@@ -192,6 +192,7 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>/Defs/ThingDef[defName="WarcasketGun_Confessor"]/verbs</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>/Defs/ThingDef[defName="WarcasketGun_Confessor"]/comps/li[@Class="CompToggleFireMode.CompProperties_ToggleFireMode"]</xpath>
 	</Operation>

--- a/ModPatches/Ancient Blade Cyborg/Patches/Ancient Blade Cyborg/Cyborg_CoveredByNaturalArmor.xml
+++ b/ModPatches/Ancient Blade Cyborg/Patches/Ancient Blade Cyborg/Cyborg_CoveredByNaturalArmor.xml
@@ -14,30 +14,35 @@
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Cyborg"]/corePart/parts/li[def="Stomach"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Cyborg"]/corePart/parts/li[def="Heart"]/coverage</xpath>
 		<value>
 			<coverage>0.04</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Cyborg"]/corePart/parts/li[def="Lung"]/coverage</xpath>
 		<value>
 			<coverage>0.055</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Cyborg"]/corePart/parts/li[def="Kidney"]/coverage</xpath>
 		<value>
 			<coverage>0.03</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Cyborg"]/corePart/parts/li[def="Liver"]/coverage</xpath>
 		<value>
@@ -100,12 +105,14 @@
 			<coverage>0.06</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Cyborg"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Humerus"]/coverage</xpath>
 		<value>
 			<coverage>0.15</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Cyborg"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Radius"]/coverage</xpath>
 		<value>

--- a/ModPatches/Androids/Patches/Androids/HediffDefs/Hediffs_Upgrades.xml
+++ b/ModPatches/Androids/Patches/Androids/HediffDefs/Hediffs_Upgrades.xml
@@ -165,6 +165,7 @@
 			<ShootingAccuracyPawn>3</ShootingAccuracyPawn>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/HediffDef[defName="ChjAndroidUpgrade_FighterModule"]/stages/li/statOffsets</xpath>
 		<value>

--- a/ModPatches/Antinium/Patches/Antinium/Bodies/Ant_Bodies.xml
+++ b/ModPatches/Antinium/Patches/Antinium/Bodies/Ant_Bodies.xml
@@ -7,30 +7,35 @@
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="Antinium"]/corePart/parts/li[def="Waist"]/groups</xpath>
 		<value>
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="Antinium"]/corePart/parts/li[def="Neck"]/groups</xpath>
 		<value>
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="Antinium"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/groups</xpath>
 		<value>
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="Antinium"]/corePart/parts/li[def="Shoulder"]/groups</xpath>
 		<value>
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="Antinium"]/corePart/parts/li[def="Leg"]/groups</xpath>
 		<value>
@@ -45,6 +50,7 @@
 			<li>OutsideSquishy</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="Antinium"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]/groups</xpath>
 		<value>
@@ -59,18 +65,21 @@
 			<li>LeftArm</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="Antinium"]/corePart/parts/li[contains(./customLabel, "left shoulder")]/groups</xpath>
 		<value>
 			<li>LeftShoulder</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="Antinium"]/corePart/parts/li[def = "Shoulder"]/parts/li[contains(./customLabel, "right arm")]/groups</xpath>
 		<value>
 			<li>RightArm</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="Antinium"]/corePart/parts/li[contains(./customLabel, "right shoulder")]/groups</xpath>
 		<value>
@@ -85,96 +94,112 @@
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Antinium"]/corePart/parts/li[def="Heart"]/coverage</xpath>
 		<value>
 			<coverage>0.04</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Antinium"]/corePart/parts/li[def="Lung"]/coverage</xpath>
 		<value>
 			<coverage>0.055</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Antinium"]/corePart/parts/li[def="Kidney"]/coverage</xpath>
 		<value>
 			<coverage>0.03</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Antinium"]/corePart/parts/li[def="Liver"]/coverage</xpath>
 		<value>
 			<coverage>0.06</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Antinium"]/corePart/parts/li[def="Neck"]/coverage</xpath>
 		<value>
 			<coverage>0.055</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Antinium"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/parts/li[def="Brain"]/coverage</xpath>
 		<value>
 			<coverage>0.9</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Antinium"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Eye"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Antinium"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Ear"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Antinium"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Ant_Antenna"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Antinium"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]/coverage</xpath>
 		<value>
 			<coverage>0.08</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Antinium"]/corePart/parts/li[def="Shoulder"]/coverage</xpath>
 		<value>
 			<coverage>0.085</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Antinium"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Clavicle"]/coverage</xpath>
 		<value>
 			<coverage>0.06</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Antinium"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Humerus"]/coverage</xpath>
 		<value>
 			<coverage>0.15</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Antinium"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Radius"]/coverage</xpath>
 		<value>
 			<coverage>0.15</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Antinium"]/corePart/parts/li[def="Leg"]/parts/li[def="Femur"]/coverage</xpath>
 		<value>
 			<coverage>0.15</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Antinium"]/corePart/parts/li[def="Leg"]/parts/li[def="Tibia"]/coverage</xpath>
 		<value>

--- a/ModPatches/Antinium/Patches/Antinium/PawnKindDefs_Ants/Ant_PawnKindsRaider.xml
+++ b/ModPatches/Antinium/Patches/Antinium/PawnKindDefs_Ants/Ant_PawnKindsRaider.xml
@@ -24,6 +24,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[defName="Ant_Combatant"]/combatPower</xpath>
 		<value>
@@ -47,6 +48,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[defName="Ant_Soldier"]/combatPower</xpath>
 		<value>
@@ -85,6 +87,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[defName="Ant_Bowman"]/combatPower</xpath>
 		<value>
@@ -123,6 +126,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[defName="Ant_Archer"]/combatPower</xpath>
 		<value>
@@ -165,6 +169,7 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/PawnKindDef[defName="Ant_SpecialArcher"]/apparelRequired</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[defName="Ant_SpecialArcher"]/combatPower</xpath>
 		<value>
@@ -192,6 +197,7 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/PawnKindDef[defName="Ant_Warrior"]/apparelRequired</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[defName="Ant_Warrior"]/combatPower</xpath>
 		<value>

--- a/ModPatches/Antinium/Patches/Antinium/ThingDefs_Misc/Ant_ThingDefs.xml
+++ b/ModPatches/Antinium/Patches/Antinium/ThingDefs_Misc/Ant_ThingDefs.xml
@@ -7,6 +7,7 @@
 			<StuffPower_Armor_Sharp>0.09</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Ant_AntiniumChitin"]/statBases</xpath>
 		<value>

--- a/ModPatches/Antinium/Patches/Antinium/ThingDefs_Races/Ant_AntiniumRace.xml
+++ b/ModPatches/Antinium/Patches/Antinium/ThingDefs_Races/Ant_AntiniumRace.xml
@@ -9,6 +9,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Ant_AntiniumRace"]/comps</xpath>
 		<value>
@@ -30,18 +31,21 @@
 			<Mass>72</Mass><!-- A human weighs 60 kg, but ants have chitin so mass is increased -->
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Ant_AntiniumRace"]/statBases/MeleeDodgeChance</xpath>
 		<value>
 			<MeleeDodgeChance>0.9</MeleeDodgeChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Ant_AntiniumRace"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>0.33</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Ant_AntiniumRace"]/statBases/ArmorRating_Blunt</xpath>
 		<value>

--- a/ModPatches/Apparello/Patches/Apparello/ThingDefs/ApparelHats_Famous.xml
+++ b/ModPatches/Apparello/Patches/Apparello/ThingDefs/ApparelHats_Famous.xml
@@ -8,18 +8,21 @@
 			<WornBulk>1</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Doom"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>36</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Doom"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>16</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName = "Apparello_Doom"]/equippedStatOffsets/MoveSpeed</xpath>
 	</Operation>
@@ -30,6 +33,7 @@
 			<ArmorRating_Sharp>0.02</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Quotee"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
@@ -43,12 +47,14 @@
 			<ArmorRating_Sharp>2</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparel_Psymask"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>3</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName = "Apparel_Psymask"]/apparel/immuneToToxGasExposure</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -58,12 +64,14 @@
 			</value>
 		</nomatch>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName = "Apparel_Psymask"]/equippedStatOffsets</xpath>
 		<value>
 			<SmokeSensitivity>-1</SmokeSensitivity>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName = "Apparel_Psymask"]</xpath>
 		<value>
@@ -79,6 +87,7 @@
 			<ArmorRating_Sharp>0.02</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Zorro" or defName="Apparello_Footy"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
@@ -93,18 +102,21 @@
 			<WornBulk>1</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Meffect" or defName = "Apparello_Meffectwo"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>18</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Meffect" or defName = "Apparello_Meffectwo"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>9</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName = "Apparello_Meffect" or defName = "Apparello_Meffectwo"]/equippedStatOffsets/MoveSpeed</xpath>
 	</Operation>
@@ -115,6 +127,7 @@
 			<ArmorRating_Sharp>4</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Kurt" or defName="Apparello_Kurtlite"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
@@ -129,6 +142,7 @@
 			<WornBulk>1</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Raideroos"]/stuffCategories/li[.="Metallic"]</xpath>
 		<value>
@@ -142,12 +156,14 @@
 			<Bulk>5</Bulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Yi"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
 		<value>
 			<AimingAccuracy>0.05</AimingAccuracy>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName = "Apparello_Yi"]/equippedStatOffsets/MoveSpeed</xpath>
 	</Operation>
@@ -158,6 +174,7 @@
 			<ArmorRating_Blunt>0.08</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Raz"]/statBases/ArmorRating_Sharp</xpath>
 		<value>

--- a/ModPatches/Apparello/Patches/Apparello/ThingDefs/ApparelHats_FurEyes.xml
+++ b/ModPatches/Apparello/Patches/Apparello/ThingDefs/ApparelHats_FurEyes.xml
@@ -7,12 +7,14 @@
 			<ArmorRating_Sharp>0.02</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Visoor"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>0.02</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Goggles" or defName="Apparello_Visoor" or defName="Apparello_Shadess" or defName="Apparello_Piloggle"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
@@ -28,12 +30,14 @@
 			<WornBulk>1</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Brimsk"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>4</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Brimsk"]/statBases/ArmorRating_Blunt</xpath>
 		<value>

--- a/ModPatches/Apparello/Patches/Apparello/ThingDefs/ApparelHats_Various.xml
+++ b/ModPatches/Apparello/Patches/Apparello/ThingDefs/ApparelHats_Various.xml
@@ -15,6 +15,7 @@
 			<ArmorRating_Sharp>1</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Hardhat"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
@@ -29,12 +30,14 @@
 			<ArmorRating_Blunt>0.03</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparello_Chefhatplus"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>0.02</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparello_Chefhatplus"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
@@ -48,12 +51,14 @@
 			<AimingAccuracy>0.05</AimingAccuracy>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Cyninja" or defName = "Apparello_Cybissar"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>8</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Cyninja" or defName = "Apparello_Cybissar"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
@@ -67,18 +72,21 @@
 			<Bulk>5</Bulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Medihelmet"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>12</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Medihelmet"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>8</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName = "Apparello_Medihelmet"]/equippedStatOffsets/MoveSpeed</xpath>
 	</Operation>
@@ -89,6 +97,7 @@
 			<ArmorRating_Blunt>0.015</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Medband"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
@@ -102,12 +111,14 @@
 			<Bulk>5</Bulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Proto" or defName = "Apparello_ProtoFin"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>6</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Proto" or defName = "Apparello_ProtoFin"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
@@ -121,30 +132,35 @@
 			<Bulk>5</Bulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Moron"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>3</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Moron"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>2</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName = "Apparello_Sandtrader"]/statBases</xpath>
 		<value>
 			<ArmorRating_Blunt>0.03</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName = "Apparello_Sandtrader"]/statBases</xpath>
 		<value>
 			<ArmorRating_Sharp>0.02</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName = "Apparello_Gassy" or defName = "Apparello_Sandtrader"]/apparel/immuneToToxGasExposure</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -154,12 +170,14 @@
 			</value>
 		</nomatch>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName = "Apparello_Gassy" or defName="Apparello_Sandtrader"]/equippedStatOffsets</xpath>
 		<value>
 			<SmokeSensitivity>-1</SmokeSensitivity>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName = "Apparello_Gassy"]</xpath>
 		<value>
@@ -168,6 +186,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName = "Apparello_Bandit" or defName="Apparello_Vandal"]/equippedStatOffsets</xpath>
 		<value>

--- a/ModPatches/Apparello/Patches/Apparello/ThingDefs/ApparelLayers.xml
+++ b/ModPatches/Apparello/Patches/Apparello/ThingDefs/ApparelLayers.xml
@@ -4,18 +4,21 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Apparello_Bandit" or defName="Apparello_Bandal" or defName="Apparello_Beret" or defName="Apparello_Brimsk" or defName="Apparello_Cyninja" or defName="Apparello_Footy" or defName="Apparello_Gassy" or defName="Apparello_Goggles" or defName="Apparello_Headset" or defName="Apparello_Hoood" or defName="Apparello_Medband" or defName="Apparel_Psymask" or defName="Apparello_Raz" or defName="Apparello_Vandal" or defName="Apparello_Shadess" or defName="Apparello_Docteur" or defName="Apparello_Visoor"]/apparel/layers/li[.="Overhead"]</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName = "Apparello_Cyninja" or defName="Apparello_Cybissar" or defName="Apparello_Doom" or defName="Apparello_Meffect" or defName="Apparello_Meffectwo" or defName="Apparello_Kurt" or defName="Apparello_Kurtlite" or defName="Apparello_ProtoFin" or defName="Apparello_Proto" or defName="Apparello_Rockman" or defName="Apparello_Wendywelder" or defName="Apparello_Yi" or defName="Apparello_Brimsk" or defName="Apparello_Gassy" or defName="Apparello_Goggles" or defName="Apparello_Headset" or defName="Apparel_Psymask" or defName="Apparello_Shadess" or defName="Apparello_Docteur" or defName="Apparello_Visoor" or defName="Apparello_Sandtrader" or defName="Apparello_Zorro"]/apparel/layers</xpath>
 		<value>
 			<li>StrappedHead</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName = "Apparello_Cyninja" or defName="Apparello_Cybissar" or defName="Apparello_ProtoFin" or defName="Apparello_Proto" or defName="Apparello_Headset" or defName="Apparello_Docteur" or defName="Apparello_Footy" or defName="Apparello_Medband" or defName="Apparello_Vandal"]/apparel/layers</xpath>
 		<value>
 			<li>OnHead</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Tribalshield"]/apparel/layers/li[.="Shell"]</xpath>
 		<value>

--- a/ModPatches/Apparello/Patches/Apparello/ThingDefs/Apparel_Pantaloons.xml
+++ b/ModPatches/Apparello/Patches/Apparello/ThingDefs/Apparel_Pantaloons.xml
@@ -7,12 +7,14 @@
 			<WornBulk>5</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Pollypocket"]/equippedStatOffsets/CarryingCapacity</xpath>
 		<value>
 			<CarryBulk>5</CarryBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName = "Apparello_Pollypocket"]/equippedStatOffsets/MoveSpeed</xpath>
 	</Operation>

--- a/ModPatches/Apparello/Patches/Apparello/ThingDefs/Apparel_RareTheHippogryff.xml
+++ b/ModPatches/Apparello/Patches/Apparello/ThingDefs/Apparel_RareTheHippogryff.xml
@@ -7,45 +7,53 @@
 			<ReloadSpeed>0.2</ReloadSpeed>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Scytherframe"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>8</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Scytherframe"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>12</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_HiveArmor"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>20</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_HiveArmor"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>45</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Steamhull"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>18</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Steamhull"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>40.5</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName = "Apparello_HiveArmor" or defName = "Apparello_Steamhull"]/equippedStatOffsets</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName = "Apparello_HiveArmor" or defName = "Apparello_Steamhull"]/statBases</xpath>
 		<value>

--- a/ModPatches/Apparello/Patches/Apparello/ThingDefs/Apparel_Stuffed.xml
+++ b/ModPatches/Apparello/Patches/Apparello/ThingDefs/Apparel_Stuffed.xml
@@ -34,6 +34,7 @@
 			<WornBulk>3</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName = "Apparello_Trypophobiaa"]/equippedStatOffsets</xpath>
 		<value>
@@ -55,6 +56,7 @@
 		<attribute>ParentName</attribute>
 		<value>ShieldBase</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Tribalshield"]/apparel</xpath>
 		<value>
@@ -65,6 +67,7 @@
 			</apparel>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName = "Apparello_Tribalshield"]/statBases</xpath>
 		<value>
@@ -72,6 +75,7 @@
 			<WornBulk>5</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName = "Apparello_Tribalshield"]</xpath>
 		<value>
@@ -86,9 +90,11 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName = "Apparello_Tribalshield"]/generateCommonality</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName = "Apparello_Tribalshield"]</xpath>
 		<value>

--- a/ModPatches/Apparello/Patches/Apparello/ThingDefs/Apparel_Stuffless_And_Bases.xml
+++ b/ModPatches/Apparello/Patches/Apparello/ThingDefs/Apparel_Stuffless_And_Bases.xml
@@ -9,12 +9,14 @@
 			<WornBulk>1</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Gspot"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>18</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Gspot"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
@@ -30,18 +32,21 @@
 			<WornBulk>5</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Gshell" or defName="Apparello_GShellII"]/equippedStatOffsets/MoveSpeed</xpath>
 		<value>
 			<CarryWeight>10</CarryWeight>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Gshell" or defName="Apparello_GShellII"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>15</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Gshell" or defName="Apparello_GShellII"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
@@ -56,6 +61,7 @@
 			<ArmorRating_Sharp>0.02</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName = "Apparello_MedicalApron"]/statBases</xpath>
 		<value>
@@ -70,6 +76,7 @@
 			<ArmorRating_Sharp>0.02</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName = "Apparello_Mogo"]/statBases</xpath>
 		<value>
@@ -84,12 +91,14 @@
 			<CarryBulk>5</CarryBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Standissue"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>0.02</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Standissue"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
@@ -106,27 +115,32 @@
 			<WornBulk>5</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName = "Apparello_Syndicatetello"]/equippedStatOffsets</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Syndicatetello"]/statBases/EnergyShieldRechargeRate</xpath>
 		<value>
 			<EnergyShieldRechargeRate>0.235</EnergyShieldRechargeRate>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Syndicatetello"]/statBases/EnergyShieldEnergyMax</xpath>
 		<value>
 			<EnergyShieldEnergyMax>2</EnergyShieldEnergyMax>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Syndicatetello" or defName="Apparello_Syndicatellorare"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>8</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Syndicatetello" or defName="Apparello_Syndicatellorare"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
@@ -141,6 +155,7 @@
 			<ArmorRating_Sharp>4</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Orkpad"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
@@ -156,6 +171,7 @@
 			<ArmorRating_Sharp>18</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Spacemarinepants"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
@@ -170,6 +186,7 @@
 			<li>Belt</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Medicade"]/statBases/StuffEffectMultiplierArmor</xpath>
 		<value>

--- a/ModPatches/Apparello/Patches/Apparello/ThingDefs/StuffPowers.xml
+++ b/ModPatches/Apparello/Patches/Apparello/ThingDefs/StuffPowers.xml
@@ -7,56 +7,66 @@
 			<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Brocade" or defName="Apparello_Urbulence" or defName="Apparello_Headset" or defName="Apparello_Vandal"]/statBases/StuffEffectMultiplierArmor</xpath>
 		<value>
 			<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_GSkin" or defName = "Apparello_XcomOne" or defName="Apparello_SFSurge" or defName="Apparello_Cookaprontosaurus" or defName="Apparello_PonPon" or defName="Apparello_Preston" or defName="Apparello_Urbskin" or defName="Apparello_Suspender" or defName="Apparello_Spacerpants" or defName="Apparello_Holdem" or defName="Apparello_Scrapants" or defName="Apparello_Pollypocket" or defName="Apparello_Jodhpurs" or defName="Apparello_Skirtwirly" or defName="Apparello_square" or defName="Apparello_Commissar" or defName="Apparello_Gassy" or defName="Apparello_Plainhat" or defName="Apparello_Cardshark" or defName="Apparello_Fedora" or defName="Apparello_Beret" or defName="Apparello_Tophat" or defName="Apparello_Bandal" or defName="Apparello_Lecap" or defName="Apparello_Sombrero"]/statBases/StuffEffectMultiplierArmor</xpath>
 		<value>
 			<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparello_Chapel" or defName="Apparello_TribalPants"]/statBases</xpath>
 		<value>
 			<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Smithaprontosaurus" or defName="Apparel_UniPjays" or defName="Apparello_Jeans" or defName="Apparello_Lederhose" or defName="Apparello_Tunic" or defName="Apparello_Tradecone"]/statBases/StuffEffectMultiplierArmor</xpath>
 		<value>
 			<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName = "Apparello_Urpad" or defName="Apparello_Rockman" or defName = "Apparello_Raideroos" or defName = "Apparello_Yi"]/statBases/ArmorRating_Sharp
 			| Defs/ThingDef[defName = "Apparello_Urpad" or defName="Apparello_Rockman" or defName = "Apparello_Raideroos" or defName = "Apparello_Yi"]/statBases/ArmorRating_Blunt </xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName = "Apparello_Urpad" or defName="Apparello_Ammobelt" or defName="Apparello_Tribalpad" or defName="Apparello_Rockman" or defName = "Apparello_Raideroos" or defName = "Apparello_Yi"]/statBases</xpath>
 		<value>
 			<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparello_Trypophobiaa" or defName="Apparello_Longlylonglong" or defName="Apparello_Skull" or defName="Apparello_Armorpants" or defName="Apparello_Hoood"]/statBases/StuffEffectMultiplierArmor</xpath>
 		<value>
 			<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName = "Apparello_Sheet"]/statBases/ArmorRating_Sharp
 			| Defs/ThingDef[defName = "Apparello_Sheet"]/statBases/ArmorRating_Blunt </xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName = "Apparello_Sheet" or defName="Apparello_Furhat"]/statBases</xpath>
 		<value>
 			<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparello_Tribalshield" or defName="Apparello_Mojo" or defName="Apparello_Mojotwo" or defName="Apparello_MojoFeather"]/statBases/StuffEffectMultiplierArmor</xpath>
 		<value>

--- a/ModPatches/Arachne/Patches/Arachne/Weapons_Arachne.xml
+++ b/ModPatches/Arachne/Patches/Arachne/Weapons_Arachne.xml
@@ -37,6 +37,7 @@
 			<li>ArachneWeapon</li>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="ArachnePninety"]/tools</xpath>
 		<value>

--- a/ModPatches/Arasaka Corporation [1.3]/Patches/Arasaka Corporation [1.3]/Cyberweeb_Hats.xml
+++ b/ModPatches/Arasaka Corporation [1.3]/Patches/Arasaka Corporation [1.3]/Cyberweeb_Hats.xml
@@ -54,6 +54,7 @@
 			<li>StrappedHead</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName = "Apparel_Hazmat_Mask_AC"]</xpath>
 		<value>

--- a/ModPatches/Arrow Please/Patches/Arrow Please/ArrowPlease_Ranged.xml
+++ b/ModPatches/Arrow Please/Patches/Arrow Please/ArrowPlease_Ranged.xml
@@ -256,48 +256,63 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Flame_Crossbow"]</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Arrow_Crossbow"]</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="FlameArrow_Crossbow"]</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Arrow_Arbalest"]</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Flame_Arbalest"]</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="FlameArrow_Arbalest"]</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Arrow_Waistcrossbow"]</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Arrow_Repeatingcrossbow"]</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Stone_Slinger"]</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Dart_Blowgun"]</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Bowshort_Flame"]</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Arrowshort_Flame"]</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Bowrecurve_Flame"]</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Arrowrecurve_Flame"]</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Bowgreat_Flame"]</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Arrowgreat_Flame"]</xpath>
 	</Operation>

--- a/ModPatches/Aspero Race/Patches/Aspero Race/CE_Patch_Animal_Meatdrake.xml
+++ b/ModPatches/Aspero Race/Patches/Aspero Race/CE_Patch_Animal_Meatdrake.xml
@@ -58,6 +58,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="Grei_MeatDrake"]</xpath>
 		<value>

--- a/ModPatches/Aspero Race/Patches/Aspero Race/CE_Patch_Bodies.xml
+++ b/ModPatches/Aspero Race/Patches/Aspero Race/CE_Patch_Bodies.xml
@@ -6,6 +6,7 @@
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd"><!-- Tail should be armored the same as the rest of the body-->
 		<xpath>Defs/BodyDef[defName = "Aspero_Body"]/corePart/parts/li[def = "Tail"]/groups</xpath>
 		<value>

--- a/ModPatches/Aspero Race/Patches/Aspero Race/CE_Patch_HediffParts.xml
+++ b/ModPatches/Aspero Race/Patches/Aspero Race/CE_Patch_HediffParts.xml
@@ -17,6 +17,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="CombatAsperoTail"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
 		<value>
@@ -35,6 +36,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="BionicAsperoTail"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
 		<value>

--- a/ModPatches/Aspero Race/Patches/Aspero Race/CE_Patch_Leather.xml
+++ b/ModPatches/Aspero Race/Patches/Aspero Race/CE_Patch_Leather.xml
@@ -6,12 +6,14 @@
 			<StuffPower_Armor_Sharp>0.10</StuffPower_Armor_Sharp><!-- Vanilla lizard is 0.81 aspero is 1 CE lizard is 0.08, so 0.1 seems to make sense. -->
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationadd"><!-- add instead of replace since aspero used leather base for blunt and didn't define a value itself -->
 		<xpath>Defs/ThingDef[defName="Leather_Aspero"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.04</StuffPower_Armor_Blunt><!-- If I understand the CE xmls right this should be the same as human leather -->
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Leather_Aspero"]/statBases/StuffPower_Armor_Heat</xpath>
 		<value>

--- a/ModPatches/Aspero Race/Patches/Aspero Race/CE_Patch_Race_Aspero.xml
+++ b/ModPatches/Aspero Race/Patches/Aspero Race/CE_Patch_Race_Aspero.xml
@@ -8,6 +8,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Grei_Aspero"]/statBases</xpath>
 		<value>
@@ -37,6 +38,7 @@
 			<li Class="CombatExtended.CompProperties_Suppressable"/>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Grei_Aspero"]/tools</xpath>
 		<value>

--- a/ModPatches/Biomes Caverns/Patches/Biomes Caverns/ThingDefs_Misc/Biomes_Cavern_CE_Patch_Resources_Leathers.xml
+++ b/ModPatches/Biomes Caverns/Patches/Biomes Caverns/ThingDefs_Misc/Biomes_Cavern_CE_Patch_Resources_Leathers.xml
@@ -22,18 +22,21 @@
 			<StuffPower_Armor_Blunt>0.09</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="BMT_CrimsonSilk"]/statBases/StuffPower_Armor_Heat</xpath>
 		<value>
 			<StuffPower_Armor_Heat>0.015</StuffPower_Armor_Heat>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="BMT_CrimsonSilk"]/statBases</xpath>
 		<value>
 			<Bulk>0.025</Bulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="BMT_CrimsonSilk"]/stuffProps/categories</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -58,12 +61,14 @@
 			<StuffPower_Armor_Sharp>0.04</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="BMT_BatWool"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.05</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="BMT_BatWool"]/statBases/StuffPower_Armor_Heat</xpath>
 		<value>
@@ -77,12 +82,14 @@
 			<StuffPower_Armor_Sharp>0.5</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="BMT_SpiderSilk"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.12</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="BMT_SpiderSilk"]/statBases/StuffPower_Armor_Heat</xpath>
 		<value>
@@ -121,18 +128,21 @@
 			<StuffPower_Armor_Sharp>0.21</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="BMT_MediumChitin"]/statBases/StuffPower_Armor_Sharp</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>1.1</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="BMT_MediumChitin"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.5</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="BMT_WeakChitin"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
@@ -146,6 +156,7 @@
 			<StuffPower_Armor_Sharp>1.7</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="BMT_CrystalChitin"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
@@ -159,6 +170,7 @@
 			<StuffPower_Armor_Sharp>2.2</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="BMT_RoyalChitin"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
@@ -172,6 +184,7 @@
 			<StuffPower_Armor_Sharp>2.0</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="BMT_DeepChitin"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
@@ -185,6 +198,7 @@
 			<StuffPower_Armor_Sharp>0.03</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="BMT_Leather_Mushroom"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
@@ -198,6 +212,7 @@
 			<StuffPower_Armor_Sharp>0.25</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="BMT_MoonlessSilk"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>

--- a/ModPatches/Biomes Caverns/Patches/Biomes Caverns/ThingDefs_Races/CE_CrystalCrab.xml
+++ b/ModPatches/Biomes Caverns/Patches/Biomes Caverns/ThingDefs_Races/CE_CrystalCrab.xml
@@ -8,6 +8,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[@Name="BMT_CrystalCrab_Base"]/statBases</xpath>
 		<value>

--- a/ModPatches/Biomes Caverns/Patches/Biomes Caverns/ThingDefs_Races/CE_CrystalMantis.xml
+++ b/ModPatches/Biomes Caverns/Patches/Biomes Caverns/ThingDefs_Races/CE_CrystalMantis.xml
@@ -15,6 +15,7 @@
 			<ArmorRating_Sharp>8</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="BMT_CrystalMantis"]/statBases/ArmorRating_Blunt</xpath>
 		<value>

--- a/ModPatches/Biomes Caverns/Patches/Biomes Caverns/ThingDefs_Races/CE_CrystalbackBeetle.xml
+++ b/ModPatches/Biomes Caverns/Patches/Biomes Caverns/ThingDefs_Races/CE_CrystalbackBeetle.xml
@@ -102,6 +102,7 @@
 			<ArmorRating_Blunt>12</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="BMT_CrystalBeetle"]/statBases/ArmorRating_Sharp</xpath>
 		<value>

--- a/ModPatches/Biomes Caverns/Patches/Biomes Caverns/ThingDefs_Races/CE_FacetMoth.xml
+++ b/ModPatches/Biomes Caverns/Patches/Biomes Caverns/ThingDefs_Races/CE_FacetMoth.xml
@@ -28,6 +28,7 @@
 			<ArmorRating_Sharp>1.5</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="BMT_FacetMothLarvae"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
@@ -92,6 +93,7 @@
 			<ArmorRating_Sharp>5</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="BMT_FacetMothPupa"]/statBases/ArmorRating_Blunt</xpath>
 		<value>

--- a/ModPatches/Biomes Caverns/Patches/Biomes Caverns/ThingDefs_Races/CE_GiantSnail.xml
+++ b/ModPatches/Biomes Caverns/Patches/Biomes Caverns/ThingDefs_Races/CE_GiantSnail.xml
@@ -17,6 +17,7 @@
 			<MeleeParryChance>0.2</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="BMT_GiantSnail"]/statBases/ArmorRating_Blunt</xpath>
 		<value>

--- a/ModPatches/Biomes Caverns/Patches/Biomes Caverns/ThingDefs_Races/CE_MetalloSnail.xml
+++ b/ModPatches/Biomes Caverns/Patches/Biomes Caverns/ThingDefs_Races/CE_MetalloSnail.xml
@@ -17,6 +17,7 @@
 			<MeleeParryChance>0.2</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="BMT_MetalloSnail"]/statBases/ArmorRating_Blunt</xpath>
 		<value>

--- a/ModPatches/Biomes Caverns/Patches/Biomes Caverns/ThingDefs_Races/CE_RoyalRhino.xml
+++ b/ModPatches/Biomes Caverns/Patches/Biomes Caverns/ThingDefs_Races/CE_RoyalRhino.xml
@@ -26,6 +26,7 @@
 			<ArmorRating_Sharp>5.0</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="BMT_RoyalRhinoLarvae"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
@@ -88,6 +89,7 @@
 			<ArmorRating_Sharp>30.0</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="BMT_RoyalRhinoPupa"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
@@ -112,12 +114,14 @@
 			<MeleeParryChance>0.13</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="BMT_RoyalRhino"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>25.0</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="BMT_RoyalRhino"]/statBases/ArmorRating_Blunt</xpath>
 		<value>

--- a/ModPatches/Biomes Caverns/Patches/Biomes Caverns/ThingDefs_Races/CE_ShatterjawBeetle.xml
+++ b/ModPatches/Biomes Caverns/Patches/Biomes Caverns/ThingDefs_Races/CE_ShatterjawBeetle.xml
@@ -75,6 +75,7 @@
 			<ArmorRating_Blunt>10</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="BMT_ShatterjawBeetlePupa"]/statBases/ArmorRating_Sharp</xpath>
 		<value>

--- a/ModPatches/Biomes Core/Patches/Biomes Core/CE_Biomes_Core_Leathers.xml
+++ b/ModPatches/Biomes Core/Patches/Biomes Core/CE_Biomes_Core_Leathers.xml
@@ -7,6 +7,7 @@
 			<StuffPower_Armor_Sharp>1.0</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="BiomesCore_CrabShell"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
@@ -21,6 +22,7 @@
 			<StuffPower_Armor_Sharp>0.6</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="BiomesCore_GreenChitin"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
@@ -34,6 +36,7 @@
 			<StuffPower_Armor_Sharp>0.4</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="BMT_GrayChitin"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
@@ -48,6 +51,7 @@
 			<StuffPower_Armor_Sharp>1.3</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="BMT_Molluskshell"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
@@ -62,6 +66,7 @@
 			<StuffPower_Armor_Sharp>0.03</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="BMT_Leather_Gastropoda"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
@@ -75,18 +80,21 @@
 			<StuffPower_Armor_Sharp>0.16</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="BMT_Leather_Amphibian"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.09</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="BMT_Leather_Magma"]/statBases/StuffPower_Armor_Sharp</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>0.5</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="BMT_Leather_Magma"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
@@ -101,6 +109,7 @@
 			<StuffPower_Armor_Sharp>0.70</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="BMT_ToughLeather"]/statBases</xpath>
 		<value>
@@ -115,6 +124,7 @@
 			<StuffPower_Armor_Sharp>0.04</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="BiomesIslands_Leather_Flamingo"]/statBases</xpath>
 		<value>

--- a/ModPatches/Black Widows/Patches/Black Widows/BodyDefs/Patch_BlackWidow_Body.xml
+++ b/ModPatches/Black Widows/Patches/Black Widows/BodyDefs/Patch_BlackWidow_Body.xml
@@ -9,12 +9,14 @@
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "BlackWidow"]/corePart/parts/li[def = "BlackWidow_Waist"]/groups</xpath>
 		<value>
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "BlackWidow"]/corePart/parts/li[def = "BlackWidow_Abdomen"]/groups</xpath>
 		<value>
@@ -37,18 +39,21 @@
 			<li>LeftArm</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "BlackWidow"]/corePart/parts/li[def = "BWTRShoulder" or def = "BWBRShoulder"]/parts/li[customLabel = "right arm" or customLabel = "right pedipalp"]/groups</xpath>
 		<value>
 			<li>RightArm</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "BlackWidow"]/corePart/parts/li[def = "BWTLShoulder" or def = "BWBLShoulder"]/groups</xpath>
 		<value>
 			<li>LeftShoulder</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "BlackWidow"]/corePart/parts/li[def = "BWTRShoulder" or def = "BWBRShoulder"]/groups</xpath>
 		<value>

--- a/ModPatches/Black Widows/Patches/Black Widows/ThingDefs_Buildings/Patch_Buildings_Widows.xml
+++ b/ModPatches/Black Widows/Patches/Black Widows/ThingDefs_Buildings/Patch_Buildings_Widows.xml
@@ -7,6 +7,7 @@
 			<Bulk>200</Bulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName = "Turret_BWWebcannon"]</xpath>
 		<value>
@@ -15,6 +16,7 @@
 			</tradeTags>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Turret_BWWebcannon"]/researchPrerequisites</xpath>
 		<value>

--- a/ModPatches/Black Widows/Patches/Black Widows/ThingDefs_Items/Patch_Items_Resources.xml
+++ b/ModPatches/Black Widows/Patches/Black Widows/ThingDefs_Items/Patch_Items_Resources.xml
@@ -7,12 +7,14 @@
 			<StuffPower_Armor_Sharp>0.3</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="WidowSilk"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.06</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="WidowSilk"]/statBases/StuffPower_Armor_Heat</xpath>
 		<value>
@@ -27,12 +29,14 @@
 			<StuffPower_Armor_Sharp>0.5</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="ThroneSilk"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.1</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="ThroneSilk"]/statBases/StuffPower_Armor_Heat</xpath>
 		<value>
@@ -47,12 +51,14 @@
 			<StuffPower_Armor_Sharp>0.7</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AbyssSilk"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.14</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AbyssSilk"]/statBases/StuffPower_Armor_Heat</xpath>
 		<value>

--- a/ModPatches/Black Widows/Patches/Black Widows/ThingDefs_Misc/Patch_Apparel_Various.xml
+++ b/ModPatches/Black Widows/Patches/Black Widows/ThingDefs_Misc/Patch_Apparel_Various.xml
@@ -29,18 +29,21 @@
 			<WornBulk>15</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparel_MAGISuit"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>18</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparel_MAGISuit"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>40.5</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparel_MAGISuit"]/equippedStatOffsets</xpath>
 		<value>
@@ -81,18 +84,21 @@
 			<WornBulk>2</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparel_BWMAGISuitHelm"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>14.4</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparel_BWMAGISuitHelm"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>32.4</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparel_BWMAGISuitHelm"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
 		<value>
@@ -109,18 +115,21 @@
 			<WornBulk>4</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparel_BWReaverHelm"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>16</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Apparel_BWReaverHelm"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>37.8</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName = "Apparel_BWReaverHelm"]</xpath>
 		<value>

--- a/ModPatches/Black Widows/Patches/Black Widows/ThingDefs_Races/Patch_Races_BlackWidow.xml
+++ b/ModPatches/Black Widows/Patches/Black Widows/ThingDefs_Races/Patch_Races_BlackWidow.xml
@@ -10,6 +10,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Races_BlackWidow"]/comps</xpath>
 		<value>
@@ -19,6 +20,7 @@
 			<li Class="CombatExtended.CompProperties_Suppressable"/>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName = "Races_BlackWidow"]/statBases/MeleeDodgeChance</xpath>
 		<value>

--- a/ModPatches/Black Widows/Patches/Black Widows/ThingDefs_Races/Patch_Races_BlackWidow_Animal.xml
+++ b/ModPatches/Black Widows/Patches/Black Widows/ThingDefs_Races/Patch_Races_BlackWidow_Animal.xml
@@ -10,6 +10,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName = "BWFlooferMoth"]/statBases</xpath>
 		<value>
@@ -99,6 +100,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName = "BWShadowWorm"]/statBases</xpath>
 		<value>

--- a/ModPatches/Black Widows/Patches/Black Widows/ThingDefs_Weapons/Patch_Weapons.xml
+++ b/ModPatches/Black Widows/Patches/Black Widows/ThingDefs_Weapons/Patch_Weapons.xml
@@ -212,6 +212,7 @@
 			<li>BlackWidowRanged</li>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Gun_BWRifle"]/tools</xpath>
 		<value>
@@ -278,6 +279,7 @@
 			<li>BlackWidowRanged</li>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Bow_BWBow"]/tools</xpath>
 		<value>
@@ -343,6 +345,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="MeleeWeapon_bwscythe"]/equippedStatOffsets</xpath>
 		<value>
@@ -350,12 +353,14 @@
 			<MeleeParryChance>0.5</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="MeleeWeapon_bwscythe"]/equippedStatOffsets/MeleeDodgeChance</xpath>
 		<value>
 			<MeleeDodgeChance>0.6</MeleeDodgeChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="MeleeWeapon_bwscythe"]/statBases/Mass</xpath>
 		<value>
@@ -364,6 +369,7 @@
 			<MeleeCounterParryBonus>0.54</MeleeCounterParryBonus>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="MeleeWeapon_bwscythe" or defName="Bow_BWBow"]/stuffCategories</xpath>
 		<value>

--- a/ModPatches/British Weapons Set/Patches/British Weapons Set/British_weapon_set.xml
+++ b/ModPatches/British Weapons Set/Patches/British Weapons Set/British_weapon_set.xml
@@ -53,6 +53,7 @@
 		<researchPrerequisite>GasOperation</researchPrerequisite>
 		<AllowWithRunAndGun>FALSE</AllowWithRunAndGun>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="BWS_Bren"]</xpath>
 		<value>
@@ -108,6 +109,7 @@
 		<researchPrerequisite>BlowbackOperation</researchPrerequisite>
 		<AllowWithRunAndGun>true</AllowWithRunAndGun>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="BWP_Browning"]</xpath>
 		<value>
@@ -165,6 +167,7 @@
 		<researchPrerequisite>PrecisionRifling</researchPrerequisite>
 		<AllowWithRunAndGun>true</AllowWithRunAndGun>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="BWP_EM"]</xpath>
 		<value>
@@ -217,6 +220,7 @@
 		<researchPrerequisite>Gunsmithing</researchPrerequisite>
 		<AllowWithRunAndGun>FALSE</AllowWithRunAndGun>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="BWS_LeeA"]</xpath>
 		<value>
@@ -269,6 +273,7 @@
 		<researchPrerequisite>Gunsmithing</researchPrerequisite>
 		<AllowWithRunAndGun>FALSE</AllowWithRunAndGun>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="BWS_LeeB"]</xpath>
 		<value>
@@ -332,6 +337,7 @@
 		<researchPrerequisite>GasOperation</researchPrerequisite>
 		<AllowWithRunAndGun>FALSE</AllowWithRunAndGun>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="BWS_LewisGun"]</xpath>
 		<value>
@@ -385,6 +391,7 @@
 		<researchPrerequisite>Gunsmithing</researchPrerequisite>
 		<AllowWithRunAndGun>FALSE</AllowWithRunAndGun>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="BWP_MartiniHenry"]</xpath>
 		<value>
@@ -442,6 +449,7 @@
 		<researchPrerequisite>BlowbackOperation</researchPrerequisite>
 		<AllowWithRunAndGun>true</AllowWithRunAndGun>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="BWS_Sten"]</xpath>
 		<value>
@@ -499,6 +507,7 @@
 		<researchPrerequisite>BlowbackOperation</researchPrerequisite>
 		<AllowWithRunAndGun>true</AllowWithRunAndGun>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="BWS_Sterling"]</xpath>
 		<value>
@@ -556,6 +565,7 @@
 		</weaponTags>
 		<researchPrerequisite>BlowbackOperation</researchPrerequisite>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="BWP_TommyB"]</xpath>
 		<value>
@@ -610,6 +620,7 @@
 		<researchPrerequisite>Gunsmithing</researchPrerequisite>
 		<AllowWithRunAndGun>true</AllowWithRunAndGun>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="BWS_Webley"]</xpath>
 		<value>
@@ -667,6 +678,7 @@
 		<researchPrerequisite>PrecisionRifling</researchPrerequisite>
 		<AllowWithRunAndGun>true</AllowWithRunAndGun>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="BWP_FAL"]</xpath>
 		<value>

--- a/ModPatches/Call of Cthulhu - Cosmic Horrors/Patches/Call of Cthulhu - Cosmic Horrors/BodyDefs_CosmicHorrors/Bodies_Migo.xml
+++ b/ModPatches/Call of Cthulhu - Cosmic Horrors/Patches/Call of Cthulhu - Cosmic Horrors/BodyDefs_CosmicHorrors/Bodies_Migo.xml
@@ -12,6 +12,7 @@
 			<groups/>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>
 			Defs/BodyDef[defName="ROM_MiGoBody"]//*[

--- a/ModPatches/Call of Duty - Zombies Pack/Patches/Call of Duty - Zombies Pack/MysteryBox.xml
+++ b/ModPatches/Call of Duty - Zombies Pack/Patches/Call of Duty - Zombies Pack/MysteryBox.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/MysteryBoxFrameWork.ItemReplacerDef[defName="Replacer_RandomWeapons"]/producedItems/Gun_SmokeLauncher</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/MysteryBoxFrameWork.ItemReplacerDef[defName="Replacer_RandomWeapons"]/producedItems/Gun_EmpLauncher</xpath>
 	</Operation>

--- a/ModPatches/Call of Duty - Zombies Pack/Patches/Call of Duty - Zombies Pack/Weapons/Base.xml
+++ b/ModPatches/Call of Duty - Zombies Pack/Patches/Call of Duty - Zombies Pack/Weapons/Base.xml
@@ -35,6 +35,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="CodZP_Gun_IncendiaryLauncher-PAP" or
@@ -70,6 +71,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="CodZP_Gun_Minigun-PAP"]/tools </xpath>
@@ -123,6 +125,7 @@
 			<li>CE_OneHandedWeapon</li>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>CodZP_Gun_Autopistol-PAP</defName>
 		<statBases>

--- a/ModPatches/Call of Duty - Zombies Pack/Patches/Call of Duty - Zombies Pack/Weapons/Melee.xml
+++ b/ModPatches/Call of Duty - Zombies Pack/Patches/Call of Duty - Zombies Pack/Weapons/Melee.xml
@@ -40,6 +40,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName = "CodZP_MeleeWeapon_Spoon"]/statBases</xpath>
 		<nomatch Class="PatchOperationAdd">

--- a/ModPatches/Call of Duty - Zombies Pack/Patches/Call of Duty - Zombies Pack/Weapons/Melee_Punched.xml
+++ b/ModPatches/Call of Duty - Zombies Pack/Patches/Call of Duty - Zombies Pack/Weapons/Melee_Punched.xml
@@ -40,6 +40,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName = "CodZP_MeleeWeapon_Spoon-PAP"]/statBases</xpath>
 		<nomatch Class="PatchOperationAdd">

--- a/ModPatches/Call of Duty - Zombies Pack/Patches/Call of Duty - Zombies Pack/Weapons/Wonder.xml
+++ b/ModPatches/Call of Duty - Zombies Pack/Patches/Call of Duty - Zombies Pack/Weapons/Wonder.xml
@@ -36,6 +36,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="CodZP_Gun_Blundergat" or
@@ -75,6 +76,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="CodZP_Gun_Thundergun" or
@@ -94,6 +96,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="CodZP_Gun_Staff-Ice" or
@@ -115,6 +118,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="CodZP_Hells_Retriever"]/tools</xpath>
 		<value>
@@ -165,6 +169,7 @@
 			<li>CE_AI_BROOM</li>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>CodZP_Gun_Acidgat</defName>
 		<statBases>
@@ -196,6 +201,7 @@
 			<li>CE_AI_BROOM</li>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>CodZP_Gun_Magmagat</defName>
 		<statBases>
@@ -255,6 +261,7 @@
 		</AmmoUser>
 		<FireModes/>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>CodZP_Gun_Staff-Wind</defName>
 		<statBases>
@@ -282,6 +289,7 @@
 		</AmmoUser>
 		<FireModes/>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>CodZP_Gun_Staff-Fire</defName>
 		<statBases>
@@ -309,6 +317,7 @@
 		</AmmoUser>
 		<FireModes/>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>CodZP_Gun_Staff-Lightning</defName>
 		<statBases>
@@ -395,6 +404,7 @@
 			<li>CE_AI_Pistol</li>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>CodZP_Gun_RayGunMkTwo</defName>
 		<statBases>
@@ -429,6 +439,7 @@
 		<weaponTags>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>CodZP_Gun_RayGunMkThree</defName>
 		<statBases>
@@ -460,6 +471,7 @@
 			<li>CE_AI_Pistol</li>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>CodZP_Gun_GKZ</defName>
 		<statBases>
@@ -491,6 +503,7 @@
 			<li>CE_AI_Pistol</li>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>CodZP_Gun_RayGunMkTwo-V</defName>
 		<statBases>
@@ -524,6 +537,7 @@
 			<li/>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>CodZP_Gun_RayGunMkTwo-X</defName>
 		<statBases>
@@ -556,6 +570,7 @@
 			<li>CE_AI_AR</li>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>CodZP_Gun_RayGunMkTwo-Y</defName>
 		<statBases>
@@ -586,6 +601,7 @@
 			<li/>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>CodZP_Gun_RayGunMkTwo-Z</defName>
 		<statBases>
@@ -647,6 +663,7 @@
 			<li/>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>CodZP_Gun_Tundragun</defName>
 		<statBases>
@@ -740,6 +757,7 @@
 			<li/>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>CodZP_Gun_Wunderwaffe_Scharf</defName>
 		<statBases>
@@ -802,6 +820,7 @@
 			<li>CE_AI_Pistol</li>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>CODZP_Gun_Zapgun_Blue</defName>
 		<statBases>
@@ -833,6 +852,7 @@
 			<li>CE_AI_Pistol</li>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>CodZP_Gun_Wavegun</defName>
 		<statBases>

--- a/ModPatches/Call of Duty - Zombies Pack/Patches/Call of Duty - Zombies Pack/Weapons/Wonder_Punched.xml
+++ b/ModPatches/Call of Duty - Zombies Pack/Patches/Call of Duty - Zombies Pack/Weapons/Wonder_Punched.xml
@@ -36,6 +36,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="CodZP_Gun_Blundergat-PAP" or
@@ -75,6 +76,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="CodZP_Gun_Thundergun-PAP" or
@@ -94,6 +96,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="CodZP_Gun_Staff-Ice-PAP" or
@@ -115,6 +118,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="CodZP_Hells_Retriever-PAP"]/tools</xpath>
 		<value>
@@ -165,6 +169,7 @@
 			<li>CE_AI_BROOM</li>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>CodZP_Gun_Acidgat-PAP</defName>
 		<statBases>
@@ -196,6 +201,7 @@
 			<li>CE_AI_BROOM</li>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>CodZP_Gun_Magmagat-PAP</defName>
 		<statBases>
@@ -255,6 +261,7 @@
 		</AmmoUser>
 		<FireModes/>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>CodZP_Gun_Staff-Wind-PAP</defName>
 		<statBases>
@@ -282,6 +289,7 @@
 		</AmmoUser>
 		<FireModes/>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>CodZP_Gun_Staff-Fire-PAP</defName>
 		<statBases>
@@ -309,6 +317,7 @@
 		</AmmoUser>
 		<FireModes/>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>CodZP_Gun_Staff-Lightning-PAP</defName>
 		<statBases>
@@ -395,6 +404,7 @@
 			<li>CE_AI_Pistol</li>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>CodZP_Gun_RayGunMkTwo-PAP</defName>
 		<statBases>
@@ -429,6 +439,7 @@
 		<weaponTags>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>CodZP_Gun_RayGunMkThree-PAP</defName>
 		<statBases>
@@ -460,6 +471,7 @@
 			<li>CE_AI_Pistol</li>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>CodZP_Gun_GKZ-PAP</defName>
 		<statBases>
@@ -491,6 +503,7 @@
 			<li>CE_AI_Pistol</li>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>CodZP_Gun_RayGunMkTwo-V-PAP</defName>
 		<statBases>
@@ -524,6 +537,7 @@
 			<li/>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>CodZP_Gun_RayGunMkTwo-X-PAP</defName>
 		<statBases>
@@ -556,6 +570,7 @@
 			<li>CE_AI_AR</li>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>CodZP_Gun_RayGunMkTwo-Y-PAP</defName>
 		<statBases>
@@ -586,6 +601,7 @@
 			<li/>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>CodZP_Gun_RayGunMkTwo-Z-PAP</defName>
 		<statBases>
@@ -647,6 +663,7 @@
 			<li/>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>CodZP_Gun_Tundragun-PAP</defName>
 		<statBases>
@@ -740,6 +757,7 @@
 			<li/>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>CodZP_Gun_Wunderwaffe_Scharf-PAP</defName>
 		<statBases>
@@ -802,6 +820,7 @@
 			<li>CE_AI_Pistol</li>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>CODZP_Gun_Zapgun_Blue-PAP</defName>
 		<statBases>
@@ -833,6 +852,7 @@
 			<li>CE_AI_Pistol</li>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>CodZP_Gun_Wavegun-PAP</defName>
 		<statBases>

--- a/ModPatches/Civilization Beyond Earth Armor Sets/Patches/Civilization Beyond Earth Armor Sets/Apparels.xml
+++ b/ModPatches/Civilization Beyond Earth Armor Sets/Patches/Civilization Beyond Earth Armor Sets/Apparels.xml
@@ -419,6 +419,7 @@
 			<WornBulk>12</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="Tier2_Armor"]/statBases/ArmorRating_Sharp</xpath>
 		<value>

--- a/ModPatches/CuprosAlloys/Patches/CuprosAlloys/ThingDefs/Patch_Materials_Alloy_Advanced.xml
+++ b/ModPatches/CuprosAlloys/Patches/CuprosAlloys/ThingDefs/Patch_Materials_Alloy_Advanced.xml
@@ -7,21 +7,25 @@
 			<MeleePenetrationFactor>1.2</MeleePenetrationFactor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_BlackSteel"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>2.2</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_BlackSteel"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>1.4</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_BlackSteel"]/statBases/SharpDamageMultiplier</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_BlackSteel"]/statBases/BluntDamageMultiplier</xpath>
 	</Operation>
@@ -33,21 +37,25 @@
 			<MeleePenetrationFactor>1.4</MeleePenetrationFactor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_Plastin"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>3.6</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_Plastin"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>2.4</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_Plastin"]/statBases/SharpDamageMultiplier</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_Plastin"]/statBases/BluntDamageMultiplier</xpath>
 	</Operation>

--- a/ModPatches/CuprosAlloys/Patches/CuprosAlloys/ThingDefs/Patch_Materials_Alloy_Decorative.xml
+++ b/ModPatches/CuprosAlloys/Patches/CuprosAlloys/ThingDefs/Patch_Materials_Alloy_Decorative.xml
@@ -7,12 +7,14 @@
 			<StuffPower_Armor_Heat>0</StuffPower_Armor_Heat>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="CAL_ShinyIngotBase"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>1.5</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="CAL_ShinyIngotBase"]/statBases/StuffPower_Armor_Sharp</xpath>
 		<value>
@@ -27,24 +29,29 @@
 			<MeleePenetrationFactor>0.9</MeleePenetrationFactor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_Brass"]/stuffProps/statFactors/ArmorRating_Blunt</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_Brass"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.8</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_Brass"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>0.62</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_Brass"]/statBases/SharpDamageMultiplier</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_Brass"]/statBases/BluntDamageMultiplier</xpath>
 	</Operation>
@@ -56,21 +63,25 @@
 			<MeleePenetrationFactor>1.02</MeleePenetrationFactor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_ChromePlatedSteel"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>1.55</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_ChromePlatedSteel"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>1.04</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_ChromePlatedSteel"]/statBases/SharpDamageMultiplier</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_ChromePlatedSteel"]/statBases/BluntDamageMultiplier</xpath>
 	</Operation>
@@ -82,21 +93,25 @@
 			<MeleePenetrationFactor>0.88</MeleePenetrationFactor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_Aurichalcum"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.74</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_Aurichalcum"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>0.38</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_Aurichalcum"]/statBases/SharpDamageMultiplier</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_Aurichalcum"]/statBases/BluntDamageMultiplier</xpath>
 	</Operation>
@@ -108,24 +123,28 @@
 			<MeleePenetrationFactor>0.9</MeleePenetrationFactor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_SterlingSilver"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.71</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_SterlingSilver"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>0.42</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="CAL_SterlingSilver"]/statBases/SharpDamageMultiplier</xpath>
 		<value>
 			<SharpDamageMultiplier>0.952</SharpDamageMultiplier>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="CAL_SterlingSilver"]/statBases/BluntDamageMultiplier</xpath>
 		<value>
@@ -140,24 +159,28 @@
 			<MeleePenetrationFactor>0.86</MeleePenetrationFactor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_RoseGold"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.9</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_RoseGold"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>0.32</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="CAL_RoseGold"]/statBases/SharpDamageMultiplier</xpath>
 		<value>
 			<SharpDamageMultiplier>0.909</SharpDamageMultiplier>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="CAL_RoseGold"]/statBases/BluntDamageMultiplier</xpath>
 		<value>
@@ -172,21 +195,25 @@
 			<MeleePenetrationFactor>0.82</MeleePenetrationFactor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_Electrum"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.66</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_Electrum"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>0.34</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_Electrum"]/statBases/SharpDamageMultiplier</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_Electrum"]/statBases/BluntDamageMultiplier</xpath>
 	</Operation>

--- a/ModPatches/CuprosAlloys/Patches/CuprosAlloys/ThingDefs/Patch_Materials_Alloy_Utility.xml
+++ b/ModPatches/CuprosAlloys/Patches/CuprosAlloys/ThingDefs/Patch_Materials_Alloy_Utility.xml
@@ -7,12 +7,14 @@
 			<StuffPower_Armor_Heat>0</StuffPower_Armor_Heat>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="CAL_DullIngotBase"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>1.5</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="CAL_DullIngotBase"]/statBases/StuffPower_Armor_Sharp</xpath>
 		<value>
@@ -27,24 +29,28 @@
 			<MeleePenetrationFactor>0.9</MeleePenetrationFactor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_Plumchalcum"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.96</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_Plumchalcum"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>0.44</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="CAL_Plumchalcum"]/statBases/SharpDamageMultiplier</xpath>
 		<value>
 			<SharpDamageMultiplier>0.909</SharpDamageMultiplier>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="CAL_Plumchalcum"]/statBases/BluntDamageMultiplier</xpath>
 		<value>
@@ -59,21 +65,25 @@
 			<MeleePenetrationFactor>0.92</MeleePenetrationFactor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_Duralumin"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.86</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_Duralumin"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>0.6</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_Duralumin"]/statBases/SharpDamageMultiplier</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_Duralumin"]/statBases/BluntDamageMultiplier</xpath>
 	</Operation>
@@ -85,24 +95,29 @@
 			<MeleePenetrationFactor>0.94</MeleePenetrationFactor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_Zamak"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.82</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_Zamak"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>0.64</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_Zamak"]/statBases/SharpDamageMultiplier</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_Zamak"]/statBases/BluntDamageMultiplier</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_Zamak"]/stuffProps/categories</xpath>
 		<value>
@@ -117,24 +132,29 @@
 			<MeleePenetrationFactor>0.96</MeleePenetrationFactor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_BismuthBronze"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.88</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_BismuthBronze"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>0.68</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_BismuthBronze"]/statBases/SharpDamageMultiplier</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_BismuthBronze"]/statBases/BluntDamageMultiplier</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_BismuthBronze"]/stuffProps/categories</xpath>
 		<value>
@@ -149,24 +169,29 @@
 			<MeleePenetrationFactor>0.80</MeleePenetrationFactor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_Bronze"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.84</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_Bronze"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>0.7</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_Bronze"]/statBases/SharpDamageMultiplier</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_Bronze"]/statBases/BluntDamageMultiplier</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_Bronze"]/stuffProps/categories</xpath>
 		<value>
@@ -181,24 +206,29 @@
 			<MeleePenetrationFactor>0.98</MeleePenetrationFactor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_Cupronickel"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.76</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_Cupronickel"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>0.72</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_Cupronickel"]/statBases/SharpDamageMultiplier</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_Cupronickel"]/statBases/BluntDamageMultiplier</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_Cupronickel"]/stuffProps/categories</xpath>
 		<value>
@@ -213,21 +243,25 @@
 			<MeleePenetrationFactor>1.06</MeleePenetrationFactor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_StainlessSteel"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>1.7</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_StainlessSteel"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>1.16</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_StainlessSteel"]/statBases/SharpDamageMultiplier</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_StainlessSteel"]/statBases/BluntDamageMultiplier</xpath>
 	</Operation>
@@ -239,24 +273,29 @@
 			<MeleePenetrationFactor>0.8</MeleePenetrationFactor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_Hepatzion"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.8</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_Hepatzion"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>0.66</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_Hepatzion"]/statBases/SharpDamageMultiplier</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_Hepatzion"]/statBases/BluntDamageMultiplier</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_Hepatzion"]/stuffProps/categories</xpath>
 		<value>

--- a/ModPatches/CuprosAlloys/Patches/CuprosAlloys/ThingDefs/Patch_Materials_BaseMetal.xml
+++ b/ModPatches/CuprosAlloys/Patches/CuprosAlloys/ThingDefs/Patch_Materials_BaseMetal.xml
@@ -7,12 +7,14 @@
 			<StuffPower_Armor_Heat>0</StuffPower_Armor_Heat>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="CAL_OreBase"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>1</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="CAL_OreBase"]/statBases/StuffPower_Armor_Sharp</xpath>
 		<value>
@@ -27,21 +29,25 @@
 			<MeleePenetrationFactor>0.86</MeleePenetrationFactor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_Copper"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.7</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_Copper"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>0.46</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_Copper"]/statBases/SharpDamageMultiplier</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_Copper"]/statBases/BluntDamageMultiplier</xpath>
 	</Operation>
@@ -53,27 +59,32 @@
 			<MeleePenetrationFactor>0.8</MeleePenetrationFactor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="CAL_Lead"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.6</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="CAL_Lead"]/statBases/StuffPower_Armor_Sharp</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>0.14</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_Lead"]/statBases/StuffPower_Armor_Heat</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="CAL_Lead"]/statBases/SharpDamageMultiplier</xpath>
 		<value>
 			<SharpDamageMultiplier>0.909</SharpDamageMultiplier>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="CAL_Lead"]/statBases/BluntDamageMultiplier</xpath>
 		<value>
@@ -88,24 +99,29 @@
 			<MeleePenetrationFactor>0.82</MeleePenetrationFactor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="CAL_Tin"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.55</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="CAL_Tin"]/statBases/StuffPower_Armor_Sharp</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>0.45</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_Tin"]/statBases/StuffPower_Armor_Heat</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_Tin"]/statBases/SharpDamageMultiplier</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_Tin"]/statBases/BluntDamageMultiplier</xpath>
 	</Operation>
@@ -117,24 +133,29 @@
 			<MeleePenetrationFactor>0.7</MeleePenetrationFactor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="CAL_Aluminum"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.325</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="CAL_Aluminum"]/statBases/StuffPower_Armor_Sharp</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>0.33</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_Aluminum"]/statBases/StuffPower_Armor_Heat</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_Aluminum"]/statBases/SharpDamageMultiplier</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_Aluminum"]/statBases/BluntDamageMultiplier</xpath>
 	</Operation>
@@ -146,6 +167,7 @@
 			<MeleePenetrationFactor>0.92</MeleePenetrationFactor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="CAL_Nickel"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
@@ -156,9 +178,11 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_Nickel"]/statBases/StuffPower_Armor_Heat</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_Nickel"]/statBases/SharpDamageMultiplier</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_Nickel"]/statBases/BluntDamageMultiplier</xpath>
 	</Operation>
@@ -170,24 +194,29 @@
 			<MeleePenetrationFactor>0.8</MeleePenetrationFactor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="CAL_Zinc"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.525</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="CAL_Zinc"]/statBases/StuffPower_Armor_Sharp</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>0.38</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_Zinc"]/statBases/StuffPower_Armor_Heat</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_Zinc"]/statBases/SharpDamageMultiplier</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_Zinc"]/statBases/BluntDamageMultiplier</xpath>
 	</Operation>
@@ -199,12 +228,14 @@
 			<MeleePenetrationFactor>0.76</MeleePenetrationFactor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_Bismuth"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.95</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_Bismuth"]/statBases</xpath>
 		<value>
@@ -219,21 +250,25 @@
 			<MeleePenetrationFactor>1.02</MeleePenetrationFactor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_Chromium"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>1.01</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CAL_Chromium"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>1.08</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_Chromium"]/statBases/SharpDamageMultiplier</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="CAL_Chromium"]/statBases/BluntDamageMultiplier</xpath>
 	</Operation>

--- a/ModPatches/Cybernetic Organism and Neural Network/Patches/Cybernetic Organism and Neural Network/Hediffs/CONN_CombatAdvancedBionics.xml
+++ b/ModPatches/Cybernetic Organism and Neural Network/Patches/Cybernetic Organism and Neural Network/Hediffs/CONN_CombatAdvancedBionics.xml
@@ -9,6 +9,7 @@
 			</statOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CONN_IndependentEye"]/statBases</xpath>
 		<value>
@@ -31,6 +32,7 @@
 			</stages>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="CONN_hediff_OuterBlade"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
 		<value>
@@ -54,6 +56,7 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/HediffDef[defName="CONN_hediff_PowerArms"]/stages</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="CONN_hediff_PowerArms"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
 		<value>

--- a/ModPatches/Cybernetic Organism and Neural Network/Patches/Cybernetic Organism and Neural Network/Hediffs/CONN_CombatBionics.xml
+++ b/ModPatches/Cybernetic Organism and Neural Network/Patches/Cybernetic Organism and Neural Network/Hediffs/CONN_CombatBionics.xml
@@ -8,6 +8,7 @@
 			<AimingAccuracy>0.6</AimingAccuracy><!-- I did the math, and with an aiming accuracy bonus of this, with two of these, a level 20 shooter basically has a sniper rifle scope on 100% sight efficiency guns. -->
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CONN_Zoom"]/statBases</xpath>
 		<value>

--- a/ModPatches/Cybernetic Organism and Neural Network/Patches/Cybernetic Organism and Neural Network/Hediffs/CONN_MindAlteringBionics.xml
+++ b/ModPatches/Cybernetic Organism and Neural Network/Patches/Cybernetic Organism and Neural Network/Hediffs/CONN_MindAlteringBionics.xml
@@ -7,12 +7,14 @@
 			<MeleeHitChance>12</MeleeHitChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="CONN_hediff_BerserkerChip"]/stages/li/statOffsets/MeleeDodgeChance</xpath>
 		<value>
 			<MeleeDodgeChance>0.4</MeleeDodgeChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/HediffDef[defName="CONN_hediff_BerserkerChip"]/stages/li</xpath>
 		<value>

--- a/ModPatches/Cybernetic Organism and Neural Network/Patches/Cybernetic Organism and Neural Network/Hediffs/CONN_ProductiveBionics.xml
+++ b/ModPatches/Cybernetic Organism and Neural Network/Patches/Cybernetic Organism and Neural Network/Hediffs/CONN_ProductiveBionics.xml
@@ -13,6 +13,7 @@
 			</stages>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="CONN_BlackPearl"]/statBases</xpath>
 		<value>

--- a/ModPatches/DD Elves/Patches/DD Elves/AnimalDefs.xml
+++ b/ModPatches/DD Elves/Patches/DD Elves/AnimalDefs.xml
@@ -99,6 +99,7 @@
 			<MeleeParryChance>0.03</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="DevDesigner_ColdOne"]/tools</xpath>
 		<value>
@@ -168,6 +169,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[defName="DevDesigner_ColdOne"]/combatPower</xpath>
 		<value>

--- a/ModPatches/DD House Sanguin/Patches/DD House Sanguin/ThingDefs_MeleeWeapons.xml
+++ b/ModPatches/DD House Sanguin/Patches/DD House Sanguin/ThingDefs_MeleeWeapons.xml
@@ -213,6 +213,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="DevDesigner_Blood_MeleeWeapon_PikeStandard"]</xpath>
 		<value>
@@ -223,6 +224,7 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="DevDesigner_Blood_MeleeWeapon_PikeStandard"]</xpath>
 		<value>

--- a/ModPatches/Dinosauria/Patches/Dinosauria/Races_Animal_Dinosauria.xml
+++ b/ModPatches/Dinosauria/Patches/Dinosauria/Races_Animal_Dinosauria.xml
@@ -21,24 +21,28 @@ https://drive.google.com/open?id=1ah4ESB3nCYnbxtD4sf7uyXvWi301o0vr1yNwt1jS6io
 			<MeleeParryChance>0.83</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="TyrannosaurusRex"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>5</MoveSpeed>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="TyrannosaurusRex"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>8</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="TyrannosaurusRex"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>0.15</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="TyrannosaurusRex"]/tools</xpath>
 		<value>
@@ -114,24 +118,28 @@ https://drive.google.com/open?id=1ah4ESB3nCYnbxtD4sf7uyXvWi301o0vr1yNwt1jS6io
 			<MeleeParryChance>0.42</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Yutyrannus"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>6.5</MoveSpeed>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Yutyrannus"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>5</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Yutyrannus"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>0.10</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Yutyrannus"]/tools</xpath>
 		<value>
@@ -207,6 +215,7 @@ https://drive.google.com/open?id=1ah4ESB3nCYnbxtD4sf7uyXvWi301o0vr1yNwt1jS6io
 			<MeleeParryChance>0.53</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Carnotaurus"]/statBases/MoveSpeed</xpath>
 		<value>
@@ -220,12 +229,14 @@ https://drive.google.com/open?id=1ah4ESB3nCYnbxtD4sf7uyXvWi301o0vr1yNwt1jS6io
 			<ArmorRating_Blunt>3</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Carnotaurus"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Carnotaurus"]/tools</xpath>
 		<value>
@@ -301,24 +312,28 @@ https://drive.google.com/open?id=1ah4ESB3nCYnbxtD4sf7uyXvWi301o0vr1yNwt1jS6io
 			<MeleeParryChance>0.43</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Allosaurus"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>5</MoveSpeed>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Allosaurus"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>5</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Allosaurus"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>0.10</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Allosaurus"]/tools</xpath>
 		<value>
@@ -394,24 +409,28 @@ https://drive.google.com/open?id=1ah4ESB3nCYnbxtD4sf7uyXvWi301o0vr1yNwt1jS6io
 			<MeleeParryChance>0.75</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Spinosaurus"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>2.6</MoveSpeed>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Spinosaurus"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>7.5</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Spinosaurus"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>0.12</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Spinosaurus"]/tools</xpath>
 		<value>
@@ -487,12 +506,14 @@ https://drive.google.com/open?id=1ah4ESB3nCYnbxtD4sf7uyXvWi301o0vr1yNwt1jS6io
 			<MeleeParryChance>0.42</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Baryonyx"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>3</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Baryonyx"]/tools</xpath>
 		<value>
@@ -568,24 +589,28 @@ https://drive.google.com/open?id=1ah4ESB3nCYnbxtD4sf7uyXvWi301o0vr1yNwt1jS6io
 			<MeleeParryChance>0.54</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Ankylosaurus"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>3</MoveSpeed>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Ankylosaurus"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>18</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Ankylosaurus"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>0.75</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Ankylosaurus"]/tools</xpath>
 		<value>
@@ -649,18 +674,21 @@ https://drive.google.com/open?id=1ah4ESB3nCYnbxtD4sf7uyXvWi301o0vr1yNwt1jS6io
 			<MeleeParryChance>0.17</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Minmi"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>10</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Minmi"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>0.40</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Minmi"]/tools</xpath>
 		<value>
@@ -724,24 +752,28 @@ https://drive.google.com/open?id=1ah4ESB3nCYnbxtD4sf7uyXvWi301o0vr1yNwt1jS6io
 			<MeleeParryChance>0.156</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Brachiosaurus"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>2.4</MoveSpeed>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Brachiosaurus"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>3</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Brachiosaurus"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Brachiosaurus"]/tools</xpath>
 		<value>
@@ -824,24 +856,28 @@ https://drive.google.com/open?id=1ah4ESB3nCYnbxtD4sf7uyXvWi301o0vr1yNwt1jS6io
 			<MeleeParryChance>1.18</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Brontosaurus"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>2.4</MoveSpeed>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Brontosaurus"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>3</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Brontosaurus"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Brontosaurus"]/tools</xpath>
 		<value>
@@ -924,24 +960,28 @@ https://drive.google.com/open?id=1ah4ESB3nCYnbxtD4sf7uyXvWi301o0vr1yNwt1jS6io
 			<MeleeParryChance>1.15</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Diplodocus"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>2.4</MoveSpeed>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Diplodocus"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>3</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Diplodocus"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Diplodocus"]/tools</xpath>
 		<value>
@@ -1024,24 +1064,28 @@ https://drive.google.com/open?id=1ah4ESB3nCYnbxtD4sf7uyXvWi301o0vr1yNwt1jS6io
 			<MeleeParryChance>0.35</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Magyarosaurus"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>4</MoveSpeed>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Magyarosaurus"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>1</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Magyarosaurus"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>0.00</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Magyarosaurus"]/tools</xpath>
 		<value>
@@ -1123,24 +1167,28 @@ https://drive.google.com/open?id=1ah4ESB3nCYnbxtD4sf7uyXvWi301o0vr1yNwt1jS6io
 			<MeleeParryChance>0.19</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Utahraptor"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>6</MoveSpeed>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Utahraptor"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>0.1</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Utahraptor"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>0.01</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Utahraptor"]/tools</xpath>
 		<value>
@@ -1220,24 +1268,28 @@ https://drive.google.com/open?id=1ah4ESB3nCYnbxtD4sf7uyXvWi301o0vr1yNwt1jS6io
 			<MeleeParryChance>0.16</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Dakotaraptor"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>6</MoveSpeed>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Dakotaraptor"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>0.1</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Dakotaraptor"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>0.01</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Dakotaraptor"]/tools</xpath>
 		<value>
@@ -1317,24 +1369,28 @@ https://drive.google.com/open?id=1ah4ESB3nCYnbxtD4sf7uyXvWi301o0vr1yNwt1jS6io
 			<MeleeParryChance>0.18</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Dilophosaurus"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>6</MoveSpeed>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Dilophosaurus"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>0.1</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Dilophosaurus"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>0.01</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Dilophosaurus"]/tools</xpath>
 		<value>
@@ -1414,24 +1470,28 @@ https://drive.google.com/open?id=1ah4ESB3nCYnbxtD4sf7uyXvWi301o0vr1yNwt1jS6io
 			<MeleeParryChance>0.03</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Velociraptor"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>7.2</MoveSpeed>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Velociraptor"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>0.00</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Velociraptor"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>0.00</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Velociraptor"]/tools</xpath>
 		<value>
@@ -1491,24 +1551,28 @@ https://drive.google.com/open?id=1ah4ESB3nCYnbxtD4sf7uyXvWi301o0vr1yNwt1jS6io
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Velociraptor"]/race/manhunterOnDamageChance</xpath>
 		<value>
 			<manhunterOnDamageChance>0.75</manhunterOnDamageChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[defName="Velociraptor"]/combatPower</xpath>
 		<value>
 			<combatPower>70</combatPower>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[defName="Velociraptor"]/wildGroupSize/min</xpath>
 		<value>
 			<min>5</min>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[defName="Velociraptor"]/wildGroupSize/max</xpath>
 		<value>
@@ -1535,12 +1599,14 @@ https://drive.google.com/open?id=1ah4ESB3nCYnbxtD4sf7uyXvWi301o0vr1yNwt1jS6io
 			<MeleeParryChance>0.00</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Compsognathus"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>6</MoveSpeed>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Compsognathus"]/tools</xpath>
 		<value>
@@ -1600,18 +1666,21 @@ https://drive.google.com/open?id=1ah4ESB3nCYnbxtD4sf7uyXvWi301o0vr1yNwt1jS6io
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[defName="Compsognathus"]/combatPower</xpath>
 		<value>
 			<combatPower>25</combatPower>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[defName="Compsognathus"]/wildGroupSize/min</xpath>
 		<value>
 			<min>2</min>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[defName="Compsognathus"]/wildGroupSize/max</xpath>
 		<value>
@@ -1638,12 +1707,14 @@ https://drive.google.com/open?id=1ah4ESB3nCYnbxtD4sf7uyXvWi301o0vr1yNwt1jS6io
 			<MeleeParryChance>0.24</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Gallimimus"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>5.8</MoveSpeed>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Gallimimus"]/tools</xpath>
 		<value>
@@ -1689,6 +1760,7 @@ https://drive.google.com/open?id=1ah4ESB3nCYnbxtD4sf7uyXvWi301o0vr1yNwt1jS6io
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[defName="Gallimimus"]/combatPower</xpath>
 		<value>
@@ -1724,12 +1796,14 @@ https://drive.google.com/open?id=1ah4ESB3nCYnbxtD4sf7uyXvWi301o0vr1yNwt1jS6io
 			<MeleeParryChance>0.32</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Gigantoraptor"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>5.4</MoveSpeed>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Gigantoraptor"]/tools</xpath>
 		<value>
@@ -1795,24 +1869,28 @@ https://drive.google.com/open?id=1ah4ESB3nCYnbxtD4sf7uyXvWi301o0vr1yNwt1jS6io
 			<MeleeParryChance>0.45</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Iguanodon"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>3.5</MoveSpeed>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Iguanodon"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>3</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Iguanodon"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Iguanodon"]/tools</xpath>
 		<value>
@@ -1858,24 +1936,28 @@ https://drive.google.com/open?id=1ah4ESB3nCYnbxtD4sf7uyXvWi301o0vr1yNwt1jS6io
 			<MeleeParryChance>0.43</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Parasaur"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>3.5</MoveSpeed>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Parasaur"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>3</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Parasaur"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Parasaur"]/tools</xpath>
 		<value>
@@ -1921,24 +2003,28 @@ https://drive.google.com/open?id=1ah4ESB3nCYnbxtD4sf7uyXvWi301o0vr1yNwt1jS6io
 			<MeleeParryChance>0.48</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Corythosaurus"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>5</MoveSpeed>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Corythosaurus"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>3</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Corythosaurus"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Corythosaurus"]/tools</xpath>
 		<value>
@@ -1984,24 +2070,28 @@ https://drive.google.com/open?id=1ah4ESB3nCYnbxtD4sf7uyXvWi301o0vr1yNwt1jS6io
 			<MeleeParryChance>0.61</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Deinocheirus"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>3.5</MoveSpeed>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Deinocheirus"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>5</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Deinocheirus"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>0.1</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Deinocheirus"]/tools</xpath>
 		<value>
@@ -2065,24 +2155,28 @@ https://drive.google.com/open?id=1ah4ESB3nCYnbxtD4sf7uyXvWi301o0vr1yNwt1jS6io
 			<MeleeParryChance>0.56</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Therizinosaurus"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>3.6</MoveSpeed>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Therizinosaurus"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>5</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Therizinosaurus"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>0.1</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Therizinosaurus"]/tools</xpath>
 		<value>
@@ -2146,12 +2240,14 @@ https://drive.google.com/open?id=1ah4ESB3nCYnbxtD4sf7uyXvWi301o0vr1yNwt1jS6io
 			<MeleeParryChance>0.16</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Pachycephalosaurus"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>1</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Pachycephalosaurus"]/tools</xpath>
 		<value>
@@ -2197,6 +2293,7 @@ https://drive.google.com/open?id=1ah4ESB3nCYnbxtD4sf7uyXvWi301o0vr1yNwt1jS6io
 			<MeleeParryChance>0.04</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Stygimoloch"]/tools</xpath>
 		<value>
@@ -2242,6 +2339,7 @@ https://drive.google.com/open?id=1ah4ESB3nCYnbxtD4sf7uyXvWi301o0vr1yNwt1jS6io
 			<MeleeParryChance>0.04</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Dryosaurus"]/tools</xpath>
 		<value>
@@ -2279,24 +2377,28 @@ https://drive.google.com/open?id=1ah4ESB3nCYnbxtD4sf7uyXvWi301o0vr1yNwt1jS6io
 			<MeleeParryChance>0.57</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Stegosaurus"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>2</MoveSpeed>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Stegosaurus"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>7</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Stegosaurus"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>0.12</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Stegosaurus"]/tools</xpath>
 		<value>
@@ -2361,24 +2463,28 @@ https://drive.google.com/open?id=1ah4ESB3nCYnbxtD4sf7uyXvWi301o0vr1yNwt1jS6io
 			<MeleeParryChance>0.70</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Triceratops"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>4</MoveSpeed>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Triceratops"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>8</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Triceratops"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>0.13</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Triceratops"]/tools</xpath>
 		<value>
@@ -2428,6 +2534,7 @@ https://drive.google.com/open?id=1ah4ESB3nCYnbxtD4sf7uyXvWi301o0vr1yNwt1jS6io
 			<MeleeParryChance>0.05</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Protoceratops"]/tools</xpath>
 		<value>
@@ -2473,18 +2580,21 @@ https://drive.google.com/open?id=1ah4ESB3nCYnbxtD4sf7uyXvWi301o0vr1yNwt1jS6io
 			<MeleeParryChance>0.29</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Quetzalcoatlus"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>3</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Quetzalcoatlus"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Quetzalcoatlus"]/tools</xpath>
 		<value>
@@ -2522,6 +2632,7 @@ https://drive.google.com/open?id=1ah4ESB3nCYnbxtD4sf7uyXvWi301o0vr1yNwt1jS6io
 			<MeleeParryChance>0.04</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Pteranodon"]/tools</xpath>
 		<value>

--- a/ModPatches/Doom Factions/Patches/Doom Factions/DoomFactions_Ammo.xml
+++ b/ModPatches/Doom Factions/Patches/Doom Factions/DoomFactions_Ammo.xml
@@ -8,42 +8,49 @@
 			<label>Plasma</label>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/DamageDef[defName="UAC_GAUSS"]/label</xpath>
 		<value>
 			<label>Plasma</label>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/DamageDef[defName="UAC_BFG"]/label</xpath>
 		<value>
 			<label>BFG Plasma</label>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/DamageDef[defName="UAC_Plasm" or defName="UAC_GAUSS" or defName="UAC_BFG"]/hediff</xpath>
 		<value>
 			<hediff>BurnSecondary</hediff>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/DamageDef[defName="UAC_Plasm"]</xpath>
 		<value>
 			<explosionCellMote>UACMote_BlastGAUSS</explosionCellMote>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/DamageDef[defName="UAC_GAUSS"]</xpath>
 		<value>
 			<minDamageToFragment>15</minDamageToFragment>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/DamageDef[defName="UAC_BFG"]</xpath>
 		<value>
 			<minDamageToFragment>150</minDamageToFragment>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/DamageDef[defName="UAC_Plasm"]</xpath>
 		<value>

--- a/ModPatches/Doom Factions/Patches/Doom Factions/DoomFactions_PawnKinds.xml
+++ b/ModPatches/Doom Factions/Patches/Doom Factions/DoomFactions_PawnKinds.xml
@@ -21,6 +21,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[@Name="SpaceMarine_FBase" or defName="Doom_MarineBerserker" or defName="Doom_MarineLight" or defName="Doom_MarineHeavy" or defName="Doom_MarineSniper" or defName="Doom_MarineBoss"]</xpath>
 		<value>

--- a/ModPatches/Doom Factions/Patches/Doom Factions/DoomFactions_Traders.xml
+++ b/ModPatches/Doom Factions/Patches/Doom Factions/DoomFactions_Traders.xml
@@ -3,18 +3,23 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/TraderKindDef[defName="SpaceMarine_Base"]/stockGenerators/li[thingDef="Shell_HighExplosive"]</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/TraderKindDef[defName="SpaceMarine_CombatSupplier"]/stockGenerators/li[thingDef="Shell_HighExplosive"]</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/TraderKindDef[defName="SpaceMarine_Supplier"]/stockGenerators/li[thingDef="Shell_HighExplosive"]</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/TraderKindDef[defName="UAC_Base"]/stockGenerators/li[thingDef="Shell_HighExplosive"]</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/TraderKindDef[defName="UAC_CombatSupplier"]/stockGenerators/li[thingDef="Shell_HighExplosive"]</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/TraderKindDef[defName="UAC_Supplier"]/stockGenerators/li[thingDef="Shell_HighExplosive"]</xpath>
 	</Operation>

--- a/ModPatches/Dragons Descent/Patches/Dragons Descent/BodyDefs/Bodies_Animal_Dragon.xml
+++ b/ModPatches/Dragons Descent/Patches/Dragons Descent/BodyDefs/Bodies_Animal_Dragon.xml
@@ -17,6 +17,7 @@
 			</value>
 		</match>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Wing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -34,6 +35,7 @@
 			</value>
 		</match>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Tail"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -51,6 +53,7 @@
 			</value>
 		</match>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Neck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -68,6 +71,7 @@
 			</value>
 		</match>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -85,6 +89,7 @@
 			</value>
 		</match>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Ear"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -102,6 +107,7 @@
 			</value>
 		</match>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -119,6 +125,7 @@
 			</value>
 		</match>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -136,6 +143,7 @@
 			</value>
 		</match>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Shoulder"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -153,6 +161,7 @@
 			</value>
 		</match>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -170,6 +179,7 @@
 			</value>
 		</match>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Paw"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -187,6 +197,7 @@
 			</value>
 		</match>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Leg"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -204,6 +215,7 @@
 			</value>
 		</match>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Leg"]/parts/li[def="Paw"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">

--- a/ModPatches/Dragons Descent/Patches/Dragons Descent/DamageDefs/DamageDef_DraconicFlame.xml
+++ b/ModPatches/Dragons Descent/Patches/Dragons Descent/DamageDefs/DamageDef_DraconicFlame.xml
@@ -9,6 +9,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/DamageDef[defName="DraconicFlame"]/defaultArmorPenetration</xpath>
 		<value>
@@ -22,6 +23,7 @@
 			<defaultArmorPenetration>2</defaultArmorPenetration>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/DamageDef[defName="DraconicExplosion"]</xpath>
 		<value>
@@ -45,6 +47,7 @@
 			<defaultArmorPenetration>25</defaultArmorPenetration>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/DamageDef[defName="DraconicBlunt"]/armorCategory</xpath>
 		<value>

--- a/ModPatches/Dragons Descent/Patches/Dragons Descent/Projectiles/Projectile_Dragon.xml
+++ b/ModPatches/Dragons Descent/Patches/Dragons Descent/Projectiles/Projectile_Dragon.xml
@@ -7,6 +7,7 @@
 			<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_DragonSpitBlunt"]/projectile</xpath>
 		<value>
@@ -32,6 +33,7 @@
 			<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_DragonSpit"]/projectile</xpath>
 		<value>
@@ -59,6 +61,7 @@
 			<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_DragonBreath_AOE"]/projectile</xpath>
 		<value>

--- a/ModPatches/Dragons Descent/Patches/Dragons Descent/ThingDefs_Items/Items_Exotic.xml
+++ b/ModPatches/Dragons Descent/Patches/Dragons Descent/ThingDefs_Items/Items_Exotic.xml
@@ -4,6 +4,7 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="DragonHorn"]/tools</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="DragonHorn"]/statBases/Mass</xpath>
 		<value>
@@ -11,6 +12,7 @@
 			<Bulk>25</Bulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAttributeSet">
 		<xpath>Defs/ThingDef[defName="DragonHorn"]</xpath>
 		<attribute>ParentName</attribute>

--- a/ModPatches/Dragons Descent/Patches/Dragons Descent/ThingDefs_Items/Items_Resource_Leather.xml
+++ b/ModPatches/Dragons Descent/Patches/Dragons Descent/ThingDefs_Items/Items_Resource_Leather.xml
@@ -8,18 +8,21 @@
 			<StuffPower_Armor_Sharp>0.907</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Dragon_Leather"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.24</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Dragon_Leather"]/statBases/StuffPower_Armor_Heat</xpath>
 		<value>
 			<StuffPower_Armor_Heat>0.178</StuffPower_Armor_Heat>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Dragon_Leather"]/stuffProps</xpath>
 		<value>
@@ -35,12 +38,14 @@
 			<StuffPower_Armor_Sharp>1.079</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Rare_Dragon_Leather"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.279</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Rare_Dragon_Leather"]/statBases/StuffPower_Armor_Heat</xpath>
 
@@ -48,6 +53,7 @@
 			<StuffPower_Armor_Heat>0.2</StuffPower_Armor_Heat>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Rare_Dragon_Leather"]/stuffProps</xpath>
 		<value>
@@ -63,12 +69,14 @@
 			<StuffPower_Armor_Sharp>1.282</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="True_Dragon_Leather"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.324</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="True_Dragon_Leather"]/statBases/StuffPower_Armor_Heat</xpath>
 
@@ -76,6 +84,7 @@
 			<StuffPower_Armor_Heat>0.226</StuffPower_Armor_Heat>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="True_Dragon_Leather"]/stuffProps</xpath>
 		<value>

--- a/ModPatches/Dragons Descent/Patches/Dragons Descent/ThingDefs_Items/Items_Resource_Scale.xml
+++ b/ModPatches/Dragons Descent/Patches/Dragons Descent/ThingDefs_Items/Items_Resource_Scale.xml
@@ -7,24 +7,28 @@
 			<Bulk>0.03</Bulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="HardScale"]/stuffProps/categories</xpath>
 		<value>
 			<li>Metallic_Weapon</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="HardScale"]/statBases/StuffPower_Armor_Sharp</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>1.02</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="HardScale"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>1.6</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="HardScale"]/statBases/StuffPower_Armor_Heat</xpath>
 		<value>

--- a/ModPatches/Dragons Descent/Patches/Dragons Descent/ThingDefs_Misc/Apparel_Headgear.xml
+++ b/ModPatches/Dragons Descent/Patches/Dragons Descent/ThingDefs_Misc/Apparel_Headgear.xml
@@ -8,12 +8,14 @@
 			<WornBulk>2</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="DD_Apparel_ScaleHelm"]/statBases/StuffEffectMultiplierArmor</xpath>
 		<value>
 			<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="DD_Apparel_ScaleHelm"]/apparel/bodyPartGroups</xpath>
 		<value>
@@ -29,6 +31,7 @@
 			<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="DD_Apparel_DragonCrown"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
 		<value>

--- a/ModPatches/Dragons Descent/Patches/Dragons Descent/ThingDefs_Misc/Apparel_Various.xml
+++ b/ModPatches/Dragons Descent/Patches/Dragons Descent/ThingDefs_Misc/Apparel_Various.xml
@@ -8,12 +8,14 @@
 			<WornBulk>5</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="DD_Apparel_ScaleMail"]/statBases/StuffEffectMultiplierArmor</xpath>
 		<value>
 			<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="DD_Apparel_ScaleMail"]/equippedStatOffsets</xpath>
 		<value>

--- a/ModPatches/Dragons Descent/Patches/Dragons Descent/ThingDefs_Misc/Weapons/MeleeDD.xml
+++ b/ModPatches/Dragons Descent/Patches/Dragons Descent/ThingDefs_Misc/Weapons/MeleeDD.xml
@@ -8,6 +8,7 @@
 			<MeleeCounterParryBonus>1.34</MeleeCounterParryBonus>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="DD_MeleeWeapon_HornedLance"]</xpath>
 		<value>
@@ -18,6 +19,7 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="DD_MeleeWeapon_HornedLance"]/tools</xpath>
 		<value>
@@ -65,6 +67,7 @@
 			<MeleeCounterParryBonus>1.04</MeleeCounterParryBonus>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="DD_MeleeWeapon_DrachenSword"]</xpath>
 		<value>
@@ -75,6 +78,7 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="DD_MeleeWeapon_DrachenSword"]/tools</xpath>
 		<value>
@@ -122,6 +126,7 @@
 			<MeleeCounterParryBonus>1.5</MeleeCounterParryBonus>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="DDMeleeWeapon_ThrumboBattleAxe"]</xpath>
 		<value>
@@ -132,6 +137,7 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="DDMeleeWeapon_ThrumboBattleAxe"]/tools</xpath>
 		<value>
@@ -169,6 +175,7 @@
 			<MeleeCounterParryBonus>0.14</MeleeCounterParryBonus>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="DDMeleeWeapon_FocusingTome"]/equippedStatOffsets</xpath>
 		<value>
@@ -177,6 +184,7 @@
 			<MeleeDodgeChance>0.07</MeleeDodgeChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="DDMeleeWeapon_FocusingTome"]/tools</xpath>
 		<value>
@@ -193,6 +201,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="DDMeleeWeapon_FocusingTome"]</xpath>
 		<value>

--- a/ModPatches/Dragons Descent/Patches/Dragons Descent/ThingDefs_Misc/Weapons/RangedDD.xml
+++ b/ModPatches/Dragons Descent/Patches/Dragons Descent/ThingDefs_Misc/Weapons/RangedDD.xml
@@ -51,6 +51,7 @@
 		<researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
 		<AllowWithRunAndGun>false</AllowWithRunAndGun>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="DD_Gun_DragonfireLauncher"]/tools</xpath>
 		<value>
@@ -130,6 +131,7 @@
 			<li>NeolithicRangedChief</li>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="DD_Bow_DoubleCrossbow"]/tools</xpath>
 		<value>

--- a/ModPatches/Dragons Descent/Patches/Dragons Descent/ThingDefs_Races/Races_Animal_Dragon_Base.xml
+++ b/ModPatches/Dragons Descent/Patches/Dragons Descent/ThingDefs_Races/Races_Animal_Dragon_Base.xml
@@ -69,18 +69,21 @@
 			<ShootingAccuracyPawn>1.75</ShootingAccuracyPawn>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="RDragonRaceBase"]/statBases/MeleeDodgeChance</xpath>
 		<value>
 			<MeleeDodgeChance>0.13</MeleeDodgeChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="RDragonRaceBase"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>48</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="RDragonRaceBase"]/statBases/ArmorRating_Sharp</xpath>
 		<value>

--- a/ModPatches/Dragons Descent/Patches/Dragons Descent/ThingDefs_Races/Races_Animal_Rare_Dragon.xml
+++ b/ModPatches/Dragons Descent/Patches/Dragons Descent/ThingDefs_Races/Races_Animal_Rare_Dragon.xml
@@ -27,6 +27,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>
 			Defs/ThingDef[
@@ -65,6 +66,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>
 			Defs/ThingDef[

--- a/ModPatches/ESCP - Trolls/Patches/ESCP - Trolls/ESCP_Hediff_TrollAffliction.xml
+++ b/ModPatches/ESCP - Trolls/Patches/ESCP - Trolls/ESCP_Hediff_TrollAffliction.xml
@@ -6,6 +6,7 @@
 			<ArmorRating_Blunt>1</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="ESCP_AfflictedTroll"]/stages/li[1]/statOffsets/ArmorRating_Sharp</xpath>
 		<value>

--- a/ModPatches/ESCP - Trolls/Patches/ESCP - Trolls/ESCP_Item_TrollLeather.xml
+++ b/ModPatches/ESCP - Trolls/Patches/ESCP - Trolls/ESCP_Item_TrollLeather.xml
@@ -5,11 +5,13 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="ESCP_GrahlTusk"]/tools</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationAttributeSet">
 		<xpath>Defs/ThingDef[defName="ESCP_GrahlTusk"]</xpath>
 		<attribute>ParentName</attribute>
 		<value>ResourceBase</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="ESCP_GrahlTusk"]/description</xpath>
 		<value>
@@ -22,11 +24,13 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="ESCP_UderfrykteTusk"]/tools</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationAttributeSet">
 		<xpath>Defs/ThingDef[defName="ESCP_UderfrykteTusk"]</xpath>
 		<attribute>ParentName</attribute>
 		<value>ResourceBase</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="ESCP_UderfrykteTusk"]/description</xpath>
 		<value>

--- a/ModPatches/ESCP - Trolls/Patches/ESCP - Trolls/ESCP_ThingDef_Trolls.xml
+++ b/ModPatches/ESCP - Trolls/Patches/ESCP - Trolls/ESCP_ThingDef_Trolls.xml
@@ -1368,6 +1368,7 @@
 			<baseHealthScale>2</baseHealthScale>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="ESCP_TrollUdyrfrykte"]</xpath>
 		<value>
@@ -1376,6 +1377,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="ESCP_TrollUdyrfrykte"]/statBases</xpath>
 		<value>

--- a/ModPatches/Equium/Patches/Equium/PawnKinds_Equium.xml
+++ b/ModPatches/Equium/Patches/Equium/PawnKinds_Equium.xml
@@ -32,6 +32,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="EquiumPackLeader"]</xpath>
 		<value>
@@ -63,6 +64,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="EquiumElder"]</xpath>
 		<value>
@@ -94,6 +96,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="EquiumTrader"]</xpath>
 		<value>
@@ -125,6 +128,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="EquiumSlave"]</xpath>
 		<value>
@@ -156,6 +160,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="HorseInBlack"]</xpath>
 		<value>
@@ -187,6 +192,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="HorseInBlackJoin"]</xpath>
 		<value>
@@ -218,6 +224,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="EquiumRefugee"]</xpath>
 		<value>
@@ -249,6 +256,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="EquiumHunter"]</xpath>
 		<value>
@@ -280,6 +288,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="EquiumSecurityGuard"]</xpath>
 		<value>

--- a/ModPatches/Equium/Patches/Equium/PawnKinds_Equium_Gangs.xml
+++ b/ModPatches/Equium/Patches/Equium/PawnKinds_Equium_Gangs.xml
@@ -32,6 +32,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="EquiumBully"]</xpath>
 		<value>
@@ -63,6 +64,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="EquiumGangLeader"]</xpath>
 		<value>
@@ -94,6 +96,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="EquiumDealer"]</xpath>
 		<value>

--- a/ModPatches/Equium/Patches/Equium/PawnKinds_Equium_Military.xml
+++ b/ModPatches/Equium/Patches/Equium/PawnKinds_Equium_Military.xml
@@ -32,6 +32,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="EquiumRecruit"]</xpath>
 		<value>
@@ -63,6 +64,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="EquiumPrivateUnarmed"]</xpath>
 		<value>
@@ -94,6 +96,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="EquiumPrivate"]</xpath>
 		<value>
@@ -125,6 +128,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="EquiumCombatSpecialist"]</xpath>
 		<value>
@@ -156,6 +160,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="EquiumMilitaryTrader"]</xpath>
 		<value>
@@ -187,6 +192,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="EquiumExplosiveSpecialist"]</xpath>
 		<value>
@@ -218,6 +224,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="EquiumXO"]</xpath>
 		<value>
@@ -249,6 +256,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="EquiumCommander"]</xpath>
 		<value>

--- a/ModPatches/Equium/Patches/Equium/PawnKinds_Equium_Tribal.xml
+++ b/ModPatches/Equium/Patches/Equium/PawnKinds_Equium_Tribal.xml
@@ -32,6 +32,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="EquiumTribalElder"]</xpath>
 		<value>
@@ -63,6 +64,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="EquiumTribalWarrior"]</xpath>
 		<value>
@@ -94,6 +96,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="EquiumTribalTrader"]</xpath>
 		<value>
@@ -125,6 +128,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="EquiumTribalArcher"]</xpath>
 		<value>
@@ -156,6 +160,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="EquiumTribalHunter"]</xpath>
 		<value>
@@ -187,6 +192,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="EquiumTribalHeavyArcher"]</xpath>
 		<value>
@@ -218,6 +224,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="EquiumTribalBerserker"]</xpath>
 		<value>
@@ -249,6 +256,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="EquiumTribalChiefMelee"]</xpath>
 		<value>
@@ -280,6 +288,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="EquiumTribalChiefRanged"]</xpath>
 		<value>

--- a/ModPatches/Erin's Wildlife/Patches/Erin's Wildlife/ThingDefs_Races.xml
+++ b/ModPatches/Erin's Wildlife/Patches/Erin's Wildlife/ThingDefs_Races.xml
@@ -319,6 +319,7 @@
 			Defs/ThingDef[defName="ERN_Armadillo"]/statBases/ArmorRating_Sharp
 		</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="ERN_Armadillo"]/statBases</xpath>
 

--- a/ModPatches/EvolvedOrgansRedux/Patches/EvolvedOrgansRedux/Brain_Evo_CE.xml
+++ b/ModPatches/EvolvedOrgansRedux/Patches/EvolvedOrgansRedux/Brain_Evo_CE.xml
@@ -14,6 +14,7 @@
 			</statOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="EVOR_Hediff_Brain_ReptilianFrontalCortex"]/stages/li[1]/statOffsets/MeleeDodgeChance</xpath>
 		<value>

--- a/ModPatches/Exotic Arsenal/Patches/Exotic Arsenal/Exotic_Weapons_CE.xml
+++ b/ModPatches/Exotic Arsenal/Patches/Exotic Arsenal/Exotic_Weapons_CE.xml
@@ -653,6 +653,7 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Xedos_BlazeSF" or defName="Xedos_GlacialSF"]/statBases</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/HighCaliber/127x108mm.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/HighCaliber/127x108mm.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_127x108mm_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -94,6 +95,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_127x108mm_AP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -155,6 +157,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_127x108mm_Incendiary"]/fixedIngredientFilter</xpath>
 		<value>
@@ -216,6 +219,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_127x108mm_HE"]/fixedIngredientFilter</xpath>
 		<value>
@@ -261,6 +265,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_127x108mm_Sabot"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/HighCaliber/145x114mm.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/HighCaliber/145x114mm.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_145x114mm_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -94,6 +95,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_145x114mm_AP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -155,6 +157,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_145x114mm_Incendiary"]/fixedIngredientFilter</xpath>
 		<value>
@@ -216,6 +219,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_145x114mm_HE"]/fixedIngredientFilter</xpath>
 		<value>
@@ -261,6 +265,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_145x114mm_Sabot"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/HighCaliber/20x102mmNATO.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/HighCaliber/20x102mmNATO.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_20x102mmNATO_AP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -102,6 +103,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_20x102mmNATO_Incendiary"]/fixedIngredientFilter</xpath>
 		<value>
@@ -163,6 +165,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_20x102mmNATO_HE"]/fixedIngredientFilter</xpath>
 		<value>
@@ -208,6 +211,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_20x102mmNATO_Sabot"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/HighCaliber/20x110mmHispano.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/HighCaliber/20x110mmHispano.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_20x110mmHispano_AP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -102,6 +103,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_20x110mmHispano_Incendiary"]/fixedIngredientFilter</xpath>
 		<value>
@@ -163,6 +165,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_20x110mmHispano_HE"]/fixedIngredientFilter</xpath>
 		<value>
@@ -208,6 +211,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_20x110mmHispano_Sabot"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/HighCaliber/25x137mmNATO.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/HighCaliber/25x137mmNATO.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_25x137mmNATO_AP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -102,6 +103,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_25x137mmNATO_Incendiary"]/fixedIngredientFilter</xpath>
 		<value>
@@ -163,6 +165,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_25x137mmNATO_HE"]/fixedIngredientFilter</xpath>
 		<value>
@@ -208,6 +211,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_25x137mmNATO_Sabot"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/HighCaliber/300WinchesterMagnum.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/HighCaliber/300WinchesterMagnum.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_300WinchesterMagnum_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -94,6 +95,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_300WinchesterMagnum_AP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -155,6 +157,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_300WinchesterMagnum_Incendiary"]/fixedIngredientFilter</xpath>
 		<value>
@@ -216,6 +219,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_300WinchesterMagnum_HE"]/fixedIngredientFilter</xpath>
 		<value>
@@ -261,6 +265,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_300WinchesterMagnum_Sabot"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/HighCaliber/30x173mmNATO.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/HighCaliber/30x173mmNATO.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_30x173mmNATO_AP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -102,6 +103,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_30x173mmNATO_Incendiary"]/fixedIngredientFilter</xpath>
 		<value>
@@ -163,6 +165,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_30x173mmNATO_HE"]/fixedIngredientFilter</xpath>
 		<value>
@@ -208,6 +211,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_30x173mmNATO_Sabot"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/HighCaliber/338Lapua.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/HighCaliber/338Lapua.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_338Lapua_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -94,6 +95,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_338Lapua_AP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -155,6 +157,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_338Lapua_Incendiary"]/fixedIngredientFilter</xpath>
 		<value>
@@ -216,6 +219,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_338Lapua_HE"]/fixedIngredientFilter</xpath>
 		<value>
@@ -261,6 +265,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_338Lapua_Sabot"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/HighCaliber/338Norma.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/HighCaliber/338Norma.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_338Norma_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -94,6 +95,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_338Norma_AP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -155,6 +157,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_338Norma_Incendiary"]/fixedIngredientFilter</xpath>
 		<value>
@@ -216,6 +219,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_338Norma_HE"]/fixedIngredientFilter</xpath>
 		<value>
@@ -261,6 +265,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_338Norma_Sabot"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/HighCaliber/408CheyenneTactical.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/HighCaliber/408CheyenneTactical.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_408CheyenneTactical_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -94,6 +95,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_408CheyenneTactical_AP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -155,6 +157,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_408CheyenneTactical_Incendiary"]/fixedIngredientFilter</xpath>
 		<value>
@@ -216,6 +219,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_408CheyenneTactical_HE"]/fixedIngredientFilter</xpath>
 		<value>
@@ -261,6 +265,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_408CheyenneTactical_Sabot"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/HighCaliber/40x311mmR.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/HighCaliber/40x311mmR.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_40x311mmR_AP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -102,6 +103,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_40x311mmR_Incendiary"]/fixedIngredientFilter</xpath>
 		<value>
@@ -163,6 +165,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_40x311mmR_HE"]/fixedIngredientFilter</xpath>
 		<value>
@@ -208,6 +211,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_40x311mmR_Sabot"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/HighCaliber/50BMG.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/HighCaliber/50BMG.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_50BMG_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -94,6 +95,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_50BMG_AP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -155,6 +157,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_50BMG_Incendiary"]/fixedIngredientFilter</xpath>
 		<value>
@@ -216,6 +219,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_50BMG_HE"]/fixedIngredientFilter</xpath>
 		<value>
@@ -261,6 +265,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_50BMG_Sabot"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_10mmAuto.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_10mmAuto.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_10mmAuto_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -93,6 +94,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_10mmAuto_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -145,6 +147,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_10mmAuto_AP"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_22LR.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_22LR.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_22LR_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -93,6 +94,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_22LR_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -145,6 +147,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_22LR_AP"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_32ACP.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_32ACP.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_32ACP_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -93,6 +94,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_32ACP_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -145,6 +147,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_32ACP_AP"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_357Magnum.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_357Magnum.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_357Magnum_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -93,6 +94,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_357Magnum_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -145,6 +147,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_357Magnum_AP"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_357SIG.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_357SIG.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_357SIG_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -93,6 +94,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_357SIG_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -145,6 +147,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_357SIG_AP"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_40SW.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_40SW.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_40SW_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -93,6 +94,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_40SW_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -145,6 +147,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_40SW_AP"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_44Magnum.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_44Magnum.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_44Magnum_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -93,6 +94,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_44Magnum_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -145,6 +147,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_44Magnum_AP"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_454Casull.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_454Casull.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_454Casull_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -93,6 +94,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_454Casull_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -145,6 +147,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_454Casull_AP"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_455Webley.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_455Webley.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_455Webley_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -93,6 +94,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_455Webley_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -145,6 +147,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_455Webley_AP"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_45ACP.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_45ACP.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_45ACP_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -93,6 +94,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_45ACP_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -145,6 +147,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_45ACP_AP"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_45Colt.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_45Colt.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_45Colt_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -93,6 +94,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_45Colt_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -145,6 +147,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_45Colt_AP"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_46x30mm.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_46x30mm.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_46x30mm_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -93,6 +94,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_46x30mm_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -145,6 +147,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_46x30mm_AP"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_500SWMagnum.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_500SWMagnum.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_500SWMagnum_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -93,6 +94,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_500SWMagnum_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -145,6 +147,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_500SWMagnum_AP"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_50AE.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_50AE.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_50AE_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -93,6 +94,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_50AE_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -145,6 +147,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_50AE_AP"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_58x21mmDAP92.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_58x21mmDAP92.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_58x21mmDAP92_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -93,6 +94,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_58x21mmDAP92_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -145,6 +147,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_58x21mmDAP92_AP"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_762x25mmTokarev.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_762x25mmTokarev.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x25mmTokarev_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -93,6 +94,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x25mmTokarev_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -145,6 +147,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x25mmTokarev_AP"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_762x38mmR.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_762x38mmR.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x38mmR_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -93,6 +94,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x38mmR_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -145,6 +147,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x38mmR_AP"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_763x25mmMauser.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_763x25mmMauser.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_763x25mmMauser_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -93,6 +94,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_763x25mmMauser_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -145,6 +147,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_763x25mmMauser_AP"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_765x20mmLongue.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_765x20mmLongue.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_765x20mmLongue_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -93,6 +94,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_765x20mmLongue_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -145,6 +147,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_765x20mmLongue_AP"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_9x18mmMakarov.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_9x18mmMakarov.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_9x18mmMakarov_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -93,6 +94,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_9x18mmMakarov_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -145,6 +147,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_9x18mmMakarov_AP"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_9x19mmPara.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_9x19mmPara.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_9x19mmPara_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -93,6 +94,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_9x19mmPara_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -145,6 +147,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_9x19mmPara_AP"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_9x21mmGyurza.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_9x21mmGyurza.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_9x21mmGyurza_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -93,6 +94,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_9x21mmGyurza_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -145,6 +147,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_9x21mmGyurza_AP"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_FN57x28mm.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_FN57x28mm.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_FN57x28mm_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -93,6 +94,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_FN57x28mm_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -145,6 +147,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_FN57x28mm_AP"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_127x55mmAR.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_127x55mmAR.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_127x55mmAR_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -94,6 +95,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_127x55mmAR_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -147,6 +149,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_127x55mmAR_AP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -208,6 +211,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_127x55mmAR_Incendiary"]/fixedIngredientFilter</xpath>
 		<value>
@@ -269,6 +273,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_127x55mmAR_HE"]/fixedIngredientFilter</xpath>
 		<value>
@@ -314,6 +319,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_127x55mmAR_Sabot"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_277Fury.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_277Fury.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_277Fury_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -94,6 +95,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_277Fury_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -147,6 +149,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_277Fury_AP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -208,6 +211,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_277Fury_Incendiary"]/fixedIngredientFilter</xpath>
 		<value>
@@ -269,6 +273,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_277Fury_HE"]/fixedIngredientFilter</xpath>
 		<value>
@@ -314,6 +319,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_277Fury_Sabot"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_3006Springfield.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_3006Springfield.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_3006Springfield_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -94,6 +95,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_3006Springfield_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -147,6 +149,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_3006Springfield_AP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -208,6 +211,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_3006Springfield_Incendiary"]/fixedIngredientFilter</xpath>
 		<value>
@@ -269,6 +273,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_3006Springfield_HE"]/fixedIngredientFilter</xpath>
 		<value>
@@ -314,6 +319,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_3006Springfield_Sabot"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_300AACBlackout.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_300AACBlackout.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_300AACBlackout_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -94,6 +95,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_300AACBlackout_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -147,6 +149,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_300AACBlackout_AP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -208,6 +211,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_300AACBlackout_Incendiary"]/fixedIngredientFilter</xpath>
 		<value>
@@ -269,6 +273,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_300AACBlackout_HE"]/fixedIngredientFilter</xpath>
 		<value>
@@ -314,6 +319,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_300AACBlackout_Sabot"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_303British.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_303British.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_303British_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -94,6 +95,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_303British_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -147,6 +149,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_303British_AP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -208,6 +211,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_303British_Incendiary"]/fixedIngredientFilter</xpath>
 		<value>
@@ -269,6 +273,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_303British_HE"]/fixedIngredientFilter</xpath>
 		<value>
@@ -314,6 +319,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_303British_Sabot"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_30Carbine.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_30Carbine.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_30Carbine_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -94,6 +95,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_30Carbine_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -147,6 +149,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_30Carbine_AP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -208,6 +211,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_30Carbine_Incendiary"]/fixedIngredientFilter</xpath>
 		<value>
@@ -269,6 +273,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_30Carbine_HE"]/fixedIngredientFilter</xpath>
 		<value>
@@ -314,6 +319,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_30Carbine_Sabot"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_545x39mmSoviet.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_545x39mmSoviet.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_545x39mmSoviet_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -94,6 +95,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_545x39mmSoviet_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -147,6 +149,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_545x39mmSoviet_AP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -208,6 +211,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_545x39mmSoviet_Incendiary"]/fixedIngredientFilter</xpath>
 		<value>
@@ -269,6 +273,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_545x39mmSoviet_HE"]/fixedIngredientFilter</xpath>
 		<value>
@@ -314,6 +319,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_545x39mmSoviet_Sabot"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_556x45mmNATO.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_556x45mmNATO.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_556x45mmNATO_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -94,6 +95,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_556x45mmNATO_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -147,6 +149,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_556x45mmNATO_AP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -208,6 +211,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_556x45mmNATO_Incendiary"]/fixedIngredientFilter</xpath>
 		<value>
@@ -269,6 +273,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_556x45mmNATO_HE"]/fixedIngredientFilter</xpath>
 		<value>
@@ -314,6 +319,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_556x45mmNATO_Sabot"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_58x42mmDBP10.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_58x42mmDBP10.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_58x42mmDBP10_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -94,6 +95,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_58x42mmDBP10_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -147,6 +149,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_58x42mmDBP10_AP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -208,6 +211,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_58x42mmDBP10_Incendiary"]/fixedIngredientFilter</xpath>
 		<value>
@@ -269,6 +273,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_58x42mmDBP10_HE"]/fixedIngredientFilter</xpath>
 		<value>
@@ -314,6 +319,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_58x42mmDBP10_Sabot"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_65x52mmCarcano.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_65x52mmCarcano.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_65x52mmCarcano_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -94,6 +95,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_65x52mmCarcano_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -147,6 +149,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_65x52mmCarcano_AP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -208,6 +211,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_65x52mmCarcano_Incendiary"]/fixedIngredientFilter</xpath>
 		<value>
@@ -269,6 +273,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_65x52mmCarcano_HE"]/fixedIngredientFilter</xpath>
 		<value>
@@ -314,6 +319,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_65x52mmCarcano_Sabot"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_75x54mmFrench.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_75x54mmFrench.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_75x54mmFrench_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -94,6 +95,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_75x54mmFrench_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -147,6 +149,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_75x54mmFrench_AP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -208,6 +211,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_75x54mmFrench_Incendiary"]/fixedIngredientFilter</xpath>
 		<value>
@@ -269,6 +273,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_75x54mmFrench_HE"]/fixedIngredientFilter</xpath>
 		<value>
@@ -314,6 +319,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_75x54mmFrench_Sabot"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_762x39mmSoviet.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_762x39mmSoviet.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x39mmSoviet_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -94,6 +95,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x39mmSoviet_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -147,6 +149,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x39mmSoviet_AP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -208,6 +211,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x39mmSoviet_Incendiary"]/fixedIngredientFilter</xpath>
 		<value>
@@ -269,6 +273,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x39mmSoviet_HE"]/fixedIngredientFilter</xpath>
 		<value>
@@ -314,6 +319,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x39mmSoviet_Sabot"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_762x51mmNATO.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_762x51mmNATO.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x51mmNATO_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -94,6 +95,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x51mmNATO_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -147,6 +149,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x51mmNATO_AP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -208,6 +211,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x51mmNATO_Incendiary"]/fixedIngredientFilter</xpath>
 		<value>
@@ -269,6 +273,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x51mmNATO_HE"]/fixedIngredientFilter</xpath>
 		<value>
@@ -314,6 +319,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x51mmNATO_Sabot"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_762x54mmR.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_762x54mmR.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x54mmR_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -94,6 +95,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x54mmR_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -147,6 +149,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x54mmR_AP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -208,6 +211,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x54mmR_Incendiary"]/fixedIngredientFilter</xpath>
 		<value>
@@ -269,6 +273,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x54mmR_HE"]/fixedIngredientFilter</xpath>
 		<value>
@@ -314,6 +319,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x54mmR_Sabot"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_77x58mmArisaka.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_77x58mmArisaka.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_77x58mmArisaka_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -94,6 +95,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_77x58mmArisaka_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -147,6 +149,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_77x58mmArisaka_AP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -208,6 +211,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_77x58mmArisaka_Incendiary"]/fixedIngredientFilter</xpath>
 		<value>
@@ -269,6 +273,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_77x58mmArisaka_HE"]/fixedIngredientFilter</xpath>
 		<value>
@@ -314,6 +319,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_77x58mmArisaka_Sabot"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_792x33mmKurz.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_792x33mmKurz.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_792x33mmKurz_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -94,6 +95,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_792x33mmKurz_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -147,6 +149,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_792x33mmKurz_AP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -208,6 +211,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_792x33mmKurz_Incendiary"]/fixedIngredientFilter</xpath>
 		<value>
@@ -269,6 +273,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_792x33mmKurz_HE"]/fixedIngredientFilter</xpath>
 		<value>
@@ -314,6 +319,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_792x33mmKurz_Sabot"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_792x57mmMauser.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_792x57mmMauser.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_792x57mmMauser_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -94,6 +95,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_792x57mmMauser_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -147,6 +149,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_792x57mmMauser_AP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -208,6 +211,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_792x57mmMauser_Incendiary"]/fixedIngredientFilter</xpath>
 		<value>
@@ -269,6 +273,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_792x57mmMauser_HE"]/fixedIngredientFilter</xpath>
 		<value>
@@ -314,6 +319,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_792x57mmMauser_Sabot"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_8x50mmRLebel.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_8x50mmRLebel.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_8x50mmRLebel_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -94,6 +95,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_8x50mmRLebel_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -147,6 +149,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_8x50mmRLebel_AP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -208,6 +211,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_8x50mmRLebel_Incendiary"]/fixedIngredientFilter</xpath>
 		<value>
@@ -269,6 +273,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_8x50mmRLebel_HE"]/fixedIngredientFilter</xpath>
 		<value>
@@ -314,6 +319,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_8x50mmRLebel_Sabot"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_9x39mmSoviet.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_9x39mmSoviet.xml
@@ -41,6 +41,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_9x39mmSoviet_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
@@ -94,6 +95,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_9x39mmSoviet_HP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -147,6 +149,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_9x39mmSoviet_AP"]/fixedIngredientFilter</xpath>
 		<value>
@@ -208,6 +211,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_9x39mmSoviet_Incendiary"]/fixedIngredientFilter</xpath>
 		<value>
@@ -269,6 +273,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_9x39mmSoviet_HE"]/fixedIngredientFilter</xpath>
 		<value>
@@ -314,6 +319,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_9x39mmSoviet_Sabot"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Shotgun/12Gauge.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Shotgun/12Gauge.xml
@@ -33,6 +33,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_12Gauge_Buck"]/fixedIngredientFilter</xpath>
 		<value>
@@ -78,6 +79,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_12Gauge_Slug"]/fixedIngredientFilter</xpath>
 		<value>
@@ -131,6 +133,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_12Gauge_Beanbag"]/fixedIngredientFilter</xpath>
 		<value>
@@ -176,6 +179,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_12Gauge_ElectroSlug"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Shotgun/20Gauge.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Shotgun/20Gauge.xml
@@ -33,6 +33,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_20Gauge_Buck"]/fixedIngredientFilter</xpath>
 		<value>
@@ -78,6 +79,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_20Gauge_Slug"]/fixedIngredientFilter</xpath>
 		<value>
@@ -131,6 +133,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_20Gauge_Beanbag"]/fixedIngredientFilter</xpath>
 		<value>
@@ -176,6 +179,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_20Gauge_ElectroSlug"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Shotgun/23x75mmR.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Shotgun/23x75mmR.xml
@@ -33,6 +33,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_23x75mmR_Buck"]/fixedIngredientFilter</xpath>
 		<value>
@@ -78,6 +79,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_23x75mmR_Slug"]/fixedIngredientFilter</xpath>
 		<value>
@@ -131,6 +133,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_23x75mmR_Beanbag"]/fixedIngredientFilter</xpath>
 		<value>
@@ -176,6 +179,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_23x75mmR_ElectroSlug"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Shotgun/410Bore.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Shotgun/410Bore.xml
@@ -33,6 +33,7 @@
 			</ingredients>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_410Bore_Buck"]/fixedIngredientFilter</xpath>
 		<value>

--- a/ModPatches/Farming Expansion/Patches/Farming Expansion/Race_CropEaterInsect.xml
+++ b/ModPatches/Farming Expansion/Patches/Farming Expansion/Race_CropEaterInsect.xml
@@ -8,6 +8,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="FE_CropEaterInsect"]/statBases/MoveSpeed</xpath>
 		<value>
@@ -17,18 +18,21 @@
 			<MeleeParryChance>0.00</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="FE_CropEaterInsect"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>0.00</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="FE_CropEaterInsect"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>0.00</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="FE_CropEaterInsect"]/tools</xpath>
 		<value>

--- a/ModPatches/Ferrex/Patches/Ferrex/Ferrex_Weapons.xml
+++ b/ModPatches/Ferrex/Patches/Ferrex/Ferrex_Weapons.xml
@@ -47,6 +47,7 @@
 			<li>CE_AI_AssaultWeapon</li>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Ferrex_P90x"]/tools</xpath>
 		<value>
@@ -145,6 +146,7 @@
 			<li>CE_AI_AssaultWeapon</li>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Ferrex_Vac"]/tools</xpath>
 		<value>

--- a/ModPatches/Ferrex/Patches/Ferrex/PawnKinds_Ferrex.xml
+++ b/ModPatches/Ferrex/Patches/Ferrex/PawnKinds_Ferrex.xml
@@ -32,6 +32,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="FerrexExecutive"]</xpath>
 		<value>
@@ -63,6 +64,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="FerrexTrader"]</xpath>
 		<value>
@@ -94,6 +96,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="FerrexSlave"]</xpath>
 		<value>
@@ -125,6 +128,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="FerrexRefugee"]</xpath>
 		<value>
@@ -156,6 +160,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="FerrexSecurityGuard"]</xpath>
 		<value>
@@ -187,6 +192,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="FerrexMerc"]</xpath>
 		<value>
@@ -218,6 +224,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="FerrexSurveyor"]</xpath>
 		<value>
@@ -249,6 +256,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="FerrexProfessional"]</xpath>
 		<value>
@@ -280,6 +288,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="FerrexNinja"]</xpath>
 		<value>

--- a/ModPatches/Forgotten Realms - Lizardfolk/Patches/Forgotten Realms - Lizardfolk/Patch_Lizardfolk_Race.xml
+++ b/ModPatches/Forgotten Realms - Lizardfolk/Patches/Forgotten Realms - Lizardfolk/Patch_Lizardfolk_Race.xml
@@ -20,6 +20,7 @@
 			<MeleeParryChance>1</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="FR_Alien_Croco"]/statBases/Mass</xpath>
 		<value>

--- a/ModPatches/Forgotten Realms - Lizardfolk/Patches/Forgotten Realms - Lizardfolk/Patch_Lizardfolk_Skin.xml
+++ b/ModPatches/Forgotten Realms - Lizardfolk/Patches/Forgotten Realms - Lizardfolk/Patch_Lizardfolk_Skin.xml
@@ -7,18 +7,21 @@
 			<StuffPower_Armor_Sharp>0.08</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Leather_Squamata"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.064</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Leather_Croco"]/statBases/StuffPower_Armor_Sharp</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>0.1</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Leather_Croco"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>

--- a/ModPatches/Forgotten Realms - Minotaur/Patches/Forgotten Realms - Minotaur/Patch_Mino_Leather.xml
+++ b/ModPatches/Forgotten Realms - Minotaur/Patches/Forgotten Realms - Minotaur/Patch_Mino_Leather.xml
@@ -7,6 +7,7 @@
 			<StuffPower_Armor_Sharp>0.07</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Leather_Minotaur"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>

--- a/ModPatches/Frontline - Additional Guns For Trenches/Patches/Frontline - Additional Guns For Trenches/FrontlineAdditionalGunsForTrenches_IA_TRHMGII.xml
+++ b/ModPatches/Frontline - Additional Guns For Trenches/Patches/Frontline - Additional Guns For Trenches/FrontlineAdditionalGunsForTrenches_IA_TRHMGII.xml
@@ -27,6 +27,7 @@
 			<li>CE_Turret</li>
 		</value>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>TR_Gun_HMGII</defName>
 		<statBases>

--- a/ModPatches/Fuck it Unboomas your Lope/Patches/Fuck it Unboomas your Lope/Noboom.xml
+++ b/ModPatches/Fuck it Unboomas your Lope/Patches/Fuck it Unboomas your Lope/Noboom.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Boomalope"]/butcherProducts</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Boomalope"]/comps/li[@Class ="CombatExtended.CompProperties_ShearableRenameable"]</xpath>
 	</Operation>

--- a/ModPatches/Gas Traps and Shells/Patches/Gas Traps and Shells/Patch_Mortars.xml
+++ b/ModPatches/Gas Traps and Shells/Patches/Gas Traps and Shells/Patch_Mortars.xml
@@ -114,30 +114,35 @@
 			<ammoClass>GasToxic</ammoClass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Shell_GasRage"]</xpath>
 		<value>
 			<ammoClass>GasRage</ammoClass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Shell_GasTear"]</xpath>
 		<value>
 			<ammoClass>GasTear</ammoClass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Shell_GasFear"]</xpath>
 		<value>
 			<ammoClass>GasFear</ammoClass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Shell_GasSleep"]</xpath>
 		<value>
 			<ammoClass>GasSleep</ammoClass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Shell_GasAcid"]</xpath>
 		<value>
@@ -180,6 +185,7 @@
 			</comps>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Shell_GasRage"]/comps</xpath>
 		<value>
@@ -199,6 +205,7 @@
 			</comps>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Shell_GasTear"]/comps</xpath>
 		<value>
@@ -218,6 +225,7 @@
 			</comps>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Shell_GasSleep"]/comps</xpath>
 		<value>
@@ -237,6 +245,7 @@
 			</comps>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Shell_GasFear"]/comps</xpath>
 		<value>
@@ -256,6 +265,7 @@
 			</comps>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Shell_GasAcid"]/comps</xpath>
 		<value>

--- a/ModPatches/Gulden Mod/Patches/Gulden Mod/Gulden_Forest_Resources_Leather.xml
+++ b/ModPatches/Gulden Mod/Patches/Gulden Mod/Gulden_Forest_Resources_Leather.xml
@@ -7,6 +7,7 @@
 			<StuffPower_Armor_Sharp>5</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="RuneBearLeatherBase"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>

--- a/ModPatches/Impact Weaponry/Patches/Impact Weaponry/ImpactRanged.xml
+++ b/ModPatches/Impact Weaponry/Patches/Impact Weaponry/ImpactRanged.xml
@@ -201,6 +201,7 @@
 			<li>CE_AI_AOE</li>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="DV_ImpactCannon"]</xpath>
 		<value>

--- a/ModPatches/Insects have chitin/Patches/Insects have chitin/ThingDefs_Items/Chitin.xml
+++ b/ModPatches/Insects have chitin/Patches/Insects have chitin/ThingDefs_Items/Chitin.xml
@@ -9,24 +9,28 @@
 			<StuffPower_Armor_Sharp>0.25</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="InsectChitin"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.05</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="InsectChitin"]/statBases/StuffPower_Armor_Heat</xpath>
 		<value>
 			<StuffPower_Armor_Heat>0.025</StuffPower_Armor_Heat>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="InsectChitin"]/statBases/SharpDamageMultiplier</xpath>
 		<value>
 			<SharpDamageMultiplier>0.6</SharpDamageMultiplier>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="InsectChitin"]/statBases/BluntDamageMultiplier</xpath>
 		<value>

--- a/ModPatches/K4G Rimworld War 2/Patches/K4G Rimworld War 2/ThingDefs_Misc/JapaneseWeapons_Ranged.xml
+++ b/ModPatches/K4G Rimworld War 2/Patches/K4G Rimworld War 2/ThingDefs_Misc/JapaneseWeapons_Ranged.xml
@@ -269,6 +269,7 @@
 			</comps>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="K4G_Gun_WW2JapaneseServiceLMG"]/weaponTags</xpath>
 		<value>

--- a/ModPatches/K4G Rimworld War 2/Patches/K4G Rimworld War 2/ThingDefs_Misc/RussianWeapons_Ranged.xml
+++ b/ModPatches/K4G Rimworld War 2/Patches/K4G Rimworld War 2/ThingDefs_Misc/RussianWeapons_Ranged.xml
@@ -394,6 +394,7 @@
 			</comps>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="K4G_Gun_WW2RussianServiceLMG"]/weaponTags</xpath>
 		<value>

--- a/ModPatches/Kobold Factions/Patches/Kobold Factions/Medieval_Kobold_Pawnkind.xml
+++ b/ModPatches/Kobold Factions/Patches/Kobold Factions/Medieval_Kobold_Pawnkind.xml
@@ -6,6 +6,7 @@
 			<li>CE_Apparel_TribalBackpack</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[ defName="LTS_MedboldScout" or defName="LTS_MedboldRanger" or defName="LTS_MedboldLord"]</xpath>
 		<value>

--- a/ModPatches/Kurin Deluxe Patch/Patches/Kurin Deluxe Patch/ThingDefs_Misc/DRNTF_Apparel.xml
+++ b/ModPatches/Kurin Deluxe Patch/Patches/Kurin Deluxe Patch/ThingDefs_Misc/DRNTF_Apparel.xml
@@ -407,24 +407,28 @@
 			<ArmorRating_Sharp>26</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/KurinDeluxeEdition.PowerArmor.KurinPowerArmorThingDef[defName="Kurin_Heavy_Power_Armor"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>30</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/KurinDeluxeEdition.PowerArmor.KurinPowerArmorThingDef[defName="Kurin_Power_Armor"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>64</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/KurinDeluxeEdition.PowerArmor.KurinPowerArmorThingDef[defName="Kurin_Heavy_Power_Armor"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>76</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/KurinDeluxeEdition.PowerArmor.KurinPowerArmorThingDef[defName="Kurin_Power_Armor" or "Kurin_Heavy_Power_Armor"]/statBases</xpath>
 		<value>
@@ -432,6 +436,7 @@
 			<WornBulk>6.5</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/KurinDeluxeEdition.PowerArmor.KurinPowerArmorThingDef[defName="Kurin_Power_Armor"
 			or "Kurin_Heavy_Power_Armor"

--- a/ModPatches/LF Red Dawn/Patches/LF Red Dawn/Armors_RD.xml
+++ b/ModPatches/LF Red Dawn/Patches/LF Red Dawn/Armors_RD.xml
@@ -10,6 +10,7 @@
 			<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_Ssh60helmet"]/stuffCategories/li[.="Metallic"]</xpath>
 		<value>
@@ -28,6 +29,7 @@
 			<ArmorRating_Heat>0.36</ArmorRating_Heat>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_Ssh68helmet"]/stuffCategories/li[.="Metallic"]</xpath>
 		<value>
@@ -67,18 +69,21 @@
 			<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_AltynMaskless"]/statBases/Mass</xpath>
 		<value>
 			<Mass>4</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_AltynMaskless"]/stuffCategories/li[.="Metallic"]</xpath>
 		<value>
 			<li>Steeled</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_AltynMaskless"]/costList</xpath>
 		<value>
@@ -98,18 +103,21 @@
 			<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_AltynMaskDown"]/statBases/Mass</xpath>
 		<value>
 			<Mass>4</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_AltynMaskDown"]/stuffCategories/li[.="Metallic"]</xpath>
 		<value>
 			<li>Steeled</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_AltynMaskDown"]/costList</xpath>
 		<value>
@@ -119,6 +127,7 @@
 			</costList>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_AltynMaskDown"]/apparel/bodyPartGroups</xpath>
 		<value>
@@ -127,6 +136,7 @@
 			</bodyPartGroups>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RD_AltynMaskDown"]</xpath>
 		<value>
@@ -146,18 +156,21 @@
 			<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_AltynMaskUP"]/statBases/Mass</xpath>
 		<value>
 			<Mass>4</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_AltynMaskUP"]/stuffCategories/li[.="Metallic"]</xpath>
 		<value>
 			<li>Steeled</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_AltynMaskUP"]/costList</xpath>
 		<value>
@@ -177,18 +190,21 @@
 			<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_PSHMaskless"]/statBases/Mass</xpath>
 		<value>
 			<Mass>4</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_PSHMaskless"]/stuffCategories/li[.="Metallic"]</xpath>
 		<value>
 			<li>Steeled</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_PSHMaskless"]/costList</xpath>
 		<value>
@@ -208,18 +224,21 @@
 			<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_PSHMaskDown"]/statBases/Mass</xpath>
 		<value>
 			<Mass>4</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_PSHMaskDown"]/stuffCategories/li[.="Metallic"]</xpath>
 		<value>
 			<li>Steeled</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_PSHMaskDown"]/costList</xpath>
 		<value>
@@ -229,6 +248,7 @@
 			</costList>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_PSHMaskDown"]/apparel/bodyPartGroups</xpath>
 		<value>
@@ -237,6 +257,7 @@
 			</bodyPartGroups>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RD_PSHMaskDown"]</xpath>
 		<value>
@@ -254,6 +275,7 @@
 			<Mass>4</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_PSHMaskUP"]/statBases/StuffEffectMultiplierArmor</xpath>
 		<value>
@@ -262,12 +284,14 @@
 			<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_PSHMaskUP"]/stuffCategories/li[.="Metallic"]</xpath>
 		<value>
 			<li>Steeled</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_PSHMaskUP"]/costList</xpath>
 		<value>
@@ -287,18 +311,21 @@
 			<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_DesertHelmet" or defName="RD_KLMKHelmet"]/stuffCategories/li[.="Metallic"]</xpath>
 		<value>
 			<li>Steeled</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_DesertHelmet" or defName="RD_KLMKHelmet"]/costStuffCount</xpath>
 		<value>
 			<costStuffCount>30</costStuffCount>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_DesertHelmet" or defName="RD_KLMKHelmet"]/costList</xpath>
 		<value>
@@ -318,30 +345,35 @@
 			<WornBulk>3</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_6b2FlakVest"]/statBases/MaxHitPoints</xpath>
 		<value>
 			<MaxHitPoints>125</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_6b2FlakVest"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>8</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_6b2FlakVest"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>14</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_6b2FlakVest"]/statBases/ArmorRating_Heat</xpath>
 		<value>
 			<ArmorRating_Heat>0</ArmorRating_Heat>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_6b2FlakVest"]/costList</xpath>
 		<value>
@@ -361,30 +393,35 @@
 			<WornBulk>3</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_6b3FlakVest"]/statBases/MaxHitPoints</xpath>
 		<value>
 			<MaxHitPoints>250</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_6b3FlakVest"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>16</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_6b3FlakVest"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>24</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_6b3FlakVest"]/statBases/ArmorRating_Heat</xpath>
 		<value>
 			<ArmorRating_Heat>0</ArmorRating_Heat>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_6b3FlakVest"]/costList</xpath>
 		<value>
@@ -404,24 +441,28 @@
 			<WornBulk>5</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_BzhVest"]/statBases/MaxHitPoints</xpath>
 		<value>
 			<MaxHitPoints>250</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_BzhVest"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>18</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_BzhVest"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>26</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_BzhVest"]/costList</xpath>
 		<value>
@@ -438,6 +479,7 @@
 			<MaxHitPoints>100</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_LightPilotFlightVest"]/statBases/Mass</xpath>
 		<value>
@@ -446,24 +488,28 @@
 			<WornBulk>2</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_LightPilotFlightVest"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>6.5</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_LightPilotFlightVest"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>10</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_LightPilotFlightVest"]/statBases/ArmorRating_Heat</xpath>
 		<value>
 			<ArmorRating_Heat>0.1</ArmorRating_Heat>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_LightPilotFlightVest"]/costList</xpath>
 		<value>
@@ -473,12 +519,14 @@
 			</costList>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_VDBVest"]/statBases/MaxHitPoints</xpath>
 		<value>
 			<MaxHitPoints>100</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_VDBVest"]/statBases/Mass</xpath>
 		<value>
@@ -487,24 +535,28 @@
 			<WornBulk>2</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_LightPilotFlightVest"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>6</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_VDBVest"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>9</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_VDBVest"]/statBases/ArmorRating_Heat</xpath>
 		<value>
 			<ArmorRating_Heat>0.12</ArmorRating_Heat>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_VDBVest"]/costList</xpath>
 		<value>
@@ -514,6 +566,7 @@
 			</costList>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RD_VDBVest"]</xpath>
 		<value>
@@ -529,6 +582,7 @@
 			<MaxHitPoints>100</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_LightPilotFlightVestCamo"]/statBases/Mass</xpath>
 		<value>
@@ -537,24 +591,28 @@
 			<WornBulk>2</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_LightPilotFlightVestCamo"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>6</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_LightPilotFlightVestCamo"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>9</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_LightPilotFlightVestCamo"]/statBases/ArmorRating_Heat</xpath>
 		<value>
 			<ArmorRating_Heat>0.12</ArmorRating_Heat>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_LightPilotFlightVestCamo"]/costList</xpath>
 		<value>

--- a/ModPatches/LF Red Dawn/Patches/LF Red Dawn/RD_Grenade.xml
+++ b/ModPatches/LF Red Dawn/Patches/LF Red Dawn/RD_Grenade.xml
@@ -44,6 +44,7 @@
 			</comps>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Weapon_RGNGrenade"]/comps</xpath>
 		<value>
@@ -56,6 +57,7 @@
 			</comps>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Weapon_RGOGrenade"]/comps</xpath>
 		<value>
@@ -68,6 +70,7 @@
 			</comps>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Weapon_F1Grenade"]/comps</xpath>
 		<value>
@@ -80,6 +83,7 @@
 			</comps>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Weapon_RKGATGrenade"]/comps</xpath>
 		<value>
@@ -92,11 +96,13 @@
 			</comps>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAttributeSet">
 		<xpath>Defs/ThingDef[defName="Weapon_F1Grenade"]</xpath>
 		<attribute>Class</attribute>
 		<value>CombatExtended.AmmoDef</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAttributeSet">
 		<xpath>Defs/ThingDef[defName="Weapon_RKGATGrenade"]</xpath>
 		<attribute>Class</attribute>

--- a/ModPatches/Leeani/Patches/Leeani/Weapons_Leeani.xml
+++ b/ModPatches/Leeani/Patches/Leeani/Weapons_Leeani.xml
@@ -8,12 +8,14 @@
 			<MeleeWeapon_DamageAmount>11</MeleeWeapon_DamageAmount>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>/ThingDefs/ThingDef[defName = "MeleeWeapon_Quarterstaff"]/statBases/MeleeWeapon_Cooldown</xpath>
 		<value>
 			<MeleeWeapon_Cooldown>0.92</MeleeWeapon_Cooldown>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>/ThingDefs/ThingDef[defName = "MeleeWeapon_Quarterstaff"]/statBases</xpath>
 		<value>
@@ -21,6 +23,7 @@
 			<Bulk>6</Bulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>/ThingDefs/ThingDef[defName = "MeleeWeapon_Quarterstaff"]</xpath>
 		<value>
@@ -30,6 +33,7 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>/ThingDefs/ThingDef[defName = "MeleeWeapon_Quarterstaff"]/verbs</xpath>
 		<value>

--- a/ModPatches/Lemolim Race/Patches/Lemolim Race/Lemolim_Leather.xml
+++ b/ModPatches/Lemolim Race/Patches/Lemolim Race/Lemolim_Leather.xml
@@ -6,6 +6,7 @@
 			<StuffPower_Armor_Sharp>0.06</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Leather_Lemolim"]/statBases</xpath>
 		<value>

--- a/ModPatches/Lemolim Race/Patches/Lemolim Race/Lemolim_Race.xml
+++ b/ModPatches/Lemolim Race/Patches/Lemolim Race/Lemolim_Race.xml
@@ -21,6 +21,7 @@
 			<SmokeSensitivity>1</SmokeSensitivity>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Lemolim"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -30,6 +31,7 @@
 			</value>
 		</nomatch>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Lemolim"]/race/baseBodySize</xpath>
 		<value>
@@ -102,6 +104,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Lemolim"]/comps</xpath>
 		<value>

--- a/ModPatches/Lemolim Race/Patches/Lemolim Race/Lemonim_Pawnkind.xml
+++ b/ModPatches/Lemolim Race/Patches/Lemolim Race/Lemonim_Pawnkind.xml
@@ -9,12 +9,14 @@
 			</apparelRequired>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[ @Name="LemolimTribalBase"]/invNutrition</xpath>
 		<value>
 			<invNutrition>1.8</invNutrition>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[ defName="LemolimTribal_Archer" or defName="LemolimTribal_Hunter" or defName="LemolimTribal_HeavyArcher" or defName="LemolimTribal_ChiefRanged"]</xpath>
 		<value>
@@ -104,6 +106,7 @@
 			<li>SpacerGun</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[ defName="LemolimPirate_Captain"]</xpath>
 		<value>
@@ -172,12 +175,14 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[defName="LemolimMercenary_ZapperEmp"]/label</xpath>
 		<value>
 			<label>advanced grenadier</label>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/PawnKindDef[defName="LemolimMercenary_ZapperEmp"]/weaponTags</xpath>
 		<value>

--- a/ModPatches/Mass Effect - Playable Geth/Patches/Mass Effect - Playable Geth/Geth_Bodies_CE.xml
+++ b/ModPatches/Mass Effect - Playable Geth/Patches/Mass Effect - Playable Geth/Geth_Bodies_CE.xml
@@ -15,12 +15,14 @@
 			<li>LeftShoulder</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="Geth"]//*[customLabel="right arm"]/groups</xpath>
 		<value>
 			<li>RightArm</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="Geth"]//*[customLabel="left arm"]/groups</xpath>
 		<value>

--- a/ModPatches/Mechanized Armor Set/Patches/Mechanized Armor Set/Ammo_&_Apparel_Defs.xml
+++ b/ModPatches/Mechanized Armor Set/Patches/Mechanized Armor Set/Ammo_&_Apparel_Defs.xml
@@ -8,12 +8,14 @@
 			<WornBulk>1</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mechanized_Helm_Apparel"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>3.5</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mechanized_Helm_Apparel"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
@@ -36,18 +38,21 @@
 			<WornBulk>12</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mechanized_Plate_Apparel"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>7.2</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mechanized_Plate_Apparel"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>10.8</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Mechanized_Plate_Apparel"]/apparel/bodyPartGroups</xpath>
 		<value>

--- a/ModPatches/MechanoidsExtraordinaire/Patches/MechanoidsExtraordinaire/BodyDefs/Bodies_Mechanoid_Chimera.xml
+++ b/ModPatches/MechanoidsExtraordinaire/Patches/MechanoidsExtraordinaire/BodyDefs/Bodies_Mechanoid_Chimera.xml
@@ -10,6 +10,7 @@
 			</groups>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "ChimeraME"]/corePart/parts/li[def = "ExtensionPortME"]</xpath>
 		<value>
@@ -18,12 +19,14 @@
 			</groups>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "ChimeraME"]/corePart/parts/li[def = "MechanicalChimeraTailME"]/groups</xpath>
 		<value>
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "ChimeraME"]/corePart/parts/li[def = "ExtensionPortME"]/parts/li[def = "WeaponHolderME"]</xpath>
 		<value>
@@ -32,6 +35,7 @@
 			</groups>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "ChimeraME"]/corePart/parts/li[def = "MechanicalNeckME"]</xpath>
 		<value>
@@ -40,12 +44,14 @@
 			</groups>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "ChimeraME"]/corePart/parts/li[def = "MechanicalNeckME"]/parts/li[def="MechanicalHeadME"]/groups</xpath>
 		<value>
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "ChimeraME"]/corePart/parts/li[def = "MechanicalLeg"]</xpath>
 		<value>
@@ -54,6 +60,7 @@
 			</groups>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "ChimeraME"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]</xpath>
 		<value>

--- a/ModPatches/MechanoidsExtraordinaire/Patches/MechanoidsExtraordinaire/BodyDefs/Bodies_Mechanoid_Goliath.xml
+++ b/ModPatches/MechanoidsExtraordinaire/Patches/MechanoidsExtraordinaire/BodyDefs/Bodies_Mechanoid_Goliath.xml
@@ -7,6 +7,7 @@
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "GoliathME"]/corePart/parts/li[def = "MechanicalShoulder"]</xpath>
 		<value>
@@ -15,6 +16,7 @@
 			</groups>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "GoliathME"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]</xpath>
 		<value>
@@ -23,6 +25,7 @@
 			</groups>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "GoliathME"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "MechanicalHand"]</xpath>
 		<value>
@@ -31,12 +34,14 @@
 			</groups>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "GoliathME"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "MechanicalHand"]/parts/li[def = "MechanicalFinger"]/groups</xpath>
 		<value>
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "GoliathME"]/corePart/parts/li[def = "MechanicalLeg"]</xpath>
 		<value>
@@ -45,6 +50,7 @@
 			</groups>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "GoliathME"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]</xpath>
 		<value>

--- a/ModPatches/MechanoidsExtraordinaire/Patches/MechanoidsExtraordinaire/BodyDefs/Bodies_Mechanoid_Hound.xml
+++ b/ModPatches/MechanoidsExtraordinaire/Patches/MechanoidsExtraordinaire/BodyDefs/Bodies_Mechanoid_Hound.xml
@@ -9,6 +9,7 @@
 			</groups>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "HoundME"]/corePart/parts/li[def = "ExtensionPortME"]</xpath>
 		<value>
@@ -17,6 +18,7 @@
 			</groups>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "HoundME"]/corePart/parts/li[def = "ExtensionPortME"]/parts/li[def = "WeaponHolderME"]</xpath>
 		<value>
@@ -25,6 +27,7 @@
 			</groups>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "HoundME"]/corePart/parts/li[def = "MechanicalNeck"]</xpath>
 		<value>
@@ -33,12 +36,14 @@
 			</groups>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "HoundME"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
 		<value>
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "HoundME"]/corePart/parts/li[def = "MechanicalLegME"]</xpath>
 		<value>
@@ -47,6 +52,7 @@
 			</groups>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "HoundME"]/corePart/parts/li[def = "MechanicalLegME"]/parts/li[def = "MechanicalPawME"]/groups</xpath>
 		<value>

--- a/ModPatches/MechanoidsExtraordinaire/Patches/MechanoidsExtraordinaire/BodyDefs/Bodies_Mechanoid_Kraken.xml
+++ b/ModPatches/MechanoidsExtraordinaire/Patches/MechanoidsExtraordinaire/BodyDefs/Bodies_Mechanoid_Kraken.xml
@@ -9,12 +9,14 @@
 			</groups>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "KrakenME"]/corePart/parts/li[def = "MechanicalHeadME"]/groups</xpath>
 		<value>
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "KrakenME"]/corePart/parts/li[def = "LimbPortME"]</xpath>
 		<value>
@@ -23,6 +25,7 @@
 			</groups>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "KrakenME"]/corePart/parts/li[def = "LimbPortME"]/parts/li[def = "MechaTentacleME"]/groups</xpath>
 		<value>

--- a/ModPatches/MechanoidsExtraordinaire/Patches/MechanoidsExtraordinaire/BodyDefs/Bodies_Mechanoid_Vespa.xml
+++ b/ModPatches/MechanoidsExtraordinaire/Patches/MechanoidsExtraordinaire/BodyDefs/Bodies_Mechanoid_Vespa.xml
@@ -9,6 +9,7 @@
 			</groups>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "VespaME"]/corePart/parts/li[def = "MechanicalNeck"]</xpath>
 		<value>
@@ -17,12 +18,14 @@
 			</groups>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "VespaME"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
 		<value>
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "VespaME"]/corePart/parts/li[def = "MechanicalShoulder"]</xpath>
 		<value>
@@ -31,6 +34,7 @@
 			</groups>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "VespaME"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]</xpath>
 		<value>
@@ -39,6 +43,7 @@
 			</groups>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "VespaME"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "MechanicalHand"]</xpath>
 		<value>
@@ -47,6 +52,7 @@
 			</groups>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "VespaME"]/corePart/parts/li[def = "MechanicalLeg"]</xpath>
 		<value>
@@ -55,6 +61,7 @@
 			</groups>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "VespaME"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]</xpath>
 		<value>

--- a/ModPatches/MechanoidsExtraordinaire/Patches/MechanoidsExtraordinaire/PawnKindDefs/PawnKinds_MechanoidsExtraordinaire.xml
+++ b/ModPatches/MechanoidsExtraordinaire/Patches/MechanoidsExtraordinaire/PawnKindDefs/PawnKinds_MechanoidsExtraordinaire.xml
@@ -6,18 +6,21 @@
 			<combatPower>550</combatPower>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[defName="Chimera"]/combatPower</xpath>
 		<value>
 			<combatPower>550</combatPower>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[defName="Kraken"]/combatPower</xpath>
 		<value>
 			<combatPower>650</combatPower>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="Vespa" or defName="Hound" or defName="Chimera" or defName="Kraken"]</xpath>
 		<value>

--- a/ModPatches/MechanoidsExtraordinaire/Patches/MechanoidsExtraordinaire/ThingDefs_Misc/Weapons_Grenades_MechanoidsExtraordinaire.xml
+++ b/ModPatches/MechanoidsExtraordinaire/Patches/MechanoidsExtraordinaire/ThingDefs_Misc/Weapons_Grenades_MechanoidsExtraordinaire.xml
@@ -6,6 +6,7 @@
 			<label>Mechanoid Grenade Launcher</label>
 		</value>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>Weapon_GrenadeLauncher_ME</defName>
 		<statBases>

--- a/ModPatches/MechanoidsExtraordinaire/Patches/MechanoidsExtraordinaire/ThingDefs_Races/Races_Mechanoid_MechanoidsExtraordinaire.xml
+++ b/ModPatches/MechanoidsExtraordinaire/Patches/MechanoidsExtraordinaire/ThingDefs_Races/Races_Mechanoid_MechanoidsExtraordinaire.xml
@@ -9,6 +9,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Mechanoid_Vespa"]/statBases</xpath>
 		<value>
@@ -20,18 +21,21 @@
 			<MeleeCritChance>0.25</MeleeCritChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mechanoid_Vespa"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>6</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mechanoid_Vespa"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>3</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mechanoid_Vespa"]/tools</xpath>
 		<value>
@@ -70,6 +74,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Mechanoid_Hound"]/statBases</xpath>
 		<value>
@@ -81,18 +86,21 @@
 			<MeleeCritChance>0.15</MeleeCritChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mechanoid_Hound"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>27</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mechanoid_Hound"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>12</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mechanoid_Hound"]/tools</xpath>
 		<value>
@@ -131,6 +139,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Mechanoid_Chimera"]/statBases</xpath>
 		<value>
@@ -142,18 +151,21 @@
 			<MeleeCritChance>0.15</MeleeCritChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mechanoid_Chimera"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>30</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mechanoid_Chimera"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>12</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mechanoid_Chimera"]/tools</xpath>
 		<value>
@@ -192,6 +204,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Mechanoid_Goliath"]/statBases</xpath>
 		<value>
@@ -203,18 +216,21 @@
 			<MeleeCritChance>0.50</MeleeCritChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mechanoid_Goliath"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>45</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mechanoid_Goliath"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>18</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mechanoid_Goliath"]/tools</xpath>
 		<value>
@@ -253,6 +269,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Mechanoid_Kraken"]/statBases</xpath>
 		<value>
@@ -264,18 +281,21 @@
 			<MeleeCritChance>0.40</MeleeCritChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mechanoid_Kraken"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>45</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mechanoid_Kraken"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>22</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mechanoid_Kraken"]/tools</xpath>
 		<value>

--- a/ModPatches/Medical System Expansion - Revived/Patches/Medical System Expansion - Revived/HediffDefs/Hediffs_AddedParts/Hediffs_AddedParts_Archotech.xml
+++ b/ModPatches/Medical System Expansion - Revived/Patches/Medical System Expansion - Revived/HediffDefs/Hediffs_AddedParts/Hediffs_AddedParts_Archotech.xml
@@ -161,6 +161,7 @@
 			</stages>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="ArchotechHand"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
 		<value>

--- a/ModPatches/Medical System Expansion - Revived/Patches/Medical System Expansion - Revived/HediffDefs/Hediffs_AddedParts/Hediffs_AddedParts_ArchotechSpecial.xml
+++ b/ModPatches/Medical System Expansion - Revived/Patches/Medical System Expansion - Revived/HediffDefs/Hediffs_AddedParts/Hediffs_AddedParts_ArchotechSpecial.xml
@@ -68,6 +68,7 @@
 			</stages>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="AdvancedPowerArm"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
 		<value>
@@ -104,6 +105,7 @@
 			</stages>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="MSE_AdvancedPowerBlade"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
 		<value>
@@ -149,6 +151,7 @@
 			</stages>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="AdvancedPowerClaw"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
 		<value>

--- a/ModPatches/Medical System Expansion - Revived/Patches/Medical System Expansion - Revived/HediffDefs/Hediffs_AddedParts/Hediffs_AddedParts_Bionic.xml
+++ b/ModPatches/Medical System Expansion - Revived/Patches/Medical System Expansion - Revived/HediffDefs/Hediffs_AddedParts/Hediffs_AddedParts_Bionic.xml
@@ -113,6 +113,7 @@
 			</stages>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="BionicHand"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
 		<value>

--- a/ModPatches/Medical System Expansion - Revived/Patches/Medical System Expansion - Revived/HediffDefs/Hediffs_AddedParts/Hediffs_AddedParts_BionicSpecial.xml
+++ b/ModPatches/Medical System Expansion - Revived/Patches/Medical System Expansion - Revived/HediffDefs/Hediffs_AddedParts/Hediffs_AddedParts_BionicSpecial.xml
@@ -68,6 +68,7 @@
 			</stages>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="PowerArm"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
 		<value>
@@ -104,6 +105,7 @@
 			</stages>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="MSE_PowerBlade"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
 		<value>

--- a/ModPatches/Medical System Expansion - Revived/Patches/Medical System Expansion - Revived/HediffDefs/Hediffs_AddedParts/Hediffs_AddedParts_Simple.xml
+++ b/ModPatches/Medical System Expansion - Revived/Patches/Medical System Expansion - Revived/HediffDefs/Hediffs_AddedParts/Hediffs_AddedParts_Simple.xml
@@ -46,6 +46,7 @@
 			</stages>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="SimpleProstheticHand"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
 		<value>

--- a/ModPatches/Medieval Overhaul/Patches/Medieval Overhaul/MO_Materials.xml
+++ b/ModPatches/Medieval Overhaul/Patches/Medieval Overhaul/MO_Materials.xml
@@ -34,6 +34,7 @@
 			<StuffPower_Armor_Sharp>0.60</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Leather_Thrumbo"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
@@ -48,6 +49,7 @@
 			<StuffPower_Armor_Sharp>0.03</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Cloth"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
@@ -62,6 +64,7 @@
 			<StuffPower_Armor_Sharp>0.2</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="DankPyon_Linen"]/statBases/StuffPower_Armor_Heat</xpath>
 		<value>
@@ -76,6 +79,7 @@
 			<StuffPower_Armor_Sharp>0.3</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="DankPyon_Silk"]/statBases/StuffPower_Armor_Heat</xpath>
 		<value>
@@ -91,6 +95,7 @@
 			<StuffPower_Armor_Sharp>0.08</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Leather_Plain"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
@@ -109,6 +114,7 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Leather_Bear"]/statBases/StuffPower_Armor_Blunt</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Leather_Bear"]/statBases</xpath>
 		<value>
@@ -122,6 +128,7 @@
 			<StuffPower_Armor_Sharp>0.03</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Leather_Light"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
@@ -135,6 +142,7 @@
 			<StuffPower_Armor_Sharp>0.09</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Leather_Bluefur"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
@@ -148,6 +156,7 @@
 			<StuffPower_Armor_Sharp>0.08</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Leather_Lizard"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
@@ -166,6 +175,7 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Leather_Rhinoceros"]/statBases/StuffPower_Armor_Blunt</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Leather_Rhinoceros"]/statBases</xpath>
 		<value>
@@ -180,6 +190,7 @@
 			<StuffPower_Armor_Sharp>0.06</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Leather_Bird"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
@@ -194,6 +205,7 @@
 			<StuffPower_Armor_Sharp>0.06</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Leather_Human"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
@@ -208,6 +220,7 @@
 			<StuffPower_Armor_Sharp>0.08</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Leather_Patch"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>

--- a/ModPatches/Megafauna/Patches/Megafauna/Races_Animal_Megafauna.xml
+++ b/ModPatches/Megafauna/Patches/Megafauna/Races_Animal_Megafauna.xml
@@ -16,6 +16,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>
 			Defs/ThingDef[
@@ -49,6 +50,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>
 			Defs/ThingDef[
@@ -68,6 +70,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>
 			Defs/ThingDef[
@@ -83,6 +86,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>
 			Defs/ThingDef[
@@ -108,18 +112,21 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.27</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Arthropleura"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>0.2</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Arthropleura"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Arthropleura"]/tools</xpath>
 		<value>
@@ -149,18 +156,21 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.35</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Doedicurus"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>18</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Doedicurus"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>0.75</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Doedicurus"]/tools</xpath>
 		<value>
@@ -231,6 +241,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.28</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Daeodon"]/tools</xpath>
 		<value>
@@ -288,6 +299,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.19</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Gigantopithecus"]/tools</xpath>
 		<value>
@@ -337,6 +349,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>1.24</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Paraceratherium"]/tools</xpath>
 		<value>
@@ -386,6 +399,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.18</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Titanis"]/tools</xpath>
 		<value>
@@ -442,6 +456,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.57</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Titanoboa"]/tools</xpath>
 		<value>
@@ -478,6 +493,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.51</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="WoollyMammoth"]/tools</xpath>
 		<value>
@@ -536,6 +552,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.48</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Elasmotherium"]/tools</xpath>
 		<value>
@@ -586,6 +603,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.2</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Smilodon"]/tools</xpath>
 		<value>
@@ -645,6 +663,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.33</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Chalicotherium"]/tools</xpath>
 		<value>
@@ -696,6 +715,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.3</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Megaloceros"]/tools</xpath>
 		<value>
@@ -768,6 +788,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.2</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Procoptodon"]/tools</xpath>
 		<value>
@@ -850,6 +871,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.25</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Megalania"]/tools</xpath>
 		<value>
@@ -909,6 +931,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.43</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Gomphotaria"]/tools</xpath>
 		<value>
@@ -946,6 +969,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.45</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Diprotodon"]/tools</xpath>
 		<value>
@@ -1005,6 +1029,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.33</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="ShortfacedBear"]/tools</xpath>
 		<value>
@@ -1080,6 +1105,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.18</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Dinocrocuta"]/tools</xpath>
 		<value>
@@ -1139,6 +1165,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.28</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Sivatherium"]/tools</xpath>
 		<value>
@@ -1198,6 +1225,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.15</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Andrewsarchus"]/tools</xpath>
 		<value>
@@ -1257,6 +1285,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.26</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Dinornis"]/tools</xpath>
 		<value>
@@ -1313,6 +1342,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.32</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Macrauchenia"]/tools</xpath>
 		<value>
@@ -1362,6 +1392,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.26</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Quinkana"]/tools</xpath>
 		<value>
@@ -1421,6 +1452,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.72</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Deinotherium"]/tools</xpath>
 		<value>
@@ -1480,6 +1512,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.28</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Aurochs"]/tools</xpath>
 		<value>
@@ -1540,18 +1573,21 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.44</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Megalochelys"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>20</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Megalochelys"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>0.85</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Megalochelys"]/tools</xpath>
 		<value>
@@ -1593,6 +1629,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.16</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Palaeeudyptes"]/tools</xpath>
 		<value>
@@ -1641,6 +1678,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.34</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Josephoartigasia"]/tools</xpath>
 		<value>
@@ -1700,6 +1738,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.43</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Gigantophis"]/tools</xpath>
 		<value>
@@ -1736,18 +1775,21 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.04</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Meganeura"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>3</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Meganeura"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Meganeura"]/tools</xpath>
 		<value>
@@ -1786,6 +1828,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.97</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Zygolophodon"]/tools</xpath>
 		<value>
@@ -1845,6 +1888,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.5</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Platybelodon"]/tools</xpath>
 		<value>
@@ -1904,6 +1948,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.62</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Purussaurus"]/tools</xpath>
 		<value>
@@ -1963,6 +2008,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.41</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Uintatherium"]/tools</xpath>
 		<value>
@@ -2013,18 +2059,21 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.05</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Pulmonoscorpius"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>3</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Pulmonoscorpius"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>0.06</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Pulmonoscorpius"]/tools</xpath>
 		<value>
@@ -2085,6 +2134,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.07</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Dinopithecus"]/tools</xpath>
 		<value>
@@ -2144,6 +2194,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.08</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Castoroides"]/tools</xpath>
 		<value>
@@ -2207,6 +2258,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 			<MeleeParryChance>0.13</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Enhydriodon"]/tools</xpath>
 		<value>

--- a/ModPatches/Miho Race/Patches/Miho Race/ThingDefs_Misc/Miho_Apparel.xml
+++ b/ModPatches/Miho Race/Patches/Miho Race/ThingDefs_Misc/Miho_Apparel.xml
@@ -538,12 +538,14 @@
 <ArmorRating_Blunt>6</ArmorRating_Blunt>-->
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Miho_Apparel_OnSkin_OrnatedOne" or defName="Miho_Apparel_OnSkin_OrnatedTwo"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>2</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Miho_Apparel_OnSkin_OrnatedOne" or defName="Miho_Apparel_OnSkin_OrnatedTwo"]/statBases/ArmorRating_Blunt</xpath>
 		<value>

--- a/ModPatches/Miho Race/Patches/Miho Race/ThingDefs_Misc/Weapons_Ranged.xml
+++ b/ModPatches/Miho Race/Patches/Miho Race/ThingDefs_Misc/Weapons_Ranged.xml
@@ -519,6 +519,7 @@
 			<aiUseBurstMode>FALSE</aiUseBurstMode>
 		</FireModes>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Miho_Weapon_Pistol"]/weaponTags</xpath>
 		<value>

--- a/ModPatches/MiningCo. MiningHelmet/Patches/MiningCo. MiningHelmet/MiningCoApparel_HelmetAndVest.xml
+++ b/ModPatches/MiningCo. MiningHelmet/Patches/MiningCo. MiningHelmet/MiningCoApparel_HelmetAndVest.xml
@@ -7,6 +7,7 @@
 			<ArmorRating_Sharp>0.02</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_MiningVest"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
@@ -20,6 +21,7 @@
 			<ArmorRating_Sharp>1.5</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_MiningHelmet"]/statBases/ArmorRating_Blunt</xpath>
 		<value>

--- a/ModPatches/Moonjelly Race/Patches/Moonjelly Race/BodyArmor_Patch.xml
+++ b/ModPatches/Moonjelly Race/Patches/Moonjelly Race/BodyArmor_Patch.xml
@@ -129,18 +129,21 @@
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "MoonjellyBody"]/corePart/parts/li[def = "NerveNet"]/groups</xpath>
 		<value>
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "MoonjellyBody"]/corePart/parts/li[def = "Stomach"]/groups</xpath>
 		<value>
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "MoonjellyBody"]/corePart/parts/li[def = "MucusGland"]/groups</xpath>
 		<value>

--- a/ModPatches/MoreMechanoids/Patches/MoreMechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/ModPatches/MoreMechanoids/Patches/MoreMechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -120,6 +120,7 @@
 			<ArmorRating_Sharp>3</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mech_Skullywag"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
@@ -219,6 +220,7 @@
 			<ArmorRating_Sharp>3</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mech_Flamebot"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
@@ -320,6 +322,7 @@
 			<ArmorRating_Sharp>22</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mech_Mammoth"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
@@ -439,6 +442,7 @@
 			<ArmorRating_Sharp>18</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mech_Assaulter"]/statBases/ArmorRating_Blunt</xpath>
 		<value>

--- a/ModPatches/MorrowRim - Bloodmoon/Patches/MorrowRim - Bloodmoon/HediffDef_Disease.xml
+++ b/ModPatches/MorrowRim - Bloodmoon/Patches/MorrowRim - Bloodmoon/HediffDef_Disease.xml
@@ -34,30 +34,35 @@
 			<Suppressability>-0.5</Suppressability>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/HediffDef[defName="MorrowRim_BloodOfHircine"]/stages/li[6]/statOffsets</xpath>
 		<value>
 			<Suppressability>-0.6</Suppressability>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/HediffDef[defName="MorrowRim_BloodOfHircine"]/stages/li[7]/statOffsets</xpath>
 		<value>
 			<Suppressability>-0.7</Suppressability>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/HediffDef[defName="MorrowRim_BloodOfHircine"]/stages/li[8]/statOffsets</xpath>
 		<value>
 			<Suppressability>-0.8</Suppressability>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/HediffDef[defName="MorrowRim_BloodOfHircine"]/stages/li[9]/statOffsets</xpath>
 		<value>
 			<Suppressability>-0.9</Suppressability>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/HediffDef[defName="MorrowRim_BloodOfHircine"]/stages/li[10]/statOffsets</xpath>
 		<value>

--- a/ModPatches/MorrowRim/Patches/MorrowRim/MorrowRim_CorpusCE.xml
+++ b/ModPatches/MorrowRim/Patches/MorrowRim/MorrowRim_CorpusCE.xml
@@ -188,6 +188,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="MorrowRim_CorprusLame"]/tools</xpath>
 		<value>

--- a/ModPatches/MorrowRim/Patches/MorrowRim/MorrowRim_XMaterials.xml
+++ b/ModPatches/MorrowRim/Patches/MorrowRim/MorrowRim_XMaterials.xml
@@ -4,17 +4,20 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="MorrowRim_KagoutiTusk"]/tools</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationAttributeSet">
 		<xpath>Defs/ThingDef[defName="MorrowRim_KagoutiTusk"]</xpath>
 		<attribute>ParentName</attribute>
 		<value>ResourceBase</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="MorrowRim_KagoutiTusk"]/description</xpath>
 		<value>
 			<description>A single horn of the mighty Kagouti. Proof that you're a warrior worthy of the title of Aberration Killer. Traders and collectors might pay a high price for this.</description>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="MorrowRim_KagoutiTusk"]/statBases/MarketValue</xpath>
 		<value>
@@ -28,6 +31,7 @@
 			<StuffPower_Armor_Sharp>0.08</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="MorrowRim_GuarHide" or defName="MorrowRim_AlbinoGuarHide"]/statBases</xpath>
 		<value>
@@ -41,12 +45,14 @@
 			<StuffPower_Armor_Sharp>0.11</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="MorrowRim_NetchLeather"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.068</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="MorrowRim_NetchLeather"]/statBases/StuffPower_Armor_Heat</xpath>
 		<value>
@@ -60,12 +66,14 @@
 			<StuffPower_Armor_Sharp>0.18</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="MorrowRim_SiltStriderChitin"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.18</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="MorrowRim_SiltStriderChitin"]/statBases/StuffPower_Armor_Heat</xpath>
 		<value>
@@ -79,18 +87,21 @@
 			<MarketValue>1.3</MarketValue>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="MorrowRim_NixHoundLeather"]/statBases/StuffPower_Armor_Sharp</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>0.08</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="MorrowRim_NixHoundLeather"]/statBases</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.06</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="MorrowRim_NixHoundLeather"]/statBases</xpath>
 		<value>
@@ -104,6 +115,7 @@
 			<StuffPower_Armor_Sharp>0.1</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="MorrowRim_HeavyLeather"]/statBases</xpath>
 		<value>
@@ -117,6 +129,7 @@
 			<StuffPower_Armor_Sharp>0.04</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="MorrowRim_DurzogLeather"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
@@ -130,12 +143,14 @@
 			<StuffPower_Armor_Sharp>0.01</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="MorrowRim_CliffRacerLeather"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.01</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="MorrowRim_CliffRacerLeather"]/statBases/StuffPower_Armor_Heat</xpath>
 		<value>
@@ -149,12 +164,14 @@
 			<StuffPower_Armor_Sharp>0.12</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="MorrowRim_DaedraHide"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.8</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="MorrowRim_DaedraHide"]/statBases</xpath>
 		<value>
@@ -168,12 +185,14 @@
 			<StuffPower_Armor_Sharp>0.02</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="MorrowRim_KreshFiber"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.01</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="MorrowRim_KreshFiber"]/statBases/StuffPower_Armor_Heat</xpath>
 		<value>

--- a/ModPatches/Moyo from the depth/Patches/Moyo from the depth/Bodies/Moyo_Bodytype.xml
+++ b/ModPatches/Moyo from the depth/Patches/Moyo from the depth/Bodies/Moyo_Bodytype.xml
@@ -139,102 +139,119 @@
 			<coverage>0.07</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Moyo"]/corePart/parts/li[def="Pelvis"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Moyo"]/corePart/parts/li[def="Stomach"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Moyo"]/corePart/parts/li[def="MoyoHeart"]/coverage</xpath>
 		<value>
 			<coverage>0.04</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Moyo"]/corePart/parts/li[def="Lung"]/coverage</xpath>
 		<value>
 			<coverage>0.055</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Moyo"]/corePart/parts/li[def="Kidney"]/coverage</xpath>
 		<value>
 			<coverage>0.03</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Moyo"]/corePart/parts/li[def="Liver"]/coverage</xpath>
 		<value>
 			<coverage>0.06</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Moyo"]/corePart/parts/li[def="Neck"]/coverage</xpath>
 		<value>
 			<coverage>0.055</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Moyo"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/parts/li[def="Brain"]/coverage</xpath>
 		<value>
 			<coverage>0.9</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Moyo"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Eye"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Moyo"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Ear"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Moyo"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]/coverage</xpath>
 		<value>
 			<coverage>0.08</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Moyo"]/corePart/parts/li[def="Shoulder"]/coverage</xpath>
 		<value>
 			<coverage>0.085</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Moyo"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Clavicle"]/coverage</xpath>
 		<value>
 			<coverage>0.06</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Moyo"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Humerus"]/coverage</xpath>
 		<value>
 			<coverage>0.15</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Moyo"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Radius"]/coverage</xpath>
 		<value>
 			<coverage>0.15</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Moyo"]/corePart/parts/li[def="Leg"]/parts/li[def="Femur"]/coverage</xpath>
 		<value>
 			<coverage>0.15</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Moyo"]/corePart/parts/li[def="Leg"]/parts/li[def="Tibia"]/coverage</xpath>
 		<value>

--- a/ModPatches/Nakin Race/Patches/Nakin Race/Nakin_Body.xml
+++ b/ModPatches/Nakin Race/Patches/Nakin Race/Nakin_Body.xml
@@ -105,6 +105,7 @@
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "Nakin_body"]/corePart/parts/li[def = "Tail"]</xpath>
 		<value>
@@ -113,6 +114,7 @@
 			</groups>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName = "Nakin_body"]/corePart/parts/li[def = "Nakin_Tentacle"]</xpath>
 		<value>

--- a/ModPatches/Nakin Race/Patches/Nakin Race/Nakin_Items.xml
+++ b/ModPatches/Nakin Race/Patches/Nakin Race/Nakin_Items.xml
@@ -7,6 +7,7 @@
 			<StuffPower_Armor_Sharp>0.06</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Leather_Nakin"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
@@ -22,6 +23,7 @@
 			<WornBulk>0</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_NakinGlasses"]/apparel/layers</xpath>
 		<value>
@@ -30,6 +32,7 @@
 			</layers>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_NakinGlasses"]/equippedStatOffsets</xpath>
 		<value>
@@ -48,6 +51,7 @@
 			<WornBulk>0.5</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_NakinGogglesA"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
@@ -61,6 +65,7 @@
 			<ArmorRating_Blunt>6</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_NakinGogglesA"]/statBases/ArmorRating_Heat</xpath>
 		<value>
@@ -74,6 +79,7 @@
 			<DevilstrandCloth>15</DevilstrandCloth>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_NakinGogglesA"]/apparel</xpath>
 		<value>
@@ -82,6 +88,7 @@
 			</layers>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_NakinGogglesA"]/equippedStatOffsets</xpath>
 		<value>

--- a/ModPatches/Nakin Race/Patches/Nakin Race/Nakin_Race.xml
+++ b/ModPatches/Nakin Race/Patches/Nakin Race/Nakin_Race.xml
@@ -15,6 +15,7 @@
 			<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="NakinRace"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
@@ -35,12 +36,14 @@
 			<NightVisionEfficiency>0.2</NightVisionEfficiency>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="NakinRace"]/statBases/MeleeDodgeChance</xpath>
 		<value>
 			<MeleeDodgeChance>1.5</MeleeDodgeChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="NakinRace"]/tools</xpath>
 		<value>

--- a/ModPatches/Nakin Race/Patches/Nakin Race/Nakin_Scenario.xml
+++ b/ModPatches/Nakin Race/Patches/Nakin Race/Nakin_Scenario.xml
@@ -10,6 +10,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ScenarioDef[defName="NakinCrashlanded"]/scenario/parts/li[thingDef="Apparel_AdvancedHelmet"]</xpath>
 	</Operation>

--- a/ModPatches/Nearmare Race/Patches/Nearmare Race/ThingDefs_Misc/Nearmare_Apparel.xml
+++ b/ModPatches/Nearmare Race/Patches/Nearmare Race/ThingDefs_Misc/Nearmare_Apparel.xml
@@ -204,6 +204,7 @@
 			<WornBulk>1</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="HAR_NM_A_EyeCover_a"]/apparel/bodyPartGroups</xpath>
 		<value>

--- a/ModPatches/Nearmare Race/Patches/Nearmare Race/ThingDefs_Misc/Weapons.xml
+++ b/ModPatches/Nearmare Race/Patches/Nearmare Race/ThingDefs_Misc/Weapons.xml
@@ -316,6 +316,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Gun_AssaultRifle_NM"]/tools</xpath>
 		<value>

--- a/ModPatches/NewRatkinPlus/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_Buildings_Security.xml
+++ b/ModPatches/NewRatkinPlus/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_Buildings_Security.xml
@@ -101,9 +101,11 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="BallistaBolt_Normal"]</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="BallistaBolt_AP"]</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="BallistaBolt_Heavy"]</xpath>
 	</Operation>
@@ -214,6 +216,7 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Bullet_Big_mouse"]</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Big_mouse"]</xpath>
 	</Operation>

--- a/ModPatches/NewRatkinPlus/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_MeleeWeapons.xml
+++ b/ModPatches/NewRatkinPlus/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_MeleeWeapons.xml
@@ -86,12 +86,14 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RK_Cleaver"]/statBases</xpath>
 		<value>
 			<Bulk>3</Bulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RK_Cleaver"]/equippedStatOffsets</xpath>
 		<value>
@@ -100,6 +102,7 @@
 			<MeleeDodgeChance>0.2</MeleeDodgeChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RK_Cleaver"]/weaponTags</xpath>
 		<value>
@@ -150,6 +153,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RK_TwoHanded"]/statBases</xpath>
 		<value>
@@ -157,6 +161,7 @@
 			<MeleeCounterParryBonus>1.13</MeleeCounterParryBonus>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RK_TwoHanded"]</xpath>
 		<value>
@@ -167,6 +172,7 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RK_TwoHanded"]/statBases/Mass</xpath>
 		<value>
@@ -216,6 +222,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RK_Fork"]/statBases</xpath>
 		<value>
@@ -223,6 +230,7 @@
 			<MeleeCounterParryBonus>2</MeleeCounterParryBonus>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RK_Fork"]/equippedStatOffsets</xpath>
 		<value>
@@ -273,6 +281,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RK_Hockey"]/statBases</xpath>
 		<value>
@@ -280,6 +289,7 @@
 			<Bulk>8</Bulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RK_Hockey"]/equippedStatOffsets</xpath>
 		<value>
@@ -401,12 +411,14 @@
 			<MeleeCounterParryBonus>0.35</MeleeCounterParryBonus>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RK_OneHanded"]/weaponTags</xpath>
 		<value>
 			<li>CE_OneHandedWeapon</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RK_OneHanded"]</xpath>
 		<value>
@@ -430,6 +442,7 @@
 			<FSX>1</FSX>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RK_MagicWand"]/tools</xpath>
 		<value>
@@ -489,6 +502,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RK_LightLance"]/statBases</xpath>
 		<value>
@@ -496,6 +510,7 @@
 			<Bulk>7</Bulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RK_LightLance"]/equippedStatOffsets</xpath>
 		<value>
@@ -549,6 +564,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RK_HeavyLance"]/statBases/Mass</xpath>
 		<value>
@@ -557,6 +573,7 @@
 			<Mass>5</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RK_HeavyLance"]/equippedStatOffsets</xpath>
 		<value>
@@ -567,6 +584,7 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RK_HeavyLance"]/stuffCategories/li[.="Metallic"]</xpath>
 		<value>
@@ -617,6 +635,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RK_Gunlance_NormalType" or defName="RK_Gunlance_SpreadType"]/statBases/Mass</xpath>
 		<value>
@@ -625,6 +644,7 @@
 			<Mass>8</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RK_Gunlance_NormalType" or defName="RK_Gunlance_SpreadType"]/equippedStatOffsets</xpath>
 		<value>
@@ -635,6 +655,7 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RK_Gunlance_NormalType" or defName="RK_Gunlance_SpreadType"]/stuffCategories/li[.="Metallic"]</xpath>
 		<value>

--- a/ModPatches/NewRatkinPlus/Patches/NewRatkinPlus/ThingDefs_Races/Race_KingHamster.xml
+++ b/ModPatches/NewRatkinPlus/Patches/NewRatkinPlus/ThingDefs_Races/Race_KingHamster.xml
@@ -9,12 +9,14 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RK_KingHamster"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>4.5</MoveSpeed>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RK_KingHamster"]/statBases</xpath>
 		<value>
@@ -23,6 +25,7 @@
 			<MeleeParryChance>0.15</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RK_KingHamster"]/tools</xpath>
 		<value>

--- a/ModPatches/NewRatkinPlus/Patches/NewRatkinPlus/ThingDefs_Races/Race_Rotti.xml
+++ b/ModPatches/NewRatkinPlus/Patches/NewRatkinPlus/ThingDefs_Races/Race_Rotti.xml
@@ -9,12 +9,14 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Rotti"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>3.9</MoveSpeed>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Rotti"]/statBases</xpath>
 		<value>
@@ -23,6 +25,7 @@
 			<MeleeParryChance>0</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Rotti"]/tools</xpath>
 		<value>

--- a/ModPatches/Nihal/Patches/Nihal/PawnKinds_NiHal.xml
+++ b/ModPatches/Nihal/Patches/Nihal/PawnKinds_NiHal.xml
@@ -42,6 +42,7 @@
 			</weaponMoney>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="NihalSlave"]</xpath>
 		<value>
@@ -169,6 +170,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/PawnKindDef[defName="NihalTownCouncilman"]</xpath>
 		<value>

--- a/ModPatches/Nihal/Patches/Nihal/ThingDefs_Misc/Apparel_Hats.xml
+++ b/ModPatches/Nihal/Patches/Nihal/ThingDefs_Misc/Apparel_Hats.xml
@@ -25,18 +25,21 @@
 			<AimingAccuracy>0.15</AimingAccuracy>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_NihalPowerArmorHelmet"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>0.8</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_NihalPowerArmorHelmet"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>0.2</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_NihalPowerArmorHelmet"]/costList/Plasteel</xpath>
 		<value>

--- a/ModPatches/Nihal/Patches/Nihal/ThingDefs_Misc/Apparel_Various.xml
+++ b/ModPatches/Nihal/Patches/Nihal/ThingDefs_Misc/Apparel_Various.xml
@@ -8,6 +8,7 @@
 			<WornBulk>6</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_CatfishArmor"]/equippedStatOffsets</xpath>
 		<value>
@@ -15,24 +16,28 @@
 			<CarryBulk>15</CarryBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_CatfishArmor"]/statBases/Mass</xpath>
 		<value>
 			<Mass>45</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_CatfishArmor"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>1</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_CatfishArmor"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>0.6</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_CatfishArmor"]/apparel/bodyPartGroups</xpath>
 		<value>

--- a/ModPatches/Paniel the Automata/Patches/Paniel the Automata/ThingDefs_Buildings/Buildings_Turrets.xml
+++ b/ModPatches/Paniel the Automata/Patches/Paniel the Automata/ThingDefs_Buildings/Buildings_Turrets.xml
@@ -76,6 +76,7 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="PN_Artillery_Turret" ]/building/fixedStorageSettings</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="PN_Artillery_Turret" ]/building/defaultStorageSettings</xpath>
 	</Operation>
@@ -179,6 +180,7 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="PN_Railgun_Turret"]/building/fixedStorageSettings</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="PN_Railgun_Turret"]/building/defaultStorageSettings</xpath>
 	</Operation>

--- a/ModPatches/Paniel the Automata/Patches/Paniel the Automata/ThingDefs_Misc/Paniel_Apparel.xml
+++ b/ModPatches/Paniel the Automata/Patches/Paniel the Automata/ThingDefs_Misc/Paniel_Apparel.xml
@@ -56,6 +56,7 @@
 			<StuffEffectMultiplierArmor>5.5</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="PN_ApparelMilitiaHat" or

--- a/ModPatches/Poleepkwa Race/Patches/Poleepkwa Race/Patch_Bodies_Prawny.xml
+++ b/ModPatches/Poleepkwa Race/Patches/Poleepkwa Race/Patch_Bodies_Prawny.xml
@@ -8,102 +8,119 @@
 			<coverage>0.07</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="PoleepkwaBody"]/corePart/parts/li[def="Pelvis"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="PoleepkwaBody"]/corePart/parts/li[def="Stomach"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="PoleepkwaBody"]/corePart/parts/li[def="Heart"]/coverage</xpath>
 		<value>
 			<coverage>0.04</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="PoleepkwaBody"]/corePart/parts/li[def="Lung"]/coverage</xpath>
 		<value>
 			<coverage>0.055</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="PoleepkwaBody"]/corePart/parts/li[def="Kidney"]/coverage</xpath>
 		<value>
 			<coverage>0.03</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="PoleepkwaBody"]/corePart/parts/li[def="Liver"]/coverage</xpath>
 		<value>
 			<coverage>0.06</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="PoleepkwaBody"]/corePart/parts/li[def="Neck"]/coverage</xpath>
 		<value>
 			<coverage>0.055</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="PoleepkwaBody"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/parts/li[def="Brain"]/coverage</xpath>
 		<value>
 			<coverage>0.9</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="PoleepkwaBody"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Eye"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="PoleepkwaBody"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Ear"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="PoleepkwaBody"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]/coverage</xpath>
 		<value>
 			<coverage>0.08</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="PoleepkwaBody"]/corePart/parts/li[def="Shoulder"]/coverage</xpath>
 		<value>
 			<coverage>0.085</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="PoleepkwaBody"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Clavicle"]/coverage</xpath>
 		<value>
 			<coverage>0.06</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="PoleepkwaBody"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Humerus"]/coverage</xpath>
 		<value>
 			<coverage>0.15</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="PoleepkwaBody"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Radius"]/coverage</xpath>
 		<value>
 			<coverage>0.15</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="PoleepkwaBody"]/corePart/parts/li[def="Leg"]/parts/li[def="Femur"]/coverage</xpath>
 		<value>
 			<coverage>0.15</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="PoleepkwaBody"]/corePart/parts/li[def="Leg"]/parts/li[def="Tibia"]/coverage</xpath>
 		<value>

--- a/ModPatches/Pratt WWII Weapons Pack/Patches/Pratt WWII Weapons Pack/PWW2_CE_Patch_Weapons_Grenades.xml
+++ b/ModPatches/Pratt WWII Weapons Pack/Patches/Pratt WWII Weapons Pack/PWW2_CE_Patch_Weapons_Grenades.xml
@@ -181,6 +181,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Weapon_MkIIGrenadeGNDE"]/comps</xpath>
 		<value>
@@ -350,6 +351,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Weapon_Type97GNDE"]/comps</xpath>
 		<value>
@@ -436,6 +438,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Weapon_RGD-33GNDE"]/comps</xpath>
 		<value>
@@ -522,6 +525,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Weapon_F1GrenadeGNDE"]/comps</xpath>
 		<value>
@@ -608,6 +612,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Weapon_MillsGrenadeGNDE"]/comps</xpath>
 		<value>

--- a/ModPatches/Project RimFactory - Materials/Patches/Project RimFactory - Materials/Items_Resource_Carbon.xml
+++ b/ModPatches/Project RimFactory - Materials/Patches/Project RimFactory - Materials/Items_Resource_Carbon.xml
@@ -16,12 +16,14 @@
 			<StuffPower_Armor_Sharp>0.95</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PRF_CarbonFiber"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>1.4</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PRF_CarbonFiber"]/statBases/StuffPower_Armor_Heat</xpath>
 		<value>
@@ -36,6 +38,7 @@
 			<MeleePenetrationFactor>0.8</MeleePenetrationFactor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="PRF_CarbonFiber"]/stuffProps/categories</xpath>
 		<value>
@@ -51,6 +54,7 @@
 			<StuffPower_Armor_Sharp>0.9</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PRF_CarbonKevlarComposite"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
@@ -65,6 +69,7 @@
 			<StuffPower_Armor_Sharp>0.5</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PRF_CarbonPlate"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
@@ -79,6 +84,7 @@
 			<StuffPower_Armor_Sharp>0.45</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PRF_CarbonPlate"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>

--- a/ModPatches/Project RimFactory - Materials/Patches/Project RimFactory - Materials/Items_Resource_Metal.xml
+++ b/ModPatches/Project RimFactory - Materials/Patches/Project RimFactory - Materials/Items_Resource_Metal.xml
@@ -17,12 +17,14 @@
 			<li>Steeled</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PRF_Iron"]/statBases/StuffPower_Armor_Sharp</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>0.8</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PRF_Iron"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
@@ -37,6 +39,7 @@
 			<StuffPower_Armor_Sharp>0.25</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PRF_Copper"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
@@ -52,18 +55,21 @@
 			<li>Steeled</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="PRF_StainlessSteel"]/stuffProps/statFactors</xpath>
 		<value>
 			<MeleePenetrationFactor>1.1</MeleePenetrationFactor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PRF_StainlessSteel"]/statBases/StuffPower_Armor_Sharp</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>1.2</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PRF_StainlessSteel"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>

--- a/ModPatches/Project RimFactory - Materials/Patches/Project RimFactory - Materials/Items_Resource_Plastics.xml
+++ b/ModPatches/Project RimFactory - Materials/Patches/Project RimFactory - Materials/Items_Resource_Plastics.xml
@@ -8,12 +8,14 @@
 			<Bulk>0.03</Bulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PRF_MixedPlastic"]/statBases/StuffPower_Armor_Sharp</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>0.02</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PRF_MixedPlastic"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
@@ -28,12 +30,14 @@
 			<Bulk>0.03</Bulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PRF_Polyester"]/statBases/StuffPower_Armor_Sharp</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>0.012</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PRF_Polyester"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
@@ -48,12 +52,14 @@
 			<Bulk>0.03</Bulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PRF_Kevlar"]/statBases/StuffPower_Armor_Sharp</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>0.5</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PRF_Kevlar"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>

--- a/ModPatches/Project RimFactory - Materials/Patches/Project RimFactory - Materials/Items_Resource_Quartz.xml
+++ b/ModPatches/Project RimFactory - Materials/Patches/Project RimFactory - Materials/Items_Resource_Quartz.xml
@@ -14,12 +14,14 @@
 			<Bulk>0.02</Bulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PRF_CrystalPowder"]/statBases/StuffPower_Armor_Sharp</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>0.01</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PRF_CrystalPowder"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>

--- a/ModPatches/PsiTech/Patches/PsiTech/PawnKindDefs/PawnKinds_PsiTech.xml
+++ b/ModPatches/PsiTech/Patches/PsiTech/PawnKindDefs/PawnKinds_PsiTech.xml
@@ -7,6 +7,7 @@
 			<combatPower>20</combatPower>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[defName="Psion_Penitent"]/weaponMoney</xpath>
 		<value>

--- a/ModPatches/PsiTech/Patches/PsiTech/ThingDefs/Equipment/PsiTechAdvancedApparel.xml
+++ b/ModPatches/PsiTech/Patches/PsiTech/ThingDefs/Equipment/PsiTechAdvancedApparel.xml
@@ -11,24 +11,28 @@
 			<WornBulk>18</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PTPsionicCommandoArmor"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>50</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PTPsionicCommandoArmor"]/statBases/Flammability</xpath>
 		<value>
 			<Flammability>0</Flammability>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PTPsionicCommandoArmor"]/statBases/MaxHitPoints</xpath>
 		<value>
 			<MaxHitPoints>625</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PTPsionicCommandoArmor"]/statBases/Mass</xpath>
 		<value>
@@ -45,6 +49,7 @@
 			<ToxicEnvironmentResistance>0.5</ToxicEnvironmentResistance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="PTPsionicCommandoArmor"]/equippedStatOffsets/MoveSpeed</xpath>
 	</Operation>
@@ -75,30 +80,35 @@
 			<WornBulk>1.2</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PTPsionicCommandoHelmet"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>40</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PTPsionicCommandoHelmet"]/statBases/Flammability</xpath>
 		<value>
 			<Flammability>0</Flammability>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PTPsionicCommandoHelmet"]/statBases/MaxHitPoints</xpath>
 		<value>
 			<MaxHitPoints>300</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PTPsionicCommandoHelmet"]/statBases/Mass</xpath>
 		<value>
 			<Mass>5.2</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="PTPsionicCommandoHelmet"]/apparel/immuneToToxGasExposure</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -144,24 +154,28 @@
 			<WornBulk>15</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PTPsionicWarriorArmor"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>45</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PTPsionicWarriorArmor"]/statBases/Flammability</xpath>
 		<value>
 			<Flammability>0</Flammability>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PTPsionicWarriorArmor"]/statBases/MaxHitPoints</xpath>
 		<value>
 			<MaxHitPoints>500</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PTPsionicWarriorArmor"]/statBases/Mass</xpath>
 		<value>
@@ -178,6 +192,7 @@
 			<ToxicEnvironmentResistance>0.5</ToxicEnvironmentResistance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="PTPsionicWarriorArmor"]/equippedStatOffsets/MoveSpeed</xpath>
 	</Operation>
@@ -208,30 +223,35 @@
 			<WornBulk>1</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PTPsionicWarriorHelmet"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>36</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PTPsionicWarriorHelmet"]/statBases/Flammability</xpath>
 		<value>
 			<Flammability>0</Flammability>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PTPsionicWarriorHelmet"]/statBases/MaxHitPoints</xpath>
 		<value>
 			<MaxHitPoints>240</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PTPsionicWarriorHelmet"]/statBases/Mass</xpath>
 		<value>
 			<Mass>4.8</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="PTPsionicWarriorHelmet"]/apparel/immuneToToxGasExposure</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -277,24 +297,28 @@
 			<WornBulk>15</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PTPsionicConduitArmor"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>41</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PTPsionicConduitArmor"]/statBases/Flammability</xpath>
 		<value>
 			<Flammability>0</Flammability>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PTPsionicConduitArmor"]/statBases/MaxHitPoints</xpath>
 		<value>
 			<MaxHitPoints>400</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PTPsionicConduitArmor"]/statBases/Mass</xpath>
 		<value>
@@ -338,30 +362,35 @@
 			<WornBulk>1</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PTPsionicConduitHelmet"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>32</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PTPsionicConduitHelmet"]/statBases/Flammability</xpath>
 		<value>
 			<Flammability>0</Flammability>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PTPsionicConduitHelmet"]/statBases/MaxHitPoints</xpath>
 		<value>
 			<MaxHitPoints>200</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PTPsionicConduitHelmet"]/statBases/Mass</xpath>
 		<value>
 			<Mass>1</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="PTPsionicConduitHelmet"]/apparel/immuneToToxGasExposure</xpath>
 		<nomatch Class="PatchOperationAdd">

--- a/ModPatches/PsiTech/Patches/PsiTech/ThingDefs/Items/PsiTechResources.xml
+++ b/ModPatches/PsiTech/Patches/PsiTech/ThingDefs/Items/PsiTechResources.xml
@@ -9,12 +9,14 @@
 			<Bulk>0.05</Bulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PTAthenium"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>1.2</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PTAthenium"]/statBases/StuffPower_Armor_Heat</xpath>
 		<value>

--- a/ModPatches/Pulse Weaponry/Patches/Pulse Weaponry/Apparel_Hats.xml
+++ b/ModPatches/Pulse Weaponry/Patches/Pulse Weaponry/Apparel_Hats.xml
@@ -61,6 +61,7 @@
 			<DevilstrandCloth>20</DevilstrandCloth>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="DV_Apparel_SuppressorMask"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
 		<value>

--- a/ModPatches/RH2 Faction - Task Force 141/Patches/RH2 Faction - Task Force 141/TaskForce141_Apparel.xml
+++ b/ModPatches/RH2 Faction - Task Force 141/Patches/RH2 Faction - Task Force 141/TaskForce141_Apparel.xml
@@ -100,24 +100,28 @@
 			<WornBulk>3</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RNApparel_CryeCAGE_Tan"]/statBases/MaxHitPoints</xpath>
 		<value>
 			<MaxHitPoints>75</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RNApparel_CryeCAGE_Tan"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>14</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RNApparel_CryeCAGE_Tan"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>20</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="RNApparel_CryeCAGE_Tan"]/equippedStatOffsets/MoveSpeed</xpath>
 	</Operation>
@@ -133,6 +137,7 @@
 			</stuffCategories>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[
 			defName="RNApparel_MICH2000_141Rook" or
@@ -199,6 +204,7 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationreplace">
 		<xpath>Defs/ThingDef[defName = "RNApparel_Backpack_CamelbakMULE"]/equippedStatOffsets
 		</xpath>
@@ -208,6 +214,7 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationreplace">
 		<xpath>Defs/ThingDef[defName = "RNApparel_Backpack_MFH"]/equippedStatOffsets
 		</xpath>

--- a/ModPatches/RH2 Faction - The Rangers/Patches/RH2 Faction - The Rangers/Rangers_CE_Patch_Apparel.xml
+++ b/ModPatches/RH2 Faction - The Rangers/Patches/RH2 Faction - The Rangers/Rangers_CE_Patch_Apparel.xml
@@ -397,6 +397,7 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationreplace">
 		<xpath>Defs/ThingDef[defName = "RNApparel_Backpack_AUGURDaypack"]/statBases/Mass
 		</xpath>

--- a/ModPatches/RH2 Rimmu-Nation² - Clothing/Patches/RH2 Rimmu-Nation² - Clothing/Armors_CE.xml
+++ b/ModPatches/RH2 Rimmu-Nation² - Clothing/Patches/RH2 Rimmu-Nation² - Clothing/Armors_CE.xml
@@ -29,6 +29,7 @@
 			<ArmorRating_Blunt>1</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="RNApparel_EyePros_8X10BallisticGoggles"]/statBases/StuffEffectMultiplierArmor </xpath>
@@ -47,6 +48,7 @@
 			<ArmorRating_Blunt>0.25</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="RNApparel_EyePros_SIBallisticMFrame"]/statBases/StuffEffectMultiplierArmor </xpath>
@@ -141,6 +143,7 @@
 			<ArmorRating_Heat>0.386</ArmorRating_Heat>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="RNApparel_M1Helmet_Vietnam"]/statBases/StuffEffectMultiplierArmor </xpath>
@@ -148,6 +151,7 @@
 			<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="RNApparel_M1Helmet_Vietnam"]/statBases/StuffEffectMultiplierArmor </xpath>
@@ -168,6 +172,7 @@
 			<ArmorRating_Heat>0.386</ArmorRating_Heat>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="RNApparel_ProTecPrime_PizzaTime"]/statBases/StuffEffectMultiplierArmor </xpath>
@@ -175,6 +180,7 @@
 			<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="RNApparel_ProTecPrime_PizzaTime"]/statBases/StuffEffectMultiplierArmor </xpath>
@@ -337,6 +343,7 @@
 			<ArmorRating_Heat>0.90</ArmorRating_Heat>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="RNApparel_MedEngHelmet_EOD9A"]/apparel/bodyPartGroups </xpath>
@@ -346,6 +353,7 @@
 			</bodyPartGroups>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="RNApparel_MedEngHelmet_EOD9A"]/costList </xpath>
@@ -370,6 +378,7 @@
 			<ArmorRating_Heat>0.90</ArmorRating_Heat>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="RNApparel_Helmet_Juggernaut"]/apparel/bodyPartGroups </xpath>
@@ -379,6 +388,7 @@
 			</bodyPartGroups>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="RNApparel_Helmet_Juggernaut"]/costList </xpath>
@@ -454,6 +464,7 @@
 			<WornBulk>20</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="RNApparel_MedEng_EOD9Suit"]/statBases/ArmorRating_Sharp </xpath>
@@ -461,6 +472,7 @@
 			<ArmorRating_Sharp>10</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="RNApparel_MedEng_EOD9Suit"]/statBases/ArmorRating_Blunt </xpath>
@@ -476,6 +488,7 @@
 			<MoveSpeed>-0.75</MoveSpeed>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[
 			defName="RNApparel_MedEng_EOD9Suit"]/equippedStatOffsets </xpath>
@@ -508,6 +521,7 @@
 			<WornBulk>20</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="RNApparel_MedEng_JuggernautSuit"]/statBases/ArmorRating_Sharp </xpath>
@@ -515,6 +529,7 @@
 			<ArmorRating_Sharp>16</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="RNApparel_MedEng_JuggernautSuit"]/statBases/ArmorRating_Blunt </xpath>
@@ -533,6 +548,7 @@
 			<AimingDelayFactor>0.15</AimingDelayFactor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="RNApparel_MedEng_JuggernautSuit"]/equippedStatOffsets/MoveSpeed </xpath>
@@ -564,6 +580,7 @@
 			<WornBulk>10</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="RNApparel_RiotSuit_SecPro"]/statBases/ArmorRating_Sharp </xpath>
@@ -571,6 +588,7 @@
 			<ArmorRating_Sharp>10</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="RNApparel_RiotSuit_SecPro"]/statBases/ArmorRating_Blunt </xpath>
@@ -614,6 +632,7 @@
 			<WornBulk>3</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="RNApparel_FlyyeFCPC_Multicam" or
@@ -635,6 +654,7 @@
 			<MaxHitPoints>75</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="RNApparel_FlyyeFCPC_Multicam" or
@@ -656,6 +676,7 @@
 			<ArmorRating_Sharp>14</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="RNApparel_FlyyeFCPC_Multicam" or
@@ -677,6 +698,7 @@
 			<ArmorRating_Blunt>20</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[
 			defName="RNApparel_FlyyeFCPC_Multicam" or
@@ -714,6 +736,7 @@
 			<MaxHitPoints>115</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RNApparel_OTV_Tan" or
 			defName="RNApparel_IOTV_UCP" or
@@ -732,6 +755,7 @@
 			<WornBulk>4</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="RNApparel_OTV_Tan" or
@@ -749,6 +773,7 @@
 			<ArmorRating_Sharp>16</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="RNApparel_OTV_Tan" or
@@ -766,6 +791,7 @@
 			<ArmorRating_Blunt>23</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[
 			defName="RNApparel_OTV_Tan" or
@@ -788,6 +814,7 @@
 			<MaxHitPoints>160</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="RNApparel_PinnacleArmor_DragonSkin"]/statBases/Mass </xpath>
@@ -797,6 +824,7 @@
 			<WornBulk>4</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="RNApparel_PinnacleArmor_DragonSkin"]/statBases/ArmorRating_Sharp </xpath>
@@ -804,6 +832,7 @@
 			<ArmorRating_Sharp>18</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="RNApparel_PinnacleArmor_DragonSkin"]/statBases/ArmorRating_Blunt </xpath>
@@ -811,6 +840,7 @@
 			<ArmorRating_Blunt>24</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[
 			defName="RNApparel_PinnacleArmor_DragonSkin"]/equippedStatOffsets/MoveSpeed </xpath>

--- a/ModPatches/RH2 Rimmu-Nation² - Clothing/Patches/RH2 Rimmu-Nation² - Clothing/Backpacks_CE.xml
+++ b/ModPatches/RH2 Rimmu-Nation² - Clothing/Patches/RH2 Rimmu-Nation² - Clothing/Backpacks_CE.xml
@@ -147,18 +147,21 @@
 			<CarryBulk>25</CarryBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName = "RNApparel_Backpack_Naotak"]/equippedStatOffsets</xpath>
 		<value>
 			<CarryBulk>27.5</CarryBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName = "RNApparel_Backpack_FANDARESling"]/equippedStatOffsets</xpath>
 		<value>
 			<CarryBulk>30</CarryBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName = "RNApparel_Backpack_Level1PUBG"]/equippedStatOffsets</xpath>
 		<value>
@@ -177,18 +180,21 @@
 			<CarryBulk>34</CarryBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName = "RNApparel_Backpack_AMAPIII" or defName = "RNApparel_Backpack_Tomahawk"]/equippedStatOffsets</xpath>
 		<value>
 			<CarryBulk>33</CarryBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName = "RNApparel_Backpack_HelloKitty" or defName = "RNApparel_Backpack_TarpBackpack"]/equippedStatOffsets</xpath>
 		<value>
 			<CarryBulk>32</CarryBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName = "RNApparel_Backpack_AnCHero" or defName = "RNApparel_Backpack_HelikonBailOutBag"]/equippedStatOffsets</xpath>
 		<value>
@@ -210,6 +216,7 @@
 			<CarryBulk>35</CarryBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName = "RNApparel_Backpack_Gootium" or defName = "RNApparel_Backpack_TactixHalfday"]/equippedStatOffsets</xpath>
 		<value>
@@ -248,6 +255,7 @@
 			<CarryBulk>60</CarryBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName = "RNApparel_Backpack_AzimutSSKangaroo" or defName = "RNApparel_Backpack_BerghausVulcanIV"]/equippedStatOffsets</xpath>
 		<value>
@@ -255,6 +263,7 @@
 			<CarryBulk>60</CarryBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName = "RNApparel_Backpack_NorthFaceTerra65L"]/equippedStatOffsets</xpath>
 		<value>

--- a/ModPatches/RH2 Rimmu-Nation² - Clothing/Patches/RH2 Rimmu-Nation² - Clothing/Bandana_Balaclava_Scarf.xml
+++ b/ModPatches/RH2 Rimmu-Nation² - Clothing/Patches/RH2 Rimmu-Nation² - Clothing/Bandana_Balaclava_Scarf.xml
@@ -70,6 +70,7 @@
 			<costStuffCount>20</costStuffCount>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="RNApparel_Balaclava_EXF"

--- a/ModPatches/RH2 Rimmu-Nation² - Clothing/Patches/RH2 Rimmu-Nation² - Clothing/Vests_CE.xml
+++ b/ModPatches/RH2 Rimmu-Nation² - Clothing/Patches/RH2 Rimmu-Nation² - Clothing/Vests_CE.xml
@@ -94,6 +94,7 @@
 			<WornBulk>5</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>
 			Defs/ThingDef[
@@ -134,6 +135,7 @@
 			<ReloadSpeed>0.1</ReloadSpeed>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName = "RHApparel_SuperBelt_Tan"]/equippedStatOffsets</xpath>
 		<value>

--- a/ModPatches/RWY Dragon's Descent Void Dwellers/Patches/RWY Dragon's Descent Void Dwellers/Projectiles/Projectile_SpaceDragon.xml
+++ b/ModPatches/RWY Dragon's Descent Void Dwellers/Patches/RWY Dragon's Descent Void Dwellers/Projectiles/Projectile_SpaceDragon.xml
@@ -55,6 +55,7 @@
 			<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_Aurelion_Breath"]/projectile</xpath>
 		<value>
@@ -77,6 +78,7 @@
 			<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_Stardust_Breath"]/projectile</xpath>
 		<value>
@@ -100,6 +102,7 @@
 			<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_Molten_Breath"]/projectile</xpath>
 		<value>
@@ -122,6 +125,7 @@
 			<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_DD_Surge_Breath"]/projectile</xpath>
 		<value>
@@ -146,6 +150,7 @@
 			<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_DD_Mind_Flay"]/projectile</xpath>
 		<value>
@@ -170,6 +175,7 @@
 			<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_DD_Hellfire"]/projectile</xpath>
 		<value>
@@ -193,6 +199,7 @@
 			<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_DD_Eclipse"]/projectile</xpath>
 		<value>
@@ -215,6 +222,7 @@
 			<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_DD_Rend"]/projectile</xpath>
 		<value>
@@ -237,6 +245,7 @@
 			<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_DD_Constrain"]/projectile</xpath>
 		<value>

--- a/ModPatches/Racc/Patches/Racc/PawnKinds_Racc.xml
+++ b/ModPatches/Racc/Patches/Racc/PawnKinds_Racc.xml
@@ -32,6 +32,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="RaccArchivist"]</xpath>
 		<value>
@@ -63,6 +64,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="RaccTrader"]</xpath>
 		<value>
@@ -94,6 +96,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="RaccSlave"]</xpath>
 		<value>
@@ -125,6 +128,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="RaccRefugee"]</xpath>
 		<value>
@@ -156,6 +160,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="RaccSecurityGuard"]</xpath>
 		<value>
@@ -187,6 +192,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="RaccTheif"]</xpath>
 		<value>
@@ -218,6 +224,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="RaccHunter"]</xpath>
 		<value>
@@ -249,6 +256,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="RaccSpy"]</xpath>
 		<value>
@@ -280,6 +288,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="RaccNinja"]</xpath>
 		<value>

--- a/ModPatches/Racc/Patches/Racc/Racc_Weapons.xml
+++ b/ModPatches/Racc/Patches/Racc/Racc_Weapons.xml
@@ -39,6 +39,7 @@
 			<li>CE_OneHandedWeapon</li>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Racc_WPPK"]/tools</xpath>
 		<value>

--- a/ModPatches/ReGrowth - Core/Patches/ReGrowth - Core/Animals_Core.xml
+++ b/ModPatches/ReGrowth - Core/Patches/ReGrowth - Core/Animals_Core.xml
@@ -1,67 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 
-	<!-- === Moa === -->
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="RG_Moa"]/statBases</xpath>
-		<value>
-			<MeleeDodgeChance>0.20</MeleeDodgeChance>
-			<MeleeCritChance>0.06</MeleeCritChance>
-			<MeleeParryChance>0.06</MeleeParryChance>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="RG_Moa"]/tools</xpath>
-		<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-					<label>claws</label>
-					<capacities>
-						<li>Cut</li>
-					</capacities>
-					<power>9</power>
-					<cooldownTime>1.42</cooldownTime>
-					<linkedBodyPartsGroup>Feet</linkedBodyPartsGroup>
-					<surpriseAttack>
-						<extraMeleeDamages>
-							<li>
-								<def>Stun</def>
-								<amount>20</amount>
-							</li>
-						</extraMeleeDamages>
-					</surpriseAttack>
-					<armorPenetrationSharp>0.08</armorPenetrationSharp>
-					<armorPenetrationBlunt>0.4</armorPenetrationBlunt>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>beak</label>
-					<capacities>
-						<li>Bite</li>
-					</capacities>
-					<power>7</power>
-					<cooldownTime>1.89</cooldownTime>
-					<linkedBodyPartsGroup>Beak</linkedBodyPartsGroup>
-					<chanceFactor>0.5</chanceFactor>
-					<armorPenetrationSharp>0.01</armorPenetrationSharp>
-					<armorPenetrationBlunt>1.250</armorPenetrationBlunt>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>head</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>3</power>
-					<cooldownTime>1.78</cooldownTime>
-					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-					<chanceFactor>0.2</chanceFactor>
-					<armorPenetrationBlunt>1</armorPenetrationBlunt>
-				</li>
-			</tools>
-		</value>
-	</Operation>
-
 	<!-- ========== Neutrolope ========== -->
 
 	<Operation Class="PatchOperationAddModExtension">
@@ -145,6 +84,107 @@
 					<chanceFactor>0.5</chanceFactor>
 					<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
 					<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<!-- ========== Rabbit ========== -->	
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="RG_Rabbit"]</xpath>
+		<value>
+			<li Class="CombatExtended.RacePropertiesExtensionCE">
+				<bodyShape>Quadruped</bodyShape>
+			</li>
+		</value>
+	</Operation>
+
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="RG_Rabbit"]</xpath>
+		<value>
+			<statBases>
+				<MeleeDodgeChance>0.24</MeleeDodgeChance>
+				<MeleeCritChance>0.02</MeleeCritChance>
+				<MeleeParryChance>0.06</MeleeParryChance>
+			</statBases>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="RG_Rabbit"]</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<capacities>
+						<li>Bite</li>
+					</capacities>
+					<power>3</power>
+					<cooldownTime>1.26</cooldownTime>
+					<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+					<armorPenetrationSharp>0.01</armorPenetrationSharp>
+					<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>1</power>
+					<cooldownTime>1.26</cooldownTime>
+					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					<chanceFactor>0.2</chanceFactor>
+					<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<!-- === Kiwi === -->
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="RG_Neutrolope"]</xpath>
+		<value>
+			<li Class="CombatExtended.RacePropertiesExtensionCE">
+				<bodyShape>Birdlike</bodyShape>
+			</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="RG_KiwiBird"]/statBases</xpath>
+		<value>
+			<MeleeDodgeChance>0.28</MeleeDodgeChance>
+			<MeleeCritChance>0.02</MeleeCritChance>
+			<MeleeParryChance>0</MeleeParryChance>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="RG_KiwiBird"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>claws</label>
+					<capacities>
+						<li>Scratch</li>
+					</capacities>
+					<power>2</power>
+					<cooldownTime>1.39</cooldownTime>
+					<linkedBodyPartsGroup>Feet</linkedBodyPartsGroup>
+					<armorPenetrationSharp>0.01</armorPenetrationSharp>
+					<armorPenetrationBlunt>0.096</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<capacities>
+						<li>Bite</li>
+					</capacities>
+					<power>2</power>
+					<cooldownTime>1.39</cooldownTime>
+					<linkedBodyPartsGroup>Beak</linkedBodyPartsGroup>
+					<armorPenetrationBlunt>0.096</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.01</armorPenetrationSharp>
 				</li>
 			</tools>
 		</value>

--- a/ModPatches/ReGrowth - Extinct Animals/Patches/ReGrowth - Extinct Animals/Extinct_Birdlike.xml
+++ b/ModPatches/ReGrowth - Extinct Animals/Patches/ReGrowth - Extinct Animals/Extinct_Birdlike.xml
@@ -248,6 +248,7 @@
 			<MeleeParryChance>0.03</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RG_Velociraptor"]/tools</xpath>
 		<value>
@@ -320,18 +321,21 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RG_Velociraptor"]/race/manhunterOnDamageChance</xpath>
 		<value>
 			<manhunterOnDamageChance>0.75</manhunterOnDamageChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[defName="RG_Velociraptor"]/combatPower</xpath>
 		<value>
 			<combatPower>85</combatPower>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[defName="RG_Velociraptor"]/wildGroupSize</xpath>
 		<value>

--- a/ModPatches/ReGrowth - Extinct Animals/Patches/ReGrowth - Extinct Animals/Extinct_Resources.xml
+++ b/ModPatches/ReGrowth - Extinct Animals/Patches/ReGrowth - Extinct Animals/Extinct_Resources.xml
@@ -5,11 +5,13 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="RG_MammothTusk"]/tools</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationAttributeSet">
 		<xpath>Defs/ThingDef[defName="RG_MammothTusk"]</xpath>
 		<attribute>ParentName</attribute>
 		<value>ResourceBase</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RG_MammothTusk"]/statBases/MarketValue</xpath>
 		<value>

--- a/ModPatches/Revia Race — biotech/Patches/Revia Race — biotech/PawnKindDefs/ReviaPawnKindDefs.xml
+++ b/ModPatches/Revia Race — biotech/Patches/Revia Race — biotech/PawnKindDefs/ReviaPawnKindDefs.xml
@@ -19,6 +19,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/PawnKindDef[defName="ReviaRaceBerserker"]/apparelTags</xpath>
 		<value>
@@ -54,6 +55,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/PawnKindDef[defName="ReviaRaceMarauder"]/apparelTags</xpath>
 		<value>
@@ -85,6 +87,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/PawnKindDef[defName="ReviaRaceRaider"]/apparelTags</xpath>
 		<value>
@@ -131,6 +134,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/PawnKindDef[defName="ReviaRaceHighTemplar"]/apparelRequired</xpath>
 		<value>
@@ -138,6 +142,7 @@
 			<li>CE_Apparel_Backpack</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/PawnKindDef[defName="ReviaRaceHighTemplar"]/apparelTags</xpath>
 		<value>
@@ -173,6 +178,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/PawnKindDef[defName="ReviaRaceInitiate"]/apparelTags</xpath>
 		<value>
@@ -208,6 +214,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/PawnKindDef[defName="ReviaRaceQuartermaster"]/apparelRequired</xpath>
 		<value>
@@ -215,6 +222,7 @@
 			<li>CE_Apparel_Backpack</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/PawnKindDef[defName="ReviaRaceQuartermaster"]/apparelTags</xpath>
 		<value>
@@ -251,6 +259,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/PawnKindDef[defName="ReviaRaceTemplar"]/apparelRequired</xpath>
 		<value>
@@ -258,6 +267,7 @@
 			<li>CE_Apparel_Backpack</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/PawnKindDef[defName="ReviaRaceTemplar"]/apparelTags</xpath>
 		<value>

--- a/ModPatches/Revia Race — biotech/Patches/Revia Race — biotech/Scenario/Revia_Scenario.xml
+++ b/ModPatches/Revia Race — biotech/Patches/Revia Race — biotech/Scenario/Revia_Scenario.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ScenarioDef[defName="ReviaExclave"]/scenario/parts/li[thingDef="ReviaThrowingKnife" and @Class="ScenPart_StartingThing_Defined"]</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ScenarioDef[defName="ReviaExclave"]/scenario/parts</xpath>
 		<value>

--- a/ModPatches/Revia Race — biotech/Patches/Revia Race — biotech/ThingDefs_Misc/Weapons_Guns.xml
+++ b/ModPatches/Revia Race — biotech/Patches/Revia Race — biotech/ThingDefs_Misc/Weapons_Guns.xml
@@ -5,9 +5,11 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="ReviaThrowingKnife"]/costStuffCount</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="ReviaThrowingKnife"]/stuffCategories</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="ReviaThrowingKnifeThrown"]/projectile</xpath>
 		<value>
@@ -23,6 +25,7 @@
 			</projectile>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="ReviaThrowingKnife"]</xpath>
 		<value>
@@ -31,11 +34,13 @@
 			<resourceReadoutPriority>First</resourceReadoutPriority>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAttributeSet">
 		<xpath>Defs/ThingDef[defName="ReviaThrowingKnife"]</xpath>
 		<attribute>Class</attribute>
 		<value>CombatExtended.AmmoDef</value>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>ReviaThrowingKnife</defName>
 		<statBases>
@@ -60,6 +65,7 @@
 			<li>ReviaRangedBasic</li>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="ReviaThrowingKnife"]/tools</xpath>
 		<value>
@@ -108,6 +114,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>ReviaRepeatingCrossbow</defName>
 		<statBases>
@@ -167,6 +174,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>ReviaFlechetteCannon</defName>
 		<statBases>
@@ -250,6 +258,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="ReviaSerratedDagger"]/statBases</xpath>
 		<value>
@@ -257,6 +266,7 @@
 			<MeleeCounterParryBonus>0.36</MeleeCounterParryBonus>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="ReviaSerratedDagger"]</xpath>
 		<value>
@@ -309,6 +319,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="ReviaBlessedSerratedDagger"]/statBases</xpath>
 		<value>
@@ -316,6 +327,7 @@
 			<MeleeCounterParryBonus>0.4</MeleeCounterParryBonus>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="ReviaBlessedSerratedDagger"]</xpath>
 		<value>
@@ -368,6 +380,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="ReviaSerratedSword"]/statBases</xpath>
 		<value>
@@ -375,6 +388,7 @@
 			<MeleeCounterParryBonus>0.4</MeleeCounterParryBonus>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="ReviaSerratedSword"]</xpath>
 		<value>
@@ -427,6 +441,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="ReviaBlessedSerratedSword"]/statBases</xpath>
 		<value>
@@ -434,6 +449,7 @@
 			<MeleeCounterParryBonus>0.44</MeleeCounterParryBonus>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="ReviaBlessedSerratedSword"]</xpath>
 		<value>
@@ -475,6 +491,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="ReviaSerratedScythe"]/statBases</xpath>
 		<value>
@@ -482,6 +499,7 @@
 			<MeleeCounterParryBonus>0.69</MeleeCounterParryBonus>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="ReviaSerratedScythe"]</xpath>
 		<value>
@@ -534,6 +552,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="ReviaWarPick"]/statBases</xpath>
 		<value>
@@ -541,6 +560,7 @@
 			<MeleeCounterParryBonus>0.69</MeleeCounterParryBonus>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="ReviaWarPick"]/equippedStatOffsets</xpath>
 		<value>
@@ -582,6 +602,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="ReviaBlessedSerratedScythe"]/statBases</xpath>
 		<value>
@@ -589,6 +610,7 @@
 			<MeleeCounterParryBonus>0.77</MeleeCounterParryBonus>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="ReviaBlessedSerratedScythe"]</xpath>
 		<value>
@@ -629,6 +651,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="ReviaChainSword"]/statBases</xpath>
 		<value>
@@ -636,6 +659,7 @@
 			<MeleeCounterParryBonus>0.4</MeleeCounterParryBonus>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="ReviaChainSword"]</xpath>
 		<value>

--- a/ModPatches/Revia Race — biotech/Patches/Revia Race — biotech/ThingDefs_Races/Race_Revia.xml
+++ b/ModPatches/Revia Race — biotech/Patches/Revia Race — biotech/ThingDefs_Races/Race_Revia.xml
@@ -11,6 +11,7 @@
 			<!-- Once they got their first upgrade they become a bit more fearless -->
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/HediffDef[defName="ReviaRaceSoulreapTier3"]/stages/li</xpath>
 		<value>
@@ -19,36 +20,42 @@
 			</statOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/HediffDef[defName="ReviaRaceSoulreapTier4"]/stages/li/statOffsets</xpath>
 		<value>
 			<Suppressability>-0.20</Suppressability>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/HediffDef[defName="ReviaRaceSoulreapTier5"]/stages/li/statOffsets</xpath>
 		<value>
 			<Suppressability>-0.30</Suppressability>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/HediffDef[defName="ReviaRaceSoulreapTier6"]/stages/li/statOffsets</xpath>
 		<value>
 			<Suppressability>-0.4</Suppressability>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/HediffDef[defName="ReviaRaceSoulreapTier7"]/stages/li/statOffsets</xpath>
 		<value>
 			<Suppressability>-0.5</Suppressability>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/HediffDef[defName="ReviaRaceSoulreapTier8"]/stages/li/statOffsets</xpath>
 		<value>
 			<Suppressability>-0.7</Suppressability>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/HediffDef[defName="ReviaRaceSoulreapTier9"]/stages/li/statOffsets</xpath>
 		<value>
@@ -73,6 +80,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="ReviaTeeth"]/comps/li/tools</xpath>
 		<value>

--- a/ModPatches/Revia Race/Patches/Revia Race/PawnKindDefs/ReviaPawnKindDefs.xml
+++ b/ModPatches/Revia Race/Patches/Revia Race/PawnKindDefs/ReviaPawnKindDefs.xml
@@ -19,6 +19,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/PawnKindDef[defName="ReviaRaceBerserker"]/apparelTags</xpath>
 		<value>
@@ -54,6 +55,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/PawnKindDef[defName="ReviaRaceMarauder"]/apparelTags</xpath>
 		<value>
@@ -85,6 +87,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/PawnKindDef[defName="ReviaRaceRaider"]/apparelTags</xpath>
 		<value>
@@ -131,6 +134,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/PawnKindDef[defName="ReviaRaceHighTemplar"]/apparelRequired</xpath>
 		<value>
@@ -138,6 +142,7 @@
 			<li>CE_Apparel_Backpack</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/PawnKindDef[defName="ReviaRaceHighTemplar"]/apparelTags</xpath>
 		<value>
@@ -173,6 +178,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/PawnKindDef[defName="ReviaRaceInitiate"]/apparelTags</xpath>
 		<value>
@@ -208,6 +214,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/PawnKindDef[defName="ReviaRaceQuartermaster"]/apparelRequired</xpath>
 		<value>
@@ -215,6 +222,7 @@
 			<li>CE_Apparel_Backpack</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/PawnKindDef[defName="ReviaRaceQuartermaster"]/apparelTags</xpath>
 		<value>
@@ -251,6 +259,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/PawnKindDef[defName="ReviaRaceTemplar"]/apparelRequired</xpath>
 		<value>
@@ -258,6 +267,7 @@
 			<li>CE_Apparel_Backpack</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/PawnKindDef[defName="ReviaRaceTemplar"]/apparelTags</xpath>
 		<value>

--- a/ModPatches/Revia Race/Patches/Revia Race/Scenario/Revia_Scenario.xml
+++ b/ModPatches/Revia Race/Patches/Revia Race/Scenario/Revia_Scenario.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ScenarioDef[defName="ReviaExclave"]/scenario/parts/li[thingDef="ReviaThrowingKnife" and @Class="ScenPart_StartingThing_Defined"]</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ScenarioDef[defName="ReviaExclave"]/scenario/parts</xpath>
 		<value>

--- a/ModPatches/Revia Race/Patches/Revia Race/ThingDefs_Bodies/Revia_Bodytype.xml
+++ b/ModPatches/Revia Race/Patches/Revia Race/ThingDefs_Bodies/Revia_Bodytype.xml
@@ -10,108 +10,126 @@
 			<coverage>0.07</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="ReviaRaceBody"]/corePart/parts/li[def="Pelvis"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="ReviaRaceBody"]/corePart/parts/li[def="Stomach"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="ReviaRaceBody"]/corePart/parts/li[def="Heart"]/coverage</xpath>
 		<value>
 			<coverage>0.04</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="ReviaRaceBody"]/corePart/parts/li[def="Lung"]/coverage</xpath>
 		<value>
 			<coverage>0.055</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="ReviaRaceBody"]/corePart/parts/li[def="Kidney"]/coverage</xpath>
 		<value>
 			<coverage>0.03</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="ReviaRaceBody"]/corePart/parts/li[def="Liver"]/coverage</xpath>
 		<value>
 			<coverage>0.06</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="ReviaRaceBody"]/corePart/parts/li[def="Neck"]/coverage</xpath>
 		<value>
 			<coverage>0.055</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="ReviaRaceBody"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/parts/li[def="Brain"]/coverage</xpath>
 		<value>
 			<coverage>0.9</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="ReviaRaceBody"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Eye"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="ReviaRaceBody"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Ear"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="ReviaRaceBody"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]/coverage</xpath>
 		<value>
 			<coverage>0.08</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="ReviaRaceBody"]/corePart/parts/li[def="Shoulder"]/coverage</xpath>
 		<value>
 			<coverage>0.085</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="ReviaRaceBody"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Clavicle"]/coverage</xpath>
 		<value>
 			<coverage>0.06</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="ReviaRaceBody"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Humerus"]/coverage</xpath>
 		<value>
 			<coverage>0.15</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="ReviaRaceBody"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Radius"]/coverage</xpath>
 		<value>
 			<coverage>0.15</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="ReviaRaceBody"]/corePart/parts/li[def="ReviaRaceTail"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="ReviaRaceBody"]/corePart/parts/li[def="Leg"]/parts/li[def="Femur"]/coverage</xpath>
 		<value>
 			<coverage>0.15</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="ReviaRaceBody"]/corePart/parts/li[def="Leg"]/parts/li[def="Tibia"]/coverage</xpath>
 		<value>

--- a/ModPatches/Revia Race/Patches/Revia Race/ThingDefs_Misc/Weapons_Guns.xml
+++ b/ModPatches/Revia Race/Patches/Revia Race/ThingDefs_Misc/Weapons_Guns.xml
@@ -5,9 +5,11 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="ReviaThrowingKnife"]/costStuffCount</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="ReviaThrowingKnife"]/stuffCategories</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="ReviaThrowingKnifeThrown"]/projectile</xpath>
 		<value>
@@ -23,6 +25,7 @@
 			</projectile>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="ReviaThrowingKnife"]</xpath>
 		<value>
@@ -31,11 +34,13 @@
 			<resourceReadoutPriority>First</resourceReadoutPriority>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAttributeSet">
 		<xpath>Defs/ThingDef[defName="ReviaThrowingKnife"]</xpath>
 		<attribute>Class</attribute>
 		<value>CombatExtended.AmmoDef</value>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>ReviaThrowingKnife</defName>
 		<statBases>
@@ -60,6 +65,7 @@
 			<li>ReviaRangedBasic</li>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="ReviaThrowingKnife"]/tools</xpath>
 		<value>
@@ -108,6 +114,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>ReviaRepeatingCrossbow</defName>
 		<statBases>
@@ -167,6 +174,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>ReviaFlechetteCannon</defName>
 		<statBases>
@@ -250,6 +258,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="ReviaSerratedDagger"]/statBases</xpath>
 		<value>
@@ -257,6 +266,7 @@
 			<MeleeCounterParryBonus>0.36</MeleeCounterParryBonus>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="ReviaSerratedDagger"]</xpath>
 		<value>
@@ -309,6 +319,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="ReviaBlessedSerratedDagger"]/statBases</xpath>
 		<value>
@@ -316,6 +327,7 @@
 			<MeleeCounterParryBonus>0.4</MeleeCounterParryBonus>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="ReviaBlessedSerratedDagger"]</xpath>
 		<value>
@@ -368,6 +380,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="ReviaSerratedSword"]/statBases</xpath>
 		<value>
@@ -375,6 +388,7 @@
 			<MeleeCounterParryBonus>0.4</MeleeCounterParryBonus>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="ReviaSerratedSword"]</xpath>
 		<value>
@@ -427,6 +441,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="ReviaBlessedSerratedSword"]/statBases</xpath>
 		<value>
@@ -434,6 +449,7 @@
 			<MeleeCounterParryBonus>0.44</MeleeCounterParryBonus>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="ReviaBlessedSerratedSword"]</xpath>
 		<value>
@@ -475,6 +491,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="ReviaSerratedScythe"]/statBases</xpath>
 		<value>
@@ -482,6 +499,7 @@
 			<MeleeCounterParryBonus>0.69</MeleeCounterParryBonus>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="ReviaSerratedScythe"]</xpath>
 		<value>
@@ -534,6 +552,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="ReviaWarPick"]/statBases</xpath>
 		<value>
@@ -541,6 +560,7 @@
 			<MeleeCounterParryBonus>0.69</MeleeCounterParryBonus>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="ReviaWarPick"]/equippedStatOffsets</xpath>
 		<value>
@@ -582,6 +602,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="ReviaBlessedSerratedScythe"]/statBases</xpath>
 		<value>
@@ -589,6 +610,7 @@
 			<MeleeCounterParryBonus>0.77</MeleeCounterParryBonus>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="ReviaBlessedSerratedScythe"]</xpath>
 		<value>
@@ -629,6 +651,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="ReviaChainSword"]/statBases</xpath>
 		<value>
@@ -636,6 +659,7 @@
 			<MeleeCounterParryBonus>0.4</MeleeCounterParryBonus>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="ReviaChainSword"]</xpath>
 		<value>

--- a/ModPatches/Revia Race/Patches/Revia Race/ThingDefs_Races/Race_Revia.xml
+++ b/ModPatches/Revia Race/Patches/Revia Race/ThingDefs_Races/Race_Revia.xml
@@ -37,6 +37,7 @@ Soulreap tier 1 is their base state, weaker than a normal human so not adding an
 			<!-- Once they got their first upgrade they become a bit more fearless -->
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/HediffDef[defName="ReviaRaceSoulreapTier3"]/stages/li</xpath>
 		<value>
@@ -45,36 +46,42 @@ Soulreap tier 1 is their base state, weaker than a normal human so not adding an
 			</statOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/HediffDef[defName="ReviaRaceSoulreapTier4"]/stages/li/statOffsets</xpath>
 		<value>
 			<Suppressability>-0.20</Suppressability>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/HediffDef[defName="ReviaRaceSoulreapTier5"]/stages/li/statOffsets</xpath>
 		<value>
 			<Suppressability>-0.30</Suppressability>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/HediffDef[defName="ReviaRaceSoulreapTier6"]/stages/li/statOffsets</xpath>
 		<value>
 			<Suppressability>-0.4</Suppressability>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/HediffDef[defName="ReviaRaceSoulreapTier7"]/stages/li/statOffsets</xpath>
 		<value>
 			<Suppressability>-0.5</Suppressability>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/HediffDef[defName="ReviaRaceSoulreapTier8"]/stages/li/statOffsets</xpath>
 		<value>
 			<Suppressability>-0.7</Suppressability>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/HediffDef[defName="ReviaRaceSoulreapTier9"]/stages/li/statOffsets</xpath>
 		<value>

--- a/ModPatches/Rim Flood/Patches/Rim Flood/CE_FloodForms.xml
+++ b/ModPatches/Rim Flood/Patches/Rim Flood/CE_FloodForms.xml
@@ -87,6 +87,7 @@
 			<ArmorRating_Blunt>3</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Combatform"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
@@ -100,6 +101,7 @@
 			<ArmorRating_Blunt>2</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Houndform"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
@@ -113,6 +115,7 @@
 			<ArmorRating_Blunt>20</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Tankform"]/statBases/ArmorRating_Sharp</xpath>
 		<value>

--- a/ModPatches/Rim Flood/Patches/Rim Flood/CE_Forerunnermetal.xml
+++ b/ModPatches/Rim Flood/Patches/Rim Flood/CE_Forerunnermetal.xml
@@ -7,6 +7,7 @@
 			<Bulk>0.025</Bulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Forerunner_Metal"]/stuffProps/statFactors</xpath>
 		<value>
@@ -14,12 +15,15 @@
 			<MeleePenetrationFactor>2.25</MeleePenetrationFactor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Forerunner_Metal"]/statBases/SharpDamageMultiplier</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Forerunner_Metal"]/statBases/BluntDamageMultiplier</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Forerunner_Metal"]/stuffProps/categories</xpath>
 		<value>
@@ -27,18 +31,21 @@
 			<li>Steeled</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Forerunner_Metal"]/statBases/StuffPower_Armor_Sharp</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>2.4</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Forerunner_Metal"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>3.6</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Forerunner_Metal"]/statBases/StuffPower_Armor_Heat</xpath>
 		<value>

--- a/ModPatches/Rim Flood/Patches/Rim Flood/CE_Forerunners.xml
+++ b/ModPatches/Rim Flood/Patches/Rim Flood/CE_Forerunners.xml
@@ -29,6 +29,7 @@
 			<ArmorRating_Blunt>3</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Sentinel"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
@@ -42,6 +43,7 @@
 			<ArmorRating_Blunt>6</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SentinelMajor"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
@@ -55,6 +57,7 @@
 			<ArmorRating_Blunt>4.5</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Forerunnerspawn"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
@@ -68,6 +71,7 @@
 			<ArmorRating_Blunt>4</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Constructor"]/statBases/ArmorRating_Sharp</xpath>
 		<value>

--- a/ModPatches/Rim of Madness - Bones/Patches/Rim of Madness - Bones/ThingDefs_Items/Patch_Items_Apparel_BoneMasks.xml
+++ b/ModPatches/Rim of Madness - Bones/Patches/Rim of Madness - Bones/ThingDefs_Items/Patch_Items_Apparel_BoneMasks.xml
@@ -9,12 +9,14 @@
 			<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="ROMB_Apparel_SkullMask"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>0.1</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="ROMB_Apparel_SkullMask"]/apparel/layers</xpath>
 		<value>
@@ -33,6 +35,7 @@
 			<ArmorRating_Sharp>1</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Sihv_Apparel_BoneArmor"]/statBases/ArmorRating_Blunt</xpath>
 		<value>

--- a/ModPatches/Rim of Madness - Bones/Patches/Rim of Madness - Bones/ThingDefs_Items/Patch_Items_Resources_Bones.xml
+++ b/ModPatches/Rim of Madness - Bones/Patches/Rim of Madness - Bones/ThingDefs_Items/Patch_Items_Resources_Bones.xml
@@ -8,12 +8,14 @@
 			<MeleePenetrationFactor>0.6</MeleePenetrationFactor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="BoneItem"]/statBases/StuffPower_Armor_Sharp</xpath>
 		<value>
 			<StuffPower_Armor_Sharp>0.25</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="BoneItem"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>

--- a/ModPatches/Rim of Madness - Vampires/Patches/Rim of Madness - Vampires/Patch_ROMV_Animals.xml
+++ b/ModPatches/Rim of Madness - Vampires/Patches/Rim of Madness - Vampires/Patch_ROMV_Animals.xml
@@ -295,6 +295,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[@Name="ROMV_ThingBaseAbyssalArm"]</xpath>
 		<value>

--- a/ModPatches/Rim-Effect Asari and Reapers/Patches/Rim-Effect Asari and Reapers/Bodies/Bodies_Asari.xml
+++ b/ModPatches/Rim-Effect Asari and Reapers/Patches/Rim-Effect Asari and Reapers/Bodies/Bodies_Asari.xml
@@ -6,102 +6,119 @@
 			<coverage>0.07</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="RE_Asari"]/corePart/parts/li[def="Pelvis"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="RE_Asari"]/corePart/parts/li[def="Stomach"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="RE_Asari"]/corePart/parts/li[def="Heart"]/coverage</xpath>
 		<value>
 			<coverage>0.04</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="RE_Asari"]/corePart/parts/li[def="Lung"]/coverage</xpath>
 		<value>
 			<coverage>0.055</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="RE_Asari"]/corePart/parts/li[def="Kidney"]/coverage</xpath>
 		<value>
 			<coverage>0.03</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="RE_Asari"]/corePart/parts/li[def="Liver"]/coverage</xpath>
 		<value>
 			<coverage>0.06</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="RE_Asari"]/corePart/parts/li[def="Neck"]/coverage</xpath>
 		<value>
 			<coverage>0.055</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="RE_Asari"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/parts/li[def="Brain"]/coverage</xpath>
 		<value>
 			<coverage>0.9</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="RE_Asari"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Eye"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="RE_Asari"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Ear"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="RE_Asari"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]/coverage</xpath>
 		<value>
 			<coverage>0.08</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="RE_Asari"]/corePart/parts/li[def="Shoulder"]/coverage</xpath>
 		<value>
 			<coverage>0.085</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="RE_Asari"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Clavicle"]/coverage</xpath>
 		<value>
 			<coverage>0.06</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="RE_Asari"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Humerus"]/coverage</xpath>
 		<value>
 			<coverage>0.15</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="RE_Asari"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Radius"]/coverage</xpath>
 		<value>
 			<coverage>0.15</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="RE_Asari"]/corePart/parts/li[def="Leg"]/parts/li[def="Femur"]/coverage</xpath>
 		<value>
 			<coverage>0.15</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="RE_Asari"]/corePart/parts/li[def="Leg"]/parts/li[def="Tibia"]/coverage</xpath>
 		<value>

--- a/ModPatches/Rim-Effect Core/Patches/Rim-Effect Core/Mechpawn_ME.xml
+++ b/ModPatches/Rim-Effect Core/Patches/Rim-Effect Core/Mechpawn_ME.xml
@@ -76,6 +76,7 @@
 			<ArmorRating_Blunt>13</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RE_Mechanoids_LOKI"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
@@ -89,6 +90,7 @@
 			<ArmorRating_Blunt>16</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RE_Mechanoids_FENRIS"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
@@ -102,6 +104,7 @@
 			<ArmorRating_Blunt>75</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RE_Mechanoids_YMIR"]/statBases/ArmorRating_Sharp</xpath>
 		<value>

--- a/ModPatches/Rim-Effect Core/Patches/Rim-Effect Core/Turrets_and_Misc_ME.xml
+++ b/ModPatches/Rim-Effect Core/Patches/Rim-Effect Core/Turrets_and_Misc_ME.xml
@@ -176,6 +176,7 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[@Name="RE_AmmoBelts"]/recipeMaker</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[@Name="RE_AmmoBelts"]/tradeTags</xpath>
 	</Operation>

--- a/ModPatches/Rim-Hivers!/Patches/Rim-Hivers!/Patch_Bodies_Hivers.xml
+++ b/ModPatches/Rim-Hivers!/Patches/Rim-Hivers!/Patch_Bodies_Hivers.xml
@@ -8,90 +8,105 @@
 			<coverage>0.07</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="HiverBody"]/corePart/parts/li[def="Pelvis"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="HiverBody"]/corePart/parts/li[def="Stomach"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="HiverBody"]/corePart/parts/li[def="Heart"]/coverage</xpath>
 		<value>
 			<coverage>0.04</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="HiverBody"]/corePart/parts/li[def="Lung"]/coverage</xpath>
 		<value>
 			<coverage>0.055</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="HiverBody"]/corePart/parts/li[def="Kidney"]/coverage</xpath>
 		<value>
 			<coverage>0.03</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="HiverBody"]/corePart/parts/li[def="Liver"]/coverage</xpath>
 		<value>
 			<coverage>0.06</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="HiverBody"]/corePart/parts/li[def="Neck"]/coverage</xpath>
 		<value>
 			<coverage>0.055</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="HiverBody"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/parts/li[def="Brain"]/coverage</xpath>
 		<value>
 			<coverage>0.9</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="HiverBody"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Eye"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="HiverBody"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Antenna"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="HiverBody"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="InsectNostril"]/coverage</xpath>
 		<value>
 			<coverage>0.08</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="HiverBody"]/corePart/parts/li[def="Shoulder"]/coverage</xpath>
 		<value>
 			<coverage>0.085</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="HiverBody"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Clavicle"]/coverage</xpath>
 		<value>
 			<coverage>0.06</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="HiverBody"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Humerus"]/coverage</xpath>
 		<value>
 			<coverage>0.15</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="HiverBody"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Radius"]/coverage</xpath>
 		<value>

--- a/ModPatches/Rim-Robots!/Patches/Rim-Robots!/Implants_Patch.xml
+++ b/ModPatches/Rim-Robots!/Patches/Rim-Robots!/Implants_Patch.xml
@@ -41,6 +41,7 @@
 			<ArmorRating_Blunt>4</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="RR_SelfAlloyingHelm"]/stages/li/statOffsets/PawnBeauty</xpath>
 		<value>
@@ -60,6 +61,7 @@
 			</capMods>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="RR_AddedScythes"]/stages/li/statOffsets</xpath>
 		<value>
@@ -90,6 +92,7 @@
 			</statOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="RR_AddedScythes"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
 		<value>

--- a/ModPatches/Rim-Robots!/Patches/Rim-Robots!/Mechanent_Body.xml
+++ b/ModPatches/Rim-Robots!/Patches/Rim-Robots!/Mechanent_Body.xml
@@ -13,24 +13,28 @@
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="CasteBody"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
 		<value>
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="CasteBody"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="HearingSensor"]/groups</xpath>
 		<value>
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="CasteBody"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalJaw"]/groups</xpath>
 		<value>
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="CasteBody"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="SmellSensor"]/groups</xpath>
 		<value>
@@ -44,18 +48,21 @@
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="CasteBody"]/corePart/parts/li[def="MechShoulder"]/parts/li[def="MechArm"]/groups</xpath>
 		<value>
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="CasteBody"]/corePart/parts/li[def="MechShoulder"]/parts/li[def="MechArm"]/parts/li[def="MechanicalHand"]/groups</xpath>
 		<value>
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="CasteBody"]/corePart/parts/li[def="MechShoulder"]/parts/li[def="MechArm"]/parts/li[def="MechanicalHand"]/parts/li[def="MechanicalFinger"]/groups</xpath>
 		<value>
@@ -69,12 +76,14 @@
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="CasteBody"]/corePart/parts/li[def="MechLeg"]/groups</xpath>
 		<value>
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="CasteBody"]/corePart/parts/li[def="MechLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
 		<value>

--- a/ModPatches/Rim-Robots!/Patches/Rim-Robots!/Pawnkind_Patch.xml
+++ b/ModPatches/Rim-Robots!/Patches/Rim-Robots!/Pawnkind_Patch.xml
@@ -9,12 +9,14 @@
 			</apparelRequired>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/PawnKindDef[ @Name="MechanentBase"]</xpath>
 		<value>
 			<invFoodDef>Chemfuel</invFoodDef>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[ defName="Mechanent_Villager" or defName="Persona_Villager" or defName="Mechanent_Guard" or defName="Mechanent_Trader" or @Name="MechanentGunnerBase" or @Name="MechanentSniperBase" or defName="Mechanent_Heavy" or defName="Mechanent_Spacer_Trooper" or defName="Mechanent_Scavenger" or defName="Mechanent_Pirate" or defName="Persona_Spacer_Trooper" or defName="Persona_Pirate" ]</xpath>
 		<value>
@@ -63,6 +65,7 @@
 			<label>advanced grenadier</label>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/PawnKindDef[defName="Mechanent_Grenadier_EMP"]/weaponTags</xpath>
 		<value>

--- a/ModPatches/Rim-Robots!/Patches/Rim-Robots!/Personae_Body.xml
+++ b/ModPatches/Rim-Robots!/Patches/Rim-Robots!/Personae_Body.xml
@@ -13,24 +13,28 @@
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="PersonaeBody"]/corePart/parts/li[def="SyntheticNeck"]/parts/li[def="SyntheticHead"]/groups</xpath>
 		<value>
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="PersonaeBody"]/corePart/parts/li[def="SyntheticNeck"]/parts/li[def="SyntheticHead"]/parts/li[def="SyntheticEar"]/groups</xpath>
 		<value>
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="PersonaeBody"]/corePart/parts/li[def="SyntheticNeck"]/parts/li[def="SyntheticHead"]/parts/li[def="SyntheticNose"]/groups</xpath>
 		<value>
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="PersonaeBody"]/corePart/parts/li[def="SyntheticNeck"]/parts/li[def="SyntheticHead"]/parts/li[def="SyntheticJaw"]/groups</xpath>
 		<value>
@@ -44,18 +48,21 @@
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="PersonaeBody"]/corePart/parts/li[def="SyntheticShoulder"]/parts/li[def="SyntheticArm"]/groups</xpath>
 		<value>
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="PersonaeBody"]/corePart/parts/li[def="SyntheticShoulder"]/parts/li[def="SyntheticArm"]/parts/li[def="SyntheticHand"]/groups</xpath>
 		<value>
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="PersonaeBody"]/corePart/parts/li[def="SyntheticShoulder"]/parts/li[def="SyntheticArm"]/parts/li[def="SyntheticHand"]/parts/li[def="SyntheticFinger"]/groups</xpath>
 		<value>
@@ -69,18 +76,21 @@
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="PersonaeBody"]/corePart/parts/li[def="SyntheticLeg"]/groups</xpath>
 		<value>
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="PersonaeBody"]/corePart/parts/li[def="SyntheticLeg"]/parts/li[def="SyntheticFoot"]/groups</xpath>
 		<value>
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="PersonaeBody"]/corePart/parts/li[def="SyntheticLeg"]/parts/li[def="SyntheticFoot"]/parts/li[def="SyntheticToe"]/groups</xpath>
 		<value>

--- a/ModPatches/Rim-Sheks!/Patches/Rim-Sheks!/Patch_Bodies_Sheks.xml
+++ b/ModPatches/Rim-Sheks!/Patches/Rim-Sheks!/Patch_Bodies_Sheks.xml
@@ -8,102 +8,119 @@
 			<coverage>0.07</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="ShekBody"]/corePart/parts/li[def="Pelvis"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="ShekBody"]/corePart/parts/li[def="Stomach"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="ShekBody"]/corePart/parts/li[def="Heart"]/coverage</xpath>
 		<value>
 			<coverage>0.04</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="ShekBody"]/corePart/parts/li[def="Lung"]/coverage</xpath>
 		<value>
 			<coverage>0.055</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="ShekBody"]/corePart/parts/li[def="Kidney"]/coverage</xpath>
 		<value>
 			<coverage>0.03</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="ShekBody"]/corePart/parts/li[def="Liver"]/coverage</xpath>
 		<value>
 			<coverage>0.06</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="ShekBody"]/corePart/parts/li[def="Neck"]/coverage</xpath>
 		<value>
 			<coverage>0.055</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="ShekBody"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/parts/li[def="Brain"]/coverage</xpath>
 		<value>
 			<coverage>0.9</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="ShekBody"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Eye"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="ShekBody"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Ear"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="ShekBody"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]/coverage</xpath>
 		<value>
 			<coverage>0.08</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="ShekBody"]/corePart/parts/li[def="Shoulder"]/coverage</xpath>
 		<value>
 			<coverage>0.085</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="ShekBody"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Clavicle"]/coverage</xpath>
 		<value>
 			<coverage>0.06</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="ShekBody"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Humerus"]/coverage</xpath>
 		<value>
 			<coverage>0.15</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="ShekBody"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Radius"]/coverage</xpath>
 		<value>
 			<coverage>0.15</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="ShekBody"]/corePart/parts/li[def="Leg"]/parts/li[def="Femur"]/coverage</xpath>
 		<value>
 			<coverage>0.15</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="ShekBody"]/corePart/parts/li[def="Leg"]/parts/li[def="Tibia"]/coverage</xpath>
 		<value>

--- a/ModPatches/RimSec-Security/Patches/RimSec-Security/AlienBase.xml
+++ b/ModPatches/RimSec-Security/Patches/RimSec-Security/AlienBase.xml
@@ -35,6 +35,7 @@
 			<CarryWeight>60</CarryWeight>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperDefenderBase"]/statBases/ArmorRating_Sharp</xpath>
 		<value>

--- a/ModPatches/RimSec-Security/Patches/RimSec-Security/Bodies.xml
+++ b/ModPatches/RimSec-Security/Patches/RimSec-Security/Bodies.xml
@@ -29,12 +29,14 @@
 			<li>LeftShoulder</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="RSPeacekeeperBody"]//*[customLabel="right arm"]/groups</xpath>
 		<value>
 			<li>RightArm</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="RSPeacekeeperBody"]//*[customLabel="left arm"]/groups</xpath>
 		<value>

--- a/ModPatches/Rimcraft Metals/Patches/Rimcraft Metals/WOW_Metals_CE.xml
+++ b/ModPatches/Rimcraft Metals/Patches/Rimcraft Metals/WOW_Metals_CE.xml
@@ -151,6 +151,7 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="WoW_adamantite"]/statBases/SharpDamageMultiplier</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="WoW_adamantite"]/statBases/BluntDamageMultiplier</xpath>
 	</Operation>
@@ -188,6 +189,7 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="WoW_hardened_adamantite"]/statBases/SharpDamageMultiplier</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="WoW_hardened_adamantite"]/statBases/BluntDamageMultiplier</xpath>
 	</Operation>

--- a/ModPatches/Rimcraft Weaponry/Patches/Rimcraft Weaponry/WOW_Horde_CE.xml
+++ b/ModPatches/Rimcraft Weaponry/Patches/Rimcraft Weaponry/WOW_Horde_CE.xml
@@ -42,6 +42,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="WoWM_Horde_WarCleaver"]/statBases</xpath>
 		<value>
@@ -108,6 +109,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="WoWM_Horde_Gladius"]/statBases</xpath>
 		<value>

--- a/ModPatches/Rimcraft Weaponry/Patches/Rimcraft Weaponry/WOW_NightElves_CE.xml
+++ b/ModPatches/Rimcraft Weaponry/Patches/Rimcraft Weaponry/WOW_NightElves_CE.xml
@@ -41,6 +41,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="WoWM_NightElf_Tomahawk"]/statBases</xpath>
 		<value>

--- a/ModPatches/Rimcraft/Patches/Rimcraft/Patch_Bodies_WOW.xml
+++ b/ModPatches/Rimcraft/Patches/Rimcraft/Patch_Bodies_WOW.xml
@@ -7,102 +7,119 @@
 			<coverage>0.07</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Tauren"]/corePart/parts/li[def="Pelvis"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Tauren"]/corePart/parts/li[def="Stomach"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Tauren"]/corePart/parts/li[def="Heart"]/coverage</xpath>
 		<value>
 			<coverage>0.04</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Tauren"]/corePart/parts/li[def="Lung"]/coverage</xpath>
 		<value>
 			<coverage>0.055</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Tauren"]/corePart/parts/li[def="Kidney"]/coverage</xpath>
 		<value>
 			<coverage>0.03</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Tauren"]/corePart/parts/li[def="Liver"]/coverage</xpath>
 		<value>
 			<coverage>0.06</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Tauren"]/corePart/parts/li[def="Neck"]/coverage</xpath>
 		<value>
 			<coverage>0.055</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Tauren"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/parts/li[def="Brain"]/coverage</xpath>
 		<value>
 			<coverage>0.7</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Tauren"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Eye"]/coverage</xpath>
 		<value>
 			<coverage>0.04</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Tauren"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Ear"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Tauren"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]/coverage</xpath>
 		<value>
 			<coverage>0.08</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Tauren"]/corePart/parts/li[def="Shoulder"]/coverage</xpath>
 		<value>
 			<coverage>0.085</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Tauren"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Clavicle"]/coverage</xpath>
 		<value>
 			<coverage>0.06</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Tauren"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Humerus"]/coverage</xpath>
 		<value>
 			<coverage>0.15</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Tauren"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Radius"]/coverage</xpath>
 		<value>
 			<coverage>0.15</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Tauren"]/corePart/parts/li[def="Leg"]/parts/li[def="Femur"]/coverage</xpath>
 		<value>
 			<coverage>0.15</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Tauren"]/corePart/parts/li[def="Leg"]/parts/li[def="Tibia"]/coverage</xpath>
 		<value>
@@ -118,54 +135,63 @@
 			<coverage>0.012</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="WoWScourgeSkeleton_Body"]/corePart/parts/li[def="Pelvis"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="WoWScourgeSkeleton_Body"]/corePart/parts/li[def="WoWScourgeSkeleton_Neck"]/coverage</xpath>
 		<value>
 			<coverage>0.055</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="WoWScourgeSkeleton_Body"]/corePart/parts/li[def="WoWScourgeSkeleton_Shoulder"]/coverage</xpath>
 		<value>
 			<coverage>0.085</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="WoWScourgeSkeleton_Body"]/corePart/parts/li[def="WoWScourgeSkeleton_Shoulder"]/parts/li[def="Clavicle"]/coverage</xpath>
 		<value>
 			<coverage>0.06</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="WoWScourgeSkeleton_Body"]/corePart/parts/li[def="WoWScourgeSkeleton_Shoulder"]/parts/li[def="WoWScourgeSkeleton_Arm"]/parts/li[def="Humerus"]/coverage</xpath>
 		<value>
 			<coverage>0.15</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="WoWScourgeSkeleton_Body"]/corePart/parts/li[def="WoWScourgeSkeleton_Shoulder"]/parts/li[def="WoWScourgeSkeleton_Arm"]/parts/li[def="Radius"]/coverage</xpath>
 		<value>
 			<coverage>0.15</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="WoWScourgeSkeleton_Body"]/corePart/parts/li[def="WoWScourgeSkeleton_Leg"]/coverage</xpath>
 		<value>
 			<coverage>0.1</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="WoWScourgeSkeleton_Body"]/corePart/parts/li[def="WoWScourgeSkeleton_Leg"]/parts/li[def="Femur"]/coverage</xpath>
 		<value>
 			<coverage>0.15</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="WoWScourgeSkeleton_Body"]/corePart/parts/li[def="WoWScourgeSkeleton_Leg"]/parts/li[def="Tibia"]/coverage</xpath>
 		<value>

--- a/ModPatches/Rimmu-Nation - Weapons/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_Grenades.xml
+++ b/ModPatches/Rimmu-Nation - Weapons/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_Grenades.xml
@@ -5,30 +5,39 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="RNThrown_HeNade"]</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="RNProj_HEGrenade"]</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="RNThrown_Vodka"]</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="RNProj_Molotov"]</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="RNThrown_Flashbang"]</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="RNProj_Flash"]</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="RNThrown_Incendiary"]</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="RNProj_Incendiary"]</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="RNThrown_Smoke"]</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="RNProj_Smoke"]</xpath>
 	</Operation>

--- a/ModPatches/Rimsenal - Spacer Faction Pack/Defs/Rimsenal - Spacer Faction Pack/Recipes_Grenades.xml
+++ b/ModPatches/Rimsenal - Spacer Faction Pack/Defs/Rimsenal - Spacer Faction Pack/Recipes_Grenades.xml
@@ -1,22 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
 
-	<!-- Rimsenal Explosive Recipe Base -->
-	<RecipeDef Name="RSExplosive_RecipeBase" Abstract="true">
-		<workSpeedStat>GeneralLaborSpeed</workSpeedStat>
-		<effectWorking>Cook</effectWorking>
-		<soundWorking>Recipe_Smith</soundWorking>
-		<workSkill>Crafting</workSkill>
-		<unfinishedThingDef>UnfinishedGun</unfinishedThingDef>
-		<fixedIngredientFilter>
-			<thingDefs>
-				<li>Plasteel</li>
-				<li>ComponentIndustrial</li>
-				<li>FSX</li>
-			</thingDefs>
-		</fixedIngredientFilter>
-	</RecipeDef>
-
 	<!-- YP BaegYa Microwave Grenades -->
 	<RecipeDef ParentName="RSExplosive_RecipeBase">
 		<defName>Craft_10_Smartgrenade</defName>

--- a/ModPatches/Rimsenal - Spacer Faction Pack/Patches/Rimsenal - Spacer Faction Pack/Apparel_Spacer_CE.xml
+++ b/ModPatches/Rimsenal - Spacer Faction Pack/Patches/Rimsenal - Spacer Faction Pack/Apparel_Spacer_CE.xml
@@ -9,12 +9,14 @@
 			<Bulk>0</Bulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Unisuit"]/statBases/StuffEffectMultiplierArmor</xpath>
 		<value>
 			<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_Unisuit"]/apparel/bodyPartGroups</xpath>
 		<value>

--- a/ModPatches/Rimsenal Core/Defs/Rimsenal Core/Ammo_JI.xml
+++ b/ModPatches/Rimsenal Core/Defs/Rimsenal Core/Ammo_JI.xml
@@ -41,7 +41,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="88mmRPzBRocketBase" ParentName="MediumAmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="SiegeRocketBase" ParentName="MediumAmmoBase" Abstract="True">
 		<description>Bulky siege rockets, fired by the heaviest of Jotun Interstellar weaponry. An outer casing of high explosives around a shaped-charge core makes it capable of engaging both hard and soft targets.</description>
 		<statBases>
 			<MaxHitPoints>150</MaxHitPoints>
@@ -58,7 +58,7 @@
 		<cookOffSound>MortarBomb_Explode</cookOffSound>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="88mmRPzBRocketBase">
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="SiegeRocketBase">
 		<defName>Ammo_JIRocket</defName>
 		<label>Siege rocket</label>
 		<graphicData>

--- a/ModPatches/Rimsenal Core/Defs/Rimsenal Core/Ammo_TE.xml
+++ b/ModPatches/Rimsenal Core/Defs/Rimsenal Core/Ammo_TE.xml
@@ -110,30 +110,6 @@
 
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef ParentName="Base556x45mmNATOBullet">
-		<defName>Bullet_TEPowerCore_KE</defName>
-		<label>TE energy blast (KE)</label>
-		<graphicData>
-			<texPath>Things/Projectile/Harrower</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>		
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>400</speed>
-			<damageDef>KineticImpact</damageDef>
-			<damageAmountBase>8</damageAmountBase>
-			<armorPenetrationSharp>70</armorPenetrationSharp>
-			<armorPenetrationBlunt>160</armorPenetrationBlunt>
-		</projectile>
-		<comps>
-			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-			<damageAmountBase>10</damageAmountBase>
-			<explosiveDamageType>KineticImpact</explosiveDamageType>
-			<explosiveRadius>0.5</explosiveRadius>
-			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-			</li>
-		</comps>
-	</ThingDef>
-
 	<ThingDef Class="CombatExtended.Lasers.LaserBeamDefCE" ParentName="LaserBulletPurple">
 		<defName>Bullet_TEPowerCore_KE</defName>
 		<label>TE energy blast (KE)</label>

--- a/ModPatches/Rimsenal Core/Defs/Rimsenal Core/Rimsenal_AmmoCategories.xml
+++ b/ModPatches/Rimsenal Core/Defs/Rimsenal Core/Rimsenal_AmmoCategories.xml
@@ -37,13 +37,6 @@
 	</CombatExtended.AmmoCategoryDef>
 
 	<CombatExtended.AmmoCategoryDef>
-		<defName>FeralNail</defName>
-		<label>nail</label>
-		<labelShort>Nail</labelShort>
-		<description>A pointy, slightly rusted metal nail. Try not to step on it.</description>
-	</CombatExtended.AmmoCategoryDef>
-
-	<CombatExtended.AmmoCategoryDef>
 		<defName>MoltenShell</defName>
 		<label>molten shell</label>
 		<labelShort>MS</labelShort>

--- a/ModPatches/Rimsenal Core/Patches/Rimsenal Core/Apparel_RS_CE.xml
+++ b/ModPatches/Rimsenal Core/Patches/Rimsenal Core/Apparel_RS_CE.xml
@@ -1154,55 +1154,46 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationConditional">
+	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_AssaultArmor"]/verbs</xpath>
-		<match Class="PatchOperationSequence">
-			<operations>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="Apparel_AssaultArmor"]/verbs</xpath>
-					<value>
-						<verbs>
-							<li Class="CombatExtended.VerbPropertiesCE">
-								<label>launch EMP grenade</label>
-								<verbClass>CombatExtended.Verb_LaunchProjectileStaticCE</verbClass>
-								<hasStandardCommand>true</hasStandardCommand>
-								<onlyManualCast>True</onlyManualCast>
-								<warmupTime>1.5</warmupTime>
-								<range>40</range>
-								<minRange>5</minRange>
-								<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
-								<soundCast>Shot_IncendiaryLauncher</soundCast>
-								<soundCastTail>GunTail_Medium</soundCastTail>
-								<muzzleFlashScale>14</muzzleFlashScale>
-								<drawHighlightWithLineOfSight>true</drawHighlightWithLineOfSight>
-								<targetParams>
-									<canTargetLocations>true</canTargetLocations>
-								</targetParams>
-								<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
-								<defaultProjectile>Bullet_30x29mmGrenade_EMP</defaultProjectile>
-								<rangedFireRulepack>Combat_RangedFire_Thrown</rangedFireRulepack>
-							</li>
-						</verbs>
-					</value>
+		<value>
+			<verbs>
+				<li Class="CombatExtended.VerbPropertiesCE">
+					<label>launch EMP grenade</label>
+					<verbClass>CombatExtended.Verb_LaunchProjectileStaticCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<onlyManualCast>True</onlyManualCast>
+					<warmupTime>1.5</warmupTime>
+					<range>40</range>
+					<minRange>5</minRange>
+					<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
+					<soundCast>Shot_IncendiaryLauncher</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>14</muzzleFlashScale>
+					<drawHighlightWithLineOfSight>true</drawHighlightWithLineOfSight>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+					<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
+					<defaultProjectile>Bullet_30x29mmGrenade_EMP</defaultProjectile>
+					<rangedFireRulepack>Combat_RangedFire_Thrown</rangedFireRulepack>
 				</li>
+			</verbs>
+		</value>
+	</Operation>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="Apparel_AssaultArmor"]/comps/li[@Class="CompProperties_Reloadable"]/ammoDef</xpath>
-					<value>
-						<ammoDef>Ammo_30x29mmGrenade_EMP</ammoDef>
-					</value>
-				</li>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_AssaultArmor"]/comps/li[@Class="CompProperties_ApparelReloadable"]/ammoDef</xpath>
+		<value>
+			<ammoDef>Ammo_30x29mmGrenade_EMP</ammoDef>
+		</value>
+	</Operation>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="Apparel_AssaultArmor"]/comps/li[@Class="CompProperties_Reloadable"]/ammoCountPerCharge</xpath>
-					<value>
-						<ammoCountPerCharge>1</ammoCountPerCharge>
-					</value>
-				</li>
-
-			</operations>
-		</match>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_AssaultArmor"]/comps/li[@Class="CompProperties_ApparelReloadable"]/ammoCountPerCharge</xpath>
+		<value>
+			<ammoCountPerCharge>1</ammoCountPerCharge>
+		</value>
 	</Operation>
 
 	<!-- ========== Assault Helmet =========== -->
@@ -1461,18 +1452,21 @@
 			<WornBulk>20</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Korp"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>15</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Korp"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>37.5</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Korp"]/equippedStatOffsets/MoveSpeed</xpath>
 		<value>
@@ -1497,55 +1491,46 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationConditional">
+	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Korp"]/verbs</xpath>
-		<match Class="PatchOperationSequence">
-			<operations>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="Apparel_Korp"]/verbs</xpath>
-					<value>
-						<verbs>
-							<li Class="CombatExtended.VerbPropertiesCE">
-								<label>launch crow feeder</label>
-								<verbClass>CombatExtended.Verb_LaunchProjectileStaticCE</verbClass>
-								<hasStandardCommand>true</hasStandardCommand>
-								<onlyManualCast>True</onlyManualCast>
-								<warmupTime>1.5</warmupTime>
-								<range>55</range>
-								<minRange>5</minRange>
-								<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
-								<soundCast>RS_ShotGrendel</soundCast>
-								<soundCastTail>GunTail_Medium</soundCastTail>
-								<muzzleFlashScale>16</muzzleFlashScale>
-								<drawHighlightWithLineOfSight>true</drawHighlightWithLineOfSight>
-								<targetParams>
-									<canTargetLocations>true</canTargetLocations>
-								</targetParams>
-								<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
-								<defaultProjectile>Bullet_JICrowFeeder</defaultProjectile>
-								<rangedFireRulepack>Combat_RangedFire_Thrown</rangedFireRulepack>
-							</li>
-						</verbs>
-					</value>
+		<value>
+			<verbs>
+				<li Class="CombatExtended.VerbPropertiesCE">
+					<label>launch crow feeder</label>
+					<verbClass>CombatExtended.Verb_LaunchProjectileStaticCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<onlyManualCast>True</onlyManualCast>
+					<warmupTime>1.5</warmupTime>
+					<range>55</range>
+					<minRange>5</minRange>
+					<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
+					<soundCast>RS_ShotGrendel</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>16</muzzleFlashScale>
+					<drawHighlightWithLineOfSight>true</drawHighlightWithLineOfSight>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+					<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
+					<defaultProjectile>Bullet_JICrowFeeder</defaultProjectile>
+					<rangedFireRulepack>Combat_RangedFire_Thrown</rangedFireRulepack>
 				</li>
+			</verbs>
+		</value>
+	</Operation>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="Apparel_Korp"]/comps/li[@Class="CompProperties_Reloadable"]/ammoDef</xpath>
-					<value>
-						<ammoDef>Ammo_JI_Alloy</ammoDef>
-					</value>
-				</li>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_Korp"]/comps/li[@Class="CompProperties_ApparelReloadable"]/ammoDef</xpath>
+		<value>
+			<ammoDef>Ammo_JI_Alloy</ammoDef>
+		</value>
+	</Operation>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="Apparel_Korp"]/comps/li[@Class="CompProperties_Reloadable"]/ammoCountPerCharge</xpath>
-					<value>
-						<ammoCountPerCharge>80</ammoCountPerCharge>
-					</value>
-				</li>
-
-			</operations>
-		</match>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_Korp"]/comps/li[@Class="CompProperties_ApparelReloadable"]/ammoCountPerCharge</xpath>
+		<value>
+			<ammoCountPerCharge>80</ammoCountPerCharge>
+		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAddModExtension">
@@ -1604,24 +1589,28 @@
 			<WornBulk>18</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_ReflactorArmor"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>18</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_ReflactorArmor"]/statBases/ArmorRating_Heat</xpath>
 		<value>
 			<ArmorRating_Heat>10</ArmorRating_Heat>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_ReflactorArmor"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>54</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_ReflactorArmor"]/equippedStatOffsets/MoveSpeed</xpath>
 		<value>
@@ -1710,18 +1699,21 @@
 			<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_ReflactorArmorH"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>15</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_ReflactorArmorH"]/statBases/ArmorRating_Heat</xpath>
 		<value>
 			<ArmorRating_Heat>10</ArmorRating_Heat>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_ReflactorArmorH"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
@@ -1779,18 +1771,21 @@
 			<WornBulk>15</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_HazardCarapace"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>16</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_HazardCarapace"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>36</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_HazardCarapace"]/statBases/ArmorRating_Heat</xpath>
 		<value>
@@ -1798,6 +1793,7 @@
 			<ArmorRating_Electric>1</ArmorRating_Electric>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_HazardCarapace"]/equippedStatOffsets/MoveSpeed</xpath>
 		<value>
@@ -1805,6 +1801,7 @@
 			<CarryBulk>25</CarryBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_HazardCarapace"]/costList/Plasteel</xpath>
 		<value>
@@ -1872,18 +1869,21 @@
 			<NightVisionEfficiency_Apparel>0.7</NightVisionEfficiency_Apparel>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_HazardCarapaceH"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>14</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_HazardCarapaceH"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>31.5</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_HazardCarapaceH"]/statBases/ArmorRating_Heat</xpath>
 		<value>
@@ -1941,6 +1941,7 @@
 			<WornBulk>20</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_CloseCombatArmor"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
@@ -1954,6 +1955,7 @@
 			<ArmorRating_Blunt>60</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_CloseCombatArmor"]/equippedStatOffsets</xpath>
 		<value>
@@ -2050,12 +2052,14 @@
 			<WornBulk>1</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_CloseCombatHelmet"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>16</ArmorRating_Sharp>
 		</value>
 	</Operation>
+	
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_CloseCombatHelmet"]/statBases/ArmorRating_Blunt</xpath>
 		<value>

--- a/ModPatches/Rimsenal Core/Patches/Rimsenal Core/Apparel_RS_CE.xml
+++ b/ModPatches/Rimsenal Core/Patches/Rimsenal Core/Apparel_RS_CE.xml
@@ -8,24 +8,28 @@
 			<Bulk>4</Bulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Carbonsuit"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>1</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Carbonsuit"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>4</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Carbonsuit"]/statBases/ArmorRating_Heat</xpath>
 		<value>
 			<ArmorRating_Heat>0.5</ArmorRating_Heat>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Carbonsuit"]/apparel/bodyPartGroups</xpath>
 		<value>
@@ -927,6 +931,7 @@
 			<WornBulk>10</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_Strikesuit"]/apparel/bodyPartGroups</xpath>
 		<value>
@@ -934,6 +939,7 @@
 			<li>Feet</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_Strikesuit"]/equippedStatOffsets</xpath>
 		<value>
@@ -1207,12 +1213,14 @@
 			<NightVisionEfficiency_Apparel>0.3</NightVisionEfficiency_Apparel>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_AssaultArmorH"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>25</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_AssaultArmorH"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
@@ -1271,18 +1279,21 @@
 			<WornBulk>20</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_FSArmor"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>15</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_FSArmor"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>37.5</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_FSArmor"]/equippedStatOffsets/MoveSpeed</xpath>
 		<value>
@@ -1372,12 +1383,14 @@
 			<NightVisionEfficiency_Apparel>0.9</NightVisionEfficiency_Apparel>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_FSArmorH"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>14</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_FSArmorH"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
@@ -1816,6 +1829,7 @@
 			<Uranium>65</Uranium>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_HazardCarapace"]/apparel/bodyPartGroups</xpath>
 		<value>

--- a/ModPatches/Rimsenal Core/Patches/Rimsenal Core/Apparel_RS_CE.xml
+++ b/ModPatches/Rimsenal Core/Patches/Rimsenal Core/Apparel_RS_CE.xml
@@ -1740,11 +1740,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Apparel_ReflactorArmorH"]</xpath>
+		<xpath>Defs/ThingDef[defName="Apparel_ReflactorArmorH"]/equippedStatOffsets</xpath>
 		<value>
-			<equippedStatOffsets>
-				<SmokeSensitivity>-1</SmokeSensitivity>
-			</equippedStatOffsets>
+			<SmokeSensitivity>-1</SmokeSensitivity>
 		</value>
 	</Operation>
 

--- a/ModPatches/Rimsenal Core/Patches/Rimsenal Core/Rimsenal_Melee.xml
+++ b/ModPatches/Rimsenal Core/Patches/Rimsenal Core/Rimsenal_Melee.xml
@@ -190,12 +190,23 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationAdd">
+	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="YP_BingJu"]/weaponTags</xpath>
-		<value>
-			<li>CE_OneHandedWeapon</li>
-		</value>
-	</Operation>	
+		<match Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="YP_BingJu"]/weaponTags</xpath>
+			<value>
+				<li>CE_OneHandedWeapon</li>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="YP_BingJu"]</xpath>
+			<value>
+				<weaponTags>
+					<li>CE_OneHandedWeapon</li>
+				</weaponTags>
+			</value>
+		</nomatch>
+	</Operation>
 
 	<!-- JI Assault Hammer -->
 	<Operation Class="PatchOperationReplace">

--- a/ModPatches/Rimsenal Core/Patches/Rimsenal Core/Rimsenal_Melee.xml
+++ b/ModPatches/Rimsenal Core/Patches/Rimsenal Core/Rimsenal_Melee.xml
@@ -41,6 +41,7 @@
 			</tools>
 		</value>
 	</Operation>
+	
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="MeleeWeapon_TorchSword"]/statBases</xpath>
 		<value>
@@ -48,6 +49,7 @@
 			<Bulk>6.5</Bulk>
 		</value>
 	</Operation>
+	
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="MeleeWeapon_TorchSword"]</xpath>
 		<value>
@@ -96,6 +98,7 @@
 			</tools>
 		</value>
 	</Operation>
+	
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="GD_Sabertooth"]/statBases</xpath>
 		<value>
@@ -103,9 +106,11 @@
 			<Bulk>3.5</Bulk>
 		</value>
 	</Operation>
+	
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="GD_Sabertooth"]/equippedStatOffsets</xpath>
 	</Operation>
+	
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="GD_Sabertooth"]</xpath>
 		<value>
@@ -116,6 +121,7 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+	
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="GD_Sabertooth"]/weaponTags</xpath>
 		<value>
@@ -164,6 +170,7 @@
 			</tools>
 		</value>
 	</Operation>
+	
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="YP_BingJu"]/statBases</xpath>
 		<value>
@@ -171,6 +178,7 @@
 			<Bulk>2.5</Bulk>
 		</value>
 	</Operation>
+	
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="YP_BingJu"]</xpath>
 		<value>
@@ -181,23 +189,13 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
-	<Operation Class="PatchOperationConditional">
+
+	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="YP_BingJu"]/weaponTags</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="YP_BingJu"]</xpath>
-			<value>
-				<weaponTags>
-					<li>CE_OneHandedWeapon</li>
-				</weaponTags>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="YP_BingJu"]/weaponTags</xpath>
-			<value>
-				<li>CE_OneHandedWeapon</li>
-			</value>
-		</match>
-	</Operation>
+		<value>
+			<li>CE_OneHandedWeapon</li>
+		</value>
+	</Operation>	
 
 	<!-- JI Assault Hammer -->
 	<Operation Class="PatchOperationReplace">
@@ -228,6 +226,7 @@
 			</tools>
 		</value>
 	</Operation>
+	
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="JI_Ormbane"]/statBases</xpath>
 		<value>
@@ -235,9 +234,11 @@
 			<Bulk>9</Bulk>
 		</value>
 	</Operation>
+	
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="JI_Ormbane"]/equippedStatOffsets</xpath>
 	</Operation>
+	
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="JI_Ormbane"]</xpath>
 		<value>
@@ -282,6 +283,7 @@
 			</tools>
 		</value>
 	</Operation>
+	
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="TE_Eris"]/statBases</xpath>
 		<value>
@@ -289,6 +291,7 @@
 			<MeleeCounterParryBonus>0.15</MeleeCounterParryBonus>
 		</value>
 	</Operation>
+	
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="TE_Eris"]</xpath>
 		<value>
@@ -299,6 +302,7 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+	
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="TE_Eris"]/weaponTags</xpath>
 		<value>

--- a/ModPatches/Rimsenal Core/Patches/Rimsenal Core/Weapons_GD_CE.xml
+++ b/ModPatches/Rimsenal Core/Patches/Rimsenal Core/Weapons_GD_CE.xml
@@ -15,8 +15,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="GD_MSSH" or
 			defName="GD_MSST" or
-			defName="GD_MSSF" or
-			defName="GD_TacticalPistol"
+			defName="GD_MSSF"
 			]/tools </xpath>
 		<value>
 			<tools>
@@ -54,46 +53,6 @@
 			defName="GD_ModularLMG" or
 			defName="GD_GrenadeLauncher"
 			]/tools </xpath>
-		<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-					<label>stock</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>8</power>
-					<cooldownTime>1.55</cooldownTime>
-					<chanceFactor>1.5</chanceFactor>
-					<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>barrel</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>5</power>
-					<cooldownTime>2.02</cooldownTime>
-					<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>muzzle</label>
-					<capacities>
-						<li>Poke</li>
-					</capacities>
-					<power>8</power>
-					<cooldownTime>1.55</cooldownTime>
-					<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-				</li>
-			</tools>
-		</value>
-	</Operation>
-
-	<!-- Carcal -->
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/thingDef[defName="GD_HVSMG"]</xpath>
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
@@ -250,13 +209,26 @@
 		</FireModes>
 	</Operation>
 
-	<Operation Class="PatchOperationAdd">
+	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="GD_MSST"]/weaponTags</xpath>
-		<value>
-			<li>CE_Sidearm</li>
-			<li>CE_AI_Pistol</li>
-			<li>CE_OneHandedWeapon</li>
-		</value>
+		<match Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="GD_MSST"]/weaponTags</xpath>
+			<value>
+				<li>CE_Sidearm</li>
+				<li>CE_AI_Pistol</li>
+				<li>CE_OneHandedWeapon</li>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="GD_MSST"]</xpath>
+			<value>
+				<weaponTags>
+					<li>CE_Sidearm</li>
+					<li>CE_AI_Pistol</li>
+					<li>CE_OneHandedWeapon</li>
+				</weaponTags>
+			</value>
+		</nomatch>
 	</Operation>
 
 	<!-- ==========  Modular Spitfire =========== -->
@@ -312,13 +284,26 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationAdd">
+	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/thingDef[defName="GD_MSSS"]/weaponTags</xpath>
-		<value>
-			<li>CE_Sidearm</li>
-			<li>CE_AI_Pistol</li>
-			<li>CE_OneHandedWeapon</li>
-		</value>
+		<match Class="PatchOperationAdd">
+			<xpath>Defs/thingDef[defName="GD_MSSS"]/weaponTags</xpath>
+			<value>
+				<li>CE_Sidearm</li>
+				<li>CE_AI_Pistol</li>
+				<li>CE_OneHandedWeapon</li>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/thingDef[defName="GD_MSSS"]</xpath>
+			<value>
+				<weaponTags>
+					<li>CE_Sidearm</li>
+					<li>CE_AI_Pistol</li>
+					<li>CE_OneHandedWeapon</li>
+				</weaponTags>
+			</value>
+		</nomatch>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
@@ -381,56 +366,22 @@
 		<FireModes />
 	</Operation>
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="GD_MSSF"]</xpath>
-		<value>
-			<weaponTags>
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="GD_MSSF"]/weaponTags</xpath>
+		<match Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="GD_MSSF"]/weaponTags</xpath>
+			<value>
 				<li>CE_OneHandedWeapon</li>
-			</weaponTags>
-		</value>
-	</Operation>
-
-	<!-- ==========  Tactical Pistol =========== -->
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>GD_TacticalPistol</defName>
-		<statBases>
-			<Mass>1.25</Mass>
-			<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
-			<SightsEfficiency>0.7</SightsEfficiency>
-			<ShotSpread>0.18</ShotSpread>
-			<SwayFactor>1.02</SwayFactor>
-			<Bulk>1.25</Bulk>
-		</statBases>
-		<Properties>
-			<recoilAmount>2</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
-			<warmupTime>0.6</warmupTime>
-			<range>12</range>
-			<soundCast>ShotLynx</soundCast>
-			<soundCastTail>GunTail_Light</soundCastTail>
-			<muzzleFlashScale>9</muzzleFlashScale>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>14</magazineSize>
-			<reloadTime>4</reloadTime>
-			<ammoSet>AmmoSet_45ACP</ammoSet>
-		</AmmoUser>
-		<FireModes>
-		</FireModes>
-		<weaponTags>
-			<li>CE_OneHandedWeapon</li>
-		</weaponTags>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="GD_TacticalPistol"]</xpath>
-		<value>
-			<weaponTags>
-				<li>CE_OneHandedWeapon</li>
-			</weaponTags>
-		</value>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="GD_MSSF"]</xpath>
+			<value>
+				<weaponTags>
+					<li>CE_OneHandedWeapon</li>
+				</weaponTags>
+			</value>
+		</nomatch>
 	</Operation>
 
 	<!-- ==========  Modular Carbine =========== -->
@@ -510,11 +461,22 @@
 		</FireModes>
 	</Operation>
 
-	<Operation Class="PatchOperationAdd">
+	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="GD_ModularRifle"]/weaponTags</xpath>
-		<value>
-			<li>CE_AI_Rifle</li>
-		</value>
+		<match Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="GD_ModularRifle"]/weaponTags</xpath>
+			<value>
+				<li>CE_AI_Rifle</li>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="GD_ModularRifle"]</xpath>
+			<value>
+				<weaponTags>
+					<li>CE_AI_Rifle</li>
+				</weaponTags>
+			</value>
+		</nomatch>
 	</Operation>
 
 	<!-- ==========  Modular DMR =========== -->

--- a/ModPatches/Rimsenal Core/Patches/Rimsenal Core/Weapons_GD_CE.xml
+++ b/ModPatches/Rimsenal Core/Patches/Rimsenal Core/Weapons_GD_CE.xml
@@ -44,6 +44,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<!-- Long guns-->
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="GD_HybridRifle" or
@@ -89,6 +90,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<!-- Carcal -->
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/thingDef[defName="GD_HVSMG"]</xpath>
@@ -163,9 +165,13 @@
 			<aiUseBurstMode>TRUE</aiUseBurstMode>
 			<aiAimMode>AimedShot</aiAimMode>
 		</FireModes>
-		<weaponTags>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="GD_HybridRifle"]/weaponTags</xpath>
+		<value>
 			<li>CE_AI_Rifle</li>
-		</weaponTags>
+		</value>
 	</Operation>
 
 	<!-- ==========  Hybrid Ocelot =========== -->
@@ -197,11 +203,15 @@
 		</AmmoUser>
 		<FireModes>
 		</FireModes>
-		<weaponTags>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="GD_MSSH"]/weaponTags</xpath>
+		<value>
 			<li>CE_Sidearm</li>
 			<li>CE_AI_Pistol</li>
 			<li>CE_OneHandedWeapon</li>
-		</weaponTags>
+		</value>
 	</Operation>
 
 	<!-- ==========  Modular Triple-shot =========== -->
@@ -238,11 +248,15 @@
 		<FireModes>
 			<noSingleShot>true</noSingleShot>
 		</FireModes>
-		<weaponTags>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="GD_MSST"]/weaponTags</xpath>
+		<value>
 			<li>CE_Sidearm</li>
 			<li>CE_AI_Pistol</li>
 			<li>CE_OneHandedWeapon</li>
-		</weaponTags>
+		</value>
 	</Operation>
 
 	<!-- ==========  Modular Spitfire =========== -->
@@ -260,6 +274,7 @@
 			</statBases>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/thingDef[defName="GD_MSSS"]/verbs</xpath>
 		<value>
@@ -280,6 +295,7 @@
 			</verbs>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/thingDef[defName="GD_MSSS"]</xpath>
 		<value>
@@ -293,13 +309,18 @@
 					<aimedBurstShotCount>3</aimedBurstShotCount>
 				</li>
 			</comps>
-			<weaponTags>
-				<li>CE_Sidearm</li>
-				<li>CE_AI_Pistol</li>
-				<li>CE_OneHandedWeapon</li>
-			</weaponTags>
 		</value>
 	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/thingDef[defName="GD_MSSS"]/weaponTags</xpath>
+		<value>
+			<li>CE_Sidearm</li>
+			<li>CE_AI_Pistol</li>
+			<li>CE_OneHandedWeapon</li>
+		</value>
+	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/thingDef[defName="GD_MSSS"]/tools</xpath>
 		<value>
@@ -357,11 +378,16 @@
 			<reloadTime>2.6</reloadTime>
 			<ammoSet>AmmoSet_25x40mmGrenade</ammoSet>
 		</AmmoUser>
-		<FireModes>
-		</FireModes>
-		<weaponTags>
-			<li>CE_OneHandedWeapon</li>
-		</weaponTags>
+		<FireModes />
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="GD_MSSF"]</xpath>
+		<value>
+			<weaponTags>
+				<li>CE_OneHandedWeapon</li>
+			</weaponTags>
+		</value>
 	</Operation>
 
 	<!-- ==========  Tactical Pistol =========== -->
@@ -396,6 +422,15 @@
 		<weaponTags>
 			<li>CE_OneHandedWeapon</li>
 		</weaponTags>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="GD_TacticalPistol"]</xpath>
+		<value>
+			<weaponTags>
+				<li>CE_OneHandedWeapon</li>
+			</weaponTags>
+		</value>
 	</Operation>
 
 	<!-- ==========  Modular Carbine =========== -->
@@ -473,9 +508,13 @@
 			<aiUseBurstMode>TRUE</aiUseBurstMode>
 			<aiAimMode>AimedShot</aiAimMode>
 		</FireModes>
-		<weaponTags>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="GD_ModularRifle"]/weaponTags</xpath>
+		<value>
 			<li>CE_AI_Rifle</li>
-		</weaponTags>
+		</value>
 	</Operation>
 
 	<!-- ==========  Modular DMR =========== -->
@@ -519,6 +558,14 @@
 		</weaponTags>
 	</Operation>
 
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="GD_ModularDMR"]/weaponTags</xpath>
+		<value>
+			<li>SniperRifle</li>
+			<li>Bipod_DMR</li>
+		</value>
+	</Operation>
+
 	<!-- ==========  Modular LMG =========== -->
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>GD_ModularLMG</defName>
@@ -557,64 +604,13 @@
 			<aiUseBurstMode>False</aiUseBurstMode>
 			<aiAimMode>SuppressFire</aiAimMode>
 		</FireModes>
-		<weaponTags>
-			<li>CE_MachineGun</li>
-			<li>Bipod_LMG</li>
-		</weaponTags>
 	</Operation>
 
-	<!-- ==========  Caracal SMG =========== -->
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/thingDef[defName="GD_HVSMG"]/statBases</xpath>
-		<value>
-			<statBases>
-				<WorkToMake>50</WorkToMake>
-				<SightsEfficiency>1</SightsEfficiency>
-				<ShotSpread>0.17</ShotSpread>
-				<SwayFactor>0.55</SwayFactor>
-				<Bulk>2.31</Bulk>
-				<Mass>3.2</Mass>
-				<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-			</statBases>
-		</value>
-	</Operation>
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/thingDef[defName="GD_HVSMG"]/verbs</xpath>
-		<value>
-			<verbs>
-				<li Class="CombatExtended.VerbPropertiesCE">
-					<recoilAmount>1.58</recoilAmount>
-					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-					<hasStandardCommand>true</hasStandardCommand>
-					<defaultProjectile>Bullet_9x19mmPara_FMJ</defaultProjectile>
-					<warmupTime>0.6</warmupTime>
-					<burstShotCount>6</burstShotCount>
-					<ticksBetweenBurstShots>7</ticksBetweenBurstShots>
-					<range>16</range>
-					<soundCast>ShotCaracal</soundCast>
-					<soundCastTail>GunTail_Light</soundCastTail>
-					<muzzleFlashScale>9</muzzleFlashScale>
-				</li>
-			</verbs>
-		</value>
-	</Operation>
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/thingDef[defName="GD_HVSMG"]</xpath>
+		<xpath>Defs/ThingDef[defName="GD_ModularLMG"]/weaponTags</xpath>
 		<value>
-			<comps>
-				<li Class="CombatExtended.CompProperties_AmmoUser">
-					<magazineSize>36</magazineSize>
-					<reloadTime>4.5</reloadTime>
-					<ammoSet>AmmoSet_9x19mmPara</ammoSet>
-				</li>
-				<li Class="CombatExtended.CompProperties_FireModes">
-					<aimedBurstShotCount>3</aimedBurstShotCount>
-				</li>
-			</comps>
-			<weaponTags>
-				<li>CE_SMG</li>
-				<li>CE_AI_AssaultWeapon</li>
-			</weaponTags>
+			<li>CE_MachineGun</li>
+			<li>Bipod_LMG</li>
 		</value>
 	</Operation>
 
@@ -673,4 +669,5 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/thingDef[defName="GD_SKGrenadeLauncher"]</xpath>
 	</Operation>
+
 </Patch>

--- a/ModPatches/Rimsenal Core/Patches/Rimsenal Core/Weapons_JI_CE.xml
+++ b/ModPatches/Rimsenal Core/Patches/Rimsenal Core/Weapons_JI_CE.xml
@@ -108,6 +108,7 @@
 			</statBases>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/thingDef[defName="JI_Trollsverd"]/verbs</xpath>
 		<value>
@@ -127,6 +128,7 @@
 			</verbs>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/thingDef[defName="JI_Trollsverd"]</xpath>
 		<value>
@@ -141,6 +143,7 @@
 			</comps>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/thingDef[defName="JI_Trollsverd"]/weaponTags</xpath>
 		<value>
@@ -164,6 +167,7 @@
 			</statBases>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/thingDef[defName="JI_Hrunting"]/verbs</xpath>
 		<value>
@@ -185,6 +189,7 @@
 			</verbs>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/thingDef[defName="JI_Hrunting"]</xpath>
 		<value>
@@ -202,6 +207,7 @@
 			</comps>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/thingDef[defName="JI_Hrunting"]</xpath>
 		<value>

--- a/ModPatches/Rimsenal Core/Patches/Rimsenal Core/Weapons_JI_CE.xml
+++ b/ModPatches/Rimsenal Core/Patches/Rimsenal Core/Weapons_JI_CE.xml
@@ -33,10 +33,11 @@
 	</Operation>
 	<!-- Long guns-->
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/thingDef[defName="JI_Hrunting" or
+		<xpath>Defs/thingDef[
+			defName="JI_Hrunting" or
 			defName="JI_Gramr" or
 			defName="JI_Muspell"
-			] </xpath>
+			]</xpath>
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
@@ -75,9 +76,7 @@
 	</Operation>
 	<!-- Heavy Weapons -->
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/thingDef[defName="JI_Grendel" or
-			defName="JI_Fafnir"
-			] </xpath>
+		<xpath>Defs/thingDef[defName="JI_Grendel" or defName="JI_Fafnir"] </xpath>
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
@@ -228,6 +227,7 @@
 			</statBases>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/thingDef[defName="JI_Gramr"]/verbs</xpath>
 		<value>
@@ -247,6 +247,7 @@
 			</verbs>
 		</value>
 	</Operation>
+	
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/thingDef[defName="JI_Gramr"]</xpath>
 		<value>
@@ -261,10 +262,9 @@
 					<aiAimMode>AimedShot</aiAimMode>
 				</li>
 			</comps>
-			<weaponTags>
-			</weaponTags>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/thingDef[defName="JI_Gramr"]</xpath>
 		<value>
@@ -274,11 +274,23 @@
 			</li>
 		</value>
 	</Operation>
-	<Operation Class="PatchOperationAdd">
+
+	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/thingDef[defName="JI_Gramr"]/weaponTags</xpath>
-		<value>
-			<li>Bipod_AMR</li>
-		</value>
+		<match Class="PatchOperationAdd">
+			<xpath>Defs/thingDef[defName="JI_Gramr"]/weaponTags</xpath>
+			<value>
+				<li>Bipod_AMR</li>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/thingDef[defName="JI_Gramr"]</xpath>
+			<value>
+				<weaponTags>
+					<li>Bipod_AMR</li>
+				</weaponTags>
+			</value>
+		</nomatch>
 	</Operation>
 
 	<!-- ========== Grendel Rocket Launcher =========== -->
@@ -296,6 +308,7 @@
 			</statBases>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/thingDef[defName="JI_Grendel"]/verbs</xpath>
 		<value>
@@ -318,6 +331,7 @@
 			</verbs>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/thingDef[defName="JI_Grendel"]</xpath>
 		<value>
@@ -332,8 +346,6 @@
 					<aiAimMode>AimedShot</aiAimMode>
 				</li>
 			</comps>
-			<weaponTags>
-			</weaponTags>
 		</value>
 	</Operation>
 
@@ -362,6 +374,7 @@
 			</statBases>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/thingDef[defName="JI_Muspell"]/verbs</xpath>
 		<value>
@@ -386,6 +399,7 @@
 			</verbs>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/thingDef[defName="JI_Muspell"]</xpath>
 		<value>
@@ -401,10 +415,9 @@
 					<aiAimMode>SuppressFire</aiAimMode>
 				</li>
 			</comps>
-			<weaponTags>
-			</weaponTags>
 		</value>
 	</Operation>
+	
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/thingDef[defName="JI_Muspell"]</xpath>
 		<value>
@@ -430,6 +443,7 @@
 			</statBases>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/thingDef[defName="JI_Fafnir"]/verbs</xpath>
 		<value>
@@ -449,6 +463,7 @@
 			</verbs>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/thingDef[defName="JI_Fafnir"]</xpath>
 		<value>
@@ -460,10 +475,9 @@
 				</li>
 				<li Class="CombatExtended.CompProperties_FireModes"/>
 			</comps>
-			<weaponTags>
-			</weaponTags>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/thingDef[defName="JI_Fafnir"]</xpath>
 		<value>
@@ -473,4 +487,5 @@
 			</li>
 		</value>
 	</Operation>
+
 </Patch>

--- a/ModPatches/Rimsenal Core/Patches/Rimsenal Core/Weapons_TE_CE.xml
+++ b/ModPatches/Rimsenal Core/Patches/Rimsenal Core/Weapons_TE_CE.xml
@@ -165,6 +165,7 @@
 			</statBases>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/thingDef[defName="TE_KineticPistol"]/verbs</xpath>
 		<value>
@@ -184,6 +185,7 @@
 			</verbs>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/thingDef[defName="TE_KineticPistol"]</xpath>
 		<value>
@@ -214,6 +216,7 @@
 			</statBases>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/thingDef[defName="TE_ThuddGun"]/verbs</xpath>
 		<value>
@@ -233,6 +236,7 @@
 			</verbs>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/thingDef[defName="TE_ThuddGun"]</xpath>
 		<value>
@@ -263,6 +267,7 @@
 			</statBases>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/thingDef[defName="TE_KineticLongRifle"]/verbs</xpath>
 		<value>
@@ -282,6 +287,7 @@
 			</verbs>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/thingDef[defName="TE_KineticLongRifle"]</xpath>
 		<value>
@@ -313,6 +319,7 @@
 			</statBases>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/thingDef[defName="TE_StormCannon"]/verbs</xpath>
 		<value>
@@ -337,6 +344,7 @@
 			</verbs>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/thingDef[defName="TE_StormCannon"]</xpath>
 		<value>
@@ -369,6 +377,7 @@
 			</statBases>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/thingDef[defName="TE_KineticLance"]/verbs</xpath>
 		<value>
@@ -390,6 +399,7 @@
 			</verbs>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/thingDef[defName="TE_KineticLance"]</xpath>
 		<value>

--- a/ModPatches/Rimsenal Core/Patches/Rimsenal Core/Weapons_TE_CE.xml
+++ b/ModPatches/Rimsenal Core/Patches/Rimsenal Core/Weapons_TE_CE.xml
@@ -31,6 +31,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<!-- Long guns-->
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/thingDef[defName="TE_KineticRifle" or
@@ -74,6 +75,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<!-- Heavy Weapons -->
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/thingDef[defName="TE_KineticLance"]</xpath>
@@ -108,6 +110,7 @@
 			</statBases>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/thingDef[defName="TE_KineticRifle"]/verbs</xpath>
 		<value>
@@ -129,6 +132,7 @@
 			</verbs>
 		</value>
 	</Operation>
+	
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/thingDef[defName="TE_KineticRifle"]</xpath>
 		<value>

--- a/ModPatches/Rimsenal Core/Patches/Rimsenal Core/Weapons_YP_CE.xml
+++ b/ModPatches/Rimsenal Core/Patches/Rimsenal Core/Weapons_YP_CE.xml
@@ -110,6 +110,7 @@
 			</statBases>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="YP_SeoLi"]/verbs</xpath>
 		<value>
@@ -130,6 +131,7 @@
 			</verbs>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="YP_SeoLi"]</xpath>
 		<value>
@@ -163,6 +165,7 @@
 			</statBases>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="YP_SagPung"]/verbs</xpath>
 		<value>
@@ -184,6 +187,7 @@
 			</verbs>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="YP_SagPung"]</xpath>
 		<value>
@@ -217,6 +221,7 @@
 			</statBases>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="YP_SangAe"]/verbs</xpath>
 		<value>
@@ -237,6 +242,7 @@
 			</verbs>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="YP_SangAe"]</xpath>
 		<value>
@@ -270,6 +276,7 @@
 			</statBases>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="YP_SeolHwa"]/verbs</xpath>
 		<value>
@@ -291,6 +298,7 @@
 			</verbs>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="YP_SeolHwa"]</xpath>
 		<value>
@@ -344,6 +352,7 @@
 			</statBases>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="YP_GeugGwang"]/verbs</xpath>
 		<value>
@@ -363,6 +372,7 @@
 			</verbs>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="YP_GeugGwang"]</xpath>
 		<value>
@@ -387,6 +397,7 @@
 			</statBases>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="YP_VectorShot"]/verbs</xpath>
 		<value>
@@ -412,6 +423,7 @@
 			</verbs>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="YP_VectorShot"]</xpath>
 		<value>

--- a/ModPatches/Rimsenal Enhanced Vanilla/Patches/Rimsenal Enhanced Vanilla/Apparel_RS_CE.xml
+++ b/ModPatches/Rimsenal Enhanced Vanilla/Patches/Rimsenal Enhanced Vanilla/Apparel_RS_CE.xml
@@ -102,30 +102,35 @@
 			<Bulk>3</Bulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_TacHelmet"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>10</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_TacHelmet"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>20</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_TacHelmet"]/statBases/ArmorRating_Heat</xpath>
 		<value>
 			<ArmorRating_Heat>0.50</ArmorRating_Heat>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_TacHelmet"]/costList</xpath>
 		<value>
 			<DevilstrandCloth>15</DevilstrandCloth>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_TacHelmet"]/costList/Plasteel</xpath>
 		<value>
@@ -145,30 +150,35 @@
 			<WornBulk>5</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Exoframe"]/statBases/Mass</xpath>
 		<value>
 			<Mass>10</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Exoframe"]/statBases/WorkToMake</xpath>
 		<value>
 			<WorkToMake>38000</WorkToMake>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Exoframe"]/statBases/MaxHitPoints</xpath>
 		<value>
 			<MaxHitPoints>300</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_Exoframe"]/costList</xpath>
 		<value>
 			<Uranium>10</Uranium>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_Exoframe"]/equippedStatOffsets</xpath>
 		<value>
@@ -186,33 +196,39 @@
 			<WornBulk>18</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_ProtectiveGear"]/statBases/WorkToMake</xpath>
 		<value>
 			<WorkToMake>42000</WorkToMake>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_ProtectiveGear"]/statBases/Mass</xpath>
 		<value>
 			<Mass>18.5</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_ProtectiveGear"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>10</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_ProtectiveGear"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>15</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Apparel_ProtectiveGear"]/equippedStatOffsets/MoveSpeed</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_ProtectiveGear"]/equippedStatOffsets</xpath>
 		<value>
@@ -220,6 +236,7 @@
 			<MeleeDodgeChance>-0.25</MeleeDodgeChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_ProtectiveGear"]/apparel/bodyPartGroups</xpath>
 		<value>
@@ -330,33 +347,39 @@
 			<WornBulk>1</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_ProtectiveHelmet"]/statBases/WorkToMake</xpath>
 		<value>
 			<WorkToMake>14000</WorkToMake>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_ProtectiveHelmet"]/statBases/Mass</xpath>
 		<value>
 			<Mass>4.5</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_ProtectiveHelmet"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>10</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_ProtectiveHelmet"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>22.5</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Apparel_ProtectiveHelmet"]/equippedStatOffsets/MoveSpeed</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="Apparel_ProtectiveHelmet"]/apparel/immuneToToxGasExposure</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -366,6 +389,7 @@
 			</value>
 		</nomatch>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_ProtectiveHelmet"]/equippedStatOffsets</xpath>
 		<value>

--- a/ModPatches/Rimsenal Enhanced Vanilla/Patches/Rimsenal Enhanced Vanilla/Weapons_Charge_CE.xml
+++ b/ModPatches/Rimsenal Enhanced Vanilla/Patches/Rimsenal Enhanced Vanilla/Weapons_Charge_CE.xml
@@ -43,6 +43,7 @@
 			<li>AdvancedGun</li>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Gun_ChargeSidearm"]/tools</xpath>
 		<value>
@@ -380,6 +381,7 @@
 			<li>NoSwitch</li>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Gun_CFR"]/tools</xpath>
 		<value>

--- a/ModPatches/Rimsenal Enhanced Vanilla/Patches/Rimsenal Enhanced Vanilla/Weapons_Dumbfire_CE.xml
+++ b/ModPatches/Rimsenal Enhanced Vanilla/Patches/Rimsenal Enhanced Vanilla/Weapons_Dumbfire_CE.xml
@@ -125,6 +125,7 @@
 			<li>CE_OneHandedWeapon</li>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Gun_DumbfirePistol"]/tools</xpath>
 		<value>

--- a/ModPatches/Rimsenal Enhanced Vanilla/Patches/Rimsenal Enhanced Vanilla/Weapons_RSGuns_CE.xml
+++ b/ModPatches/Rimsenal Enhanced Vanilla/Patches/Rimsenal Enhanced Vanilla/Weapons_RSGuns_CE.xml
@@ -182,6 +182,7 @@
 			<li>CE_OneHandedWeapon</li>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Gun_PistolHeavyRevolver"]/tools</xpath>
 		<value>
@@ -428,6 +429,7 @@
 			<li>NoSwitch</li>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Gun_FR"]/tools</xpath>
 		<value>

--- a/ModPatches/Rimsenal Enhanced Vanilla/Patches/Rimsenal Enhanced Vanilla/Weapons_Ranged_CE.xml
+++ b/ModPatches/Rimsenal Enhanced Vanilla/Patches/Rimsenal Enhanced Vanilla/Weapons_Ranged_CE.xml
@@ -45,6 +45,7 @@
 			<li>CE_Bow</li>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Bow_Compound"]/tools</xpath>
 		<value>
@@ -68,9 +69,11 @@
 		<attribute>ParentName</attribute>
 		<value>BaseWeapon</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Gun_ThrowingAxes"]/costList</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Gun_ThrowingAxes"]</xpath>
 		<value>
@@ -79,15 +82,18 @@
 			</thingCategories>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Gun_ThrowingAxes"]/recipeMaker</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Gun_ThrowingAxes"]/label</xpath>
 		<value>
 			<label>Throwing axe</label>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Gun_ThrowingAxes"]/statBases</xpath>
 		<value>
@@ -106,6 +112,7 @@
 			</tradeTags>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Gun_ThrowingAxes"]/verbs</xpath>
 		<value>
@@ -121,6 +128,7 @@
 			</verbs>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Gun_ThrowingAxes"]/tools</xpath>
 		<value>
@@ -157,12 +165,15 @@
 		<attribute>ParentName</attribute>
 		<value>BaseWeapon</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Gun_ThrowingClubs"]/costList</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Gun_ThrowingClubs"]/recipeMaker</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Gun_ThrowingClubs"]</xpath>
 		<value>
@@ -172,12 +183,14 @@
 			</thingCategories>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Gun_ThrowingClubs"]/label</xpath>
 		<value>
 			<label>Throwing club</label>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Gun_ThrowingClubs"]/statBases</xpath>
 		<value>
@@ -196,6 +209,7 @@
 			</tradeTags>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Gun_ThrowingClubs"]/verbs</xpath>
 		<value>
@@ -211,6 +225,7 @@
 			</verbs>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Gun_ThrowingClubs"]/tools</xpath>
 		<value>

--- a/ModPatches/Rimsenal Federation/Defs/Rimsenal Federation/ThingDefs_Misc/Ammo_Fed.xml
+++ b/ModPatches/Rimsenal Federation/Defs/Rimsenal Federation/ThingDefs_Misc/Ammo_Fed.xml
@@ -92,7 +92,7 @@
 	<!-- ==========  Plasma Rifle Projectile =========== -->
 
 	<ThingDef ParentName="Base556x45mmNATOBullet">
-		<defName>Bullet_PlasmaRifle</defName>
+		<defName>Bullet_PlasmaRifle_Fed</defName>
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		<label>plasma sphere</label>
 		<graphicData>

--- a/ModPatches/Rimsenal Federation/Defs/Rimsenal Federation/ThingDefs_Misc/Ammo_Fed.xml
+++ b/ModPatches/Rimsenal Federation/Defs/Rimsenal Federation/ThingDefs_Misc/Ammo_Fed.xml
@@ -49,7 +49,7 @@
 	<!-- ==========  Crucible Cannon Projectile =========== -->
 
 	<ThingDef ParentName="Base40x365mmBoforsBullet">
-		<defName>Bullet_CrucibleCannon</defName>
+		<defName>Bullet_CrucibleCannon_CE</defName>
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		<label>energy bolt</label>
 		<graphicData>

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_Apparel.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_Apparel.xml
@@ -7,6 +7,7 @@
 			<Bulk>3</Bulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="FedSuit"]</xpath>
 		<value>
@@ -15,12 +16,14 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="FedSuit"]/apparel/bodyPartGroups</xpath>
 		<value>
 			<li>Feet</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="FedSuit"]/statBases/ArmorRating_Sharp</xpath>
 		<value>

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_Explosives.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_Explosives.xml
@@ -60,6 +60,7 @@
 			<tickerType>Normal</tickerType>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AD_FedPlasmaGrenades"]/graphicData</xpath>
 		<value>

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_MechWeapons.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_MechWeapons.xml
@@ -41,7 +41,7 @@
 			<recoilAmount>1.18</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_CrucibleCannon</defaultProjectile>
+			<defaultProjectile>Bullet_CrucibleCannon_CE</defaultProjectile>
 			<warmupTime>2.6</warmupTime>
 			<burstShotCount>13</burstShotCount>
 			<ticksBetweenBurstShots>22</ticksBetweenBurstShots>

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_MeleeWeapons.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_MeleeWeapons.xml
@@ -30,6 +30,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="AD_ConcussionBaton"]/statBases</xpath>
 		<value>
@@ -37,6 +38,7 @@
 			<MeleeCounterParryBonus>0.24</MeleeCounterParryBonus>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="AD_ConcussionBaton"]</xpath>
 		<value>
@@ -55,6 +57,7 @@
 			<MeleeCounterParryBonus>0.24</MeleeCounterParryBonus>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="AD_FedConcussionBaton"]</xpath>
 		<value>

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_RangedWeapons.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_RangedWeapons.xml
@@ -107,7 +107,7 @@
 			<recoilAmount>1.48</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_PlasmaRifle</defaultProjectile>
+			<defaultProjectile>Bullet_PlasmaRifle_Fed</defaultProjectile>
 			<warmupTime>1.1</warmupTime>
 			<range>55</range>
 			<soundCast>RS_ShotCR</soundCast>

--- a/ModPatches/Rimsenal Feral/Patches/Rimsenal Feral/ThingDefs_Misc/Feral_Explosives.xml
+++ b/ModPatches/Rimsenal Feral/Patches/Rimsenal Feral/ThingDefs_Misc/Feral_Explosives.xml
@@ -200,6 +200,7 @@
 			</ThingDef>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Gun_RatStick"]</xpath>
 		<value>

--- a/ModPatches/Rimsenal Feral/Patches/Rimsenal Feral/ThingDefs_Misc/Feral_MeleeWeapons.xml
+++ b/ModPatches/Rimsenal Feral/Patches/Rimsenal Feral/ThingDefs_Misc/Feral_MeleeWeapons.xml
@@ -41,12 +41,14 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="MeleeWeapon_FeralGlaive"]/statBases</xpath>
 		<value>
 			<Bulk>12</Bulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="MeleeWeapon_FeralGlaive"]</xpath>
 		<value>
@@ -100,12 +102,14 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="MeleeWeapon_FeralCleaver"]/statBases</xpath>
 		<value>
 			<Bulk>4.5</Bulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="MeleeWeapon_FeralCleaver"]/weaponTags</xpath>
 		<value>
@@ -144,12 +148,14 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Carver"]/statBases</xpath>
 		<value>
 			<Bulk>12</Bulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Carver"]/weaponTags</xpath>
 		<value>
@@ -198,6 +204,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Sunderer"]/statBases</xpath>
 		<value>

--- a/ModPatches/Rimsenal Feral/Patches/Rimsenal Feral/ThingDefs_Misc/Feral_RangedWeapons.xml
+++ b/ModPatches/Rimsenal Feral/Patches/Rimsenal Feral/ThingDefs_Misc/Feral_RangedWeapons.xml
@@ -389,6 +389,7 @@
 			</statBases>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Gun_Scorcher"]/costList</xpath>
 		<value>
@@ -399,6 +400,7 @@
 			</costList>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Gun_Scorcher"]</xpath>
 		<value>
@@ -407,6 +409,7 @@
 			</recipeMaker>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Gun_Scorcher"]/verbs</xpath>
 		<value>
@@ -431,6 +434,7 @@
 			</verbs>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Gun_Scorcher"]</xpath>
 		<value>

--- a/ModPatches/Rimsenal Feral/Patches/Rimsenal Feral/ThingDefs_Races/Race_Razortooth.xml
+++ b/ModPatches/Rimsenal Feral/Patches/Rimsenal Feral/ThingDefs_Races/Race_Razortooth.xml
@@ -10,6 +10,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Mutant_Razortooth"]/statBases</xpath>
 		<value>
@@ -21,6 +22,7 @@
 			<SmokeSensitivity>0.4</SmokeSensitivity>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mutant_Razortooth"]/tools</xpath>
 		<value>

--- a/ModPatches/Rimsenal Security/Defs/Rimsenal Security/Ammo_Security.xml
+++ b/ModPatches/Rimsenal Security/Defs/Rimsenal Security/Ammo_Security.xml
@@ -35,7 +35,7 @@
 		<defName>AmmoSet_MoltenShell</defName>
 		<label>molten shells</label>
 		<ammoTypes>
-			<Ammo_MoltenShell>Bullet_MoltenShell</Ammo_MoltenShell>
+			<Ammo_MoltenShell>Bullet_MoltenShell_CE</Ammo_MoltenShell>
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
 
@@ -75,7 +75,7 @@
 	<!-- ================== Projectiles ================== -->
 
 	<ThingDef ParentName="Base90mmCannonShell">
-		<defName>Bullet_MoltenShell</defName>
+		<defName>Bullet_MoltenShell_CE</defName>
 		<label>molten shell</label>
 		<graphicData>
 			<texPath>Things/Projectile/Cannon/HEAT</texPath>

--- a/ModPatches/Rimsenal Security/Patches/Rimsenal Security/Patch_Security.xml
+++ b/ModPatches/Rimsenal Security/Patches/Rimsenal Security/Patch_Security.xml
@@ -337,7 +337,7 @@
 					<li Class="CombatExtended.VerbPropertiesCE">
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
-						<defaultProjectile>Bullet_MoltenShell</defaultProjectile>
+						<defaultProjectile>Bullet_MoltenShell_CE</defaultProjectile>
 						<warmupTime>4.5</warmupTime>
 						<range>86</range>
 						<soundCast>RS_ShotJI</soundCast>

--- a/ModPatches/Risk of Rain UES Contact Light Armory/Patches/Risk of Rain UES Contact Light Armory/Risk_Of_Rain_Armor_Patches.xml
+++ b/ModPatches/Risk of Rain UES Contact Light Armory/Patches/Risk of Rain UES Contact Light Armory/Risk_Of_Rain_Armor_Patches.xml
@@ -93,6 +93,7 @@
 			<MaxHitPoints>260</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_BladeMarine_Helmet"]/statBases</xpath>
 		<value>
@@ -100,18 +101,21 @@
 			<WornBulk>0.25</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoRA_BladeMarine_Helmet"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>23</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoRA_BladeMarine_Helmet"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>48</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_BladeMarine_Helmet"]/equippedStatOffsets</xpath>
 		<value>
@@ -120,6 +124,7 @@
 			<ToxicEnvironmentResistance>0.80</ToxicEnvironmentResistance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<!-- Blademarine Armor -->
 		<xpath>Defs/ThingDef[defName="RoRA_BladeMarine_Armor"]/statBases/MaxHitPoints</xpath>
@@ -127,12 +132,14 @@
 			<MaxHitPoints>490</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoRA_BladeMarine_Armor"]/statBases/Mass</xpath>
 		<value>
 			<Mass>45</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_BladeMarine_Armor"]/statBases</xpath>
 		<value>
@@ -140,18 +147,21 @@
 			<WornBulk>12</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoRA_BladeMarine_Armor"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>25</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoRA_BladeMarine_Armor"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>48</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_BladeMarine_Armor"]/equippedStatOffsets</xpath>
 		<value>
@@ -162,6 +172,7 @@
 			<MeleeParryChance>0.5</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_BladeMarine_Armor"]/apparel/bodyPartGroups</xpath>
 		<value>
@@ -169,6 +180,7 @@
 			<li>Feet</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_BladeMarine_Armor"]/apparel/layers</xpath>
 		<value>
@@ -183,6 +195,7 @@
 			<MaxHitPoints>200</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_Conscript_Helmet"]/statBases</xpath>
 		<value>
@@ -190,18 +203,21 @@
 			<WornBulk>0.25</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoRA_Conscript_Helmet"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>17</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoRA_Conscript_Helmet"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>39</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_Conscript_Helmet"]/equippedStatOffsets</xpath>
 		<value>
@@ -209,6 +225,7 @@
 			<ToxicEnvironmentResistance>0.9</ToxicEnvironmentResistance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<!-- Conscript Armor -->
 		<xpath>Defs/ThingDef[defName="RoRA_Conscript_Armor"]/statBases/MaxHitPoints</xpath>
@@ -216,12 +233,14 @@
 			<MaxHitPoints>440</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoRA_Conscript_Armor"]/statBases/Mass</xpath>
 		<value>
 			<Mass>40</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_Conscript_Armor"]/statBases</xpath>
 		<value>
@@ -229,9 +248,11 @@
 			<WornBulk>10</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="RoRA_Conscript_Armor"]/equippedStatOffsets/MoveSpeed</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_Conscript_Armor"]/equippedStatOffsets</xpath>
 		<value>
@@ -241,18 +262,21 @@
 			<ReloadSpeed>0.5</ReloadSpeed>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoRA_Conscript_Armor"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>18</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoRA_Conscript_Armor"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>40</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_Conscript_Armor"]/apparel/bodyPartGroups</xpath>
 		<value>
@@ -260,6 +284,7 @@
 			<li>Feet</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_Conscript_Armor"]/apparel/layers</xpath>
 		<value>
@@ -274,6 +299,7 @@
 			<MaxHitPoints>260</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_Enforcer_Helmet"]/statBases</xpath>
 		<value>
@@ -281,18 +307,21 @@
 			<WornBulk>2</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoRA_Enforcer_Helmet"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>25</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoRA_Enforcer_Helmet"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>50</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_Enforcer_Helmet"]/equippedStatOffsets</xpath>
 		<value>
@@ -300,6 +329,7 @@
 			<ToxicEnvironmentResistance>0.80</ToxicEnvironmentResistance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<!-- Emforcer Armor -->
 		<xpath>Defs/ThingDef[defName="RoRA_Enforcer_Armor"]/statBases/MaxHitPoints</xpath>
@@ -307,12 +337,14 @@
 			<MaxHitPoints>560</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoRA_Enforcer_Armor"]/statBases/Mass</xpath>
 		<value>
 			<Mass>60</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_Enforcer_Armor"]/statBases</xpath>
 		<value>
@@ -320,21 +352,25 @@
 			<WornBulk>15</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoRA_Enforcer_Armor"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>29</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoRA_Enforcer_Armor"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>52</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="RoRA_Enforcer_Armor"]/equippedStatOffsets/MoveSpeed</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_Enforcer_Armor"]/equippedStatOffsets</xpath>
 		<value>
@@ -345,6 +381,7 @@
 			<ReloadSpeed>0.25</ReloadSpeed>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_Enforcer_Armor"]/apparel/bodyPartGroups</xpath>
 		<value>
@@ -352,6 +389,7 @@
 			<li>Feet</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_Enforcer_Armor"]/apparel/layers</xpath>
 		<value>
@@ -366,6 +404,7 @@
 			<MaxHitPoints>220</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_Engineer_Helmet"]/statBases</xpath>
 		<value>
@@ -373,24 +412,28 @@
 			<WornBulk>0.25</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoRA_Engineer_Helmet"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>17</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoRA_Engineer_Helmet"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>42</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_Engineer_Helmet"]/equippedStatOffsets</xpath>
 		<value>
 			<ToxicEnvironmentResistance>0.70</ToxicEnvironmentResistance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<!-- Engineer Armor -->
 		<xpath>Defs/ThingDef[defName="RoRA_Engineer_Armor"]/statBases/MaxHitPoints</xpath>
@@ -398,12 +441,14 @@
 			<MaxHitPoints>440</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoRA_Engineer_Armor"]/statBases/Mass</xpath>
 		<value>
 			<Mass>40</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_Engineer_Armor"]/statBases</xpath>
 		<value>
@@ -411,21 +456,25 @@
 			<WornBulk>10</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoRA_Engineer_Armor"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>19</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoRA_Engineer_Armor"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>48</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="RoRA_Engineer_Armor"]/equippedStatOffsets/MoveSpeed</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_Engineer_Armor"]/equippedStatOffsets</xpath>
 		<value>
@@ -434,6 +483,7 @@
 			<ToxicEnvironmentResistance>0.50</ToxicEnvironmentResistance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_Engineer_Armor"]/apparel/bodyPartGroups</xpath>
 		<value>
@@ -441,6 +491,7 @@
 			<li>Feet</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_Engineer_Armor"]/apparel/layers</xpath>
 		<value>
@@ -455,6 +506,7 @@
 			<MaxHitPoints>220</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_Specialist_Helmet"]/statBases</xpath>
 		<value>
@@ -462,18 +514,21 @@
 			<WornBulk>2</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoRA_Specialist_Helmet"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>22</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoRA_Specialist_Helmet"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>48</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_Specialist_Helmet"]/equippedStatOffsets</xpath>
 		<value>
@@ -482,6 +537,7 @@
 			<ToxicEnvironmentResistance>0.60</ToxicEnvironmentResistance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<!-- Specialist Armor -->
 		<xpath>Defs/ThingDef[defName="RoRA_Specialist_Armor"]/statBases/MaxHitPoints</xpath>
@@ -489,24 +545,28 @@
 			<MaxHitPoints>520</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoRA_Specialist_Armor"]/statBases/Mass</xpath>
 		<value>
 			<Mass>55</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoRA_Specialist_Armor"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>25</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoRA_Specialist_Armor"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>48</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_Specialist_Armor"]/statBases</xpath>
 		<value>
@@ -514,9 +574,11 @@
 			<WornBulk>15</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="RoRA_Specialist_Armor"]/equippedStatOffsets/MoveSpeed</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_Specialist_Armor"]/equippedStatOffsets</xpath>
 		<value>
@@ -527,6 +589,7 @@
 			<ReloadSpeed>0.25</ReloadSpeed>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_Specialist_Armor"]/apparel/bodyPartGroups</xpath>
 		<value>
@@ -534,6 +597,7 @@
 			<li>Feet</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_Specialist_Armor"]/apparel/layers</xpath>
 		<value>
@@ -548,6 +612,7 @@
 			<MaxHitPoints>200</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_Ranger_Helmet"]/equippedStatOffsets</xpath>
 		<value>
@@ -555,18 +620,21 @@
 			<ToxicEnvironmentResistance>0.60</ToxicEnvironmentResistance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoRA_Ranger_Helmet"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>19</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoRA_Ranger_Helmet"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>40</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_Ranger_Helmet"]/statBases</xpath>
 		<value>
@@ -574,6 +642,7 @@
 			<WornBulk>0.25</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<!-- Ranger Armor -->
 		<xpath>Defs/ThingDef[defName="RoRA_Ranger_Armor"]/statBases/MaxHitPoints</xpath>
@@ -581,24 +650,28 @@
 			<MaxHitPoints>480</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoRA_Ranger_Armor"]/statBases/Mass</xpath>
 		<value>
 			<Mass>40</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoRA_Ranger_Armor"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>20</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoRA_Ranger_Armor"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>42</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_Ranger_Armor"]/statBases</xpath>
 		<value>
@@ -606,6 +679,7 @@
 			<WornBulk>10</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_Ranger_Armor"]/equippedStatOffsets</xpath>
 		<value>
@@ -614,6 +688,7 @@
 			<ToxicEnvironmentResistance>0.50</ToxicEnvironmentResistance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_Ranger_Armor"]/apparel/bodyPartGroups</xpath>
 		<value>
@@ -621,6 +696,7 @@
 			<li>Feet</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_Ranger_Armor"]/apparel/layers</xpath>
 		<value>
@@ -635,18 +711,21 @@
 			<MaxHitPoints>200</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoRA_Miner_Helmet"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>22</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoRA_Miner_Helmet"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>45</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_Miner_Helmet"]/statBases</xpath>
 		<value>
@@ -654,6 +733,7 @@
 			<WornBulk>1</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_Miner_Helmet"]/equippedStatOffsets</xpath>
 		<value>
@@ -661,6 +741,7 @@
 			<ToxicEnvironmentResistance>0.60</ToxicEnvironmentResistance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<!-- Miner Armor -->
 		<xpath>Defs/ThingDef[defName="RoRA_Miner_Armor"]/statBases/MaxHitPoints</xpath>
@@ -668,24 +749,28 @@
 			<MaxHitPoints>510</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoRA_Miner_Armor"]/statBases/Mass</xpath>
 		<value>
 			<Mass>50</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoRA_Miner_Armor"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>23</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RoRA_Miner_Armor"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>45</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_Miner_Armor"]/statBases</xpath>
 		<value>
@@ -693,9 +778,11 @@
 			<WornBulk>12</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="RoRA_Miner_Armor"]/equippedStatOffsets/MoveSpeed</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_Miner_Armor"]/equippedStatOffsets</xpath>
 		<value>
@@ -712,6 +799,7 @@
 			<li>Feet</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RoRA_Miner_Armor"]/apparel/layers</xpath>
 		<value>

--- a/ModPatches/SCP/Patches/SCP/Headgear_SCP.xml
+++ b/ModPatches/SCP/Patches/SCP/Headgear_SCP.xml
@@ -21,6 +21,7 @@
 			<StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_CIInsurgentBalaclava"]/apparel/layers</xpath>
 		<value>

--- a/ModPatches/SYR Harpy/Patches/SYR Harpy/Patch_Bodies_Harpy.xml
+++ b/ModPatches/SYR Harpy/Patches/SYR Harpy/Patch_Bodies_Harpy.xml
@@ -7,18 +7,21 @@
 			<li>LeftArm</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="Harpy_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[customLabel = "right arm"]/groups</xpath>
 		<value>
 			<li>RightArm</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="Harpy_Body"]/corePart/parts/li[customLabel = "left shoulder"]/groups</xpath>
 		<value>
 			<li>LeftShoulder</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="Harpy_Body"]/corePart/parts/li[customLabel = "right shoulder"]/groups</xpath>
 		<value>
@@ -33,108 +36,126 @@
 			<coverage>0.07</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Harpy_Body"]/corePart/parts/li[def="Pelvis"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Harpy_Body"]/corePart/parts/li[def="Stomach"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Harpy_Body"]/corePart/parts/li[def="Heart"]/coverage</xpath>
 		<value>
 			<coverage>0.04</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Harpy_Body"]/corePart/parts/li[def="Lung"]/coverage</xpath>
 		<value>
 			<coverage>0.055</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Harpy_Body"]/corePart/parts/li[def="Kidney"]/coverage</xpath>
 		<value>
 			<coverage>0.03</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Harpy_Body"]/corePart/parts/li[def="Liver"]/coverage</xpath>
 		<value>
 			<coverage>0.06</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Harpy_Body"]/corePart/parts/li[def="Neck"]/coverage</xpath>
 		<value>
 			<coverage>0.055</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Harpy_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/parts/li[def="Brain"]/coverage</xpath>
 		<value>
 			<coverage>0.9</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Harpy_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Eye"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Harpy_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Ear"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Harpy_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]/coverage</xpath>
 		<value>
 			<coverage>0.08</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Harpy_Body"]/corePart/parts/li[def="Shoulder"]/coverage</xpath>
 		<value>
 			<coverage>0.085</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Harpy_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Clavicle"]/coverage</xpath>
 		<value>
 			<coverage>0.06</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Harpy_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def="ArmHarpy"]/parts/li[def="WingHarpy"]/coverage</xpath>
 		<value>
 			<coverage>0.15</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Harpy_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def="ArmHarpy"]/parts/li[def="Humerus"]/coverage</xpath>
 		<value>
 			<coverage>0.15</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Harpy_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def="ArmHarpy"]/parts/li[def="Radius"]/coverage</xpath>
 		<value>
 			<coverage>0.15</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Harpy_Body"]/corePart/parts/li[def="Leg"]/parts/li[def="Femur"]/coverage</xpath>
 		<value>
 			<coverage>0.15</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Harpy_Body"]/corePart/parts/li[def="Leg"]/parts/li[def="Tibia"]/coverage</xpath>
 		<value>

--- a/ModPatches/SYR Harpy/Patches/SYR Harpy/Patch_Race_Harpy.xml
+++ b/ModPatches/SYR Harpy/Patches/SYR Harpy/Patch_Race_Harpy.xml
@@ -17,6 +17,7 @@
 			<MeleeParryChance>1.06</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Harpy"]/statBases/MeleeDodgeChance</xpath>
 		<value>

--- a/ModPatches/SYR Naga/Patches/SYR Naga/Patch_Bodies_Naga.xml
+++ b/ModPatches/SYR Naga/Patches/SYR Naga/Patch_Bodies_Naga.xml
@@ -8,18 +8,21 @@
 			<li>LeftArm</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="Naga_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[customLabel = "right arm"]/groups</xpath>
 		<value>
 			<li>RightArm</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="Naga_Body"]/corePart/parts/li[customLabel = "left shoulder"]/groups</xpath>
 		<value>
 			<li>LeftShoulder</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="Naga_Body"]/corePart/parts/li[customLabel = "right shoulder"]/groups</xpath>
 		<value>
@@ -34,90 +37,105 @@
 			<coverage>0.07</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Naga_Body"]/corePart/parts/li[def="Pelvis"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Naga_Body"]/corePart/parts/li[def="Stomach"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Naga_Body"]/corePart/parts/li[def="Heart"]/coverage</xpath>
 		<value>
 			<coverage>0.04</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Naga_Body"]/corePart/parts/li[def="Lung"]/coverage</xpath>
 		<value>
 			<coverage>0.055</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Naga_Body"]/corePart/parts/li[def="Kidney"]/coverage</xpath>
 		<value>
 			<coverage>0.03</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Naga_Body"]/corePart/parts/li[def="Liver"]/coverage</xpath>
 		<value>
 			<coverage>0.06</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Naga_Body"]/corePart/parts/li[def="Neck"]/coverage</xpath>
 		<value>
 			<coverage>0.055</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Naga_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/parts/li[def="Brain"]/coverage</xpath>
 		<value>
 			<coverage>0.9</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Naga_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Eye"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Naga_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Ear"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Naga_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]/coverage</xpath>
 		<value>
 			<coverage>0.08</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Naga_Body"]/corePart/parts/li[def="Shoulder"]/coverage</xpath>
 		<value>
 			<coverage>0.085</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Naga_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Clavicle"]/coverage</xpath>
 		<value>
 			<coverage>0.06</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Naga_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Humerus"]/coverage</xpath>
 		<value>
 			<coverage>0.15</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Naga_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Radius"]/coverage</xpath>
 		<value>

--- a/ModPatches/Save Our Ship 2/Patches/Save Our Ship 2/Apparel_SOS2.xml
+++ b/ModPatches/Save Our Ship 2/Patches/Save Our Ship 2/Apparel_SOS2.xml
@@ -33,18 +33,21 @@
 			<WornBulk>1</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitHelmet"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>6.5</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitHelmet"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>20</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitHelmet"]/apparel/immuneToToxGasExposure</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -54,6 +57,7 @@
 			</value>
 		</nomatch>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitHelmet"]/equippedStatOffsets</xpath>
 		<value>
@@ -77,12 +81,14 @@
 			<ArmorRating_Sharp>14</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitHelmetHeavy"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>36</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitHelmetHeavy"]/apparel/immuneToToxGasExposure</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -92,6 +98,7 @@
 			</value>
 		</nomatch>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitHelmetHeavy"]/equippedStatOffsets</xpath>
 		<value>
@@ -152,12 +159,14 @@
 			<ArmorRating_Sharp>20</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitBodyHeavy"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>45</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitBodyHeavy"]/statBases</xpath>
 		<value>

--- a/ModPatches/Save Our Ship 2/Patches/Save Our Ship 2/Creatures_SOS2.xml
+++ b/ModPatches/Save Our Ship 2/Patches/Save Our Ship 2/Creatures_SOS2.xml
@@ -9,6 +9,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[@Name="BaseInsectSpace"]/statBases</xpath>
 		<value>
@@ -239,6 +240,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[@Name="BaseShuttle"]/statBases</xpath>
 		<value>

--- a/ModPatches/Spartan Foundry/Patches/Spartan Foundry/Apparel_Armors.xml
+++ b/ModPatches/Spartan Foundry/Patches/Spartan Foundry/Apparel_Armors.xml
@@ -9,12 +9,14 @@
 			<MaxHitPoints>1200</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_PoweredAssaultArmor"]/statBases/Mass</xpath>
 		<value>
 			<Mass>60</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_PoweredAssaultArmor"]/equippedStatOffsets</xpath>
 		<value>
@@ -26,24 +28,28 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="SF_PoweredAssaultArmor"]/costList</xpath>
 		<value>
 			<DevilstrandCloth>100</DevilstrandCloth>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_PoweredAssaultArmor"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>26</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_PoweredAssaultArmor"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>59</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_PoweredAssaultArmor"]/statBases/Flammability</xpath>
 		<value>
@@ -67,6 +73,7 @@
 			<Mass>60</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_EngineerPowerArmor"]/equippedStatOffsets</xpath>
 		<value>
@@ -80,24 +87,28 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="SF_EngineerPowerArmor"]/costList</xpath>
 		<value>
 			<DevilstrandCloth>100</DevilstrandCloth>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_EngineerPowerArmor"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>20</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_EngineerPowerArmor"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>65</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_EngineerPowerArmor"]/statBases/Flammability</xpath>
 		<value>
@@ -114,12 +125,14 @@
 			<MaxHitPoints>1200</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_ExplorerPowerArmor"]/statBases/Mass</xpath>
 		<value>
 			<Mass>50</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_ExplorerPowerArmor"]/equippedStatOffsets</xpath>
 		<value>
@@ -133,24 +146,28 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="SF_ExplorerPowerArmor"]/costList</xpath>
 		<value>
 			<DevilstrandCloth>100</DevilstrandCloth>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_ExplorerPowerArmor"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>18</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_ExplorerPowerArmor"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>45</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_ExplorerPowerArmor"]/statBases/Flammability</xpath>
 		<value>
@@ -167,12 +184,14 @@
 			<MaxHitPoints>1200</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_GrenadierPowerArmor"]/statBases/Mass</xpath>
 		<value>
 			<Mass>80</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_GrenadierPowerArmor"]/equippedStatOffsets</xpath>
 		<value>
@@ -185,24 +204,28 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="SF_GrenadierPowerArmor"]/costList</xpath>
 		<value>
 			<DevilstrandCloth>100</DevilstrandCloth>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_GrenadierPowerArmor"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>28</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_GrenadierPowerArmor"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>91</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_GrenadierPowerArmor"]/statBases/Flammability</xpath>
 		<value>
@@ -219,12 +242,14 @@
 			<MaxHitPoints>1200</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_CommandoArmor"]/statBases/Mass</xpath>
 		<value>
 			<Mass>60</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_CommandoArmor"]/equippedStatOffsets</xpath>
 		<value>
@@ -236,24 +261,28 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="SF_CommandoArmor"]/costList</xpath>
 		<value>
 			<DevilstrandCloth>100</DevilstrandCloth>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_CommandoArmor"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>22</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_CommandoArmor"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>50</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_CommandoArmor"]/statBases/Flammability</xpath>
 		<value>
@@ -270,12 +299,14 @@
 			<MaxHitPoints>1200</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_HazardOperationsArmor"]/statBases/Mass</xpath>
 		<value>
 			<Mass>70</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_HazardOperationsArmor"]/equippedStatOffsets</xpath>
 		<value>
@@ -289,24 +320,28 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="SF_HazardOperationsArmor"]/costList</xpath>
 		<value>
 			<DevilstrandCloth>100</DevilstrandCloth>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_HazardOperationsArmor"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>20</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_HazardOperationsArmor"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>45</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_HazardOperationsArmor"]/statBases/Flammability</xpath>
 		<value>
@@ -323,12 +358,14 @@
 			<MaxHitPoints>1200</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_DiplomatPowerArmor"]/statBases/Mass</xpath>
 		<value>
 			<Mass>60</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_DiplomatPowerArmor"]/equippedStatOffsets</xpath>
 		<value>
@@ -342,24 +379,28 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="SF_DiplomatPowerArmor"]/costList</xpath>
 		<value>
 			<DevilstrandCloth>100</DevilstrandCloth>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_DiplomatPowerArmor"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>22</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_DiplomatPowerArmor"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>55</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_DiplomatPowerArmor"]/statBases/Flammability</xpath>
 		<value>
@@ -376,12 +417,14 @@
 			<MaxHitPoints>1200</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_DefenderPowerArmor"]/statBases/Mass</xpath>
 		<value>
 			<Mass>73.3</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_DefenderPowerArmor"]/equippedStatOffsets</xpath>
 		<value>
@@ -396,24 +439,28 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="SF_DefenderPowerArmor"]/costList</xpath>
 		<value>
 			<DevilstrandCloth>100</DevilstrandCloth>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_DefenderPowerArmor"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>20</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_DefenderPowerArmor"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>55</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_DefenderPowerArmor"]/statBases/Flammability</xpath>
 		<value>
@@ -430,12 +477,14 @@
 			<MaxHitPoints>1200</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_ScoutPowerArmor"]/statBases/Mass</xpath>
 		<value>
 			<Mass>53.33</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_ScoutPowerArmor"]/equippedStatOffsets</xpath>
 		<value>
@@ -449,24 +498,28 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="SF_ScoutPowerArmor"]/costList</xpath>
 		<value>
 			<DevilstrandCloth>100</DevilstrandCloth>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_ScoutPowerArmor"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>20</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_ScoutPowerArmor"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>45</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_ScoutPowerArmor"]/statBases/Flammability</xpath>
 		<value>
@@ -483,12 +536,14 @@
 			<MaxHitPoints>1200</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_SamuraiPowerArmor"]/statBases/Mass</xpath>
 		<value>
 			<Mass>53.3</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_SamuraiPowerArmor"]/equippedStatOffsets</xpath>
 		<value>
@@ -503,24 +558,28 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="SF_SamuraiPowerArmor"]/costList</xpath>
 		<value>
 			<DevilstrandCloth>100</DevilstrandCloth>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_SamuraiPowerArmor"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>16</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_SamuraiPowerArmor"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>36</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_SamuraiPowerArmor"]/statBases/Flammability</xpath>
 		<value>
@@ -537,12 +596,14 @@
 			<MaxHitPoints>1200</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_ShockTrooperArmor"]/statBases/Mass</xpath>
 		<value>
 			<Mass>53.33</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_ShockTrooperArmor"]/equippedStatOffsets</xpath>
 		<value>
@@ -557,24 +618,28 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="SF_ShockTrooperArmor"]/costList</xpath>
 		<value>
 			<DevilstrandCloth>100</DevilstrandCloth>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_ShockTrooperArmor"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>19</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_ShockTrooperArmor"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>52</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_ShockTrooperArmor"]/statBases/Flammability</xpath>
 		<value>
@@ -591,12 +656,14 @@
 			<MaxHitPoints>1200</MaxHitPoints>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_ReconPowerArmor"]/statBases/Mass</xpath>
 		<value>
 			<Mass>46.7</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_ReconPowerArmor"]/equippedStatOffsets</xpath>
 		<value>
@@ -612,24 +679,28 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="SF_ReconPowerArmor"]/costList</xpath>
 		<value>
 			<DevilstrandCloth>100</DevilstrandCloth>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_ReconPowerArmor"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>20</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_ReconPowerArmor"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>55</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_ReconPowerArmor"]/statBases/Flammability</xpath>
 		<value>

--- a/ModPatches/Spartan Foundry/Patches/Spartan Foundry/Apparel_Headgear.xml
+++ b/ModPatches/Spartan Foundry/Patches/Spartan Foundry/Apparel_Headgear.xml
@@ -10,6 +10,7 @@
 			<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="SF_PoweredAssaultArmorHelmet"]/apparel/immuneToToxGasExposure</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -19,6 +20,7 @@
 			</value>
 		</nomatch>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_PoweredAssaultArmorHelmet"]/equippedStatOffsets</xpath>
 		<value>
@@ -30,30 +32,35 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="SF_PoweredAssaultArmorHelmet"]/costList</xpath>
 		<value>
 			<DevilstrandCloth>40</DevilstrandCloth>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_PoweredAssaultArmorHelmet"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>20</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_PoweredAssaultArmorHelmet"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>45</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_PoweredAssaultArmorHelmet"]/statBases/Flammability</xpath>
 		<value>
 			<Flammability>0</Flammability>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="SF_PoweredAssaultArmorHelmet"]/apparel/layers</xpath>
 		<value>
@@ -72,6 +79,7 @@
 			<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="SF_EngineerPowerArmorHelmet"]/apparel/immuneToToxGasExposure</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -81,6 +89,7 @@
 			</value>
 		</nomatch>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_EngineerPowerArmorHelmet"]/equippedStatOffsets</xpath>
 		<value>
@@ -94,30 +103,35 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="SF_EngineerPowerArmorHelmet"]/costList</xpath>
 		<value>
 			<DevilstrandCloth>40</DevilstrandCloth>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_EngineerPowerArmorHelmet"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>16</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_EngineerPowerArmorHelmet"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>44</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_EngineerPowerArmorHelmet"]/statBases/Flammability</xpath>
 		<value>
 			<Flammability>0</Flammability>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="SF_EngineerPowerArmorHelmet"]/apparel/layers</xpath>
 		<value>
@@ -136,6 +150,7 @@
 			<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="SF_ExplorerPowerArmorHelmet"]/apparel/immuneToToxGasExposure</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -145,6 +160,7 @@
 			</value>
 		</nomatch>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_ExplorerPowerArmorHelmet"]/equippedStatOffsets</xpath>
 		<value>
@@ -158,30 +174,35 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="SF_ExplorerPowerArmorHelmet"]/costList</xpath>
 		<value>
 			<DevilstrandCloth>40</DevilstrandCloth>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_ExplorerPowerArmorHelmet"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>14</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_ExplorerPowerArmorHelmet"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>35</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_ExplorerPowerArmorHelmet"]/statBases/Flammability</xpath>
 		<value>
 			<Flammability>0</Flammability>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="SF_ExplorerPowerArmorHelmet"]/apparel/layers</xpath>
 		<value>
@@ -200,6 +221,7 @@
 			<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="SF_GrenadierPowerArmorHelmet"]/apparel/immuneToToxGasExposure</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -209,6 +231,7 @@
 			</value>
 		</nomatch>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_GrenadierPowerArmorHelmet"]/equippedStatOffsets</xpath>
 		<value>
@@ -219,30 +242,35 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="SF_GrenadierPowerArmorHelmet"]/costList</xpath>
 		<value>
 			<DevilstrandCloth>40</DevilstrandCloth>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_GrenadierPowerArmorHelmet"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>22</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_GrenadierPowerArmorHelmet"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>71</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_GrenadierPowerArmorHelmet"]/statBases/Flammability</xpath>
 		<value>
 			<Flammability>0</Flammability>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="SF_GrenadierPowerArmorHelmet"]/apparel/layers</xpath>
 		<value>
@@ -261,6 +289,7 @@
 			<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="SF_CommandoArmorHelmet"]/apparel/immuneToToxGasExposure</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -270,6 +299,7 @@
 			</value>
 		</nomatch>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_CommandoArmorHelmet"]/equippedStatOffsets</xpath>
 		<value>
@@ -281,30 +311,35 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="SF_CommandoArmorHelmet"]/costList</xpath>
 		<value>
 			<DevilstrandCloth>40</DevilstrandCloth>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_CommandoArmorHelmet"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>16</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_CommandoArmorHelmet"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>36</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_CommandoArmorHelmet"]/statBases/Flammability</xpath>
 		<value>
 			<Flammability>0</Flammability>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="SF_CommandoArmorHelmet"]/apparel/layers</xpath>
 		<value>
@@ -323,6 +358,7 @@
 			<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="SF_HazardOperationsArmorHelmet"]/apparel/immuneToToxGasExposure</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -332,6 +368,7 @@
 			</value>
 		</nomatch>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_HazardOperationsArmorHelmet"]/equippedStatOffsets</xpath>
 		<value>
@@ -344,30 +381,35 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="SF_HazardOperationsArmorHelmet"]/costList</xpath>
 		<value>
 			<DevilstrandCloth>40</DevilstrandCloth>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_HazardOperationsArmorHelmet"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>16</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_HazardOperationsArmorHelmet"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>35</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_HazardOperationsArmorHelmet"]/statBases/Flammability</xpath>
 		<value>
 			<Flammability>0</Flammability>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="SF_HazardOperationsArmorHelmet"]/apparel/layers</xpath>
 		<value>
@@ -386,6 +428,7 @@
 			<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="SF_DiplomatPowerArmorHelmet"]/apparel/immuneToToxGasExposure</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -395,6 +438,7 @@
 			</value>
 		</nomatch>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_DiplomatPowerArmorHelmet"]/equippedStatOffsets</xpath>
 		<value>
@@ -408,30 +452,35 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="SF_DiplomatPowerArmorHelmet"]/costList</xpath>
 		<value>
 			<DevilstrandCloth>40</DevilstrandCloth>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_DiplomatPowerArmorHelmet"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>16</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_DiplomatPowerArmorHelmet"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>40</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_DiplomatPowerArmorHelmet"]/statBases/Flammability</xpath>
 		<value>
 			<Flammability>0</Flammability>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="SF_DiplomatPowerArmorHelmet"]/apparel/layers</xpath>
 		<value>
@@ -450,6 +499,7 @@
 			<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="SF_DefenderPowerArmorHelmet"]/apparel/immuneToToxGasExposure</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -459,6 +509,7 @@
 			</value>
 		</nomatch>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_DefenderPowerArmorHelmet"]/equippedStatOffsets</xpath>
 		<value>
@@ -472,30 +523,35 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="SF_DefenderPowerArmorHelmet"]/costList</xpath>
 		<value>
 			<DevilstrandCloth>40</DevilstrandCloth>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_DefenderPowerArmorHelmet"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>21</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_DefenderPowerArmorHelmet"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>58</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_DefenderPowerArmorHelmet"]/statBases/Flammability</xpath>
 		<value>
 			<Flammability>0</Flammability>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="SF_DefenderPowerArmorHelmet"]/apparel/layers</xpath>
 		<value>
@@ -514,6 +570,7 @@
 			<NightVisionEfficiency_Apparel>0.7</NightVisionEfficiency_Apparel>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="SF_ScoutPowerArmorHelmet"]/apparel/immuneToToxGasExposure</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -523,6 +580,7 @@
 			</value>
 		</nomatch>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_ScoutPowerArmorHelmet"]/equippedStatOffsets</xpath>
 		<value>
@@ -534,30 +592,35 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="SF_ScoutPowerArmorHelmet"]/costList</xpath>
 		<value>
 			<DevilstrandCloth>40</DevilstrandCloth>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_ScoutPowerArmorHelmet"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>16</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_ScoutPowerArmorHelmet"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>36</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_ScoutPowerArmorHelmet"]/statBases/Flammability</xpath>
 		<value>
 			<Flammability>0</Flammability>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="SF_ScoutPowerArmorHelmet"]/apparel/layers</xpath>
 		<value>
@@ -576,6 +639,7 @@
 			<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="SF_SamuraiPowerArmorHelmet"]/apparel/immuneToToxGasExposure</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -585,6 +649,7 @@
 			</value>
 		</nomatch>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_SamuraiPowerArmorHelmet"]/equippedStatOffsets</xpath>
 		<value>
@@ -599,30 +664,35 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="SF_SamuraiPowerArmorHelmet"]/costList</xpath>
 		<value>
 			<DevilstrandCloth>40</DevilstrandCloth>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_SamuraiPowerArmorHelmet"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>16</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_SamuraiPowerArmorHelmet"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>36</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_SamuraiPowerArmorHelmet"]/statBases/Flammability</xpath>
 		<value>
 			<Flammability>0</Flammability>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="SF_SamuraiPowerArmorHelmet"]/apparel/layers</xpath>
 		<value>
@@ -641,6 +711,7 @@
 			<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="SF_ShockTrooperArmorHelmet"]/apparel/immuneToToxGasExposure</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -650,6 +721,7 @@
 			</value>
 		</nomatch>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_ShockTrooperArmorHelmet"]/equippedStatOffsets</xpath>
 		<value>
@@ -664,30 +736,35 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="SF_ShockTrooperArmorHelmet"]/costList</xpath>
 		<value>
 			<DevilstrandCloth>40</DevilstrandCloth>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_ShockTrooperArmorHelmet"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>16</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_ShockTrooperArmorHelmet"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>44</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_ShockTrooperArmorHelmet"]/statBases/Flammability</xpath>
 		<value>
 			<Flammability>0</Flammability>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="SF_ShockTrooperArmorHelmet"]/apparel/layers</xpath>
 		<value>
@@ -706,6 +783,7 @@
 			<NightVisionEfficiency_Apparel>0.7</NightVisionEfficiency_Apparel>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_ReconPowerArmorHelmet"]/equippedStatOffsets</xpath>
 		<value>
@@ -720,30 +798,35 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="SF_ReconPowerArmorHelmet"]/costList</xpath>
 		<value>
 			<DevilstrandCloth>40</DevilstrandCloth>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_ReconPowerArmorHelmet"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>12</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_ReconPowerArmorHelmet"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>33</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="SF_ReconPowerArmorHelmet"]/statBases/Flammability</xpath>
 		<value>
 			<Flammability>0</Flammability>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="SF_ReconPowerArmorHelmet"]/apparel/layers</xpath>
 		<value>

--- a/ModPatches/Star Crafter's Armory/Patches/Star Crafter's Armory/PPS.xml
+++ b/ModPatches/Star Crafter's Armory/Patches/Star Crafter's Armory/PPS.xml
@@ -82,6 +82,7 @@
 			<DevilstrandCloth>80</DevilstrandCloth>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PPSa"]/costList/Uranium</xpath>
 		<value>

--- a/ModPatches/Star Wars - Factions/Patches/Star Wars - Factions/Patch_Apparel.xml
+++ b/ModPatches/Star Wars - Factions/Patches/Star Wars - Factions/Patch_Apparel.xml
@@ -15,6 +15,7 @@
 			<Bulk>4</Bulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="PJ_ImpUniform" or
@@ -30,6 +31,7 @@
 			<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="PJ_ImpUniform" or
@@ -45,6 +47,7 @@
 			<ArmorRating_Blunt>1</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="PJ_ImpUniform" or

--- a/ModPatches/Starship Troopers Arachnids/Patches/Starship Troopers Arachnids/Weapons_Bugs.xml
+++ b/ModPatches/Starship Troopers Arachnids/Patches/Starship Troopers Arachnids/Weapons_Bugs.xml
@@ -74,6 +74,7 @@
 			<requireLineOfSight>false</requireLineOfSight>
 		</Properties>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Gun_PlasmaBugPlasma"]</xpath>
 		<value>

--- a/ModPatches/Steves Animals/Patches/Steves Animals/Bast_Resources.xml
+++ b/ModPatches/Steves Animals/Patches/Steves Animals/Bast_Resources.xml
@@ -4,11 +4,13 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Bast_CeratokHorn"]/tools</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationAttributeSet">
 		<xpath>Defs/ThingDef[defName="Bast_CeratokHorn"]</xpath>
 		<attribute>ParentName</attribute>
 		<value>ResourceBase</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Bast_CeratokHorn"]/statBases/MarketValue</xpath>
 		<value>
@@ -23,12 +25,14 @@
 			<StuffPower_Armor_Sharp>0.09</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Leather_Bahlrin"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.04</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Leather_Bahlrin"]/statBases/StuffPower_Armor_Heat</xpath>
 		<value>
@@ -43,6 +47,7 @@
 			<StuffPower_Armor_Sharp>0.08</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Leather_Bastyon"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
@@ -65,6 +70,7 @@
 			<StuffPower_Armor_Sharp>0.06</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Leather_Chem_Tegu"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
@@ -79,12 +85,14 @@
 			<StuffPower_Armor_Sharp>0.046</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Leather_Scire"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.02</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Leather_Scire"]/statBases/StuffPower_Armor_Heat</xpath>
 		<value>
@@ -99,6 +107,7 @@
 			<StuffPower_Armor_Sharp>0.07</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Leather_Ethereal_Lion"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
@@ -113,12 +122,14 @@
 			<StuffPower_Armor_Sharp>0.12</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Leather_Ceratok"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.064</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Leather_Ceratok"]/statBases/StuffPower_Armor_Heat</xpath>
 		<value>
@@ -133,6 +144,7 @@
 			<StuffPower_Armor_Sharp>0.03</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Leather_Soul_Eater"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
@@ -151,6 +163,7 @@
 			<StuffPower_Armor_Sharp>0.03</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Leather_Vorpal_Bunny"
 			or defName="Leather_Vorpal_Bunny_Enraged"

--- a/ModPatches/Steves Animals/Patches/Steves Animals/BetaAnimals_CE_Patch_Projectiles.xml
+++ b/ModPatches/Steves Animals/Patches/Steves Animals/BetaAnimals_CE_Patch_Projectiles.xml
@@ -68,6 +68,7 @@
 			</projectile>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Bast_CritterSpike"]/projectile</xpath>
 		<value>
@@ -81,6 +82,7 @@
 			</projectile>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Bast_AlluviumGoo"]/projectile</xpath>
 		<value>
@@ -99,6 +101,7 @@
 			</projectile>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Bast_ScireFireBall"]/projectile</xpath>
 		<value>

--- a/ModPatches/Steves Animals/Patches/Steves Animals/CE_Patch_BastRace_All2.xml
+++ b/ModPatches/Steves Animals/Patches/Steves Animals/CE_Patch_BastRace_All2.xml
@@ -389,6 +389,7 @@
 			<ArmorRating_Blunt>8</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Bast_Gray_Terror"]/statBases/ArmorRating_Sharp</xpath>
 		<value>

--- a/ModPatches/T's Samurai Faction/Patches/T's Samurai Faction/T_Samurai_Apparel.xml
+++ b/ModPatches/T's Samurai Faction/Patches/T's Samurai Faction/T_Samurai_Apparel.xml
@@ -111,6 +111,7 @@
 			</stuffCategories>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="TSFApparel_AshigaruArmor" or

--- a/ModPatches/The Joris Experience/Patches/The Joris Experience/Bear_Resources.xml
+++ b/ModPatches/The Joris Experience/Patches/The Joris Experience/Bear_Resources.xml
@@ -4,6 +4,7 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="JE_GoldenUniJorisHorn"]/tools</xpath>
 	</Operation>
+
 	<Operation Class="PatchOperationAttributeSet">
 		<xpath>Defs/ThingDef[defName="JE_GoldenUniJorisHorn"]</xpath>
 		<attribute>ParentName</attribute>

--- a/ModPatches/Thrumkin/Patches/Thrumkin/Patch_Bodies_Thrumkin.xml
+++ b/ModPatches/Thrumkin/Patches/Thrumkin/Patch_Bodies_Thrumkin.xml
@@ -7,18 +7,21 @@
 			<li>LeftArm</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[customLabel = "right arm"]/groups</xpath>
 		<value>
 			<li>RightArm</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[customLabel = "left shoulder"]/groups</xpath>
 		<value>
 			<li>LeftShoulder</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[customLabel = "right shoulder"]/groups</xpath>
 		<value>
@@ -34,102 +37,119 @@
 			<coverage>0.07</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Pelvis"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Stomach"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Heart"]/coverage</xpath>
 		<value>
 			<coverage>0.04</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Lung"]/coverage</xpath>
 		<value>
 			<coverage>0.055</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Kidney"]/coverage</xpath>
 		<value>
 			<coverage>0.03</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Liver"]/coverage</xpath>
 		<value>
 			<coverage>0.06</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Neck"]/coverage</xpath>
 		<value>
 			<coverage>0.055</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/parts/li[def="Brain"]/coverage</xpath>
 		<value>
 			<coverage>0.9</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Eye"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Ear"]/coverage</xpath>
 		<value>
 			<coverage>0.05</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]/coverage</xpath>
 		<value>
 			<coverage>0.08</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Shoulder"]/coverage</xpath>
 		<value>
 			<coverage>0.085</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Clavicle"]/coverage</xpath>
 		<value>
 			<coverage>0.06</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Humerus"]/coverage</xpath>
 		<value>
 			<coverage>0.15</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Radius"]/coverage</xpath>
 		<value>
 			<coverage>0.15</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Leg"]/parts/li[def="Femur"]/coverage</xpath>
 		<value>
 			<coverage>0.15</coverage>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Leg"]/parts/li[def="Tibia"]/coverage</xpath>
 		<value>
@@ -144,6 +164,7 @@
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Tail"]</xpath>
 		<value>
@@ -152,24 +173,28 @@
 			</groups>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Neck"]/groups</xpath>
 		<value>
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/groups</xpath>
 		<value>
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Jaw"]/groups</xpath>
 		<value>
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]</xpath>
 		<value>
@@ -178,48 +203,56 @@
 			</groups>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Ear"]/groups</xpath>
 		<value>
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="HornThrumkin"]/groups</xpath>
 		<value>
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Shoulder"]/groups</xpath>
 		<value>
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/groups</xpath>
 		<value>
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Hand"]/groups</xpath>
 		<value>
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Hand"]/parts/li[def="Finger"]/groups</xpath>
 		<value>
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Leg"]/groups</xpath>
 		<value>
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Leg"]/parts/li[def="Hoof"]</xpath>
 		<value>

--- a/ModPatches/Thrumkin/Patches/Thrumkin/Patch_PawnKinds_Thrumkin.xml
+++ b/ModPatches/Thrumkin/Patches/Thrumkin/Patch_PawnKinds_Thrumkin.xml
@@ -48,6 +48,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[defName="Thrumkin_Archer"]/combatPower</xpath>
 		<value>
@@ -71,6 +72,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[defName="Thrumkin_Warrior"]/combatPower</xpath>
 		<value>
@@ -109,6 +111,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[defName="Thrumkin_Hunter"]/combatPower</xpath>
 		<value>
@@ -132,6 +135,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[defName="Thrumkin_Berserker"]/combatPower</xpath>
 		<value>
@@ -170,6 +174,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[defName="Thrumkin_HeavyArcher"]/combatPower</xpath>
 		<value>
@@ -284,6 +289,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[defName="Thrumkin_Villager"]/combatPower</xpath>
 		<value>
@@ -316,6 +322,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[defName="Thrumkin_Guard"]/combatPower</xpath>
 		<value>
@@ -355,6 +362,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[defName="Thrumkin_Gunner"]/combatPower</xpath>
 		<value>
@@ -378,6 +386,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[defName="Thrumkin_Slasher"]/combatPower</xpath>
 		<value>

--- a/ModPatches/Thrumkin/Patches/Thrumkin/Patch_Race_Thrumkin.xml
+++ b/ModPatches/Thrumkin/Patches/Thrumkin/Patch_Race_Thrumkin.xml
@@ -9,6 +9,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Thrumkin"]/comps</xpath>
 		<value>
@@ -40,30 +41,35 @@
 			<Mass>120</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName = "Thrumkin"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>0.4</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName = "Thrumkin"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>0.6</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName = "Thrumkin"]/statBases/LeatherAmount</xpath>
 		<value>
 			<LeatherAmount>20</LeatherAmount>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName = "Thrumkin"]/comps/li[@Class="CompProperties_Shearable"]/woolAmount</xpath>
 		<value>
 			<woolAmount>10</woolAmount>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName = "Thrumkin"]/race/baseHealthScale</xpath>
 		<value>

--- a/ModPatches/Thrumkin/Patches/Thrumkin/Patch_Things_Thrumkin.xml
+++ b/ModPatches/Thrumkin/Patches/Thrumkin/Patch_Things_Thrumkin.xml
@@ -17,6 +17,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="WoodLog_GhostAsh"]</xpath>
 		<value>
@@ -27,6 +28,7 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="WoodLog_GhostAsh"]/statBases</xpath>
 		<value>
@@ -41,24 +43,28 @@
 			<StuffPower_Armor_Sharp>0.2</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="WoodLog_GhostAsh"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.4</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="WoodLog_GhostAsh"]/statBases/SharpDamageMultiplier</xpath>
 		<value>
 			<SharpDamageMultiplier>0.8</SharpDamageMultiplier>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="WoodLog_GhostAsh"]/statBases/BluntDamageMultiplier</xpath>
 		<value>
 			<BluntDamageMultiplier>0.6</BluntDamageMultiplier>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="WoodLog_GhostAsh"]/stuffProps/statFactors</xpath>
 		<value>
@@ -162,6 +168,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Thrumkin_Sword"]</xpath>
 		<value>
@@ -172,6 +179,7 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Thrumkin_Sword"]/statBases/Mass</xpath>
 		<value>

--- a/ModPatches/Vanilla Apparel Expanded - Accessories/Patches/Vanilla Apparel Expanded - Accessories/Apparel_Utility.xml
+++ b/ModPatches/Vanilla Apparel Expanded - Accessories/Patches/Vanilla Apparel Expanded - Accessories/Apparel_Utility.xml
@@ -2,14 +2,14 @@
 <Patch>
 	<!-- == Backpack == -->
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/VAE_Accessories.CaravanCapacityApparelDef[defName="VAEA_Apparel_Backpack"]/statBases</xpath>
+		<xpath>Defs/ThingDef[defName="VAEA_Apparel_Backpack"]/statBases</xpath>
 		<value>
 			<Bulk>3</Bulk>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/VAE_Accessories.CaravanCapacityApparelDef[defName="VAEA_Apparel_Backpack"]/carryingCapacity</xpath>
+		<xpath>Defs/ThingDef[defName="VAEA_Apparel_Backpack"]/equippedStatOffsets</xpath>
 		<value>
 			<equippedStatOffsets>
 				<CarryBulk>30</CarryBulk>
@@ -18,7 +18,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/VAE_Accessories.CaravanCapacityApparelDef[defName="VAEA_Apparel_Backpack"]/apparel/bodyPartGroups</xpath>
+		<xpath>Defs/ThingDef[defName="VAEA_Apparel_Backpack"]/apparel/bodyPartGroups</xpath>
 		<value>
 			<bodyPartGroups>
 				<li>Shoulders</li>
@@ -27,7 +27,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/VAE_Accessories.CaravanCapacityApparelDef[defName="VAEA_Apparel_Backpack"]/apparel/layers</xpath>
+		<xpath>Defs/ThingDef[defName="VAEA_Apparel_Backpack"]/apparel/layers</xpath>
 		<value>
 			<layers>
 				<li>Backpack</li>
@@ -184,7 +184,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="VAEA_Apparel_MiniTurretPack"]/comps</xpath>
 		<value>
-			<li Class="CompProperties_Reloadable">
+			<li Class="CompProperties_ApparelReloadable">
 				<maxCharges>25</maxCharges>
 				<ammoDef>Ammo_556x45mmNATO_FMJ</ammoDef>
 				<ammoCountPerCharge>1</ammoCountPerCharge>

--- a/ModPatches/Vanilla Apparel Expanded/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Apparel_Footwear.xml
+++ b/ModPatches/Vanilla Apparel Expanded/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Apparel_Footwear.xml
@@ -9,6 +9,7 @@
 			<Mass>0.8</Mass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="VAE_Footwear_Boots"]/statBases/StuffEffectMultiplierArmor</xpath>
 		<value>

--- a/ModPatches/Vanilla Apparel Expanded/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Apparel_Industrial.xml
+++ b/ModPatches/Vanilla Apparel Expanded/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Apparel_Industrial.xml
@@ -72,6 +72,7 @@
 			<StuffEffectMultiplierArmor>1.4</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="VAE_Apparel_MilitaryUniform"]/costList/Steel</xpath>
 		<value>
@@ -89,6 +90,7 @@
 			<ArmorRating_Sharp>0.2</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="VAE_Apparel_BuildersJacket"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
@@ -102,6 +104,7 @@
 			<Cloth>60</Cloth>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="VAE_Apparel_BuildersJacket"]/costList/Silver</xpath>
 		<value>
@@ -145,24 +148,28 @@
 			<costStuffCount>15</costStuffCount>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="VAE_Apparel_CasualTShirt" or defName="VAE_Apparel_Shorts" or defName="VAE_Apparel_Skirt"]/costStuffCount</xpath>
 		<value>
 			<costStuffCount>20</costStuffCount>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="VAE_Apparel_ShirtandTie" or defName="VAE_Apparel_Overalls" or defName="VAE_Apparel_FleeceShirt" or defName="VAE_Apparel_SheriffShirt" or defName="VAE_Apparel_Trousers"]/costStuffCount</xpath>
 		<value>
 			<costStuffCount>25</costStuffCount>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="VAE_Apparel_Hoodie" or defName="VAE_Apparel_Jeans" or defName="VAE_Apparel_ChefsUniform"]/costStuffCount</xpath>
 		<value>
 			<costStuffCount>30</costStuffCount>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="VAE_Apparel_MilitaryUniform" or defName="VAE_Apparel_Jumpsuit" or defName="VAE_Apparel_MilitaryJacket" or defName="VAE_Apparel_SuitJacket"]/costStuffCount</xpath>
 		<value>

--- a/ModPatches/Vanilla Apparel Expanded/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Apparel_Medieval.xml
+++ b/ModPatches/Vanilla Apparel Expanded/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Apparel_Medieval.xml
@@ -38,6 +38,7 @@
 			<costStuffCount>20</costStuffCount>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="VAE_Apparel_Tunic"]/costStuffCount</xpath>
 		<value>

--- a/ModPatches/Vanilla Apparel Expanded/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Headgear_Industrial.xml
+++ b/ModPatches/Vanilla Apparel Expanded/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Headgear_Industrial.xml
@@ -19,6 +19,7 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="VAE_Headgear_Scarf"]/apparel/layers</xpath>
 		<value>
@@ -57,6 +58,7 @@
 			<WornBulk>1</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="VAE_Headgear_Hardhat"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
@@ -74,6 +76,7 @@
 			<WornBulk>0</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="VAE_Headgear_SurgicalMask"]/statBases/ArmorRating_Sharp</xpath>
 		<value>

--- a/ModPatches/Vanilla Armour Expanded/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Footwear.xml
+++ b/ModPatches/Vanilla Armour Expanded/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Footwear.xml
@@ -70,6 +70,7 @@
 			<ArmorRating_Sharp>18</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/statBases/ArmorRating_Blunt</xpath>
 		<value>

--- a/ModPatches/Vanilla Factions Expanded - Pirates/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Apparel_Warcaskets.xml
+++ b/ModPatches/Vanilla Factions Expanded - Pirates/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Apparel_Warcaskets.xml
@@ -839,6 +839,7 @@
 			<ammoCountPerCharge>1</ammoCountPerCharge>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Barrage"]/comps/li[@Class="CompProperties_ApparelReloadable"]/maxCharges</xpath>
 		<value>

--- a/ModPatches/Vanilla Furniture Expanded - Security/Defs/Vanilla Furniture Expanded - Security/NewRaiderArtillery.xml
+++ b/ModPatches/Vanilla Furniture Expanded - Security/Defs/Vanilla Furniture Expanded - Security/NewRaiderArtillery.xml
@@ -68,9 +68,6 @@
 		<uiIconPath>Things/Building/Artillery/TurretArtillery_MenuIcon</uiIconPath>
 		<uiIconScale>0.9</uiIconScale>
 		<constructionSkillPrerequisite>5</constructionSkillPrerequisite>
-		<researchPrerequisites>
-			<li>VFES_Artillery_Debug</li>
-		</researchPrerequisites>
 		<modExtensions>
 			<li Class="CombatExtended.ThingDefExtensionCE">
 				<MenuHidden>True</MenuHidden>

--- a/ModPatches/Vanilla Furniture Expanded - Security/Defs/Vanilla Furniture Expanded - Security/NewRaiderArtillery.xml
+++ b/ModPatches/Vanilla Furniture Expanded - Security/Defs/Vanilla Furniture Expanded - Security/NewRaiderArtillery.xml
@@ -71,6 +71,11 @@
 		<researchPrerequisites>
 			<li>VFES_Artillery_Debug</li>
 		</researchPrerequisites>
+		<modExtensions>
+			<li Class="CombatExtended.ThingDefExtensionCE">
+				<MenuHidden>True</MenuHidden>
+			</li>
+		</modExtensions>		
 	</ThingDef>
 
 	<ThingDef ParentName="BaseArtilleryWeapon">
@@ -144,19 +149,4 @@
 		</building>
 	</ThingDef>
 
-	<!-- Dummy research project. This allows raiders to spawn and build their own variation of the artillery gun without the player being able to access it. -->
-
-	<ResearchProjectDef ParentName="VFES_ResearchBase">
-		<defName>VFES_Artillery_Debug</defName>
-		<label>Combat Extended Artillery Debug</label>
-		<description>Ignore this project. A dummy research project as a workaround for raider artillery compatibility. Not intended for the player.</description>
-		<baseCost>99999</baseCost>
-		<techLevel>Ultra</techLevel>
-		<requiredResearchFacilities>
-			<li>MultiAnalyzer</li>
-		</requiredResearchFacilities>
-		<requiredResearchBuilding>HiTechResearchBench</requiredResearchBuilding>
-		<researchViewX>10</researchViewX>
-		<researchViewY>0</researchViewY>
-	</ResearchProjectDef>
 </Defs>

--- a/ModPatches/Vanilla Genetics Expanded/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_ArchoCentipede.xml
+++ b/ModPatches/Vanilla Genetics Expanded/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_ArchoCentipede.xml
@@ -28,6 +28,7 @@
 			<ArmorRating_Blunt>500</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="GR_ArchotechCentipede"]/statBases/ArmorRating_Sharp</xpath>
 		<value>

--- a/ModPatches/Vanilla Genetics Expanded/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_AvianHybrids.xml
+++ b/ModPatches/Vanilla Genetics Expanded/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_AvianHybrids.xml
@@ -217,6 +217,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="GR_Chickenrabbit"]</xpath>
 		<value>

--- a/ModPatches/Vanilla Genetics Expanded/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_ColossalHybrids.xml
+++ b/ModPatches/Vanilla Genetics Expanded/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_ColossalHybrids.xml
@@ -444,6 +444,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="GR_Thrumbocat"]</xpath>
 		<value>

--- a/ModPatches/Vanilla Genetics Expanded/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_FelineHybrids.xml
+++ b/ModPatches/Vanilla Genetics Expanded/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_FelineHybrids.xml
@@ -337,6 +337,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="GR_Catwolf"]</xpath>
 		<value>

--- a/ModPatches/Vanilla Genetics Expanded/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_InsectoidHybrids.xml
+++ b/ModPatches/Vanilla Genetics Expanded/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_InsectoidHybrids.xml
@@ -17,6 +17,7 @@
 			<MeleeParryChance>0.27</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="GR_Bearscarab"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
@@ -225,6 +226,7 @@
 			<ArmorRating_Blunt>0.75</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="GR_Muffalopede"]/statBases/ArmorRating_Sharp</xpath>
 		<value>

--- a/ModPatches/Vanilla Genetics Expanded/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_MechanoidHybrids.xml
+++ b/ModPatches/Vanilla Genetics Expanded/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_MechanoidHybrids.xml
@@ -26,6 +26,7 @@
 			<ArmorRating_Blunt>32</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="GR_Mechabear"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
@@ -95,6 +96,7 @@
 			<ArmorRating_Blunt>16</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="GR_Mechalope"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
@@ -146,6 +148,7 @@
 			<ArmorRating_Blunt>1</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="GR_Mechachicken"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
@@ -197,6 +200,7 @@
 			<ArmorRating_Blunt>25</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="GR_Mechaspider"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
@@ -300,6 +304,7 @@
 			<ArmorRating_Blunt>0.6</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="GR_Mecharat"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
@@ -351,6 +356,7 @@
 			<ArmorRating_Blunt>58</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="GR_Mechaturtle"]/statBases/ArmorRating_Sharp</xpath>
 		<value>

--- a/ModPatches/Vanilla Genetics Expanded/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_Paragons.xml
+++ b/ModPatches/Vanilla Genetics Expanded/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_Paragons.xml
@@ -146,6 +146,7 @@
 			<MeleeCritChance>0.02</MeleeCritChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="GR_ParagonChicken"]/tools</xpath>
 		<value>

--- a/ModPatches/Vanilla Genetics Expanded/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_UrsineHybrids.xml
+++ b/ModPatches/Vanilla Genetics Expanded/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_UrsineHybrids.xml
@@ -460,6 +460,7 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="GR_Bearcat"]</xpath>
 		<value>

--- a/ModPatches/Vanilla Ideology Expanded - Dryads/Patches/Vanilla Ideology Expanded - Dryads/DamageDefs/Animal_Projectile_Shoot.xml
+++ b/ModPatches/Vanilla Ideology Expanded - Dryads/Patches/Vanilla Ideology Expanded - Dryads/DamageDefs/Animal_Projectile_Shoot.xml
@@ -23,6 +23,7 @@
 			</verbs>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="VDE_Dryad_Spitter"]/verbs</xpath>
 		<value>

--- a/ModPatches/Vanilla Ideology Expanded - Dryads/Patches/Vanilla Ideology Expanded - Dryads/ThingDefs_Items/Items_Resource_Stuff.xml
+++ b/ModPatches/Vanilla Ideology Expanded - Dryads/Patches/Vanilla Ideology Expanded - Dryads/ThingDefs_Items/Items_Resource_Stuff.xml
@@ -7,12 +7,14 @@
 			<StuffPower_Armor_Sharp>0.05</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="VDE_Gaubric"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.04</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="VDE_Gaubric"]/statBases/StuffPower_Armor_Heat</xpath>
 		<value>

--- a/ModPatches/Vanilla Weapons Expanded - Grenades/Patches/Vanilla Weapons Expanded - Grenades/Apparel_Packs-NonLethal.xml
+++ b/ModPatches/Vanilla Weapons Expanded - Grenades/Patches/Vanilla Weapons Expanded - Grenades/Apparel_Packs-NonLethal.xml
@@ -20,7 +20,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VWE_Apparel_GrenadeTearGasBelt"]/comps/li[@Class="CompProperties_Reloadable"]/ammoCountToRefill</xpath>
+					<xpath>Defs/ThingDef[defName="VWE_Apparel_GrenadeTearGasBelt"]/comps/li[@Class="CompProperties_ApparelReloadable"]/ammoCountToRefill</xpath>
 					<value>
 						<ammoCountPerCharge>1</ammoCountPerCharge>
 					</value>

--- a/ModPatches/Vanilla Weapons Expanded - Grenades/Patches/Vanilla Weapons Expanded - Grenades/Apparel_Packs.xml
+++ b/ModPatches/Vanilla Weapons Expanded - Grenades/Patches/Vanilla Weapons Expanded - Grenades/Apparel_Packs.xml
@@ -12,7 +12,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="VWE_Apparel_GrenadeFragBelt"]/comps/li[@Class="CompProperties_Reloadable"]/ammoCountToRefill</xpath>
+		<xpath>Defs/ThingDef[defName="VWE_Apparel_GrenadeFragBelt"]/comps/li[@Class="CompProperties_ApparelReloadable"]/ammoCountToRefill</xpath>
 		<value>
 			<ammoCountPerCharge>1</ammoCountPerCharge>
 		</value>
@@ -57,7 +57,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="VWE_Apparel_GrenadeMolotovBelt"]/comps/li[@Class="CompProperties_Reloadable"]/ammoCountToRefill</xpath>
+		<xpath>Defs/ThingDef[defName="VWE_Apparel_GrenadeMolotovBelt"]/comps/li[@Class="CompProperties_ApparelReloadable"]/ammoCountToRefill</xpath>
 		<value>
 			<ammoCountPerCharge>1</ammoCountPerCharge>
 		</value>
@@ -102,7 +102,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="VWE_Apparel_GrenadeEMPBelt"]/comps/li[@Class="CompProperties_Reloadable"]/ammoCountToRefill</xpath>
+		<xpath>Defs/ThingDef[defName="VWE_Apparel_GrenadeEMPBelt"]/comps/li[@Class="CompProperties_ApparelReloadable"]/ammoCountToRefill</xpath>
 		<value>
 			<ammoCountPerCharge>1</ammoCountPerCharge>
 		</value>

--- a/ModPatches/Xenn/Patches/Xenn/PawnKindDefs_Humanlikes/PawnKinds_Xenn.xml
+++ b/ModPatches/Xenn/Patches/Xenn/PawnKindDefs_Humanlikes/PawnKinds_Xenn.xml
@@ -32,6 +32,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="XennPackLeader"]</xpath>
 		<value>
@@ -63,6 +64,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="XennTrader"]</xpath>
 		<value>
@@ -94,6 +96,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="XennSlave"]</xpath>
 		<value>
@@ -125,6 +128,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="XennRefugee"]</xpath>
 		<value>
@@ -156,6 +160,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="XennSecurityGuard"]</xpath>
 		<value>
@@ -187,6 +192,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="XennRecruit"]</xpath>
 		<value>
@@ -218,6 +224,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="XennHunter"]</xpath>
 		<value>
@@ -249,6 +256,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="XennCommando"]</xpath>
 		<value>
@@ -280,6 +288,7 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="XennCommandoElite"]</xpath>
 		<value>

--- a/ModPatches/Xenn/Patches/Xenn/ThingDefs_Misc/Apparel_Various.xml
+++ b/ModPatches/Xenn/Patches/Xenn/ThingDefs_Misc/Apparel_Various.xml
@@ -203,6 +203,7 @@
 			<WornBulk>1</WornBulk>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "XennSunglasses"]/statBases/ArmorRating_Sharp</xpath>
 		<value>

--- a/ModPatches/Xenn/Patches/Xenn/ThingDefs_Misc/Xenn_Weps.xml
+++ b/ModPatches/Xenn/Patches/Xenn/ThingDefs_Misc/Xenn_Weps.xml
@@ -37,6 +37,7 @@
 			<li>CE_AI_AssaultWeapon</li>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="XennBurnCannon"]/tools</xpath>
 		<value>
@@ -114,6 +115,7 @@
 			<li>CE_AI_AssaultWeapon</li>
 		</weaponTags>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="XennFrostCannon"]/tools</xpath>
 		<value>

--- a/ModPatches/YetAnotherProsthetics - Core/Patches/YetAnotherProsthetics - Core/Patches/Bionics_Patch.xml
+++ b/ModPatches/YetAnotherProsthetics - Core/Patches/YetAnotherProsthetics - Core/Patches/Bionics_Patch.xml
@@ -187,6 +187,7 @@
 			<ArmorRating_Sharp>1.75</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="BIE_UltratechBionicSkin"]/stages/li/statOffsets/ArmorRating_Blunt</xpath>
 		<value>
@@ -201,6 +202,7 @@
 			<ArmorRating_Sharp>3</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="SoSArchotechSkin"]/stages/li/statOffsets/ArmorRating_Blunt</xpath>
 		<value>


### PR DESCRIPTION
## Changes
- Load VFE - Tribals and Classical after CE, so their thrown weapons have the correct base.
- No longer force VFE - Mechanoids to load before CE.
- ReGrowth: Core - remove moa patch, add kiwi patch.
- Rimsenal Spacer Faction - Remove duplicate explosive recipe parent base.
- Rimsenal Core:
   - Fix JI siege rocket parent name.
   - Update apparel verbs
   - Fix duplicate Fed plasma projectile defName
   - Remove duplicate FeralNail ammo category.
   - Load Factions before CE and make some weaponTag operations conditional to prevent errors about duplicates.
- VFE: Security - Menu hide the raider artillery and remove the dummy research project
- VWE: Grenades & VAE: Accessories - Update apparel verbs. 
- Small whitespace changes in a **bunch** of files to improve readability.

## Reasoning
- Necessary fixes.

## Alternatives
- Leave stuff broken, I guess.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
