### PR TITLE
Melee damage factor for Psycho

### DIFF
--- a/Defs/Drugs/Psychite_Psycho.xml
+++ b/Defs/Drugs/Psychite_Psycho.xml
@@ -153,6 +153,7 @@
 				</capMods>
 				<statFactors>
 					<Suppressability>0.1</Suppressability>
+					<MeleeDamageFactor>1.2</MeleeDamageFactor>
 				</statFactors>
 			</li>
 		</stages>


### PR DESCRIPTION
## Additions

- Added a 20% melee damage factor to Psycho's peak high hediff.

## Reasoning

- Fits the drug and the tribals could use the buff to melee damage and AP even if for a short period of time. The x1.2 factor itself becomes x1.15 for melee AP after the post processing.

## Alternatives

- No buff?

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
