### PR TITLE
Moyo 2 patch

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -598,5 +598,6 @@
 		<li IfModActive="Neronix17.OuterRim.DroidDepot">ModPatches/Outer Rim - Droid Depot</li>
 		<li IfModActive="VAMV.MaruRaceMod">ModPatches/Maru Race</li>
 		<li IfModActive="det.boglegs">ModPatches/Det's Xenotypes - Boglegs</li>		
+    <li IfModActive="Nemonian.MY2.Beta">ModPatches/Moyo 2</li>	
 	</v1.5>
 </loadFolders>

--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -598,6 +598,6 @@
 		<li IfModActive="Neronix17.OuterRim.DroidDepot">ModPatches/Outer Rim - Droid Depot</li>
 		<li IfModActive="VAMV.MaruRaceMod">ModPatches/Maru Race</li>
 		<li IfModActive="det.boglegs">ModPatches/Det's Xenotypes - Boglegs</li>		
-    <li IfModActive="Nemonian.MY2.Beta">ModPatches/Moyo 2</li>	
+		<li IfModActive="Nemonian.MY2.Beta">ModPatches/Moyo 2</li>	
 	</v1.5>
 </loadFolders>

--- a/ModPatches/Moyo 2/Defs/Moyo 2/Ammo/Ammo_Moyo_Industrial.xml
+++ b/ModPatches/Moyo 2/Defs/Moyo 2/Ammo/Ammo_Moyo_Industrial.xml
@@ -5,7 +5,7 @@
 	<CombatExtended.AmmoCategoryDef>
 		<defName>MoyoHarpoon</defName>
 		<label>Harpoon</label>
-		<labelShort>Cons.</labelShort>
+		<labelShort>Harpoon</labelShort>
 		<description>Metal rods converted for combat use.</description>
 	</CombatExtended.AmmoCategoryDef>
 
@@ -170,15 +170,17 @@
 		</ingredients>
 		<fixedIngredientFilter>
 			<thingDefs>
-				<li>Bioferrite</li>
 				<li>Steel</li>
-				<li>ComponentIndustrial</li>
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
 			<Ammo_SmallMoyoHarpoon>100</Ammo_SmallMoyoHarpoon>
 		</products>
 		<workAmount>5000</workAmount>
+		<recipeUsers Inherit="False">
+			<li>Moyo2_FabricationBench</li>
+			<li>TableMachining</li>
+		</recipeUsers>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
@@ -205,6 +207,10 @@
 			<Ammo_LargeMoyoHarpoon>25</Ammo_LargeMoyoHarpoon>
 		</products>
 		<workAmount>10000</workAmount>
+		<recipeUsers Inherit="False">
+			<li>Moyo2_FabricationBench</li>
+			<li>TableMachining</li>
+		</recipeUsers>
 	</RecipeDef>
 	
 </Defs>

--- a/ModPatches/Moyo 2/Defs/Moyo 2/Ammo/Ammo_Moyo_Industrial.xml
+++ b/ModPatches/Moyo 2/Defs/Moyo 2/Ammo/Ammo_Moyo_Industrial.xml
@@ -9,7 +9,6 @@
 		<description>Metal rods converted for combat use.</description>
 	</CombatExtended.AmmoCategoryDef>
 
-
 	<ThingCategoryDef>
 		<defName>AmmoSmallMoyoHarpoon</defName>
 		<label>Spearjack</label>

--- a/ModPatches/Moyo 2/Defs/Moyo 2/Ammo/Ammo_Moyo_Industrial.xml
+++ b/ModPatches/Moyo 2/Defs/Moyo 2/Ammo/Ammo_Moyo_Industrial.xml
@@ -1,0 +1,210 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+	<!-- ================== Harpoon ================== -->
+	
+	<CombatExtended.AmmoCategoryDef>
+		<defName>MoyoHarpoon</defName>
+		<label>Harpoon</label>
+		<labelShort>Cons.</labelShort>
+		<description>Metal rods converted for combat use.</description>
+	</CombatExtended.AmmoCategoryDef>
+
+
+	<ThingCategoryDef>
+		<defName>AmmoSmallMoyoHarpoon</defName>
+		<label>Spearjack</label>
+		<parent>AmmoAdvanced</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberCharge</iconPath>
+	</ThingCategoryDef>
+	
+	<ThingCategoryDef>
+		<defName>AmmoLargeMoyoHarpoon</defName>
+		<label>Heavy Spearjack</label>
+		<parent>AmmoAdvanced</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberChargeLarge</iconPath>
+	</ThingCategoryDef>
+	
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_SmallMoyoHarpoon</defName>
+		<label>Spearjack</label>
+		<ammoTypes>
+			<Ammo_SmallMoyoHarpoon>Bullet_SmallMoyoHarpoon</Ammo_SmallMoyoHarpoon>
+		</ammoTypes>
+		<similarTo>AmmoSet_ChargedRifle</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_LargeMoyoHarpoon</defName>
+		<label>Heavy Spearjack</label>
+		<ammoTypes>
+			<Ammo_LargeMoyoHarpoon>Bullet_LargeMoyoHarpoon</Ammo_LargeMoyoHarpoon>
+		</ammoTypes>
+		<similarTo>AmmoSet_ChargedHeavy</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="SmallMoyoHarpoonBase" ParentName="SpacerSmallAmmoBase" Abstract="True">
+		<description>Metal harpoons modified for launching in a spearjack.</description>
+		<statBases>
+			<Mass>0.25</Mass>
+			<Bulk>0.09</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting_FabricationBench</li>
+		</tradeTags>
+		<thingCategories>
+			<li>AmmoSmallMoyoHarpoon</li>
+		</thingCategories>
+		<stackLimit>5000</stackLimit>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="SmallMoyoHarpoonBase">
+		<defName>Ammo_SmallMoyoHarpoon</defName>
+		<label>Spearjack</label>
+		<graphicData>
+			<texPath>Things/Ammo/Railgun/HighCaliber</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.97</MarketValue>
+		</statBases>
+		<ammoClass>MoyoHarpoon</ammoClass>
+	</ThingDef>
+	
+	<ThingDef Class="CombatExtended.AmmoDef" Name="LargeMoyoHarpoonBase" ParentName="SpacerMediumAmmoBase" Abstract="True">
+		<description>Metal harpoons modified for launching in a spearjack.</description>
+		<statBases>
+			<Mass>2</Mass>
+			<Bulk>1.21</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting_FabricationBench</li>
+		</tradeTags>
+		<thingCategories>
+			<li>AmmoLargeMoyoHarpoon</li>
+		</thingCategories>
+		<stackLimit>250</stackLimit>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="LargeMoyoHarpoonBase">
+		<defName>Ammo_LargeMoyoHarpoon</defName>
+		<label>Heavy Spearjack</label>
+		<graphicData>
+			<texPath>Things/Ammo/Railgun/HighCaliber</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>7.94</MarketValue>
+		</statBases>
+		<ammoClass>MoyoHarpoon</ammoClass>
+	</ThingDef>
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef Name="BaseSmallMoyoHarpoonBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Weapon/MoyoSpear</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<drawSize>(1.0,1.0)</drawSize>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>40</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="BaseSmallMoyoHarpoonBullet">
+		<defName>Bullet_SmallMoyoHarpoon</defName>
+		<label>Spearjack harpoon</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>26</damageAmountBase>
+			<armorPenetrationSharp>9</armorPenetrationSharp>
+			<armorPenetrationBlunt>100</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+	
+	<ThingDef Name="BaseLargeMoyoHarpoonBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Weapon/MoyoHarpoon</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<drawSize>(1.5,1.5)</drawSize>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>40</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="BaseLargeMoyoHarpoonBullet">
+		<defName>Bullet_LargeMoyoHarpoon</defName>
+		<label>Heavy Spearjack harpoon</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>75</damageAmountBase>
+			<armorPenetrationSharp>18</armorPenetrationSharp>
+			<armorPenetrationBlunt>800</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_SmallMoyoHarpoon</defName>
+		<label>make Spearjack x100</label>
+		<description>Craft 100 Spearjack.</description>
+		<jobString>Making Spearjack.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>50</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Bioferrite</li>
+				<li>Steel</li>
+				<li>ComponentIndustrial</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_SmallMoyoHarpoon>100</Ammo_SmallMoyoHarpoon>
+		</products>
+		<workAmount>5000</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_LargeMoyoHarpoon</defName>
+		<label>make Heavy Spearjack x25</label>
+		<description>Craft 25 Heavy Spearjack.</description>
+		<jobString>Making Heavy Spearjack.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>100</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_LargeMoyoHarpoon>25</Ammo_LargeMoyoHarpoon>
+		</products>
+		<workAmount>10000</workAmount>
+	</RecipeDef>
+	
+</Defs>

