### PR TITLE
Smarter ai

### DIFF
--- a/Patches/Core/DutyDefs/Duties_Misc.xml
+++ b/Patches/Core/DutyDefs/Duties_Misc.xml
@@ -44,5 +44,17 @@
 		<attribute>Class</attribute>
 		<value>CombatExtended.JobGiver_ManTurretsNearPointCE</value>
 	</Operation>
+  
+  <!-- ========== Patch attack duties ========== -->
+
+  <Operation Class="PatchOperationInsert">
+    <xpath>Defs/DutyDef/thinkNode/subNodes/li[@Class="JobGiver_AIFightEnemies" or @Class="JobGiver_AIDefendEscortee" or @Class="JobGiver_AIDefendPoint"]</xpath>
+    <value>
+      <li Class="CombatExtended.JobGiver_CEFlee">
+        <enemyDistToFleeRange>0.9~7.9</enemyDistToFleeRange>
+        <fleeDistRange>13.5~20</fleeDistRange>
+      </li>
+    </value>
+  </Operation>
 
 </Patch>

--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -637,6 +637,54 @@ namespace CombatExtended
             }
         }
 
+        public static Dictionary<BodyPartRecord, float> GetArmorByBodyParts(Pawn pawn, StatDef stat, Dictionary<BodyPartRecord, float> armorCache = null)
+        {
+            if (armorCache == null)
+            {
+                armorCache = new Dictionary<BodyPartRecord, float>();
+            }
+            else
+            {
+                armorCache.Clear();
+            }
+            float naturalArmor = pawn.GetStatValue(stat);
+            List<Apparel> wornApparel = pawn.apparel?.WornApparel;
+            foreach (BodyPartRecord part in pawn.RaceProps.body.AllParts)
+            {
+                //TODO: 1.5 should be Neck
+                if (part.depth == BodyPartDepth.Outside && (part.coverage >= 0.1 || (part.def == BodyPartDefOf.Eye || part.def == BodyPartDefOf.Eye)))
+                {
+                    float armorValue = part.IsInGroup(CE_BodyPartGroupDefOf.CoveredByNaturalArmor) ? naturalArmor : 0f;
+                    if (wornApparel != null)
+                    {
+                        foreach (var apparel in wornApparel)
+                        {
+                            if (apparel.def.apparel.CoversBodyPart(part))
+                            {
+                                armorValue += apparel.PartialStat(stat, part);
+                            }
+                        }
+                    }
+                    armorCache[part] = armorValue;
+                }
+            }
+            return armorCache;
+        }
+        public static float AverageArmor(Pawn pawn, StatDef stat)
+        {
+            var armorCache = GetArmorByBodyParts(pawn, stat);
+            float averageArmor = 0;
+            float bodyCoverage = 0;
+            foreach (var bodyPartValue in armorCache)
+            {
+                BodyPartRecord part = bodyPartValue.Key;
+                float armorValue = bodyPartValue.Value;
+                averageArmor += armorValue * part.coverage;
+                bodyCoverage += part.coverage;
+            }
+            averageArmor /= bodyCoverage;
+            return averageArmor;
+        }
         #endregion
     }
 }

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -577,7 +577,7 @@ namespace CombatExtended
         /// </summary>
         /// <param name="pawn">Pawn to calculate speed of</param>
         /// <returns>Move speed in cells per second</returns>
