### PR TITLE
Don't show ammoPerShot for Melee Weapons

### DIFF
--- a/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_AmmoConsumedPerShotCount.cs
+++ b/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_AmmoConsumedPerShotCount.cs
@@ -30,7 +30,7 @@ namespace CombatExtended
 
         public override bool ShouldShowFor(StatRequest req)
         {
-            return base.ShouldShowFor(req) &&
+            return base.ShouldShowFor(req) && !GunDef(req).IsMeleeWeapon &&
             (((GunDef(req)?.GetCompProperties<CompProperties_AmmoUser>() as CompProperties_AmmoUser)?.ammoSet?.ammoConsumedPerShot != 1) ||
              (GunDef(req)?.Verbs?.Any(x => ((x as VerbPropertiesCE)?.ammoConsumedPerShotCount ?? 1) > 1) ?? false));
         }


### PR DESCRIPTION
## Changes

- Stop showing AmmoConsumedPerShot for Melee Weapons

## Reasoning

It doesn't make sense

## Alternatives

Leave it be

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
