### PR TITLE
SOS2 shuttles VF Explosive damage type patch

### DIFF
--- a/ModPatches/Save Our Ship 2/Patches/Save Our Ship 2/Vehicles_Explosions_Fix.xml
+++ b/ModPatches/Save Our Ship 2/Patches/Save Our Ship 2/Vehicles_Explosions_Fix.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="SoS2_Shuttle_Personal" or
+			defName="SoS2_Shuttle" or
+			defName="SoS2_Shuttle_Heavy" or
+			defName="SoS2_Shuttle_Superheavy"
+			]/components/li[key="FirstThruster"]/reactors/li[@Class = "Vehicles.Reactor_Explosive"]/damageDef</xpath>
+		<value>
+			<damageDef>Bomb</damageDef>
+		</value>
+	</Operation>
+
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="SoS2_Shuttle_Personal" or
+			defName="SoS2_Shuttle" or
+			defName="SoS2_Shuttle_Heavy" or
+			defName="SoS2_Shuttle_Superheavy"
+			]/components/li[key="SecondThruster"]/reactors/li[@Class = "Vehicles.Reactor_Explosive"]/damageDef</xpath>
+		<value>
+			<damageDef>Bomb</damageDef>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="SoS2_Shuttle_Personal" or
+			defName="SoS2_Shuttle" or
+			defName="SoS2_Shuttle_Heavy" or
+			defName="SoS2_Shuttle_Superheavy"
+			]/components/li[key="ThirdThruster"]/reactors/li[@Class = "Vehicles.Reactor_Explosive"]/damageDef</xpath>
+		<value>
+			<damageDef>Bomb</damageDef>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="SoS2_Shuttle_Personal" or
+			defName="SoS2_Shuttle" or
+			defName="SoS2_Shuttle_Heavy" or
+			defName="SoS2_Shuttle_Superheavy"
+			]/components/li[key="FourthThruster"]/reactors/li[@Class = "Vehicles.Reactor_Explosive"]/damageDef</xpath>
+		<value>
+			<damageDef>Bomb</damageDef>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="SoS2_Shuttle_Personal"]/components/li[key="Chemtank"]/reactors/li[@Class = "Vehicles.Reactor_Explosive"]/damageDef</xpath>
+		<value>
+			<damageDef>Bomb</damageDef>
+		</value>
+	</Operation>
+
+</Patch>


### PR DESCRIPTION
## Additions
patch SOS2 shuttles to damage them selves when explode.
## Changes
## References

## Reasoning
the vanilla damage def was not damaging the shuttles at all.
## Alternatives

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
