### PR TITLE
Minor bug fix for Rimsenal Spacer Faction

### DIFF
--- a/ModPatches/Rimsenal - Spacer Faction Pack/Defs/Rimsenal - Spacer Faction Pack/Recipes_Grenades.xml
+++ b/ModPatches/Rimsenal - Spacer Faction Pack/Defs/Rimsenal - Spacer Faction Pack/Recipes_Grenades.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
 
-	<!-- YP BaegYa Microwave Grenades -->
+	<!-- Smart Grenades -->
 	<RecipeDef ParentName="GrenadeRecipeBase">
 		<defName>Craft_10_Smartgrenade</defName>
 		<label>Craft 10 smart grenades</label>

--- a/ModPatches/Rimsenal - Spacer Faction Pack/Defs/Rimsenal - Spacer Faction Pack/Recipes_Grenades.xml
+++ b/ModPatches/Rimsenal - Spacer Faction Pack/Defs/Rimsenal - Spacer Faction Pack/Recipes_Grenades.xml
@@ -2,7 +2,7 @@
 <Defs>
 
 	<!-- YP BaegYa Microwave Grenades -->
-	<RecipeDef ParentName="RSExplosive_RecipeBase">
+	<RecipeDef ParentName="GrenadeRecipeBase">
 		<defName>Craft_10_Smartgrenade</defName>
 		<label>Craft 10 smart grenades</label>
 		<description>Craft 10 smart grenades.</description>


### PR DESCRIPTION
## Additions

Change recipedef name for smart grenadex10 production to prevent red error on startup when loaded without Rimsenal Core

## Changes

Changes Parentname: RSExplosive_RecipeBase, which only exist in Rimsenal Core to GrenadeRecipeBase. That's it. 

## Reasoning

Rimsenal faction is meant to be able to be used standalone. 

## Alternatives

None. 


