### PR TITLE
Add Anomaly to built files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
     - name: package
       run: |
         mkdir CombatExtended
-        cp -r Source/ Assemblies/ AssembliesCore/ AssembliesCompat/ About/ Defs/ Languages/ Patches/ Royalty/ Ideology/ Biotech/ Sounds/ Textures/ ModPatches/ LoadFolders.xml README.md SupportedThirdPartyMods.md CombatExtended
+        cp -r Source/ Assemblies/ AssembliesCore/ AssembliesCompat/ About/ Defs/ Languages/ Patches/ Royalty/ Ideology/ Biotech/ Anomaly/ Sounds/ Textures/ ModPatches/ LoadFolders.xml README.md SupportedThirdPartyMods.md CombatExtended
         zip -9 -r build.zip CombatExtended
     - name: Upload to DO
       run: |

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -46,7 +46,7 @@ jobs:
     - name: package
       run: |
         mkdir CombatExtended
-        cp -r Source/ Assemblies/ AssembliesCompat/ AssembliesCore/ About/ Defs/ Languages/ Patches/ Royalty/ Ideology/ Biotech/ Sounds/ Textures/ ModPatches/ LoadFolders.xml README.md SupportedThirdPartyMods.md CombatExtended
+        cp -r Source/ Assemblies/ AssembliesCompat/ AssembliesCore/ About/ Defs/ Languages/ Patches/ Royalty/ Ideology/ Biotech/ Anomaly/ Sounds/ Textures/ ModPatches/ LoadFolders.xml README.md SupportedThirdPartyMods.md CombatExtended
         zip -9 -r build.zip CombatExtended
     - name: Upload to DO
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
     - name: package
       run: |
         mkdir CombatExtended
-        cp -r Assemblies/ AssembliesCore/ AssembliesCompat/ About/ Defs/ Languages/ Patches/ Royalty/ Ideology/ Biotech/ Sounds/ Textures/ ModPatches/ LoadFolders.xml README.md SupportedThirdPartyMods.md CombatExtended
+        cp -r Assemblies/ AssembliesCore/ AssembliesCompat/ About/ Defs/ Languages/ Patches/ Royalty/ Ideology/ Biotech/ Anomaly/ Sounds/ Textures/ ModPatches/ LoadFolders.xml README.md SupportedThirdPartyMods.md CombatExtended
         zip -9 -r CombatExtended.zip CombatExtended
     - name: Upload Package
       id: upload-package


### PR DESCRIPTION
## Changes
- Include the Anomaly patch folder in the files built by the github actions.

## Reasoning
- Because I forgot to add it to the original Anomaly PR.

## Alternatives
- Suffer.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
