### PR TITLE
1.5 Release Fixes & Tweaks

### DIFF
--- a/Anomaly/Patches/PawnKinds/PawnKinds_Horaxian.xml
+++ b/Anomaly/Patches/PawnKinds/PawnKinds_Horaxian.xml
@@ -27,4 +27,30 @@
 		</value>
 	</Operation>
 
+	<!-- ========== Highthrall ========== -->
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/PawnKindDef[defName="Horaxian_Highthrall"]</xpath>
+		<value>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>20</min>
+					<max>40</max>
+				</primaryMagazineCount>
+				<sidearms>
+					<li>
+						<generateChance>0.33</generateChance>
+						<sidearmMoney>
+							<min>90</min>
+							<max>250</max>
+						</sidearmMoney>
+						<weaponTags>
+							<li>CE_Sidearm_Melee</li>
+						</weaponTags>
+					</li>
+				</sidearms>
+			</li>
+		</value>
+	</Operation>
+
 </Patch>

--- a/Defs/Ammo/Medieval/CannonBall.xml
+++ b/Defs/Ammo/Medieval/CannonBall.xml
@@ -118,6 +118,7 @@
 				<explosiveExpandPerStackcount>0.033</explosiveExpandPerStackcount>
 				<startWickOnDamageTaken>
 					<li>Bomb</li>
+					<li>Flame</li>
 				</startWickOnDamageTaken>
 				<startWickHitPointsPercent>0.5</startWickHitPointsPercent>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/Defs/Ammo/Medieval/MiniCannonBall.xml
+++ b/Defs/Ammo/Medieval/MiniCannonBall.xml
@@ -76,6 +76,7 @@
 				<explosiveExpandPerStackcount>0.033</explosiveExpandPerStackcount>
 				<startWickOnDamageTaken>
 					<li>Bomb</li>
+					<li>Flame</li>
 				</startWickOnDamageTaken>
 				<startWickHitPointsPercent>0.5</startWickHitPointsPercent>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/Defs/ThingDefs_Misc/Apparel_Shield.xml
+++ b/Defs/ThingDefs_Misc/Apparel_Shield.xml
@@ -170,8 +170,12 @@
 					</defaultData>
 					<dataEast>
 						<layer>-5</layer>
-						<offset>(0, 0, -0.1)</offset>						
+						<offset>(0, 0, -0.1)</offset>
+						<rotationOffset>30</rotationOffset>
 					</dataEast>
+					<dataWest>
+						<rotationOffset>-30</rotationOffset>
+					</dataWest>						
 					<dataNorth>
 						<layer>-5</layer>
 						<offset>(0.15, 0, -0.1)</offset>

--- a/Defs/ThingDefs_Misc/Apparel_Shield.xml
+++ b/Defs/ThingDefs_Misc/Apparel_Shield.xml
@@ -78,7 +78,7 @@
 				<drawData>
 					<scale>0.8</scale>
 					<defaultData>
-						<layer>91</layer>
+						<layer>80</layer>
 					</defaultData>
 					<dataEast>
 						<layer>-5</layer>
@@ -166,7 +166,7 @@
 				<drawData>
 					<scale>0.8</scale>
 					<defaultData>
-						<layer>91</layer>
+						<layer>80</layer>
 					</defaultData>
 					<dataEast>
 						<layer>-5</layer>

--- a/Defs/ThingDefs_Misc/Weapons_Ranged.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Ranged.xml
@@ -161,10 +161,7 @@
 			<li Class="CombatExtended.CompProperties_FireModes">
 				<aiUseBurstMode>FALSE</aiUseBurstMode>
 				<aiAimMode>AimedShot</aiAimMode>
-			</li>
-			<li Class="CombatExtended.CompProperties_AmmoUser">
-				<AmmoGenPerMagOverride>2</AmmoGenPerMagOverride>
-			</li>			
+			</li>	
 		</comps>
 		<tools>
 			<li Class="CombatExtended.ToolCE">

--- a/Defs/ThingDefs_Misc/Weapons_Ranged.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Ranged.xml
@@ -161,7 +161,7 @@
 			<li Class="CombatExtended.CompProperties_FireModes">
 				<aiUseBurstMode>FALSE</aiUseBurstMode>
 				<aiAimMode>AimedShot</aiAimMode>
-			</li>	
+			</li>
 		</comps>
 		<tools>
 			<li Class="CombatExtended.ToolCE">

--- a/Defs/ThingDefs_Misc/Weapons_Ranged.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Ranged.xml
@@ -57,7 +57,7 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_AmmoUser">
 				<magazineSize>1</magazineSize>
