### PR TITLE
Tactital Comp deactivation for turned mutants and crawling mutants

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompTacticalManager.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompTacticalManager.cs
@@ -106,6 +106,8 @@ namespace CombatExtended
             }
         }
 
+        public bool Active => (!SelPawn.mutant?.HasTurned ?? true) && !SelPawn.Crawling;
+
         private readonly TargetIndex[] _targetIndices = new TargetIndex[]
         {
             TargetIndex.A,
@@ -116,7 +118,7 @@ namespace CombatExtended
         public override void CompTick()
         {
             base.CompTick();
-            if (parent.IsHashIntervalTick(120))
+            if (parent.IsHashIntervalTick(120) && Active)
             {
                 /*
                  * Clear the cache if it's very outdated to allow GC to take over
@@ -196,6 +198,10 @@ namespace CombatExtended
         public override void CompTickRare()
         {
             base.CompTickRare();
+            if (!Active)
+            {
+                return;
+            }
             TryGiveTacticalJobs();
             if (_counter++ % 2 == 0)
             {
@@ -259,15 +265,18 @@ namespace CombatExtended
 
         public void Notify_BulletImpactNearby()
         {
-            foreach (ICompTactics comp in TacticalComps)
+            if (Active)
             {
-                try
+                foreach (ICompTactics comp in TacticalComps)
                 {
-                    comp.Notify_BulletImpactNearBy();
-                }
-                catch (Exception er)
-                {
-                    Log.Error($"CE: Error running Notify_BulletImpactNearBy {comp.GetType()} with error {er}");
+                    try
+                    {
+                        comp.Notify_BulletImpactNearBy();
+                    }
+                    catch (Exception er)
+                    {
+                        Log.Error($"CE: Error running Notify_BulletImpactNearBy {comp.GetType()} with error {er}");
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Tactial comps not used for shamblers (and crawling pawns) anymore


## Reasoning

Why did you choose to implement things this way, e.g.
- Shamblers with guns and melee weapons

## Alternatives

Describe alternative implementations you have considered, e.g.
- Lose against shamblers (maybe even gorehulks and other) with rifles?

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (shamblers do not pick up weapons on the same save)