--- a/ModPatches/Moyo 2/Defs/Moyo 2/Ammo/Ammo_Moyo_Laminar.xml
+++ b/ModPatches/Moyo 2/Defs/Moyo 2/Ammo/Ammo_Moyo_Laminar.xml
@@ -195,83 +195,55 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>Bioferrite</li>
+						<li>Moyo2_Abyssteel</li>
 					</thingDefs>
 				</filter>
-				<count>21</count>
-			</li>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>Steel</li>
-					</thingDefs>
-				</filter>
-				<count>14</count>
-			</li>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>ComponentIndustrial</li>
-					</thingDefs>
-				</filter>
-				<count>10</count>
+				<count>50</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
 			<thingDefs>
-				<li>Bioferrite</li>
-				<li>Steel</li>
-				<li>ComponentIndustrial</li>
+				<li>Moyo2_Abyssteel</li>
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
 			<Ammo_MoyoLaminarSlug>500</Ammo_MoyoLaminarSlug>
 		</products>
-		<workAmount>15800</workAmount>
+		<workAmount>20000</workAmount>
+		<researchPrerequisite>Moyo2_Abysstech_LaminarTheory</researchPrerequisite>
+		<recipeUsers Inherit="False">
+			<li>Moyo2_FabricationBench</li>
+		</recipeUsers>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
 		<defName>MakeAmmo_MoyoLaminarBolt</defName>
-		<label>make Laminar Bolt cartridge x200</label>
-		<description>Craft 200 Laminar Bolt cartridges.</description>
+		<label>make Laminar Bolt cartridge x25</label>
+		<description>Craft 25 Laminar Bolt cartridges.</description>
 		<jobString>Making Laminar Bolt cartridges.</jobString>
 		<ingredients>
 			<li>
 				<filter>
 					<thingDefs>
-						<li>Bioferrite</li>
+						<li>Moyo2_Abyssteel</li>
 					</thingDefs>
 				</filter>
-				<count>16</count>
-			</li>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>Steel</li>
-					</thingDefs>
-				</filter>
-				<count>24</count>
-			</li>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>ComponentIndustrial</li>
-					</thingDefs>
-				</filter>
-				<count>8</count>
+				<count>50</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
 			<thingDefs>
-				<li>Bioferrite</li>
-				<li>Steel</li>
-				<li>ComponentIndustrial</li>
+				<li>Moyo2_Abyssteel</li>
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_MoyoLaminarBolt>200</Ammo_MoyoLaminarBolt>
+			<Ammo_MoyoLaminarBolt>25</Ammo_MoyoLaminarBolt>
 		</products>
-		<workAmount>13600</workAmount>
+		<workAmount>20000</workAmount>
+		<researchPrerequisite>Moyo2_Abysstech_LaminarTheory</researchPrerequisite>
+		<recipeUsers Inherit="False">
+			<li>Moyo2_FabricationBench</li>
+		</recipeUsers>
 	</RecipeDef>
 	
 </Defs>

--- a/ModPatches/Moyo 2/Defs/Moyo 2/Ammo/Ammo_Moyo_Laminar.xml
+++ b/ModPatches/Moyo 2/Defs/Moyo 2/Ammo/Ammo_Moyo_Laminar.xml
@@ -10,7 +10,6 @@
 		<description>Heavy bolts stabilised by an extended energy field.</description>
 	</CombatExtended.AmmoCategoryDef>
 
-
 	<ThingCategoryDef>
 		<defName>AmmoMoyoLaminarSlug</defName>
 		<label>Laminar Slug</label>

--- a/ModPatches/Moyo 2/Defs/Moyo 2/Ammo/Ammo_Moyo_Laminar.xml
+++ b/ModPatches/Moyo 2/Defs/Moyo 2/Ammo/Ammo_Moyo_Laminar.xml
@@ -1,0 +1,277 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+	<!-- ================== Holy Projectiles ================== -->
+	
+	<CombatExtended.AmmoCategoryDef>
+		<defName>MoyoLaminarSlug</defName>
+		<label>Laminar</label>
+		<labelShort>LMR.</labelShort>
+		<description>Heavy bolts stabilised by an extended energy field.</description>
+	</CombatExtended.AmmoCategoryDef>
+
+
+	<ThingCategoryDef>
+		<defName>AmmoMoyoLaminarSlug</defName>
+		<label>Laminar Slug</label>
+		<parent>AmmoAdvanced</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberCharge</iconPath>
+	</ThingCategoryDef>
+	
+	<ThingCategoryDef>
+		<defName>AmmoMoyoLaminarBolt</defName>
+		<label>Laminar Bolt</label>
+		<parent>AmmoAdvanced</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberChargeLarge</iconPath>
+	</ThingCategoryDef>
+	
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_MoyoLaminarSlug</defName>
+		<label>Laminar Slug</label>
+		<ammoTypes>
+			<Ammo_MoyoLaminarSlug>Bullet_MoyoLaminarSlug</Ammo_MoyoLaminarSlug>
+		</ammoTypes>
+		<similarTo>AmmoSet_ChargedRifle</similarTo>
+	</CombatExtended.AmmoSetDef>
+	
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_MoyoLaminarSlug_HV</defName>
+		<label>Laminar Slug</label>
+		<ammoTypes>
+			<Ammo_MoyoLaminarSlug>Bullet_MoyoLaminarSlug_HV</Ammo_MoyoLaminarSlug>
+		</ammoTypes>
+		<similarTo>AmmoSet_ChargedRifle</similarTo>
+	</CombatExtended.AmmoSetDef>
+	
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_MoyoLaminarBolt</defName>
+		<label>Laminar Bolt</label>
+		<ammoTypes>
+			<Ammo_MoyoLaminarBolt>Bullet_MoyoLaminarBolt</Ammo_MoyoLaminarBolt>
+		</ammoTypes>
+		<similarTo>AmmoSet_ChargedHeavy</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="MoyoLaminarSlugBase" ParentName="SpacerSmallAmmoBase" Abstract="True">
+		<description>Heavy rounds for use in laminar weapons.</description>
+		<statBases>
+			<Mass>0.025</Mass>
+			<Bulk>0.02</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting_FabricationBench</li>
+		</tradeTags>
+		<thingCategories>
+			<li>AmmoMoyoLaminarSlug</li>
+		</thingCategories>
+		<stackLimit>5000</stackLimit>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="MoyoLaminarSlugBase">
+		<defName>Ammo_MoyoLaminarSlug</defName>
+		<label>Laminar Slug</label>
+		<graphicData>
+			<texPath>Things/Ammo/Charged/MediumMech</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.94</MarketValue>
+		</statBases>
+		<ammoClass>MoyoLaminarSlug</ammoClass>
+	</ThingDef>
+	
+	<ThingDef Class="CombatExtended.AmmoDef" Name="MoyoLaminarBoltBase" ParentName="SpacerMediumAmmoBase" Abstract="True">
+		<description>Large bore round for use in heavy laminar weapons.</description>
+		<statBases>
+			<Mass>0.5</Mass>
+			<Bulk>0.39</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting_FabricationBench</li>
+		</tradeTags>
+		<thingCategories>
+			<li>AmmoMoyoLaminarBolt</li>
+		</thingCategories>
+		<stackLimit>750</stackLimit>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="MoyoLaminarBoltBase">
+		<defName>Ammo_MoyoLaminarBolt</defName>
+		<label>Laminar Bolt</label>
+		<graphicData>
+			<texPath>Things/Ammo/Charged/LargeMech</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>18.67</MarketValue>
+		</statBases>
+		<ammoClass>MoyoLaminarSlug</ammoClass>
+	</ThingDef>
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef Name="BaseMoyoLaminarSlugBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Weapon/MoyoBullet1</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<drawSize>(1,1)</drawSize>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>120</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="BaseMoyoLaminarSlugBullet">
+		<defName>Bullet_MoyoLaminarSlug</defName>
+		<label>Laminar Slug bullet</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>25</damageAmountBase>
+			<armorPenetrationSharp>18</armorPenetrationSharp>
+			<armorPenetrationBlunt>90</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+	
+	<ThingDef ParentName="BaseMoyoLaminarSlugBullet">
+		<defName>Bullet_MoyoLaminarSlug_HV</defName>
+		<label>Laminar Slug bullet</label>
+		<graphicData>
+			<texPath>Weapon/MoyoBullet1</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<drawSize>(1.3,1.3)</drawSize>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<speed>160</speed>
+			<damageAmountBase>31</damageAmountBase>
+			<armorPenetrationSharp>21</armorPenetrationSharp>
+			<armorPenetrationBlunt>160</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+	
+	<ThingDef Name="BaseMoyoLaminarBoltBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Weapon/MoyoBullet1</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<drawSize>(1.5,1.5)</drawSize>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>120</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="BaseMoyoLaminarBoltBullet">
+		<defName>Bullet_MoyoLaminarBolt</defName>
+		<label>Laminar Bolt bullet</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>99</damageAmountBase>
+			<armorPenetrationSharp>60</armorPenetrationSharp>
+			<armorPenetrationBlunt>1800</armorPenetrationBlunt>
+		</projectile>
+		<comps>
+			<li Class="CombatExtended.CompProperties_ExplosiveCE">
+				<damageAmountBase>36</damageAmountBase>
+				<explosiveDamageType>Moyo2_Damage_LMRBoltDemolish</explosiveDamageType>
+				<explosiveRadius>0.9</explosiveRadius>
+				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			</li>
+		</comps>
+	</ThingDef>
+
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_MoyoLaminarSlug</defName>
+		<label>make Laminar Slug cartridge x500</label>
+		<description>Craft 500 Laminar Slug cartridges.</description>
+		<jobString>Making Laminar Slug cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Bioferrite</li>
+					</thingDefs>
+				</filter>
+				<count>21</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>14</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>10</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Bioferrite</li>
+				<li>Steel</li>
+				<li>ComponentIndustrial</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_MoyoLaminarSlug>500</Ammo_MoyoLaminarSlug>
+		</products>
+		<workAmount>15800</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_MoyoLaminarBolt</defName>
+		<label>make Laminar Bolt cartridge x200</label>
+		<description>Craft 200 Laminar Bolt cartridges.</description>
+		<jobString>Making Laminar Bolt cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Bioferrite</li>
+					</thingDefs>
+				</filter>
+				<count>16</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>24</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>8</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Bioferrite</li>
+				<li>Steel</li>
+				<li>ComponentIndustrial</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_MoyoLaminarBolt>200</Ammo_MoyoLaminarBolt>
+		</products>
+		<workAmount>13600</workAmount>
+	</RecipeDef>
+	
+</Defs>