-				<AmmoGenPerMagOverride>3</AmmoGenPerMagOverride>
+				<AmmoGenPerMagOverride>4</AmmoGenPerMagOverride>
 				<reloadTime>2.2</reloadTime>
 				<ammoSet>AmmoSet_40x46mmGrenade</ammoSet>
 			</li>
@@ -162,6 +162,9 @@
 				<aiUseBurstMode>FALSE</aiUseBurstMode>
 				<aiAimMode>AimedShot</aiAimMode>
 			</li>
+			<li Class="CombatExtended.CompProperties_AmmoUser">
+				<AmmoGenPerMagOverride>2</AmmoGenPerMagOverride>
+			</li>			
 		</comps>
 		<tools>
 			<li Class="CombatExtended.ToolCE">

--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -190,7 +190,7 @@
 		<li IfModActive="latta.infusion">ModPatches/Infusion 2</li>
 		<li IfModActive="SirMashedPotato.InsectsHaveChitin">ModPatches/Insects have chitin</li>
 		<li IfModActive="Poetik.JapaneseDogs">ModPatches/Japanese Dogs</li>
-		<li IfModActive="JangoDsoul.CastleWalls">ModPatches/JDS Castle Walls</li>
+		<li IfModActive="JangoDsoul.CastleWalls,gideon.castlewalls">ModPatches/JDS Castle Walls</li>
 		<li IfModActive="JangoDsoul.EFT.Apparel">ModPatches/JDS EFT Apparel</li>
 		<li IfModActive="JangoDsoul.TheForge.NCRArmory">ModPatches/JDS The Forge - NCR Armory</li>
 		<li IfModActive="JPT.OpenTheWindows">ModPatches/JPT Open The Windows</li>

--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -14,14 +14,14 @@
 		<li IfModActive="ADE.AdvancedTurretsA.copy.Mod">ModPatches/ADE Advanced turrets PLUS</li>
 		<li IfModActive="ADE.pulseTurrets.Mod">ModPatches/ADE Pulse Turrets PLUS</li>
 		<li IfModActive="spoonshortage.ADogSaidAnimalProsthetics">ModPatches/ADogSaid</li>
-    <li IfModActive="SamBucher.ADogSaidAnimalProsthetics2">ModPatches/ADogSaid2</li>
+		<li IfModActive="SamBucher.ADogSaidAnimalProsthetics2">ModPatches/ADogSaid2</li>
 		<li IfModActive="Ravvy.AMW">ModPatches/Advanced Mechanoid Warfare</li>
 		<li IfModActive="Mlie.AdvancedMortar">ModPatches/Advanced Mortar</li>
 		<li IfModActive="EV.all.tech.melee">ModPatches/All-Tech Melee</li>
 		<li IfModActive="sarg.alphaanimals">ModPatches/Alpha Animals</li>
 		<li IfModActive="sarg.alphabiomes">ModPatches/Alpha Biomes</li>
 		<li IfModActive="sarg.alphagenes">ModPatches/Alpha Genes</li>
-    <li IfModActive="sarg.alphaimplants">ModPatches/Alpha Implants</li>
+		<li IfModActive="sarg.alphaimplants">ModPatches/Alpha Implants</li>
 		<li IfModActive="Sarg.AlphaMemes">ModPatches/Alpha Memes</li>
 		<li IfModActive="sarg.magicalmenagerie">ModPatches/Alpha Mythology</li>
 		<li IfModActive="sarg.alphaships">ModPatches/Alpha Ships</li>
@@ -238,7 +238,7 @@
 		<li IfModActive="DankPyon.Medieval.Overhaul">ModPatches/Medieval Overhaul</li>
 		<li IfModActive="Arisher.Medieval.Tailor">ModPatches/Medieval Tailor</li>
 		<li IfModActive="Spino.Megafauna">ModPatches/Megafauna</li>
-    <li IfModActive="co.uk.epicguru.meleeanimation">ModPatches/Melee Animation</li>
+		<li IfModActive="co.uk.epicguru.meleeanimation">ModPatches/Melee Animation</li>
 		<li IfModActive="AOBA.Gekko">ModPatches/Metal Gear Rimworld-Gekko</li>
 		<li IfModActive="Killathon.MechHumanlikes.AndroidTiersCore">ModPatches/MH Android Tiers Core</li>
 		<li IfModActive="Killathon.MechHumanlikes.MechanicalBiomimetics">ModPatches/MH Mechanical Biomimetics</li>
@@ -314,8 +314,8 @@
 		<li IfModActive="Mlie.RamboWeaponsPack">ModPatches/Rambo Weapons Pack</li>
 		<li IfModActive="Rin.RatkinApparel">ModPatches/Ratkin Apparel+</li>
 		<li IfModActive="JangoDsoul.Ratnik3">ModPatches/Ratnik-3 Prototype Armor</li>
