### PR TITLE
DrawAt: use parameter instead of property

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -1218,7 +1218,7 @@ namespace CombatExtended
                 }
                 //Projectile
                 //Graphics.DrawMesh(MeshPool.plane10, DrawPos, DrawRotation, def.DrawMatSingle, 0);
-                Graphics.DrawMesh(MeshPool.GridPlane(def.graphicData.drawSize), DrawPos, projectileRotation, def.DrawMatSingle, 0);
+                Graphics.DrawMesh(MeshPool.GridPlane(def.graphicData.drawSize), drawLoc, projectileRotation, def.DrawMatSingle, 0);
 
                 //Shadow
                 if (castShadow)


### PR DESCRIPTION

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Parameter instead of property. Doesn't affect default render of Projectile in fact

## References

Links to the associated issues or other related pull requests, e.g.
- https://discord.com/channels/278818534069501953/322827713335394304/1256120395640209469

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (checked mortar and few weapons)
