### PR TITLE
HEDP and HEAT ammo tweaks

### DIFF
--- a/Defs/Ammo/Grenade/25x59mmGrenade.xml
+++ b/Defs/Ammo/Grenade/25x59mmGrenade.xml
@@ -175,13 +175,13 @@
 		<thingClass>CombatExtended.BulletCE</thingClass>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<damageAmountBase>30</damageAmountBase>
+			<damageAmountBase>32</damageAmountBase>
 			<armorPenetrationSharp>50</armorPenetrationSharp>
-			<armorPenetrationBlunt>4.818</armorPenetrationBlunt>
+			<armorPenetrationBlunt>3.613</armorPenetrationBlunt>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>16</damageAmountBase>
+				<damageAmountBase>12</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
 				<explosiveRadius>0.5</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/Defs/Ammo/Grenade/30x29mmGrenade.xml
+++ b/Defs/Ammo/Grenade/30x29mmGrenade.xml
@@ -177,11 +177,11 @@
 			<damageDef>Bullet</damageDef>
 			<damageAmountBase>35</damageAmountBase>
 			<armorPenetrationSharp>45</armorPenetrationSharp>
-			<armorPenetrationBlunt>5.569</armorPenetrationBlunt>
+			<armorPenetrationBlunt>4.177</armorPenetrationBlunt>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>19</damageAmountBase>
+				<damageAmountBase>14</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
 				<explosiveRadius>0.5</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/Defs/Ammo/Grenade/35x32mmSRGrenade.xml