-    <li IfModActive="ReBuild.COTR.DoorsAndCorners">ModPatches/ReBuild - Doors and Corners</li>
-    <li IfModActive="Bonible.ReconMech">ModPatches/Recon Mechanoid</li>
+		<li IfModActive="ReBuild.COTR.DoorsAndCorners">ModPatches/ReBuild - Doors and Corners</li>
+		<li IfModActive="Bonible.ReconMech">ModPatches/Recon Mechanoid</li>
 		<li IfModActive="Mlie.RedArmy">ModPatches/Red Army</li>
 		<li IfModActive="vonschtirlitz.RCA">ModPatches/Redcoat Apparel</li>
 		<li IfModActive="ReGrowth.BOTR.Core">ModPatches/ReGrowth - Core</li>
@@ -379,7 +379,7 @@
 		<li IfModActive="Rottweiler.SimplyMoreMelee, Mlie.SimplyMoreMelee">ModPatches/Simply More Melee</li>
 		<li IfModActive="PunkyRoo.SlimeRancher">ModPatches/Slime Rancher</li>
 		<li IfModActive="Ayameduki.HARSolark">ModPatches/Solark Race</li>
-    <li IfModActive="LTS.PS">ModPatches/Spacer Shields</li>
+		<li IfModActive="LTS.PS">ModPatches/Spacer Shields</li>
 		<li IfModActive="Mlie.SpaceWorms">ModPatches/Spaceworm</li>
 		<li IfModActive="HALO.RSF, Mlie.RimworldSpartanFoundry">ModPatches/Spartan Foundry</li>
 		<li IfModActive="Mlie.SpidercampsHorses">ModPatches/Spidercamp&apos;s Horses</li>

--- a/ModPatches/JDS Castle Walls/Patches/JDS Castle Walls/ThingDefs_Tower.xml
+++ b/ModPatches/JDS Castle Walls/Patches/JDS Castle Walls/ThingDefs_Tower.xml
@@ -44,7 +44,7 @@
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Projectile_GreatArrow_Stone</defaultProjectile>
 			<warmupTime>1.3</warmupTime>
-			<range>32</range>
+			<range>34</range>
 			<soundCast>Bow_Large</soundCast>
 		</Properties>
 		<AmmoUser>
@@ -61,4 +61,5 @@
 			<noSingleShot>true</noSingleShot>
 		</FireModes>
 	</Operation>
+
 </Patch>

--- a/ModPatches/Vanilla Furniture Expanded - Security/Defs/Vanilla Furniture Expanded - Security/Ammo_Security.xml
+++ b/ModPatches/Vanilla Furniture Expanded - Security/Defs/Vanilla Furniture Expanded - Security/Ammo_Security.xml
@@ -30,6 +30,8 @@
 		<ammoTypes>
 			<Shell_HighExplosive>Bullet_155mmHowitzerShell_HE</Shell_HighExplosive>
 			<Shell_Incendiary>Bullet_155mmHowitzerShell_Incendiary</Shell_Incendiary>
+			<Shell_Toxic MayRequire="Ludeon.RimWorld.Biotech">Bullet_81mmMortarShell_Tox</Shell_Toxic>
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
+
 </Defs>


### PR DESCRIPTION
## Additions
- Add some rotation to ballistic shield when pawn is facing east or west.
- Add ammo to the Anomaly highthrall pawnkind.
- Allow VFE: Security raider heavy artillery to fire tox shells.

## Changes
- LoadFolder.xml housekeeping.
- Add 'Castle Walls Reborn' to LoadFolder, slightly increase range of greatbow tower.
- Set shields to render on layer 80, preventing them from rendering in front of weapons.
- Increase the mag count override of the M72 and M79, so pawnkinds spawning with them get a bit more ammo.

## Reasoning
- Makes the carrying position of the shield look a bit more natural and less rigid as the pawn is moving.
- Highthrall needs ammo, too.
- Sieges will be supplied with tox shells, so it makes sense to let the raider arty fire them. We don't have a dedicated 155mm tox shell, but the 81mm is sufficient for the task.
- General sanity and cleanliness.
- Easy to do, since JDS version hasn't updated yet. Also, firing from an elevated position _should_ go a bit farther.
- It's not desirable to have shields rendering in front of pawn's weapons.
- Pawnkinds getting the M79 generally only had 12 - 14 shots, usually leaving them with extra space in their inventory. Increasing the override bumps that to 16 - 24.

## Alternatives


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