-        public static float GetMoveSpeed(Pawn pawn)
+        public static float GetMoveSpeed(this Pawn pawn)
         {
             if (!pawn.pather.Moving)
             {
@@ -1536,5 +1536,24 @@ namespace CombatExtended
         }
 
         public static FactionStrengthTracker GetStrengthTracker(this Faction faction) => Find.World.GetComponent<WorldStrengthTracker>().GetFactionTracker(faction);
+
+        public static bool TryGetMaxPenetration(this Thing thing, out float sharp, out float blunt)
+        {
+            sharp = 0; blunt = 0;
+            var ammoUser = thing.TryGetComp<CompAmmoUser>();
+            if (ammoUser != null)
+            {
+                sharp = ammoUser.Props.ammoSet.ammoTypes.Max(x => (x.projectile.projectile as ProjectilePropertiesCE).armorPenetrationSharp);
+                blunt = ammoUser.Props.ammoSet.ammoTypes.Max(x => (x.projectile.projectile as ProjectilePropertiesCE).armorPenetrationBlunt);
+                return true;
+            }
+            if (!thing.def.Verbs.NullOrEmpty())
+            {
+                sharp = thing.def.verbs.Select(x => x.defaultProjectile.projectile).OfType<ProjectilePropertiesCE>().Max(x => x.armorPenetrationSharp);
+                blunt = thing.def.verbs.Select(x => x.defaultProjectile.projectile).OfType<ProjectilePropertiesCE>().Max(x => x.armorPenetrationSharp);
+                return true;
+            }
+            return false;
+        }
     }
 }

--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_CEFlee.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_CEFlee.cs
@@ -1,0 +1,98 @@
+﻿using CombatExtended.AI;
+using RimWorld;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using Verse;
+using Verse.AI;
+
+namespace CombatExtended
+{
+    public class JobGiver_CEFlee : JobGiver_FleeForDistance
+    {
+        public JobGiver_CEFlee() : base() { }
+        public bool meleeOnly = false;
+        public List<string> weaponTags;
+        public List<string> weaponTagsOfDanger;
+        public bool doNotFleeIfCantPenetrate = true;
+        public bool doNotFleeIfFaster = true;
+        public bool mechs = true;
+        public bool humanlike = true;
+        public override Job TryGiveJob(Pawn pawn)
+        {
+            if (pawn.RaceProps.IsMechanoid ^ mechs && pawn.RaceProps.Humanlike ^ humanlike)
+            {
+                return null;
+            }
+            var equipment = pawn.equipment.PrimaryEq;
+            if (equipment?.PrimaryVerb.IsMeleeAttack ?? true)
+            {
+                return null; // Melee fighters do not flee
+            }
+            if (!weaponTags.NullOrEmpty() && !equipment.parent.def.weaponTags.Any(x => weaponTags.Contains(x)))
+            {
+                return null; //If weaponsTags specified, check if pawn equipment has one of weapon tags
+            }
+            if (equipment.PrimaryVerb.EffectiveRange < this.fleeDistRange.min)
+            {
+                return null;
+            }
+            if (GenAI.EnemyIsNear(pawn, this.enemyDistToFleeRange.min, out _, meleeOnly, true))
+            {
+                return null;
+            }
+            foreach (var danger in AI_Utility.EnemiesNear(pawn, this.enemyDistToFleeRange.max, meleeOnly, true))
+            {
+                if (danger is Pawn dangerPawn)
+                {
+                    var dangerWeapon = dangerPawn.equipment.PrimaryEq;
+                    if (!weaponTagsOfDanger.NullOrEmpty() && (!dangerWeapon?.parent.def.weaponTags.Any(x => weaponTagsOfDanger.Contains(x)) ?? true))
+                    {
+                        continue; //If weaponTagsOfDanger specified, check if dangerous pawn equipment has one of weapon tags
+                    }
+                    if (doNotFleeIfCantPenetrate)
+                    {
+                        float sharpOfPawn = ArmorUtilityCE.AverageArmor(pawn, StatDefOf.ArmorRating_Sharp), bluntOfPawn = ArmorUtilityCE.AverageArmor(pawn, StatDefOf.ArmorRating_Blunt);
+                        float sharpOfAttacker = 0, bluntOfAttacker = 0;
+                        if (dangerWeapon == null || dangerWeapon.PrimaryVerb.IsMeleeAttack || !dangerWeapon.parent.TryGetMaxPenetration(out sharpOfAttacker, out bluntOfAttacker))
+                        {
+                            var verbs = dangerPawn.meleeVerbs.GetUpdatedAvailableVerbsList(false).Select(x=>x.verb).OfType<Verb_MeleeAttackCE>().ToArray();
+                            if (verbs.Length > 0)
+                            {
+                                sharpOfAttacker = verbs.Max(x => x.ArmorPenetrationSharp);
+                                bluntOfAttacker = verbs.Max(x => x.ArmorPenetrationBlunt);
+                            }
+                        }
+                        
+                        if (sharpOfAttacker < sharpOfPawn && bluntOfAttacker < bluntOfPawn)
+                        {
+                            continue;
+                        }
+                    }
+
+                    if (doNotFleeIfFaster && dangerPawn.GetMoveSpeed() > pawn.GetMoveSpeed() * 1.3f)
+                    {
+                        return null; // Do not run if ANY of dangers faster than you
+                    }
+                    return FleeUtility.FleeJob(pawn, danger, Mathf.CeilToInt(new FloatRange(fleeDistRange.min, Mathf.Max(equipment.PrimaryVerb.EffectiveRange, fleeDistRange.max)).RandomInRange));
+                }
+            }
+            return null;
+        }
+        public override ThinkNode DeepCopy(bool resolve = true)
+        {
+            var copy = (JobGiver_CEFlee)base.DeepCopy(resolve);
+            copy.meleeOnly = meleeOnly;
+            copy.weaponTags = weaponTags?.ToList();
+            copy.weaponTagsOfDanger = weaponTagsOfDanger?.ToList();
+            copy.doNotFleeIfCantPenetrate = doNotFleeIfCantPenetrate;
+            copy.doNotFleeIfFaster = doNotFleeIfFaster;
+            copy.mechs = mechs;
+            copy.humanlike = humanlike;
+            return copy;
+        }
+    }
+}