--- a/ModPatches/Moyo 2/Defs/Moyo 2/Ammo/Ammo_Moyo_Laminar_Charged.xml
+++ b/ModPatches/Moyo 2/Defs/Moyo 2/Ammo/Ammo_Moyo_Laminar_Charged.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+	
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_MoyoLaminarSlug_OC</defName>
+		<label>Laminar Slug</label>
+		<ammoTypes>
+			<Ammo_MoyoLaminarSlug>Bullet_MoyoLaminarSlug_OC</Ammo_MoyoLaminarSlug>
+		</ammoTypes>
+		<similarTo>AmmoSet_ChargedRifle</similarTo>
+	</CombatExtended.AmmoSetDef>
+	
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_MoyoLaminarSlug_OC_HV</defName>
+		<label>Laminar Slug</label>
+		<ammoTypes>
+			<Ammo_MoyoLaminarSlug>Bullet_MoyoLaminarSlug_OC_HV</Ammo_MoyoLaminarSlug>
+		</ammoTypes>
+		<similarTo>AmmoSet_ChargedRifle</similarTo>
+	</CombatExtended.AmmoSetDef>
+	
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_MoyoLaminarBolt_OC</defName>
+		<label>Laminar Bolt</label>
+		<ammoTypes>
+			<Ammo_MoyoLaminarBolt>Bullet_MoyoLaminarBolt_OC</Ammo_MoyoLaminarBolt>
+		</ammoTypes>
+		<similarTo>AmmoSet_ChargedHeavy</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef Name="BaseMoyoLaminarSlug_OCBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Weapon/MoyoBullet2</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<drawSize>(1,1)</drawSize>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>180</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="BaseMoyoLaminarSlug_OCBullet">
+		<defName>Bullet_MoyoLaminarSlug_OC</defName>
+		<label>Laminar Slug bullet</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>33</damageAmountBase>
+			<armorPenetrationSharp>24</armorPenetrationSharp>
+			<armorPenetrationBlunt>202.5</armorPenetrationBlunt>
+		</projectile>
+		<comps>
+			<li Class="CombatExtended.CompProperties_ExplosiveCE">
+				<damageAmountBase>20</damageAmountBase>
+				<explosiveDamageType>Moyo2_Damage_LMRBolt</explosiveDamageType>
+				<explosiveRadius>0.9</explosiveRadius>
+				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			</li>
+		</comps>
+	</ThingDef>
+	
+	<ThingDef ParentName="BaseMoyoLaminarSlug_OCBullet">
+		<defName>Bullet_MoyoLaminarSlug_OC_HV</defName>
+		<label>Laminar Slug bullet</label>
+		<graphicData>
+			<texPath>Weapon/MoyoBullet2</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<drawSize>(1.3,1.3)</drawSize>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<speed>240</speed>
+			<damageAmountBase>41</damageAmountBase>
+			<armorPenetrationSharp>30</armorPenetrationSharp>
+			<armorPenetrationBlunt>360</armorPenetrationBlunt>
+		</projectile>
+		<comps>
+			<li Class="CombatExtended.CompProperties_ExplosiveCE">
+				<damageAmountBase>24</damageAmountBase>
+				<explosiveDamageType>Moyo2_Damage_LMRBolt</explosiveDamageType>
+				<explosiveRadius>0.9</explosiveRadius>
+				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			</li>
+		</comps>
+	</ThingDef>
+	
+	<ThingDef Name="BaseMoyoLaminarBolt_OCBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Weapon/MoyoBullet2</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<drawSize>(1.5,1.5)</drawSize>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>120</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="BaseMoyoLaminarBolt_OCBullet">
+		<defName>Bullet_MoyoLaminarBolt_OC</defName>
+		<label>Laminar Bolt bullet</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>132</damageAmountBase>
+			<armorPenetrationSharp>80</armorPenetrationSharp>
+			<armorPenetrationBlunt>4050</armorPenetrationBlunt>
+		</projectile>
+		<comps>
+			<li Class="CombatExtended.CompProperties_ExplosiveCE">
+				<damageAmountBase>79</damageAmountBase>
+				<explosiveDamageType>Moyo2_Damage_LMRBoltDemolish</explosiveDamageType>
+				<explosiveRadius>2.9</explosiveRadius>
+				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			</li>
+		</comps>
+	</ThingDef>
+	
+</Defs>

--- a/ModPatches/Moyo 2/Patches/Moyo 2/PawnKindDefs/Moyo_PawnKind.xml
+++ b/ModPatches/Moyo 2/Patches/Moyo 2/PawnKindDefs/Moyo_PawnKind.xml
@@ -62,4 +62,5 @@
 			<li>CE_Apparel_Backpack</li>
 		</value>
 	</Operation>
+
 </Patch>

--- a/ModPatches/Moyo 2/Patches/Moyo 2/PawnKindDefs/Moyo_PawnKind.xml
+++ b/ModPatches/Moyo 2/Patches/Moyo 2/PawnKindDefs/Moyo_PawnKind.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<!--Ammo-->
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/PawnKindDef[@ParentName="Moyo2_NPCBase"] </xpath>
+		<value>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>0</min>
+					<max>2</max>
+				</primaryMagazineCount>
+			</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/PawnKindDef[@ParentName="Moyo2_NPCFighterMid"]</xpath>
+		<value>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>3</min>
+					<max>5</max>
+				</primaryMagazineCount>
+			</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/PawnKindDef[@Name="Moyo2_NPCDiverLight"]</xpath>
+		<value>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>3</min>
+					<max>5</max>
+				</primaryMagazineCount>
+			</li>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/PawnKindDef[@Name="Moyo2_NPCDiverheavy"]</xpath>
+		<value>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>3</min>
+					<max>5</max>
+				</primaryMagazineCount>
+			</li>
+		</value>
+	</Operation>
+
+	<!--Backpack-->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/PawnKindDef[
+			@ParentName="Moyo2_NPCFighterMid" or
+			@Name="Moyo2_NPCDiverLight" or
+			@Name="Moyo2_NPCDiverheavy"
+			]/apparelRequired </xpath>
+		<value>
+			<li>CE_Apparel_Backpack</li>
+		</value>
+	</Operation>
+</Patch>

