### PR TITLE
Use Neck BodyPart for melee targeting

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompMeleeTargettingGizmo.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompMeleeTargettingGizmo.cs
@@ -93,9 +93,9 @@ namespace CombatExtended
             if (PawnParent.skills.GetSkill(SkillDefOf.Melee).Level >= 16)
             {
                 //TODO: 1.5 Should be neck?
-                targetBodyPart = BodyPartDefOf.Eye;
+                targetBodyPart = CE_BodyPartDefOf.Neck;
 
-                var neck = target.health.hediffSet.GetNotMissingParts(BodyPartHeight.Top).Where(y => y.def == BodyPartDefOf.Eye).FirstOrFallback();
+                var neck = target.health.hediffSet.GetNotMissingParts(BodyPartHeight.Top).Where(y => y.def == CE_BodyPartDefOf.Neck).FirstOrFallback();
 
                 if (neck != null)
                 {

--- a/Source/CombatExtended/CombatExtended/Comps/CompMeleeTargettingGizmo.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompMeleeTargettingGizmo.cs
@@ -25,8 +25,19 @@ namespace CombatExtended
             }
         }
     }
+
+    [StaticConstructorOnStartup]
     public class CompMeleeTargettingGizmo : ThingComp
     {
+        static CompMeleeTargettingGizmo()
+        {
+            priorityList = new List<BodyPartDef>() {
+                CE_BodyPartDefOf.Neck,
+                BodyPartDefOf.Eye,
+                BodyPartDefOf.Head
+            };
+        }
+        private static List<BodyPartDef> priorityList = null;
         #region Fields
         public Pawn PawnParent => (Pawn)this.parent;
 
@@ -92,26 +103,26 @@ namespace CombatExtended
 
             if (PawnParent.skills.GetSkill(SkillDefOf.Melee).Level >= 16)
             {
-                //TODO: 1.5 Should be neck?
-                targetBodyPart = CE_BodyPartDefOf.Neck;
-
-                var neck = target.health.hediffSet.GetNotMissingParts(BodyPartHeight.Top).Where(y => y.def == CE_BodyPartDefOf.Neck).FirstOrFallback();
-
-                if (neck != null)
+                foreach (var bpd in priorityList)
                 {
-                    var neckApparel = target.apparel?.WornApparel?.Find(x => x.def.apparel.CoversBodyPart(neck));
+                    targetBodyPart = bpd;
+                    var bp = target.health.hediffSet.GetNotMissingParts(BodyPartHeight.Top).Where(y => y.def == bpd).FirstOrFallback();
 
-                    if (neckApparel != null && maxWeaponPen < neckApparel.GetStatValue(StatDefOf.ArmorRating_Sharp))
+                    if (bp != null)
                     {
-                        targetBodyPart = null;
-                        return BodyPartHeight.Bottom;
-                    }
-                    else
-                    {
-                        targetBodyPart = neck.def;
+                        var bpApparel = target.apparel?.WornApparel?.Find(x => x.def.apparel.CoversBodyPart(bp));
+
+                        if (bpApparel != null && maxWeaponPen < bpApparel.GetStatValue(StatDefOf.ArmorRating_Sharp))
+                        {
+                            targetBodyPart = null;
+                            return BodyPartHeight.Bottom;
+                        }
+                        else
+                        {
+                            targetBodyPart = bp.def;
+                        }
                     }
                 }
-
                 return BodyPartHeight.Top;
             }
 

--- a/Source/CombatExtended/CombatExtended/DefOfs/CE_BodyPartDefOf.cs
+++ b/Source/CombatExtended/CombatExtended/DefOfs/CE_BodyPartDefOf.cs
@@ -1,0 +1,12 @@
+using System;
+using Verse;
+using RimWorld;
+
+namespace CombatExtended
+{
+    [DefOf]
+    public static class CE_BodyPartDefOf
+    {
+        public static BodyPartDef Neck;
+    }
+}

--- a/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
@@ -520,7 +520,7 @@ namespace CombatExtended
             foreach (BodyPartRecord part in SelPawnForGear.RaceProps.body.AllParts)
             {
                 //TODO: 1.5 should be Neck
-                if (part.depth == BodyPartDepth.Outside && (part.coverage >= 0.1 || (part.def == BodyPartDefOf.Eye || part.def == BodyPartDefOf.Eye)))
+                if (part.depth == BodyPartDepth.Outside && (part.coverage >= 0.1 || (part.def == CE_BodyPartDefOf.Neck || part.def == CE_BodyPartDefOf.Neck)))
                 {
                     float armorValue = part.IsInGroup(CE_BodyPartGroupDefOf.CoveredByNaturalArmor) ? naturalArmor : 0f;
                     if (wornApparel != null)

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
@@ -401,7 +401,7 @@ namespace CombatExtended
                 {
                     //TODO: 1.5 Should be neck?
                     var neck = pawn.health.hediffSet.GetNotMissingParts(BodyPartHeight.Top, BodyPartDepth.Outside)
-                               .FirstOrDefault(r => r.def == BodyPartDefOf.Eye);
+                               .FirstOrDefault(r => r.def == CE_BodyPartDefOf.Neck);
                     damageInfo.SetHitPart(neck);
                 }
                 //for some reason, when all parts of height are missing their incode count is 3

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
@@ -400,9 +400,14 @@ namespace CombatExtended
                 if (caster.def.race.predator && IsTargetImmobile(target))
                 {
                     //TODO: 1.5 Should be neck?
-                    var neck = pawn.health.hediffSet.GetNotMissingParts(BodyPartHeight.Top, BodyPartDepth.Outside)
+                    var hp = pawn.health.hediffSet.GetNotMissingParts(BodyPartHeight.Top, BodyPartDepth.Outside)
                                .FirstOrDefault(r => r.def == CE_BodyPartDefOf.Neck);
-                    damageInfo.SetHitPart(neck);
+                    if (hp == null)
+                    {
+                        hp = pawn.health.hediffSet.GetNotMissingParts(BodyPartHeight.Top, BodyPartDepth.Outside)
+                               .FirstOrDefault(r => r.def == BodyPartDefOf.Head);
+                    }
+                    damageInfo.SetHitPart(hp);
                 }
                 //for some reason, when all parts of height are missing their incode count is 3
                 if (pawn.health.hediffSet.GetNotMissingParts(bodyRegion).Count() <= 3)

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
@@ -456,7 +456,11 @@ namespace CombatExtended
 
                             if (damageInfo.HitPart != null)
                             {
-                                damageInfo.SetHitPart(damageInfo.HitPart.GetDirectChildParts().RandomElementByWeight(x => x.coverage));
+                                var children = damageInfo.HitPart.GetDirectChildParts();
+                                if (children.Count() > 0)
+                                {
+                                    damageInfo.SetHitPart(children.RandomElementByWeight(x => x.coverage));
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## Changes

1.5 removed the Neck def from the BodyPartDefOf provided by core RW.  This adds it to our own CE_BodyPartDefOf and uses it for the targeting pieces that used to target neck (and currently target eyes).


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