+++ b/Defs/Ammo/Grenade/35x32mmSRGrenade.xml
@@ -137,13 +137,13 @@
 		<label>35x32mmSR grenade (HEDP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<damageAmountBase>31</damageAmountBase>
+			<damageAmountBase>33</damageAmountBase>
 			<armorPenetrationSharp>55</armorPenetrationSharp>
-			<armorPenetrationBlunt>4.961</armorPenetrationBlunt>
+			<armorPenetrationBlunt>3.721</armorPenetrationBlunt>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>17</damageAmountBase>
+				<damageAmountBase>12</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
 				<explosiveRadius>0.5</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/Defs/Ammo/Grenade/40x46mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x46mmGrenade.xml
@@ -194,11 +194,11 @@
 			<damageDef>Bullet</damageDef>
 			<damageAmountBase>35</damageAmountBase>
 			<armorPenetrationSharp>63</armorPenetrationSharp>
-			<armorPenetrationBlunt>5.543</armorPenetrationBlunt>
+			<armorPenetrationBlunt>4.157</armorPenetrationBlunt>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>18</damageAmountBase>
+				<damageAmountBase>14</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
 				<explosiveRadius>0.5</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/Defs/Ammo/Grenade/40x53mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmGrenade.xml
@@ -179,11 +179,11 @@
 			<damageDef>Bullet</damageDef>
 			<damageAmountBase>36</damageAmountBase>
 			<armorPenetrationSharp>76</armorPenetrationSharp>
-			<armorPenetrationBlunt>5.768</armorPenetrationBlunt>
+			<armorPenetrationBlunt>4.326</armorPenetrationBlunt>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>19</damageAmountBase>
+				<damageAmountBase>14</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
 				<explosiveRadius>0.5</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/Defs/Ammo/Grenade/83mmPIATGrenade.xml
+++ b/Defs/Ammo/Grenade/83mmPIATGrenade.xml
@@ -103,11 +103,11 @@
 			<damageDef>Bullet</damageDef>
 			<damageAmountBase>268</damageAmountBase>
 			<armorPenetrationSharp>100</armorPenetrationSharp>
-			<armorPenetrationBlunt>41.818</armorPenetrationBlunt>
+			<armorPenetrationBlunt>31.364</armorPenetrationBlunt>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>139</damageAmountBase>
+				<damageAmountBase>105</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
 				<explosiveRadius>1</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/Defs/Ammo/Projectiles_Fragments.xml
+++ b/Defs/Ammo/Projectiles_Fragments.xml
@@ -65,12 +65,12 @@
 			<damageAmountBase>50</damageAmountBase>
 			<speed>40</speed>
 			<armorPenetrationSharp>70</armorPenetrationSharp>
-			<armorPenetrationBlunt>6.387</armorPenetrationBlunt>
+			<armorPenetrationBlunt>4.79</armorPenetrationBlunt>
 			<gravityFactor>5</gravityFactor>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>25</damageAmountBase>
+				<damageAmountBase>16</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
 				<explosiveRadius>0.5</explosiveRadius>
 			</li>

--- a/Defs/Ammo/Rocket/127mmJavelinMissile.xml
+++ b/Defs/Ammo/Rocket/127mmJavelinMissile.xml
@@ -15,13 +15,13 @@
 			<damageDef>Bullet</damageDef>
 			<damageAmountBase>363</damageAmountBase>
 			<armorPenetrationSharp>750</armorPenetrationSharp>
-			<armorPenetrationBlunt>175.402</armorPenetrationBlunt>
+			<armorPenetrationBlunt>131.552</armorPenetrationBlunt>
 			<speed>57</speed>
 			<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>585</damageAmountBase>
+				<damageAmountBase>439</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
 				<explosiveRadius>3</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/Defs/Ammo/Rocket/150mmMBTLAWMissile.xml
+++ b/Defs/Ammo/Rocket/150mmMBTLAWMissile.xml
@@ -15,13 +15,13 @@
 			<damageDef>Bullet</damageDef>
 			<damageAmountBase>281</damageAmountBase>
 			<armorPenetrationSharp>600</armorPenetrationSharp>
-			<armorPenetrationBlunt>137.525</armorPenetrationBlunt>
+			<armorPenetrationBlunt>103.144</armorPenetrationBlunt>
 			<speed>54</speed>
 			<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>458</damageAmountBase>
+				<damageAmountBase>344</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
 				<explosiveRadius>2.5</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/Defs/Ammo/Rocket/57mmS5Rocket.xml
+++ b/Defs/Ammo/Rocket/57mmS5Rocket.xml
@@ -216,11 +216,11 @@
 			<damageDef>Bullet</damageDef>
 			<damageAmountBase>158</damageAmountBase>
 			<armorPenetrationSharp>172</armorPenetrationSharp>
-			<armorPenetrationBlunt>26.312</armorPenetrationBlunt>
+			<armorPenetrationBlunt>19.734</armorPenetrationBlunt>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>88</damageAmountBase>
+				<damageAmountBase>66</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
 				<explosiveRadius>1</explosiveRadius>
 				<explosionSound>MortarBomb_Explode</explosionSound>

--- a/Defs/Ammo/Rocket/70mmAPKWS.xml
+++ b/Defs/Ammo/Rocket/70mmAPKWS.xml
@@ -111,11 +111,11 @@
 			<damageDef>Bullet</damageDef>
 			<damageAmountBase>248</damageAmountBase>
 			<armorPenetrationSharp>300</armorPenetrationSharp>
-			<armorPenetrationBlunt>44.285</armorPenetrationBlunt>
+			<armorPenetrationBlunt>33.215</armorPenetrationBlunt>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>148</damageAmountBase>
+				<damageAmountBase>111</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
 				<explosiveRadius>1.5</explosiveRadius>
 				<explosionSound>MortarBomb_Explode</explosionSound>

--- a/Defs/Ammo/Rocket/83mmSMAW.xml
+++ b/Defs/Ammo/Rocket/83mmSMAW.xml
@@ -137,11 +137,11 @@
 			<damageDef>Bullet</damageDef>
 			<damageAmountBase>248</damageAmountBase>
 			<armorPenetrationSharp>600</armorPenetrationSharp>
-			<armorPenetrationBlunt>39.494</armorPenetrationBlunt>
+			<armorPenetrationBlunt>29.621</armorPenetrationBlunt>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>132</damageAmountBase>
+				<damageAmountBase>99</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
 				<explosiveRadius>1</explosiveRadius>
 				<explosionSound>MortarBomb_Explode</explosionSound>

--- a/Defs/Ammo/Rocket/84mmAT4.xml
+++ b/Defs/Ammo/Rocket/84mmAT4.xml
@@ -15,13 +15,13 @@
 			<damageDef>Bullet</damageDef>
 			<damageAmountBase>248</damageAmountBase>
 			<armorPenetrationSharp>420</armorPenetrationSharp>
-			<armorPenetrationBlunt>31.995</armorPenetrationBlunt>
+			<armorPenetrationBlunt>23.994</armorPenetrationBlunt>
 			<speed>63</speed>
 			<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>107</damageAmountBase>
+				<damageAmountBase>80</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
 				<explosiveRadius>1</explosiveRadius>
 				<explosionSound>MortarBomb_Explode</explosionSound>

--- a/Defs/Ammo/Rocket/84x246mmR.xml
+++ b/Defs/Ammo/Rocket/84x246mmR.xml
@@ -273,12 +273,12 @@
 			<damageDef>Bullet</damageDef>
 			<damageAmountBase>248</damageAmountBase>
 			<armorPenetrationSharp>400</armorPenetrationSharp>
-			<armorPenetrationBlunt>33.03</armorPenetrationBlunt>
+			<armorPenetrationBlunt>24.773</armorPenetrationBlunt>
 			<speed>64</speed>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>110</damageAmountBase>
+				<damageAmountBase>83</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
 				<explosiveRadius>1</explosiveRadius>
 				<explosionSound>MortarBomb_Explode</explosionSound>

--- a/Defs/Ammo/Rocket/88mmRPzB.xml
+++ b/Defs/Ammo/Rocket/88mmRPzB.xml
@@ -103,11 +103,11 @@
 			<damageDef>Bullet</damageDef>
 			<damageAmountBase>208</damageAmountBase>
 			<armorPenetrationSharp>220</armorPenetrationSharp>
-			<armorPenetrationBlunt>37.321</armorPenetrationBlunt>
+			<armorPenetrationBlunt>27.991</armorPenetrationBlunt>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>124</damageAmountBase>
+				<damageAmountBase>93</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
 				<explosiveRadius>1</explosiveRadius>
 				<explosionSound>MortarBomb_Explode</explosionSound>

--- a/Defs/Ammo/Rocket/90mmMATADOR.xml
+++ b/Defs/Ammo/Rocket/90mmMATADOR.xml
@@ -15,13 +15,13 @@
 			<damageDef>Bullet</damageDef>
 			<damageAmountBase>248</damageAmountBase>
 			<armorPenetrationSharp>500</armorPenetrationSharp>
-			<armorPenetrationBlunt>33.233</armorPenetrationBlunt>
+			<armorPenetrationBlunt>24.925</armorPenetrationBlunt>
 			<speed>63</speed>
 			<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>111</damageAmountBase>
+				<damageAmountBase>83</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
 				<explosiveRadius>1</explosiveRadius>
 				<explosionSound>MortarBomb_Explode</explosionSound>

--- a/Defs/Ammo/Rocket/90mmRecoilless.xml
+++ b/Defs/Ammo/Rocket/90mmRecoilless.xml
@@ -134,11 +134,11 @@
 			<damageDef>Bullet</damageDef>
 			<damageAmountBase>239</damageAmountBase>
 			<armorPenetrationSharp>350</armorPenetrationSharp>
-			<armorPenetrationBlunt>31.885</armorPenetrationBlunt>
+			<armorPenetrationBlunt>23.914</armorPenetrationBlunt>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>106</damageAmountBase>
+				<damageAmountBase>80</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
 				<explosiveRadius>1</explosiveRadius>
 				<explosionSound>MortarBomb_Explode</explosionSound>

--- a/Defs/Ammo/Rocket/M6.xml
+++ b/Defs/Ammo/Rocket/M6.xml
@@ -106,11 +106,11 @@
 			<damageDef>Bullet</damageDef>
 			<damageAmountBase>208</damageAmountBase>
 			<armorPenetrationSharp>76</armorPenetrationSharp>
-			<armorPenetrationBlunt>42.273</armorPenetrationBlunt>
+			<armorPenetrationBlunt>31.705</armorPenetrationBlunt>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>141</damageAmountBase>
+				<damageAmountBase>106</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
 				<explosiveRadius>1.5</explosiveRadius>
 				<explosionSound>MortarBomb_Explode</explosionSound>

--- a/Defs/Ammo/Rocket/M6A1.xml
+++ b/Defs/Ammo/Rocket/M6A1.xml
@@ -95,11 +95,11 @@
 			<damageDef>Bullet</damageDef>
 			<damageAmountBase>208</damageAmountBase>
 			<armorPenetrationSharp>76</armorPenetrationSharp>
-			<armorPenetrationBlunt>42.273</armorPenetrationBlunt>
+			<armorPenetrationBlunt>31.705</armorPenetrationBlunt>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>141</damageAmountBase>
+				<damageAmountBase>106</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
 				<explosiveRadius>1.5</explosiveRadius>
 				<explosionSound>MortarBomb_Explode</explosionSound>

--- a/Defs/Ammo/Rocket/M6A3.xml
+++ b/Defs/Ammo/Rocket/M6A3.xml
@@ -119,11 +119,11 @@
 			<damageDef>Bullet</damageDef>
 			<damageAmountBase>208</damageAmountBase>
 			<armorPenetrationSharp>76</armorPenetrationSharp>
-			<armorPenetrationBlunt>42.273</armorPenetrationBlunt>
+			<armorPenetrationBlunt>31.705</armorPenetrationBlunt>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>141</damageAmountBase>
+				<damageAmountBase>106</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
 				<explosiveRadius>1.5</explosiveRadius>
 				<explosionSound>MortarBomb_Explode</explosionSound>

--- a/Defs/Ammo/Rocket/M72LAW.xml
+++ b/Defs/Ammo/Rocket/M72LAW.xml
@@ -16,7 +16,7 @@
 			<damageDef>Bullet</damageDef>
 			<damageAmountBase>248</damageAmountBase>
 			<armorPenetrationSharp>300</armorPenetrationSharp>
-			<armorPenetrationBlunt>31.584</armorPenetrationBlunt>
+			<armorPenetrationBlunt>23.688</armorPenetrationBlunt>
 			<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
 			<dropsCasings>true</dropsCasings>
 			<casingMoteDefname>Fleck_DisposableLauncherCasing</casingMoteDefname>
@@ -24,7 +24,7 @@
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>105</damageAmountBase>
+				<damageAmountBase>79</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
 				<explosiveRadius>1</explosiveRadius>
 				<explosionSound>MortarBomb_Explode</explosionSound>

--- a/Defs/Ammo/Rocket/RPG28.xml
+++ b/Defs/Ammo/Rocket/RPG28.xml
@@ -15,13 +15,13 @@
 			<damageDef>Bullet</damageDef>
 			<damageAmountBase>279</damageAmountBase>
 			<armorPenetrationSharp>1000</armorPenetrationSharp>
-			<armorPenetrationBlunt>46.227</armorPenetrationBlunt>
+			<armorPenetrationBlunt>34.67</armorPenetrationBlunt>
 			<speed>65</speed>
 			<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>154</damageAmountBase>
+				<damageAmountBase>116</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
 				<explosiveRadius>1.5</explosiveRadius>
 				<explosionSound>MortarBomb_Explode</explosionSound>

--- a/Defs/Ammo/Rocket/RPG32.xml
+++ b/Defs/Ammo/Rocket/RPG32.xml
@@ -118,11 +118,11 @@
 			<damageDef>Bullet</damageDef>
 			<damageAmountBase>264</damageAmountBase>
 			<armorPenetrationSharp>650</armorPenetrationSharp>
-			<armorPenetrationBlunt>41.818</armorPenetrationBlunt>
+			<armorPenetrationBlunt>31.364</armorPenetrationBlunt>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>139</damageAmountBase>
+				<damageAmountBase>105</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
 				<explosiveRadius>1</explosiveRadius>
 				<explosionSound>MortarBomb_Explode</explosionSound>

--- a/Defs/Ammo/Rocket/RPG7.xml
+++ b/Defs/Ammo/Rocket/RPG7.xml
@@ -137,13 +137,13 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<damageAmountBase>275</damageAmountBase>
+			<damageAmountBase>304</damageAmountBase>
 			<armorPenetrationSharp>500</armorPenetrationSharp>
-			<armorPenetrationBlunt>44.956</armorPenetrationBlunt>
+			<armorPenetrationBlunt>33.718</armorPenetrationBlunt>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>150</damageAmountBase>
+				<damageAmountBase>112</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
 				<explosiveRadius>1.5</explosiveRadius>
 				<explosionSound>MortarBomb_Explode</explosionSound>
@@ -170,7 +170,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<explosionRadius>5</explosionRadius>
 			<damageDef>Thermobaric</damageDef>
-			<damageAmountBase>275</damageAmountBase>
+			<damageAmountBase>344</damageAmountBase>
 			<armorPenetrationSharp>0</armorPenetrationSharp>
 			<armorPenetrationBlunt>0</armorPenetrationBlunt>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/Defs/Ammo/Rocket/SPG9.xml
+++ b/Defs/Ammo/Rocket/SPG9.xml
@@ -154,11 +154,11 @@
 			<damageDef>Bullet</damageDef>
 			<damageAmountBase>248</damageAmountBase>
 			<armorPenetrationSharp>400</armorPenetrationSharp>
-			<armorPenetrationBlunt>26.53</armorPenetrationBlunt>
+			<armorPenetrationBlunt>19.897</armorPenetrationBlunt>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>88</damageAmountBase>
+				<damageAmountBase>66</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
 				<explosiveRadius>1.0</explosiveRadius>
 				<explosionSound>MortarBomb_Explode</explosionSound>

--- a/Defs/Ammo/Shell/100x695mmR.xml
+++ b/Defs/Ammo/Shell/100x695mmR.xml
@@ -97,11 +97,11 @@
 			<damageAmountBase>341</damageAmountBase>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<armorPenetrationSharp>380</armorPenetrationSharp>
-			<armorPenetrationBlunt>52.045</armorPenetrationBlunt>
+			<armorPenetrationBlunt>39.034</armorPenetrationBlunt>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>173</damageAmountBase>
+				<damageAmountBase>130</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
 				<explosiveRadius>1.5</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
@@ -109,7 +109,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>27</Fragment_Large>
-					<Fragment_Small>60</Fragment_Small>
+					<Fragment_Small>15</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Shell/105mmHowitzer.xml
+++ b/Defs/Ammo/Shell/105mmHowitzer.xml
@@ -323,11 +323,11 @@
 			<damageAmountBase>352</damageAmountBase>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<armorPenetrationSharp>375</armorPenetrationSharp>
-			<armorPenetrationBlunt>46.013</armorPenetrationBlunt>
+			<armorPenetrationBlunt>34.51</armorPenetrationBlunt>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>153</damageAmountBase>
+				<damageAmountBase>115</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
 				<explosiveRadius>1.5</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/Defs/Ammo/Shell/105x607mmR.xml
+++ b/Defs/Ammo/Shell/105x607mmR.xml
@@ -97,11 +97,11 @@
 			<damageAmountBase>341</damageAmountBase>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<armorPenetrationSharp>410</armorPenetrationSharp>
-			<armorPenetrationBlunt>53.916</armorPenetrationBlunt>
+			<armorPenetrationBlunt>40.437</armorPenetrationBlunt>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>180</damageAmountBase>
+				<damageAmountBase>135</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
 				<explosiveRadius>1.5</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/Defs/Ammo/Shell/105x617mmR.xml
+++ b/Defs/Ammo/Shell/105x617mmR.xml
@@ -98,11 +98,11 @@
 			<damageAmountBase>316</damageAmountBase>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<armorPenetrationSharp>390</armorPenetrationSharp>
-			<armorPenetrationBlunt>46.013</armorPenetrationBlunt>
+			<armorPenetrationBlunt>34.51</armorPenetrationBlunt>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>153</damageAmountBase>
+				<damageAmountBase>115</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
 				<explosiveRadius>1.5</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/Defs/Ammo/Shell/120mmCannon.xml
+++ b/Defs/Ammo/Shell/120mmCannon.xml
@@ -96,11 +96,11 @@
 			<damageAmountBase>405</damageAmountBase>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<armorPenetrationSharp>420</armorPenetrationSharp>
-			<armorPenetrationBlunt>62.411</armorPenetrationBlunt>
+			<armorPenetrationBlunt>46.809</armorPenetrationBlunt>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>208</damageAmountBase>
+				<damageAmountBase>156</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
 				<explosiveRadius>1.5</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/Defs/Ammo/Shell/762x385mmRCannon.xml
+++ b/Defs/Ammo/Shell/762x385mmRCannon.xml
@@ -142,11 +142,11 @@
 			<damageAmountBase>264</damageAmountBase>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<armorPenetrationSharp>300</armorPenetrationSharp>
-			<armorPenetrationBlunt>32.966</armorPenetrationBlunt>
+			<armorPenetrationBlunt>24.725</armorPenetrationBlunt>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>110</damageAmountBase>
+				<damageAmountBase>82</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
 				<explosiveRadius>1</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/Defs/Ammo/Shell/90mmCannon.xml
+++ b/Defs/Ammo/Shell/90mmCannon.xml
@@ -160,11 +160,11 @@
 			<damageAmountBase>304</damageAmountBase>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<armorPenetrationSharp>500</armorPenetrationSharp>
-			<armorPenetrationBlunt>38.005</armorPenetrationBlunt>
+			<armorPenetrationBlunt>28.541</armorPenetrationBlunt>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>127</damageAmountBase>
+				<damageAmountBase>95</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
 				<explosiveRadius>1</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>


### PR DESCRIPTION
## Changes

- Changed the formula used for HEDP bullet damage calculations in the projectile spreadsheet to be similar to HEAT ammo and made the necessary changes in xml.
- Decreased the bomb damage from HEDP and HEAT sources by 25%

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070

## Reasoning

- HEAT and HEDP are pretty much the same thing.
- It never made sense to me that the explosive part of HEAT ammo types competed with HE ammo bomb damage, it's meant to push the jet forward, not be a strong explosion in a short radius that is on par with HE ammo type explosions. The 25% damage decrease should address that appropriately.

## Alternatives

- Leave the bomb damage component be?

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