--- a/ModPatches/Moyo 2/Patches/Moyo 2/ThingDefs/Patch_Items_Resources.xml
+++ b/ModPatches/Moyo 2/Patches/Moyo 2/ThingDefs/Patch_Items_Resources.xml
@@ -87,4 +87,5 @@
 			<StuffPower_Armor_Electric>0.025</StuffPower_Armor_Electric>
 		</value>
 	</Operation>
+
 </Patch>

--- a/ModPatches/Moyo 2/Patches/Moyo 2/ThingDefs/Patch_Items_Resources.xml
+++ b/ModPatches/Moyo 2/Patches/Moyo 2/ThingDefs/Patch_Items_Resources.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<!-- ==========  Abyssteel  =========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_Abyssteel"]/statBases/StuffPower_Armor_Sharp</xpath>
+		<value>
+			<StuffPower_Armor_Sharp>2.25</StuffPower_Armor_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_Abyssteel"]/statBases/StuffPower_Armor_Blunt</xpath>
+		<value>
+			<StuffPower_Armor_Blunt>3</StuffPower_Armor_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_Abyssteel"]/statBases/StuffPower_Armor_Heat</xpath>
+		<value>
+			<StuffPower_Armor_Heat>0.05</StuffPower_Armor_Heat>
+			<StuffPower_Armor_Electric>0.05</StuffPower_Armor_Electric>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Moyo2_Abyssteel"]/stuffProps/categories</xpath>
+		<value>
+			<li>Metallic_Weapon</li>
+			<li>Steeled</li>
+		</value>
+	</Operation>
+	
+	<!-- ==========  Hadal Shard  =========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_HadalShard"]/statBases/StuffPower_Armor_Sharp</xpath>
+		<value>
+			<StuffPower_Armor_Sharp>1.2</StuffPower_Armor_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_HadalShard"]/statBases/StuffPower_Armor_Blunt</xpath>
+		<value>
+			<StuffPower_Armor_Blunt>0.5</StuffPower_Armor_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_HadalShard"]/statBases/StuffPower_Armor_Heat</xpath>
+		<value>
+			<StuffPower_Armor_Heat>0.15</StuffPower_Armor_Heat>
+			<StuffPower_Armor_Electric>0.25</StuffPower_Armor_Electric>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Moyo2_HadalShard"]/stuffProps/categories</xpath>
+		<value>
+			<li>Metallic_Weapon</li>
+			<li>Steeled</li>
+		</value>
+	</Operation>
+
+	<!-- ==========  Depthweave  =========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_Cloth_Depthweave"]/statBases/StuffPower_Armor_Sharp</xpath>
+		<value>
+			<StuffPower_Armor_Sharp>0.25</StuffPower_Armor_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_Cloth_Depthweave"]/statBases/StuffPower_Armor_Blunt</xpath>
+		<value>
+			<StuffPower_Armor_Blunt>0.08</StuffPower_Armor_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_Cloth_Depthweave"]/statBases/StuffPower_Armor_Heat</xpath>
+		<value>
+			<StuffPower_Armor_Heat>0.025</StuffPower_Armor_Heat>
+			<StuffPower_Armor_Electric>0.025</StuffPower_Armor_Electric>
+		</value>
+	</Operation>
+</Patch>

--- a/ModPatches/Moyo 2/Patches/Moyo 2/ThingDefs/Patch_Moyo_Apparel.xml
+++ b/ModPatches/Moyo 2/Patches/Moyo 2/ThingDefs/Patch_Moyo_Apparel.xml
@@ -585,4 +585,5 @@
 			</layers>
 		</value>
 	</Operation>
+
 </Patch>

