### PR TITLE
12 Gauge Charged spread tweak

### DIFF
--- a/Defs/Ammo/Advanced/12GaugeCharged.xml
+++ b/Defs/Ammo/Advanced/12GaugeCharged.xml
@@ -143,7 +143,7 @@
 			<armorPenetrationSharp>8</armorPenetrationSharp>
 			<armorPenetrationBlunt>14.4</armorPenetrationBlunt>
 			<pelletCount>6</pelletCount>
-			<spreadMult>17.8</spreadMult>
+			<spreadMult>8.9</spreadMult>
 			<empShieldBreakChance>0.025</empShieldBreakChance>
 		</projectile>
 	</ThingDef>


### PR DESCRIPTION
## Changes

- Changed the spread multiplier of the 12 gauge charged ammo to be in line with other shotgun ammo types, 17.8 to 8.9.

## Reasoning

- Forgor? There was a reason it was not touched but can't remember...

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
