### PR TITLE
No hats for imperial fighters

### DIFF
--- a/Royalty/Patches/PawnKindDefs_Royalty/PawnKinds_Royalty.xml
+++ b/Royalty/Patches/PawnKindDefs_Royalty/PawnKinds_Royalty.xml
@@ -29,12 +29,7 @@
 
 	<!-- ========== Fighters ========== -->
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/PawnKindDef[@Name="ImperialFighterBase"]</xpath>
-		<value>
-			<apparelIgnoreSeasons>true</apparelIgnoreSeasons>
-		</value>
-	</Operation>
+	<!-- ====== Trooper ====== -->
 
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="Empire_Fighter_Trooper"]</xpath>
@@ -88,7 +83,16 @@
 		</value>
 	</Operation>
 
+	<!-- ====== Janissary ====== -->
+
 	<!--removed gunlink-->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/PawnKindDef[defName="Empire_Fighter_Janissary"]</xpath>
+		<value>
+			<apparelIgnoreSeasons>true</apparelIgnoreSeasons>
+		</value>
+	</Operation>
 
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/PawnKindDef[defName="Empire_Fighter_Janissary"]/specificApparelRequirements/li[bodyPartGroup="UpperHead"]/alternateTagChoices/li[tag="Gunlink"]</xpath>
@@ -146,6 +150,8 @@
 		</value>
 	</Operation>
 
+	<!-- ====== Champion ====== -->
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="Empire_Fighter_Champion"]</xpath>
 		<value>
@@ -194,27 +200,26 @@
 		</value>
 	</Operation>
 
+	<!-- ====== Grenadier ====== -->
+
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/PawnKindDef[@Name="CataphractBase"]</xpath>
+		<xpath>Defs/PawnKindDef[defName="Empire_Fighter_Grenadier"]</xpath>
 		<value>
-			<minGenerationAge>18</minGenerationAge>
+			<apparelIgnoreSeasons>true</apparelIgnoreSeasons>
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/PawnKindDef[defName="Empire_Fighter_Cataphract"]/weaponTags</xpath>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/PawnKindDef[defName="Empire_Fighter_Grenadier"]/weaponTags</xpath>
 		<value>
-			<li>Minigun</li>
+			<weaponTags>
+				<li>GunHeavy</li>
+			</weaponTags>
 		</value>
-	</Operation>
-
-	<!--removed gunlink-->
-	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/PawnKindDef[defName="Empire_Fighter_Cataphract"]/specificApparelRequirements/li[1]</xpath>
 	</Operation>
 
 	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/PawnKindDef[defName="Empire_Fighter_Cataphract"]</xpath>
+		<xpath>Defs/PawnKindDef[defName="Empire_Fighter_Grenadier"]</xpath>
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
@@ -265,17 +270,37 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/PawnKindDef[defName="Empire_Fighter_Grenadier"]/weaponTags</xpath>
+	<!-- ====== Cataphracts ====== -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/PawnKindDef[@Name="CataphractBase"]</xpath>
 		<value>
-			<weaponTags>
-				<li>GunHeavy</li>
-			</weaponTags>
+			<apparelIgnoreSeasons>true</apparelIgnoreSeasons>
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/PawnKindDef[@Name="CataphractBase"]</xpath>
+		<value>
+			<minGenerationAge>18</minGenerationAge>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/PawnKindDef[defName="Empire_Fighter_Cataphract"]/weaponTags</xpath>
+		<value>
+			<li>Minigun</li>
+		</value>
+	</Operation>
+
+	<!--removed gunlink-->
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/PawnKindDef[defName="Empire_Fighter_Cataphract"]/specificApparelRequirements/li[1]</xpath>
+	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/PawnKindDef[defName="Empire_Fighter_Grenadier"]</xpath>
+		<xpath>Defs/PawnKindDef[defName="Empire_Fighter_Cataphract"]</xpath>
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>

--- a/Royalty/Patches/PawnKindDefs_Royalty/PawnKinds_Royalty.xml
+++ b/Royalty/Patches/PawnKindDefs_Royalty/PawnKinds_Royalty.xml
@@ -29,6 +29,13 @@
 
 	<!-- ========== Fighters ========== -->
 
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/PawnKindDef[@Name="ImperialFighterBase"]</xpath>
+		<value>
+			<apparelIgnoreSeasons>true</apparelIgnoreSeasons>
+		</value>
+	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="Empire_Fighter_Trooper"]</xpath>
 		<value>


### PR DESCRIPTION
## Changes

- Made sure imperial fighters retain their proper headgear regardless of the seasonal weather.

## Reasoning

- Empire fighter pawnkinds can spawn with seasonal apparel and lack the `<apparelIgnoreSeasons>true</apparelIgnoreSeasons>` node leading them to forego armor in favor of tuques and other junk, helmets are irrelevant in vanilla but not CE.

## Alternatives

- Cataphracts that wear tuques.
- Can target specific heavy units nut I prefer all the fighters keeping their helmets.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Works)
