### PR TITLE
Recoil animation tweaks

### DIFF
--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -760,15 +760,15 @@ namespace CombatExtended
         private static readonly SimpleCurve RecoilCurveAxisY = new SimpleCurve
     {
         new CurvePoint(0f, 0f),
-        new CurvePoint(1f, 0.05f),
-        new CurvePoint(2f, 0.075f)
+        new CurvePoint(1f, 0.03f),
+        new CurvePoint(2f, 0.04f)
     };
 
         private static readonly SimpleCurve RecoilCurveRotation = new SimpleCurve
     {
         new CurvePoint(0f, 0f),
-        new CurvePoint(1f, 3f),
-        new CurvePoint(2f, 4f)
+        new CurvePoint(1f, 2.5f),
+        new CurvePoint(2f, 3f)
     };
 
         const float RecoilMagicNumber = 2.6f;


### PR DESCRIPTION
## Changes

- Toned down the recoil animations, especially for the higher end. Turrets travel less in the Y axis and there's slightly less muzzle rise for high recoil guns.

## Reasoning

- Current curve leads to absurd muzzle rises and turret top movements.

## Alternatives

- Suffer and tear the proverbial eyes out.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Looks better)