--- a/ModPatches/Moyo 2/Patches/Moyo 2/ThingDefs/Patch_Moyo_Apparel.xml
+++ b/ModPatches/Moyo 2/Patches/Moyo 2/ThingDefs/Patch_Moyo_Apparel.xml
@@ -1,0 +1,588 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<!--========= Fixed Armor Value =========-->
+
+	<!--Bodysuit-->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Moyo2_BasicSuit"]/statBases</xpath>
+		<value>
+			<Bulk>2</Bulk>
+			<WornBulk>0</WornBulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_BasicSuit"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>0.75</ArmorRating_Sharp>
+			<ArmorRating_Electric>0.15</ArmorRating_Electric>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_BasicSuit"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>0.1</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Moyo2_BasicSuit"]/apparel/bodyPartGroups</xpath>
+		<value>
+			<li>Hands</li>
+			<li>Feet</li>
+		</value>
+	</Operation>
+	
+	<!--Hood-->
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Moyo2_CartelHood"]/statBases</xpath>
+		<value>
+			<Bulk>10</Bulk>
+			<WornBulk>2</WornBulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_CartelHood"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>3</ArmorRating_Sharp>
+			<ArmorRating_Electric>0.30</ArmorRating_Electric>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_CartelHood"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>0.5</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<!--Engineering Suit-->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Moyo2_EGHarness" or defName="Moyo2_EGJacket"]/statBases</xpath>
+		<value>
+			<Bulk>10</Bulk>
+			<WornBulk>4</WornBulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_EGHarness" or defName="Moyo2_EGJacket"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>6</ArmorRating_Sharp>
+			<ArmorRating_Electric>0.3</ArmorRating_Electric>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_EGHarness" or defName="Moyo2_EGJacket"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>2</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<!--Engineering Mask-->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Moyo2_EGHelmet"]/statBases</xpath>
+		<value>
+			<Bulk>4</Bulk>
+			<WornBulk>4</WornBulk>
+			<NightVisionEfficiency_Apparel>0.1</NightVisionEfficiency_Apparel>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_EGHelmet"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>8</ArmorRating_Sharp>
+			<ArmorRating_Electric>0.25</ArmorRating_Electric>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_EGHelmet"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>12</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_EGHelmet"]/apparel/layers</xpath>
+		<value>
+			<layers>
+				<li>OnHead</li>
+				<li>StrappedHead</li>
+				<li>Overhead</li>
+			</layers>
+		</value>
+	</Operation>
+
+	<!--Adv Suit-->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Moyo2_AdvancedSuit"]/statBases</xpath>
+		<value>
+			<Bulk>5</Bulk>
+			<WornBulk>4</WornBulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_AdvancedSuit" or defName="Moyo2_HoloSuit"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>3.5</ArmorRating_Sharp>
+			<ArmorRating_Electric>0.30</ArmorRating_Electric>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_AdvancedSuit" or defName="Moyo2_HoloSuit"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>4</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Moyo2_AdvancedSuit" or defName="Moyo2_HoloSuit"]/apparel/bodyPartGroups</xpath>
+		<value>
+			<li>Hands</li>
+			<li>Feet</li>
+		</value>
+	</Operation>
+	
+	<!--Royal suits-->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Moyo2_RoyalSuit"]/statBases</xpath>
+		<value>
+			<Bulk>5</Bulk>
+			<WornBulk>3</WornBulk>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Moyo2_HoloSuit"]/statBases</xpath>
+		<value>
+			<Bulk>4</Bulk>
+			<WornBulk>0</WornBulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_RoyalSuit"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>5</ArmorRating_Sharp>
+			<ArmorRating_Electric>0.40</ArmorRating_Electric>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_RoyalSuit"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>6.25</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Moyo2_RoyalSuit"]/apparel/bodyPartGroups</xpath>
+		<value>
+			<li>Hands</li>
+			<li>Feet</li>
+		</value>
+	</Operation>
+
+	<!--Deepdiving Gear-->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Moyo2_DeepDivingShell"]/statBases</xpath>
+		<value>
+			<Bulk>125</Bulk>
+			<WornBulk>20</WornBulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_DeepDivingShell"]/statBases/Mass</xpath>
+		<value>
+			<Mass>75</Mass>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_DeepDivingShell"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>16</ArmorRating_Sharp>
+			<ArmorRating_Electric>0.60</ArmorRating_Electric>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_DeepDivingShell"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>64</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_DeepDivingShell"]/statBases/Flammability</xpath>
+		<value>
+			<Flammability>0</Flammability>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Moyo2_DeepDivingShell"]/equippedStatOffsets</xpath>
+		<value>
+			<CarryWeight>85</CarryWeight>
+			<CarryBulk>10</CarryBulk>
+			<ToxicEnvironmentResistance>0.50</ToxicEnvironmentResistance>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_DeepDivingShell"]/costList/Moyo2_Abyssteel</xpath>
+		<value>
+			<Moyo2_Abyssteel>190</Moyo2_Abyssteel>
+			<DevilstrandCloth>40</DevilstrandCloth>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Moyo2_DeepDivingShell"]/apparel/bodyPartGroups</xpath>
+		<value>
+			<li>Hands</li>
+			<li>Feet</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="Moyo2_DeepDivingShell"]</xpath>
+		<value>
+			<li Class="CombatExtended.PartialArmorExt">
+				<stats>
+					<li>
+						<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+						<parts>
+							<li>Neck</li>
+							<li>Leg</li>
+							<li>Arm</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+						<parts>
+							<li>Neck</li>
+							<li>Leg</li>
+							<li>Arm</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+						<parts>
+							<li>Hand</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+						<parts>
+							<li>Hand</li>
+						</parts>
+					</li>
+				</stats>
+			</li>
+		</value>
+	</Operation>
+
+	<!--Deepdiving Helmet-->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Moyo2_DeepDivingHelmet"]/statBases</xpath>
+		<value>
+			<Bulk>6</Bulk>
+			<WornBulk>3</WornBulk>
+			<NightVisionEfficiency_Apparel>0.4</NightVisionEfficiency_Apparel>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_DeepDivingHelmet"]/statBases/Mass</xpath>
+		<value>
+			<Mass>5</Mass>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_DeepDivingHelmet"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>16</ArmorRating_Sharp>
+			<ArmorRating_Electric>0.55</ArmorRating_Electric>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_DeepDivingHelmet"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>64</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_DeepDivingHelmet"]/statBases/Flammability</xpath>
+		<value>
+			<Flammability>0</Flammability>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="Moyo2_DeepDivingHelmet"]/apparel/immuneToToxGasExposure</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Moyo2_DeepDivingHelmet"]/apparel</xpath>
+			<value>
+				<immuneToToxGasExposure>true</immuneToToxGasExposure>
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_DeepDivingHelmet"]/equippedStatOffsets/MoveSpeed</xpath>
+		<value>
+			<SmokeSensitivity>-1</SmokeSensitivity>
+			<ToxicEnvironmentResistance>0.50</ToxicEnvironmentResistance>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_DeepDivingHelmet"]/costList/Moyo2_Abyssteel</xpath>
+		<value>
+			<Moyo2_Abyssteel>60</Moyo2_Abyssteel>
+			<DevilstrandCloth>20</DevilstrandCloth>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_DeepDivingHelmet"]/apparel/layers</xpath>
+		<value>
+			<layers>
+				<li>OnHead</li>
+				<li>StrappedHead</li>
+				<li>Overhead</li>
+			</layers>
+		</value>
+	</Operation>
+
+	<!--Diving Gear-->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Moyo2_StreamlineDivingShell"]/statBases</xpath>
+		<value>
+			<Bulk>125</Bulk>
+			<WornBulk>15</WornBulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_StreamlineDivingShell"]/statBases/Mass</xpath>
+		<value>
+			<Mass>60</Mass>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_StreamlineDivingShell"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>16</ArmorRating_Sharp>
+			<ArmorRating_Electric>0.50</ArmorRating_Electric>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_StreamlineDivingShell"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>45</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_StreamlineDivingShell"]/statBases/Flammability</xpath>
+		<value>
+			<Flammability>0</Flammability>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Moyo2_StreamlineDivingShell"]</xpath>
+		<value>
+			<equippedStatOffsets>
+				<CarryWeight>75</CarryWeight>
+				<CarryBulk>10</CarryBulk>
+				<ToxicEnvironmentResistance>0.50</ToxicEnvironmentResistance>
+			</equippedStatOffsets>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_StreamlineDivingShell"]/costList/Moyo2_Abyssteel</xpath>
+		<value>
+			<Moyo2_Abyssteel>150</Moyo2_Abyssteel>
+			<DevilstrandCloth>30</DevilstrandCloth>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Moyo2_StreamlineDivingShell"]/apparel/bodyPartGroups</xpath>
+		<value>
+			<li>Hands</li>
+			<li>Feet</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="Moyo2_StreamlineDivingShell"]</xpath>
+		<value>
+			<li Class="CombatExtended.PartialArmorExt">
+				<stats>
+					<li>
+						<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+						<parts>
+							<li>Neck</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+						<parts>
+							<li>Neck</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+						<parts>
+							<li>Leg</li>
+							<li>Arm</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+						<parts>
+							<li>Leg</li>
+							<li>Arm</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+						<parts>
+							<li>Hand</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+						<parts>
+							<li>Hand</li>
+						</parts>
+					</li>
+				</stats>
+			</li>
+		</value>
+	</Operation>
+
+	<!--Diving Helmet-->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Moyo2_StreamlineDivingHelmet"]/statBases</xpath>
+		<value>
+			<Bulk>6</Bulk>
+			<WornBulk>2</WornBulk>
+			<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_StreamlineDivingHelmet"]/statBases/Mass</xpath>
+		<value>
+			<Mass>1.5</Mass>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_StreamlineDivingHelmet"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>14</ArmorRating_Sharp>
+			<ArmorRating_Electric>0.35</ArmorRating_Electric>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_StreamlineDivingHelmet"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>42</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_StreamlineDivingHelmet"]/statBases/Flammability</xpath>
+		<value>
+			<Flammability>0</Flammability>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="Moyo2_StreamlineDivingHelmet"]/apparel/immuneToToxGasExposure</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Moyo2_StreamlineDivingHelmet"]/apparel</xpath>
+			<value>
+				<immuneToToxGasExposure>true</immuneToToxGasExposure>
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Moyo2_StreamlineDivingHelmet"]</xpath>
+		<value>
+			<equippedStatOffsets>
+				<SmokeSensitivity>-1</SmokeSensitivity>
+				<ToxicEnvironmentResistance>0.50</ToxicEnvironmentResistance>
+			</equippedStatOffsets>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_StreamlineDivingHelmet"]/costList/Moyo2_Abyssteel</xpath>
+		<value>
+			<Moyo2_Abyssteel>50</Moyo2_Abyssteel>
+			<DevilstrandCloth>15</DevilstrandCloth>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="Moyo2_StreamlineDivingHelmet"]</xpath>
+		<value>
+			<li Class="CombatExtended.PartialArmorExt">
+				<stats>
+					<li>
+						<ArmorRating_Sharp>0.70</ArmorRating_Sharp>
+						<parts>
+							<li>Eye</li>
+							<li>Nose</li>
+							<li>Jaw</li>
+						</parts>
+					</li>
+				</stats>
+			</li>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_StreamlineDivingHelmet"]/apparel/layers</xpath>
+		<value>
+			<layers>
+				<li>OnHead</li>
+				<li>StrappedHead</li>
+				<li>Overhead</li>
+			</layers>
+		</value>
+	</Operation>
+</Patch>

--- a/ModPatches/Moyo 2/Patches/Moyo 2/ThingDefs/Patch_Moyo_Guns.xml
+++ b/ModPatches/Moyo 2/Patches/Moyo 2/ThingDefs/Patch_Moyo_Guns.xml
@@ -4,10 +4,7 @@
 	<!-- ========== Tools ========== -->
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[
-		defName="Moyo2_NailGun" or 
-		@Name="Moyo2_LMRPistol"
-		]/tools</xpath>
+		<xpath>Defs/ThingDef[defName="Moyo2_NailGun" or @Name="Moyo2_LMRPistol"]/tools</xpath>
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
@@ -36,9 +33,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>
-			Defs/ThingDef[@Name="Moyo2_LMRRifle"]/tools
-		</xpath>
+		<xpath>Defs/ThingDef[@Name="Moyo2_LMRRifle"]/tools</xpath>
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
@@ -77,9 +72,7 @@
 	</Operation>
 	
 	<Operation Class="PatchOperationReplace">
-		<xpath>
-			Defs/ThingDef[defName="Moyo2_SpearGun"]/tools
-		</xpath>
+		<xpath>Defs/ThingDef[defName="Moyo2_SpearGun"]/tools</xpath>
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
@@ -119,9 +112,7 @@
 	</Operation>
 	
 	<Operation Class="PatchOperationReplace">