--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_CEFlee.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_CEFlee.cs
@@ -59,14 +59,14 @@ namespace CombatExtended
                         float sharpOfAttacker = 0, bluntOfAttacker = 0;
                         if (dangerWeapon == null || dangerWeapon.PrimaryVerb.IsMeleeAttack || !dangerWeapon.parent.TryGetMaxPenetration(out sharpOfAttacker, out bluntOfAttacker))
                         {
-                            var verbs = dangerPawn.meleeVerbs.GetUpdatedAvailableVerbsList(false).Select(x=>x.verb).OfType<Verb_MeleeAttackCE>().ToArray();
+                            var verbs = dangerPawn.meleeVerbs.GetUpdatedAvailableVerbsList(false).Select(x => x.verb).OfType<Verb_MeleeAttackCE>().ToArray();
                             if (verbs.Length > 0)
                             {
                                 sharpOfAttacker = verbs.Max(x => x.ArmorPenetrationSharp);
                                 bluntOfAttacker = verbs.Max(x => x.ArmorPenetrationBlunt);
                             }
                         }
-                        
+
                         if (sharpOfAttacker < sharpOfPawn && bluntOfAttacker < bluntOfPawn)
                         {
                             continue;

--- a/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
@@ -514,28 +514,7 @@ namespace CombatExtended
         // RimWorld.ITab_Pawn_Gear
         private void RebuildArmorCache(Dictionary<BodyPartRecord, float> armorCache, StatDef stat)
         {
-            armorCache.Clear();
-            float naturalArmor = SelPawnForGear.GetStatValue(stat);
-            List<Apparel> wornApparel = SelPawnForGear.apparel?.WornApparel;
-            foreach (BodyPartRecord part in SelPawnForGear.RaceProps.body.AllParts)
-            {
-                //TODO: 1.5 should be Neck
-                if (part.depth == BodyPartDepth.Outside && (part.coverage >= 0.1 || (part.def == BodyPartDefOf.Eye || part.def == BodyPartDefOf.Eye)))
-                {
-                    float armorValue = part.IsInGroup(CE_BodyPartGroupDefOf.CoveredByNaturalArmor) ? naturalArmor : 0f;
-                    if (wornApparel != null)
-                    {
-                        foreach (var apparel in wornApparel)
-                        {
-                            if (apparel.def.apparel.CoversBodyPart(part))
-                            {
-                                armorValue += apparel.PartialStat(stat, part);
-                            }
-                        }
-                    }
-                    armorCache[part] = armorValue;
-                }
-            }
+            ArmorUtilityCE.GetArmorByBodyParts(this.SelPawnForGear, stat, armorCache);
         }
 
         private void TryDrawOverallArmor(Dictionary<BodyPartRecord, float> armorCache, ref float curY, float width, StatDef stat, string label, string unit)


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Keep distance jobGiver. Behaviour can be changed by:
 - By enemy weapon tag (weaponTagsOfDanger)
 - By owner  weapon tag (weaponTags)
 - By race (humanlike\mech)
 - By speed of enemy (doNotFleeIfFaster)
 - By owner armor (doNotFleeIfCantPenetrate)
 - By weapon type of enemy (meleeOnly)


## Reasoning

Why did you choose to implement things this way, e.g.
- Make AI smarter

## Alternatives

Describe alternative implementations you have considered, e.g.
- Snipers will fight in melee

## Example

```
<Operation Class="PatchOperationInsert"> <!--Make human sniper and machine-gunners stay away from CQB-->
    <xpath>Defs/DutyDef/thinkNode/subNodes/li[@Class="JobGiver_AIFightEnemies" or @Class="JobGiver_AIDefendEscortee" or @Class="JobGiver_AIDefendPoint"]</xpath>
    <value>
      <li Class="CombatExtended.JobGiver_CEFlee">
        <weaponTags> <!--Applies to pawns with weapon that have these tags (if null or empty applied to all pawns)-->
          <li>Sniper</li>
          <li>LMG</li>
        </weaponTags>
        <meleeOnly>false</meleeOnly> <!--Optional, by defaul false. Should we flee from melee weaopon users only-->
        <weaponTagsOfDanger> <!--Optional, if specified flee if danger source armed with weapon, that have one of these tag, otherwise flee from all-->
          <li>Melee</li>
          <li>Shotgun</li>
          <li>Smg</li>
          <li>AR</li>
        </weaponTagsOfDanger>
        <mechs>false</mechs> <!--Optional, by default true. Should mechs use this JobGiver or not-->
        <humanlike>true</humanlike>  <!--Optional, by default true. Should humanlike use this JobGiver or not-->
        <enemyDistToFleeRange>0.9~7.9</enemyDistToFleeRange> <!--Distance to search dangerous targets-->
        <fleeDistRange>13.5~20</fleeDistRange> <!--How far should we run (pawn won't run further than weapon range)-->
        <doNotFleeIfCantPenetrate>false</doNotFleeIfCantPenetrate> <!--Optional, true by default. Do not flee if danger source can't penetrate pawn-->
        <doNotFleeIfFaster>true</doNotFleeIfFaster> <!--Optional, true by default. Do not flee if ANY danger source around faster than pawn-->
      </li>
    </value>
  </Operation>
  
    <Operation Class="PatchOperationInsert"> <!--Make AR users stay away from everybody-->
    <xpath>Defs/DutyDef/thinkNode/subNodes/li[@Class="JobGiver_AIFightEnemies" or @Class="JobGiver_AIDefendEscortee" or @Class="JobGiver_AIDefendPoint"]</xpath>
    <value>
      <li Class="CombatExtended.JobGiver_CEFlee">
        <weaponTags> <!--Applies to pawns with weapon that have these tags (if null or empty applied to all pawns)-->
          <li>AR</li>
        </weaponTags>
        <enemyDistToFleeRange>0.9~4.9</enemyDistToFleeRange> <!--Distance to search dangerous targets-->
        <fleeDistRange>7.5~14</fleeDistRange> <!--How far should we run (pawn won't run further than weapon range)-->
        <doNotFleeIfCantPenetrate>false</doNotFleeIfCantPenetrate> <!--Optional, true by default. Do not flee if danger source can't penetrate pawn-->
        <doNotFleeIfFaster>false</doNotFleeIfFaster> <!--Optional, true by default. Do not flee if ANY danger source around faster than pawn-->
      </li>
    </value>
  </Operation>
```

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
