### PR TITLE
Patch Dev's Xenotypes - Boglegs

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -595,5 +595,6 @@
 		<li IfModActive="Mlie.XennRace">ModPatches/Xenn</li>
 		<li IfModActive="Neronix17.OuterRim.DroidDepot">ModPatches/Outer Rim - Droid Depot</li>
 		<li IfModActive="VAMV.MaruRaceMod">ModPatches/Maru Race</li>
+		<li IfModActive="det.boglegs">ModPatches/Det's Xenotypes - Boglegs</li>		
 	</v1.5>
 </loadFolders>

--- a/ModPatches/Det's Xenotypes - Boglegs/Patches/Det's Xenotypes - Boglegs/Abilities_Boglegs.xml
+++ b/ModPatches/Det's Xenotypes - Boglegs/Patches/Det's Xenotypes - Boglegs/Abilities_Boglegs.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- ========== Muck Spit ========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AbilityDef[defName="DV_MuckSpit"]/verbProperties/range</xpath>
+		<value>
+			<range>8.9</range>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Det's Xenotypes - Boglegs/Patches/Det's Xenotypes - Boglegs/Hediff_Boglegs.xml
+++ b/ModPatches/Det's Xenotypes - Boglegs/Patches/Det's Xenotypes - Boglegs/Hediff_Boglegs.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+    <!-- Knuckle Dusters -->
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName = "DV_Handwear_KnuckleDusters"]/statBases</xpath>
+		<value>
+            <Bulk>0.6</Bulk>
+            <WornBulk>0</WornBulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/HediffDef[defName = "DV_KnuckleDusters"]/comps/li/tools</xpath>
+		<value>
+			<tools>
+                <li Class="CombatExtended.ToolCE">
+                    <label>knuckles</label>
+                    <capacities>
+                        <li>Blunt</li>
+                    </capacities>
+                    <power>2</power>
+                    <cooldownTime>1.5</cooldownTime>
+                    <soundMeleeHit>MeleeHit_Metal_Blunt</soundMeleeHit>
+                    <armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+                </li>
+			</tools>
+		</value>
+	</Operation>
+
+    <!-- Stored Blubber -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/HediffDef[defName = "Bogleg_FatHediff"]/comps/li[@Class = "Boglegs.HediffCompProperties_Fat"]/bluntProtectionCurve/points</xpath>
+		<value>
+              <points>
+                <li>(0, 0)</li>
+                <li>(0.10, 0.08)</li>
+                <li>(0.20, 0.26)</li>
+                <li>(0.30, 0.42)</li>
+                <li>(0.40, 0.60)</li>
+              </points>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Det's Xenotypes - Boglegs/Patches/Det's Xenotypes - Boglegs/Hediff_Boglegs.xml
+++ b/ModPatches/Det's Xenotypes - Boglegs/Patches/Det's Xenotypes - Boglegs/Hediff_Boglegs.xml
@@ -11,7 +11,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/HediffDef[defName = "DV_KnuckleDusters"]/comps/li/tools</xpath>
+		<xpath>Defs/HediffDef[defName = "DV_KnuckleDusters"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
 		<value>
 			<tools>
                 <li Class="CombatExtended.ToolCE">
@@ -30,7 +30,7 @@
 
     <!-- Stored Blubber -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/HediffDef[defName = "Bogleg_FatHediff"]/comps/li[@Class = "Boglegs.HediffCompProperties_Fat"]/bluntProtectionCurve/points</xpath>
+		<xpath>Defs/HediffDef[defName = "Bogleg_FatHediff"]/comps/li[@Class="Boglegs.HediffCompProperties_Fat"]/bluntProtectionCurve/points</xpath>
 		<value>
               <points>
                 <li>(0, 0)</li>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -165,6 +165,7 @@ Dark Ages : Medieval Tools  |
 Darkest Night SK Steam	|
 Darkest Rim: Apparel	|
 Det's Energy Weapons    |
+Det's Xenotypes - Boglegs   |
 Devilstrand Animals |
 Devilstrand Colour Bundle   |
 Dinosauria |


### PR DESCRIPTION
## Additions
- Patch boglegs xenotype.
  - Rebalance blunt armor values added by stored blubber hediff.
  - Patch knuckleduster melee attack along the lines of the brass knuckles from my CE Weapons mod (which I made stats for a long while ago).
  - Slightly increase the range of the muck spit ability.

## References
Close #3043 

## Reasoning
- Set appropriate values for CE balance.
- Didn't see a point in patching the muck spit verb or projectile, since all it does is create a patch of filth.

## Alternatives
- Different stat values, I suppose.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