-		<xpath>
-			Defs/ThingDef[defName="Moyo2_HarpoonGun"]/tools
-		</xpath>
+		<xpath>Defs/ThingDef[defName="Moyo2_HarpoonGun"]/tools</xpath>
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
@@ -329,8 +320,7 @@
 			<li>CE_OneHandedWeapon</li>
 		</weaponTags>
 	</Operation>
-	
-	
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Moyo2_LMRPistol"]/comps/li[@Class="Moyo2_ItemFormChange.CompPropertiesFormChange"]</xpath>
 		<value>
@@ -361,7 +351,6 @@
 			</li>
 		</value>
 	</Operation>
-	
 
 	<!-- ========== Laminar Rifle ========== -->
 
@@ -508,7 +497,6 @@
 			</li>
 		</value>
 	</Operation>
-	
 	
 	<!-- ========== Laminar Boltgun ========== -->
 

--- a/ModPatches/Moyo 2/Patches/Moyo 2/ThingDefs/Patch_Moyo_Guns.xml
+++ b/ModPatches/Moyo 2/Patches/Moyo 2/ThingDefs/Patch_Moyo_Guns.xml
@@ -37,11 +37,7 @@
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>
-			Defs/ThingDef[
-			defName="Moyo2_SpearGun" or
-			defName="Moyo2_HarpoonGun" or
-			@Name="Moyo2_LMRRifle"
-			]/tools
+			Defs/ThingDef[@Name="Moyo2_LMRRifle"]/tools
 		</xpath>
 		<value>
 			<tools>
@@ -74,6 +70,90 @@
 					<power>8</power>
 					<cooldownTime>1.55</cooldownTime>
 					<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>
+			Defs/ThingDef[defName="Moyo2_SpearGun"]/tools
+		</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>stock</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>8</power>
+					<cooldownTime>1.55</cooldownTime>
+					<chanceFactor>1.5</chanceFactor>
+					<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>barrel</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>5</power>
+					<cooldownTime>2.02</cooldownTime>
+					<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>pile</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>26</power>
+					<cooldownTime>3.3</cooldownTime>
+					<armorPenetrationSharp>9</armorPenetrationSharp>
+					<armorPenetrationBlunt>100</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>
+			Defs/ThingDef[defName="Moyo2_HarpoonGun"]/tools
+		</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>stock</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>8</power>
+					<cooldownTime>1.55</cooldownTime>
+					<chanceFactor>1.5</chanceFactor>
+					<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>barrel</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>5</power>
+					<cooldownTime>2.02</cooldownTime>
+					<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>pile</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>75</power>
+					<cooldownTime>7</cooldownTime>
+					<armorPenetrationSharp>18</armorPenetrationSharp>
+					<armorPenetrationBlunt>800</armorPenetrationBlunt>
 					<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 				</li>
 			</tools>

