### PR TITLE
Only allow repair armor repair of non-hostile pawns.

### DIFF
--- a/Defs/JobDefs/Jobs_CE.xml
+++ b/Defs/JobDefs/Jobs_CE.xml
@@ -115,7 +115,7 @@
 	<JobDef>
 		<defName>RepairNaturalArmor</defName>
 		<driverClass>CombatExtended.JobDriver_RepairNaturalArmor</driverClass>
-		<reportString>Fixing TargetA 's natural armor.</reportString>
+		<reportString>Fixing TargetA's natural armor.</reportString>
 	</JobDef>
 
 	<JobDef>

--- a/Source/CombatExtended/CombatExtended/Comps/CompArmorDurability.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompArmorDurability.cs
@@ -176,7 +176,7 @@ namespace CombatExtended
 
         public override IEnumerable<FloatMenuOption> CompFloatMenuOptions(Pawn selPawn)
         {
-            if (durabilityProps.Repairable)
+            if (durabilityProps.Repairable && !this.parent.HostileTo(selPawn))
             {
                 var firstIngredientProvidedOrNotNeeded = true;
                 var secondIngredientProvidedOrNotNeeded = true;


### PR DESCRIPTION
## Changes

- Removed right click menu option to repair hostile pawns

## Reasoning

- Player does not need an option to repair hostile mechs.

## Alternatives

  - Allow player to send pawns to commit suicide attempting to repair an angry hostile centipede.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (21 minutes)
