### PR TITLE
Fixed incorrect penetration value

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/BulletCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/BulletCE.cs
@@ -27,7 +27,7 @@ namespace CombatExtended
             {
                 var projectilePropsCE = (ProjectilePropertiesCE)def.projectile;
                 var isSharpDmg = def.projectile.damageDef.armorCategory == DamageArmorCategoryDefOf.Sharp;
-                return equipment?.GetStatValue(StatDefOf.RangedWeapon_DamageMultiplier) ?? 1f * (isSharpDmg ? projectilePropsCE.armorPenetrationSharp : projectilePropsCE.armorPenetrationBlunt);
+                return (equipment?.GetStatValue(StatDefOf.RangedWeapon_DamageMultiplier) ?? 1f) * (isSharpDmg ? projectilePropsCE.armorPenetrationSharp : projectilePropsCE.armorPenetrationBlunt);
             }
         }
 


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Fixed incorrect calculations due to syntax sugar

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #3190 

## Reasoning

Why did you choose to implement things this way, e.g.
- No damage

Original code was compiled to this:
![image](https://github.com/CombatExtended-Continued/CombatExtended/assets/78953324/a26c7942-9174-4fdd-aa03-0007112030a1)


## Alternatives

Describe alternative implementations you have considered, e.g.
- Destroy centipede with molotov

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (tested and compared pentration of disposable launcher)