--- a/ModPatches/Moyo 2/Patches/Moyo 2/ThingDefs/Patch_Moyo_Guns.xml
+++ b/ModPatches/Moyo 2/Patches/Moyo 2/ThingDefs/Patch_Moyo_Guns.xml
@@ -1,0 +1,501 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- ========== Tools ========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[
+		defName="Moyo2_NailGun" or 
+		@Name="Moyo2_LMRPistol"
+		]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>grip</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>2</power>
+					<cooldownTime>1.54</cooldownTime>
+					<chanceFactor>1.5</chanceFactor>
+					<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>muzzle</label>
+					<capacities>
+						<li>Poke</li>
+					</capacities>
+					<power>2</power>
+					<cooldownTime>1.54</cooldownTime>
+					<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>
+			Defs/ThingDef[
+			defName="Moyo2_SpearGun" or
+			defName="Moyo2_HarpoonGun" or
+			@Name="Moyo2_LMRRifle"
+			]/tools
+		</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>stock</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>8</power>
+					<cooldownTime>1.55</cooldownTime>
+					<chanceFactor>1.5</chanceFactor>
+					<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>barrel</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>5</power>
+					<cooldownTime>2.02</cooldownTime>
+					<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>muzzle</label>
+					<capacities>
+						<li>Poke</li>
+					</capacities>
+					<power>8</power>
+					<cooldownTime>1.55</cooldownTime>
+					<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[
+			@Name="Moyo2_LMRBalista" or
+			@Name="Moyo_LMRAutoCannon"
+			]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>barrel</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>10</power>
+					<cooldownTime>2.44</cooldownTime>
+					<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+	
+	<!-- ========== Nailgun ========== -->
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Moyo2_NailGun</defName>
+		<statBases>
+			<Mass>1.20</Mass>
+			<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+			<SightsEfficiency>0.7</SightsEfficiency>
+			<ShotSpread>0.16</ShotSpread>
+			<SwayFactor>1.07</SwayFactor>
+			<Bulk>2.00</Bulk>
+		</statBases>
+		<Properties>
+			<recoilAmount>2.24</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_Nail_HV</defaultProjectile>
+			<warmupTime>0.6</warmupTime>
+			<range>18</range>
+			<burstShotCount>10</burstShotCount>
+			<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+			<soundCast>Industrial_Nailgun</soundCast>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>60</magazineSize>
+			<reloadTime>4.3</reloadTime>
+			<ammoSet>AmmoSet_Nail_HV</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aimedBurstShotCount>5</aimedBurstShotCount>
+			<aiUseBurstMode>FALSE</aiUseBurstMode>
+			<aiAimMode>Snapshot</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>CE_SMG</li>
+			<li>CE_AI_BROOM</li>
+			<li>CE_OneHandedWeapon</li>
+		</weaponTags>
+	</Operation>
+	
+	<!-- ========== Light Harpoon ========== -->
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Moyo2_SpearGun</defName>
+		<statBases>
+			<Mass>3.60</Mass>
+			<RangedWeapon_Cooldown>0.99</RangedWeapon_Cooldown>
+			<SightsEfficiency>1</SightsEfficiency>
+			<ShotSpread>0.2</ShotSpread>
+			<SwayFactor>1.71</SwayFactor>
+			<Bulk>11.25</Bulk>
+		</statBases>
+		<Properties>
+			<recoilAmount>5.28</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_SmallMoyoHarpoon</defaultProjectile>
+			<warmupTime>1.1</warmupTime>
+			<range>31</range>
+			<soundCast>Industrial_SpearGun</soundCast>
+			<soundCastTail>GunTail_Light</soundCastTail>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>1</magazineSize>
+			<reloadTime>2.2</reloadTime>
+			<ammoSet>AmmoSet_SmallMoyoHarpoon</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aiAimMode>AimedShot</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>CE_AI_SR</li>
+		</weaponTags>
+	</Operation>
+	
+	<!-- ========== Heavy Harpoon ========== -->
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Moyo2_HarpoonGun</defName>
+		<statBases>
+			<Mass>9.00</Mass>
+			<RangedWeapon_Cooldown>1.17</RangedWeapon_Cooldown>
+			<SightsEfficiency>1</SightsEfficiency>
+			<ShotSpread>0.02</ShotSpread>
+			<SwayFactor>2.59</SwayFactor>
+			<Bulk>13.50</Bulk>
+		</statBases>
+		<Properties>
+			<recoilAmount>9.44</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_LargeMoyoHarpoon</defaultProjectile>
+			<warmupTime>2.6</warmupTime>
+			<range>31</range>
+			<soundCast>Industrial_HarpoonGun</soundCast>
+			<soundCastTail>GunTail_Light</soundCastTail>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>1</magazineSize>
+			<reloadTime>4.4</reloadTime>
+			<ammoSet>AmmoSet_LargeMoyoHarpoon</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aiAimMode>AimedShot</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>CE_AI_SR</li>
+		</weaponTags>
+	</Operation>
+
+	<!-- ========== Laminar Pistol ========== -->
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Moyo2_LMRPistol</defName>
+		<statBases>
+			<Mass>2.50</Mass>
+			<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
+			<SightsEfficiency>0.7</SightsEfficiency>
+			<ShotSpread>0.01</ShotSpread>
+			<SwayFactor>1.69</SwayFactor>
+			<Bulk>2.50</Bulk>
+		</statBases>
+		<Properties>
+			<recoilAmount>2.47</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_MoyoLaminarSlug</defaultProjectile>
+			<warmupTime>0.6</warmupTime>
+			<range>31</range>
+			<soundCast>Laminar_Pistol</soundCast>
+			<soundCastTail>GunTail_Medium</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>7</magazineSize>
+			<reloadTime>4</reloadTime>
+			<ammoSet>AmmoSet_MoyoLaminarSlug</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aiUseBurstMode>FALSE</aiUseBurstMode>
+			<aiAimMode>Snapshot</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>CE_Sidearm</li>
+			<li>CE_AI_BROOM</li>
+			<li>CE_OneHandedWeapon</li>
+		</weaponTags>
+	</Operation>
+	
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_LMRPistol"]/comps/li[@Class="Moyo2_ItemFormChange.CompPropertiesFormChange"]</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_UnderBarrel">
+				<standardLabel>switch to normal mode</standardLabel>
+				<underBarrelLabel>switch to overclock mode</underBarrelLabel>
+				<oneAmmoHolder>True</oneAmmoHolder>
+				<propsUnderBarrel>
+					<magazineSize>7</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_MoyoLaminarSlug_OC</ammoSet>
+				</propsUnderBarrel>
+				<verbPropsUnderBarrel>
+					<recoilAmount>4.94</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_MoyoLaminarSlug_OC</defaultProjectile>
+					<warmupTime>3.6</warmupTime>
+					<range>37</range>
+					<soundCast>Laminar_Pistol</soundCast>
+					<soundAiming>Laminar_Chargeup2</soundAiming>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</verbPropsUnderBarrel>
+				<propsFireModesUnderBarrel>
+					<aiAimMode>AimedShot</aiAimMode>
+				</propsFireModesUnderBarrel>
+			</li>
+		</value>
+	</Operation>
+	
+
+	<!-- ========== Laminar Rifle ========== -->
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Moyo2_LMRRifle</defName>
+		<statBases>
+			<Mass>6.50</Mass>
+			<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+			<SightsEfficiency>1.1</SightsEfficiency>
+			<ShotSpread>0.02</ShotSpread>
+			<SwayFactor>1.60</SwayFactor>
+			<Bulk>9.50</Bulk>
+		</statBases>
+		<Properties>
+			<recoilAmount>1.75</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_MoyoLaminarSlug</defaultProjectile>
+			<warmupTime>1</warmupTime>
+			<range>55</range>
+			<soundCast>Laminar_Rifle</soundCast>
+			<soundCastTail>GunTail_Medium</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>15</magazineSize>
+			<reloadTime>4</reloadTime>
+			<ammoSet>AmmoSet_MoyoLaminarSlug</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aiAimMode>AimedShot</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>CE_AI_SR</li>
+		</weaponTags>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_LMRRifle"]/comps/li[@Class="Moyo2_ItemFormChange.CompPropertiesFormChange"]</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_UnderBarrel">
+				<standardLabel>switch to normal mode</standardLabel>
+				<underBarrelLabel>switch to overclock mode</underBarrelLabel>
+				<oneAmmoHolder>True</oneAmmoHolder>
+				<propsUnderBarrel>
+					<magazineSize>15</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_MoyoLaminarSlug_OC_HV</ammoSet>
+				</propsUnderBarrel>
+				<verbPropsUnderBarrel>
+					<recoilAmount>3.5</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_MoyoLaminarSlug_OC_HV</defaultProjectile>
+					<warmupTime>4</warmupTime>
+					<range>65</range>
+					<soundCast>Laminar_Rifle</soundCast>
+					<soundAiming>Laminar_Chargeup2</soundAiming>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</verbPropsUnderBarrel>
+				<propsFireModesUnderBarrel>
+					<aiAimMode>AimedShot</aiAimMode>
+				</propsFireModesUnderBarrel>
+			</li>
+		</value>
+	</Operation>
+	
+	<!-- ========== Laminar Autocannon ========== -->
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Moyo2_LMRAutoCannon</defName>
+		<statBases>
+			<Mass>9.50</Mass>
+			<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
+			<SightsEfficiency>1.1</SightsEfficiency>
+			<ShotSpread>0.05</ShotSpread>
+			<SwayFactor>1.37</SwayFactor>
+			<Bulk>13.50</Bulk>
+		</statBases>
+		<Properties>
+			<recoilAmount>1.31</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_MoyoLaminarSlug</defaultProjectile>
+			<warmupTime>1</warmupTime>
+			<range>51</range>
+			<ticksBetweenBurstShots>15</ticksBetweenBurstShots>
+			<burstShotCount>5</burstShotCount>
+			<soundCast>Laminar_Rifle</soundCast>
+			<soundCastTail>GunTail_Medium</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+			<targetParams>
+				<canTargetLocations>true</canTargetLocations>
+			</targetParams>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>60</magazineSize>
+			<reloadTime>4.9</reloadTime>
+			<ammoSet>AmmoSet_MoyoLaminarSlug</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aimedBurstShotCount>3</aimedBurstShotCount>
+			<aiUseBurstMode>FALSE</aiUseBurstMode>
+			<aiAimMode>SuppressFire</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>CE_MachineGun</li>
+			<li>CE_AI_LMG</li>
+		</weaponTags>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_LMRAutoCannon"]/comps/li[@Class="Moyo2_ItemFormChange.CompPropertiesFormChange"]</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_UnderBarrel">
+				<standardLabel>switch to normal mode</standardLabel>
+				<underBarrelLabel>switch to overclock mode</underBarrelLabel>
+				<oneAmmoHolder>True</oneAmmoHolder>
+				<propsUnderBarrel>
+					<magazineSize>60</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_MoyoLaminarSlug</ammoSet>
+				</propsUnderBarrel>
+				<verbPropsUnderBarrel>
+					<recoilAmount>2.61</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_MoyoLaminarSlug</defaultProjectile>
+					<warmupTime>4</warmupTime>
+					<range>51</range>
+					<ticksBetweenBurstShots>9</ticksBetweenBurstShots>
+					<burstShotCount>20</burstShotCount>
+					<soundCast>Laminar_Rifle</soundCast>
+					<soundAiming>Laminar_Chargeup2</soundAiming>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</verbPropsUnderBarrel>
+				<propsFireModesUnderBarrel>
+					<aiAimMode>SuppressFire</aiAimMode>
+					<noSingleShot>true</noSingleShot>
+					<aimedBurstShotCount>20</aimedBurstShotCount>
+				</propsFireModesUnderBarrel>
+			</li>
+		</value>
+	</Operation>
+	
+	
+	<!-- ========== Laminar Boltgun ========== -->
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Moyo2_LMRBalista</defName>
+		<statBases>
+			<Mass>9.50</Mass>
+			<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+			<SightsEfficiency>1.1</SightsEfficiency>
+			<ShotSpread>0.02</ShotSpread>
+			<SwayFactor>2.53</SwayFactor>
+			<Bulk>12.50</Bulk>
+		</statBases>
+		<Properties>
+			<recoilAmount>7.96</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_MoyoLaminarBolt</defaultProjectile>
+			<warmupTime>2.5</warmupTime>
+			<range>48</range>
+			<soundAiming>Laminar_Chargeup2</soundAiming>
+			<soundCast>Laminar_Balista</soundCast>
+			<soundCastTail>GunTail_Heavy</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>4</magazineSize>
+			<reloadTime>4.9</reloadTime>
+			<ammoSet>AmmoSet_MoyoLaminarBolt</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aiAimMode>AimedShot</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>CE_AI_SR</li>
+		</weaponTags>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_LMRBalista"]/comps/li[@Class="Moyo2_ItemFormChange.CompPropertiesFormChange"]</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_UnderBarrel">
+				<standardLabel>switch to normal mode</standardLabel>
+				<underBarrelLabel>switch to overclock mode</underBarrelLabel>
+				<oneAmmoHolder>True</oneAmmoHolder>
+				<propsUnderBarrel>
+					<magazineSize>4</magazineSize>
+					<reloadTime>4.9</reloadTime>
+					<ammoSet>AmmoSet_MoyoLaminarBolt_OC</ammoSet>
+				</propsUnderBarrel>
+				<verbPropsUnderBarrel>
+					<recoilAmount>15.92</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_MoyoLaminarBolt_OC</defaultProjectile>
+					<warmupTime>5.5</warmupTime>
+					<range>52</range>
+					<soundAiming>Laminar_Chargeup2</soundAiming>
+					<soundCast>Laminar_Balista</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</verbPropsUnderBarrel>
+				<propsFireModesUnderBarrel>
+					<aiAimMode>AimedShot</aiAimMode>
+				</propsFireModesUnderBarrel>
+			</li>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Moyo 2/Patches/Moyo 2/ThingDefs/Patch_Moyo_Melee.xml
+++ b/ModPatches/Moyo 2/Patches/Moyo 2/ThingDefs/Patch_Moyo_Melee.xml
@@ -1,0 +1,313 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- ==========  Moyo Wrench  =========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_Wrench"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>handle</label>
+					<capacities>
+						<li>Poke</li>
+					</capacities>
+					<power>4</power>
+					<cooldownTime>1.84</cooldownTime>
+					<armorPenetrationBlunt>1.125</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>19</power>
+					<cooldownTime>2.61</cooldownTime>
+					<chanceFactor>1.5</chanceFactor>
+					<armorPenetrationBlunt>7.605</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Moyo2_Wrench"]/statBases</xpath>
+		<value>
+			<MeleeCounterParryBonus>0.25</MeleeCounterParryBonus>
+			<Bulk>3.5</Bulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Moyo2_Wrench"]/equippedStatOffsets</xpath>
+		<value>
+			<MeleeCritChance>0.67</MeleeCritChance>
+			<MeleeParryChance>0.25</MeleeParryChance>
+			<MeleeDodgeChance>0.33</MeleeDodgeChance>
+		</value>
+	</Operation>
+	
+	<!-- ========== Throw ========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AbilityDef[defName="Moyo2_WrenchThrow"]/verbProperties</xpath>
+		<value>
+			<verbProperties Class="CombatExtended.VerbPropertiesCE">		
+				<soundCast>ThrowGrenade</soundCast>
+				<verbClass>CombatExtended.Verb_LaunchProjectileStaticCE</verbClass>
+				<range>5.5</range>
+				<defaultProjectile>Moyo2_Bullet_WrenchThrow</defaultProjectile>
+				<warmupTime>1.3</warmupTime>
+				<burstShotCount>1</burstShotCount>
+				<stopBurstWithoutLos>false</stopBurstWithoutLos>
+			</verbProperties>	
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_Bullet_WrenchThrow"]/projectile</xpath>
+		<value>
+			<thingClass>CombatExtended.BulletCE</thingClass>	
+			<projectile Class="CombatExtended.ProjectilePropertiesCE">
+				<damageDef>Moyo2_Damage_WrenchThrow</damageDef>
+				<damageAmountBase>19</damageAmountBase>
+				<speed>30</speed>
+				<armorPenetrationSharp>0</armorPenetrationSharp>
+				<armorPenetrationBlunt>7.2</armorPenetrationBlunt>
+				<spinRate>3</spinRate>
+				<secondaryDamage>
+					<li>
+						<def>Stun</def>
+						<amount>5</amount>
+					</li>
+				</secondaryDamage>
+			</projectile>
+		</value>
+	</Operation>
+
+	<!-- ==========  Moyo Knife  =========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_Knife"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>handle</label>
+					<capacities>
+						<li>Poke</li>
+					</capacities>
+					<power>5</power>
+					<cooldownTime>2.01</cooldownTime>
+					<chanceFactor>0.4</chanceFactor>
+					<armorPenetrationBlunt>1.6</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>point</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>11</power>
+					<cooldownTime>1.26</cooldownTime>
+					<chanceFactor>1</chanceFactor>
+					<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+					<armorPenetrationSharp>1.67</armorPenetrationSharp>
+					<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>edge</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>10</power>
+					<cooldownTime>1.18</cooldownTime>
+					<chanceFactor>1</chanceFactor>
+					<armorPenetrationBlunt>0.36</armorPenetrationBlunt>
+					<armorPenetrationSharp>1.2</armorPenetrationSharp>
+					<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Moyo2_Knife"]/statBases</xpath>
+		<value>
+			<MeleeCounterParryBonus>0.39</MeleeCounterParryBonus>
+			<Bulk>1.5</Bulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Moyo2_Knife"]/equippedStatOffsets</xpath>
+		<value>
+			<MeleeCritChance>0.08</MeleeCritChance>
+			<MeleeParryChance>0.24</MeleeParryChance>
+			<MeleeDodgeChance>1.07</MeleeDodgeChance>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Moyo2_Knife"]/weaponTags</xpath>
+		<value>
+			<li>CE_OneHandedWeapon</li>
+		</value>
+	</Operation>
+	
+	<!-- ==========  Moyo Knife  =========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_Saw"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>sawblade</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>5</power>
+					<cooldownTime>0.1</cooldownTime>
+					<chanceFactor>3</chanceFactor>
+					<armorPenetrationBlunt>0.36</armorPenetrationBlunt>
+					<armorPenetrationSharp>1.2</armorPenetrationSharp>
+					<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Moyo2_Saw"]/statBases</xpath>
+		<value>
+			<MeleeCounterParryBonus>0.39</MeleeCounterParryBonus>
+			<Bulk>6.5</Bulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Moyo2_Saw"]/equippedStatOffsets</xpath>
+		<value>
+			<MeleeCritChance>0</MeleeCritChance>
+			<MeleeParryChance>0</MeleeParryChance>
+			<MeleeDodgeChance>1.07</MeleeDodgeChance>
+		</value>
+	</Operation>
+
+	<!-- ==========  Moyo Glaive  =========== -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Moyo2_LMRGlaive"]/statBases</xpath>
+		<value>
+			<MeleeCounterParryBonus>1.08</MeleeCounterParryBonus>
+			<Bulk>12.50</Bulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Moyo2_LMRGlaive"]</xpath>
+		<value>
+			<equippedStatOffsets>
+				<MeleeCritChance>0.22</MeleeCritChance>
+				<MeleeParryChance>1.53</MeleeParryChance>
+				<MeleeDodgeChance>0.67</MeleeDodgeChance>
+			</equippedStatOffsets>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_LMRGlaive"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>blade</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>41</power>
+					<cooldownTime>1.72</cooldownTime>
+					<chanceFactor>1</chanceFactor>
+					<armorPenetrationBlunt>2.59</armorPenetrationBlunt>
+					<armorPenetrationSharp>18</armorPenetrationSharp>
+					<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>point</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>24</power>
+					<cooldownTime>1.72</cooldownTime>
+					<chanceFactor>1</chanceFactor>
+					<armorPenetrationBlunt>1.25</armorPenetrationBlunt>
+					<armorPenetrationSharp>28</armorPenetrationSharp>
+					<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>handle</label>
+					<capacities>
+						<li>Poke</li>
+						<li>Blunt</li>
+					</capacities>
+					<power>11</power>
+					<cooldownTime>1.38</cooldownTime>
+					<chanceFactor>0.2</chanceFactor>
+					<armorPenetrationBlunt>4.05</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+	
+	<!-- ==========  Moyo Power Fist : Powered weapon, +55MPA Blunt  =========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Moyo2_LMRFist"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>Fist</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>26</power>
+					<cooldownTime>2.74</cooldownTime>
+					<armorPenetrationBlunt>72</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>Body</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>26</power>
+					<cooldownTime>2.74</cooldownTime>
+					<armorPenetrationBlunt>72</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Moyo2_LMRFist"]/statBases</xpath>
+		<value>
+			<MeleeCounterParryBonus>0.2</MeleeCounterParryBonus>
+			<Bulk>5</Bulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Moyo2_LMRFist"]/equippedStatOffsets</xpath>
+		<value>
+			<MeleeCritChance>0.85</MeleeCritChance>
+			<MeleeParryChance>0.05</MeleeParryChance>
+			<MeleeDodgeChance>0.17</MeleeDodgeChance>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Moyo2_LMRFist"]/weaponTags</xpath>
+		<value>
+			<li>CE_OneHandedWeapon</li>
+		</value>
+	</Operation>
+	
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -340,6 +340,7 @@ MorrowRim - Just the Animals	|
 Moyo - From the Depth   |
 Moyo - Light in the Abyss   |
 Moyo - The Cartel Arrives   |
+Moyo 2.0-Blood Stained Business |
 Multiplayer |
 Nakin Race  |
 Nanosuit    |


### PR DESCRIPTION
## Additions

Patches for the new version of moyo content. Old stuff remains since they're a different mod technically and there's a cont'd version on the workshop that if it has the same package ID as the original, should load our patches anyway

## Changes

Minor changes to the abyssteel. A number of weapons are outright different or don't have old equivalents.

## Reasoning

Currently, we use the now shared ammo underbarrel comp to do the overclocked firing modes. In vanilla this actually outright changes what the weapon is, but that functionality breaks the ammo comp that we have, not transfering said data across.

## Alternatives

We could make the guns fire from inventory, which sidesteps the ammo deleting/unloading problem when switching the item from one to the other. Alternatavely, a compatability module could be set up for the specifc comp.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
