### PR TITLE
Charged ammo diameter fix

### DIFF
--- a/Defs/Ammo/Advanced/12GaugeCharged.xml
+++ b/Defs/Ammo/Advanced/12GaugeCharged.xml
@@ -27,7 +27,7 @@
 		<description>Multi-pellet charge shot cartridge designed for shotgun-type weapons.</description>
 		<statBases>
 			<Mass>0.047</Mass>
-			<Bulk>0.07</Bulk>
+			<Bulk>0.08</Bulk>
 		</statBases>
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>

--- a/Defs/Ammo/Advanced/12x64mmCharged.xml
+++ b/Defs/Ammo/Advanced/12x64mmCharged.xml
@@ -25,7 +25,7 @@
 		<description>Mechanoid-built high-caliber charged shot ammo used in heavy weapons.</description>
 		<statBases>
 			<Mass>0.058</Mass>
-			<Bulk>0.04</Bulk>
+			<Bulk>0.05</Bulk>
 		</statBases>
 		<thingCategories>
 			<li>Ammo12x64mmCharged</li>

--- a/Defs/Ammo/Advanced/12x72mmCharged.xml
+++ b/Defs/Ammo/Advanced/12x72mmCharged.xml
@@ -27,7 +27,7 @@
 		<description>High-caliber charged shot ammo used by advanced heavy machine guns and anti-materiel rifles.</description>
 		<statBases>
 			<Mass>0.058</Mass>
-			<Bulk>0.04</Bulk>
+			<Bulk>0.05</Bulk>
 		</statBases>
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>

--- a/Defs/Ammo/Advanced/15x65mmDiffusingCharged.xml
+++ b/Defs/Ammo/Advanced/15x65mmDiffusingCharged.xml
@@ -122,7 +122,7 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_12x64mmCharged>200</Ammo_12x64mmCharged>
+			<Ammo_15x65mmDiffusingCharged>200</Ammo_15x65mmDiffusingCharged>
 		</products>
 		<skillRequirements>
 			<Crafting>8</Crafting>

--- a/Defs/Ammo/Advanced/15x65mmDiffusingCharged.xml
+++ b/Defs/Ammo/Advanced/15x65mmDiffusingCharged.xml
@@ -25,7 +25,7 @@
 		<description>Mechanoid-built cartridge designed to split upon firing.</description>
 		<statBases>
 			<Mass>0.11</Mass>
-			<Bulk>0.04</Bulk>
+			<Bulk>0.05</Bulk>
 		</statBases>
 		<thingCategories>
 			<li>Ammo15x65mmDiffusingCharged</li>

--- a/Defs/Ammo/Advanced/20x105mmCharged.xml
+++ b/Defs/Ammo/Advanced/20x105mmCharged.xml
@@ -27,7 +27,7 @@
 		<description>High-caliber charged shot ammo used by advanced autocannons.</description>
 		<statBases>
 			<Mass>0.13</Mass>
-			<Bulk>0.12</Bulk>
+			<Bulk>0.14</Bulk>
 		</statBases>
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>

--- a/Defs/Ammo/Advanced/8x35mmCharged.xml
+++ b/Defs/Ammo/Advanced/8x35mmCharged.xml
@@ -27,7 +27,7 @@
 		<description>Charged shot ammo used by advanced assault rifle designs.</description>
 		<statBases>
 			<Mass>0.018</Mass>
-			<Bulk>0.01</Bulk>
+			<Bulk>0.02</Bulk>
 		</statBases>
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>

--- a/Defs/Ammo/Advanced/8x40mmCharged.xml
+++ b/Defs/Ammo/Advanced/8x40mmCharged.xml
@@ -25,7 +25,7 @@
 		<description>Mechanoid-built high power charged shot ammo used in long range assault weapons.</description>
 		<statBases>
 			<Mass>0.021</Mass>
-			<Bulk>0.01</Bulk>
+			<Bulk>0.02</Bulk>
 		</statBases>
 		<thingCategories>
 			<li>Ammo8x40mmCharged</li>

--- a/Defs/Ammo/Advanced/8x50mmCharged.xml
+++ b/Defs/Ammo/Advanced/8x50mmCharged.xml
@@ -27,7 +27,7 @@
 		<description>High power charged shot ammo used by advanced battle rifles, machineguns and sniper rifles.</description>
 		<statBases>
 			<Mass>0.027</Mass>
-			<Bulk>0.01</Bulk>
+			<Bulk>0.02</Bulk>
 		</statBases>
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>


### PR DESCRIPTION
## Changes

- Fixed the diameter of charged ammo types.
- Fixed and incorrect ammo recipe output.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit?gid=1393347070#gid=1393347070

## Reasoning

- Charged ammo is telescoping caseless but the case diameter is the same exact as the projectile diameter, Added 2mm to the total diameter of the ammo.
