### PR TITLE
Patch pphhyy's Lightless Empyrean

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -600,5 +600,6 @@
 		<li IfModActive="det.boglegs">ModPatches/Det's Xenotypes - Boglegs</li>		
 		<li IfModActive="Nemonian.MY2.Beta">ModPatches/Moyo 2</li>
 		<li IfModActive="polonium.RorenRaceMod">ModPatches/Roren Race</li>
+		<li IfModActive="pphhyy.LightlessEmpyrean">ModPatches/pphhyy's Lightless Empyrean</li>
 	</v1.5>
 </loadFolders>

--- a/ModPatches/pphhyy's Lightless Empyrean/Patches/pphhyy's Lightless Empyrean/Bodies_Jellyfish.xml
+++ b/ModPatches/pphhyy's Lightless Empyrean/Patches/pphhyy's Lightless Empyrean/Bodies_Jellyfish.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- ==================== Cnidarian Body ==================== -->
+
+	<!-- ========== Add groups entry if it doesn't exist already ========== -->
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/BodyDef[defName="pphhyy_LightlessEmpyrean_CnidarianBody"]/corePart/groups</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/BodyDef[defName="pphhyy_LightlessEmpyrean_CnidarianBody"]/corePart</xpath>
+			<value>
+				<groups/>
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/BodyDef[defName="pphhyy_LightlessEmpyrean_CnidarianBody"]/corePart/parts/li[def="Head"]/groups</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/BodyDef[defName="pphhyy_LightlessEmpyrean_CnidarianBody"]/corePart/parts/li[def="Head"]</xpath>
+			<value>
+				<groups/>
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/BodyDef[defName="pphhyy_LightlessEmpyrean_CnidarianBody"]/corePart/parts/li[def="Head"]/parts/li[def="AnimalJaw"]/groups</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/BodyDef[defName="pphhyy_LightlessEmpyrean_CnidarianBody"]/corePart/parts/li[def="Head"]/parts/li[def="AnimalJaw"]</xpath>
+			<value>
+				<groups/>
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/BodyDef[defName="pphhyy_LightlessEmpyrean_CnidarianBody"]/corePart/parts/li[def="pphhyy_LightlessEmpyrean_CnidarianTentacle"]/groups</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/BodyDef[defName="pphhyy_LightlessEmpyrean_CnidarianBody"]/corePart/parts/li[def="pphhyy_LightlessEmpyrean_CnidarianTentacle"]</xpath>
+			<value>
+				<groups/>
+			</value>
+		</nomatch>
+	</Operation>
+
+	<!-- ========== Add armor coverage ========== -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/BodyDef[defName="pphhyy_LightlessEmpyrean_CnidarianBody"]/corePart/groups</xpath>
+		<value>
+			<li>CoveredByNaturalArmor</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/BodyDef[defName="pphhyy_LightlessEmpyrean_CnidarianBody"]/corePart/parts/li[def="pphhyy_LightlessEmpyrean_CnidarianTentacle"]/groups</xpath>
+		<value>
+			<li>CoveredByNaturalArmor</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/BodyDef[defName="pphhyy_LightlessEmpyrean_CnidarianBody"]/corePart/parts/li[def="Head"]/groups</xpath>
+		<value>
+			<li>CoveredByNaturalArmor</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/BodyDef[defName="pphhyy_LightlessEmpyrean_CnidarianBody"]/corePart/parts/li[def="Head"]/parts/li[def="AnimalJaw"]/groups</xpath>
+		<value>
+			<li>CoveredByNaturalArmor</li>
+		</value>
+	</Operation>
+
+	<!-- ========== Set parts as squishy ========== -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/BodyPartDef[defName="pphhyy_LightlessEmpyrean_CnidarianTentacle" or defName="pphhyy_LightlessEmpyrean_CnidarianSensoryOrgan" or defName="AnimalJaw"]/tags</xpath>
+		<value>
+			<li>OutsideSquishy</li>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/pphhyy's Lightless Empyrean/Patches/pphhyy's Lightless Empyrean/Race_Animals.xml
+++ b/ModPatches/pphhyy's Lightless Empyrean/Patches/pphhyy's Lightless Empyrean/Race_Animals.xml
@@ -1,0 +1,322 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- Jellyfish Base -->
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[@Name="pphhyy_LightlessEmpyrean_JellyfishBase"]</xpath>
+		<value>
+			<li Class="CombatExtended.RacePropertiesExtensionCE">
+				<bodyShape>Humanoid</bodyShape>
+			</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[@Name="pphhyy_LightlessEmpyrean_JellyfishBase"]/statBases</xpath>
+		<value>
+			<MeleeCritChance>1</MeleeCritChance>
+			<MeleeParryChance>1</MeleeParryChance>
+			<MeleeDodgeChance>1</MeleeDodgeChance>			
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[@Name="pphhyy_LightlessEmpyrean_JellyfishBase"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>tentacle</label>
+					<capacities>
+						<li>ScratchToxic</li>
+					</capacities>
+					<power>4</power>
+					<cooldownTime>1.26</cooldownTime>
+					<linkedBodyPartsGroup>pphhyy_LightlessEmpyrean_TentacleAttackTool</linkedBodyPartsGroup>
+					<armorPenetrationBlunt>0.450</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.25</armorPenetrationSharp>					
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>3</power>
+					<cooldownTime>3.49</cooldownTime>
+					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					<chanceFactor>0.2</chanceFactor>
+					<armorPenetrationBlunt>0.625</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<!-- Sirius -->
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="pphhyy_LightlessEmpyrean_Sirius"]</xpath>
+		<value>
+			<li Class="CombatExtended.RacePropertiesExtensionCE">
+				<bodyShape>Humanoid</bodyShape>
+			</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="pphhyy_LightlessEmpyrean_Sirius"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>tentacle</label>
+					<capacities>
+						<li>ScratchToxic</li>
+					</capacities>
+					<power>10</power>
+					<cooldownTime>1.26</cooldownTime>
+					<linkedBodyPartsGroup>pphhyy_LightlessEmpyrean_TentacleAttackTool</linkedBodyPartsGroup>
+					<armorPenetrationBlunt>1.25</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.85</armorPenetrationSharp>					
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>8</power>
+					<cooldownTime>3.49</cooldownTime>
+					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					<chanceFactor>0.2</chanceFactor>
+					<armorPenetrationBlunt>1.25</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<!-- Gaster -->
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="pphhyy_LightlessEmpyrean_Gaster"]</xpath>
+		<value>
+			<li Class="CombatExtended.RacePropertiesExtensionCE">
+				<bodyShape>Quadruped</bodyShape>
+			</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="pphhyy_LightlessEmpyrean_Gaster"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>mandibles</label>
+					<capacities>
+						<li>Bite</li>
+					</capacities>
+					<power>9</power>
+					<cooldownTime>1.5</cooldownTime>
+					<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
+					<armorPenetrationSharp>0.24</armorPenetrationSharp>
+					<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>1</power>
+					<cooldownTime>1.26</cooldownTime>
+					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					<chanceFactor>0.2</chanceFactor>
+					<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="pphhyy_LightlessEmpyrean_Gaster"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>2.25</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="pphhyy_LightlessEmpyrean_Gaster"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>0.7</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="pphhyy_LightlessEmpyrean_Gaster"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="pphhyy_LightlessEmpyrean_Gaster"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="pphhyy_LightlessEmpyrean_Gaster"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>150</Durability>
+				<Regenerates>true</Regenerates>
+				<RegenInterval>600</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<MinArmorPct>0.5</MinArmorPct>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- Lemures -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="pphhyy_LightlessEmpyrean_Lemures"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>left fist</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>12.5</power>
+					<cooldownTime>1.66</cooldownTime>
+					<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+					<armorPenetrationBlunt>6</armorPenetrationBlunt>
+					<surpriseAttack>
+						<extraMeleeDamages>
+						  <li>
+							<def>Stun</def>
+							<amount>14</amount>
+						  </li>
+						</extraMeleeDamages>
+					</surpriseAttack>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>right fist</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>12.5</power>
+					<cooldownTime>1.66</cooldownTime>
+					<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+					<armorPenetrationBlunt>6</armorPenetrationBlunt>
+					<surpriseAttack>
+						<extraMeleeDamages>
+						  <li>
+							<def>Stun</def>
+							<amount>14</amount>
+						  </li>
+						</extraMeleeDamages>
+					</surpriseAttack>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>teeth</label>
+					<capacities>
+						<li>Bite</li>
+					</capacities>
+					<power>10</power>
+					<cooldownTime>2</cooldownTime>
+					<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+					<soundMeleeHit>Pawn_Melee_HumanBite_Hit</soundMeleeHit>
+					<soundMeleeMiss>Pawn_Melee_HumanBite_Miss</soundMeleeMiss>
+					<armorPenetrationSharp>1.25</armorPenetrationSharp>
+					<armorPenetrationBlunt>4.25</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>8</power>
+					<cooldownTime>4.49</cooldownTime>
+					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					<chanceFactor>0.2</chanceFactor>
+					<armorPenetrationBlunt>4</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="pphhyy_LightlessEmpyrean_Lemures"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>2.25</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="pphhyy_LightlessEmpyrean_Lemures"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>0.7</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<!-- Shades -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="pphhyy_LightlessEmpyrean_Shade"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>left fist</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>12.5</power>
+					<cooldownTime>1.66</cooldownTime>
+					<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+					<armorPenetrationBlunt>6</armorPenetrationBlunt>
+					<surpriseAttack>
+						<extraMeleeDamages>
+						  <li>
+							<def>Stun</def>
+							<amount>14</amount>
+						  </li>
+						</extraMeleeDamages>
+					</surpriseAttack>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>right fist</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>12.5</power>
+					<cooldownTime>1.66</cooldownTime>
+					<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+					<armorPenetrationBlunt>6</armorPenetrationBlunt>
+					<surpriseAttack>
+						<extraMeleeDamages>
+						  <li>
+							<def>Stun</def>
+							<amount>14</amount>
+						  </li>
+						</extraMeleeDamages>
+					</surpriseAttack>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>teeth</label>
+					<capacities>
+						<li>Bite</li>
+					</capacities>
+					<power>10</power>
+					<cooldownTime>2</cooldownTime>
+					<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+					<soundMeleeHit>Pawn_Melee_HumanBite_Hit</soundMeleeHit>
+					<soundMeleeMiss>Pawn_Melee_HumanBite_Miss</soundMeleeMiss>
+					<armorPenetrationSharp>1.25</armorPenetrationSharp>
+					<armorPenetrationBlunt>4.25</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>8</power>
+					<cooldownTime>4.49</cooldownTime>
+					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					<chanceFactor>0.2</chanceFactor>
+					<armorPenetrationBlunt>4</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/pphhyy's Lightless Empyrean/Patches/pphhyy's Lightless Empyrean/Race_Animals.xml
+++ b/ModPatches/pphhyy's Lightless Empyrean/Patches/pphhyy's Lightless Empyrean/Race_Animals.xml
@@ -109,22 +109,22 @@
 					<capacities>
 						<li>Bite</li>
 					</capacities>
-					<power>9</power>
+					<power>11</power>
 					<cooldownTime>1.5</cooldownTime>
 					<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
-					<armorPenetrationSharp>0.24</armorPenetrationSharp>
-					<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.64</armorPenetrationSharp>
+					<armorPenetrationBlunt>1.02</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>head</label>
 					<capacities>
 						<li>Blunt</li>
 					</capacities>
-					<power>1</power>
+					<power>5</power>
 					<cooldownTime>1.26</cooldownTime>
 					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 					<chanceFactor>0.2</chanceFactor>
-					<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+					<armorPenetrationBlunt>1.250</armorPenetrationBlunt>
 				</li>
 			</tools>
 		</value>
@@ -133,14 +133,14 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="pphhyy_LightlessEmpyrean_Gaster"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
-			<ArmorRating_Blunt>2.25</ArmorRating_Blunt>
+			<ArmorRating_Blunt>4.2</ArmorRating_Blunt>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="pphhyy_LightlessEmpyrean_Gaster"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
-			<ArmorRating_Sharp>0.7</ArmorRating_Sharp>
+			<ArmorRating_Sharp>2.4</ArmorRating_Sharp>
 		</value>
 	</Operation>
 

--- a/ModPatches/pphhyy's Lightless Empyrean/Patches/pphhyy's Lightless Empyrean/Race_Animals.xml
+++ b/ModPatches/pphhyy's Lightless Empyrean/Patches/pphhyy's Lightless Empyrean/Race_Animals.xml
@@ -14,9 +14,9 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[@Name="pphhyy_LightlessEmpyrean_JellyfishBase"]/statBases</xpath>
 		<value>
-			<MeleeCritChance>1</MeleeCritChance>
-			<MeleeParryChance>1</MeleeParryChance>
-			<MeleeDodgeChance>1</MeleeDodgeChance>			
+			<MeleeCritChance>0.05</MeleeCritChance>
+			<MeleeParryChance>0.02</MeleeParryChance>
+			<MeleeDodgeChance>0.18</MeleeDodgeChance>			
 		</value>
 	</Operation>
 
@@ -130,6 +130,15 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="pphhyy_LightlessEmpyrean_Gaster"]/statBases</xpath>
+		<value>
+			<MeleeDodgeChance>0.18</MeleeDodgeChance>
+			<MeleeCritChance>0.05</MeleeCritChance>
+			<MeleeParryChance>0.04</MeleeParryChance>
+		</value>
+	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="pphhyy_LightlessEmpyrean_Gaster"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
@@ -233,6 +242,15 @@
 					<armorPenetrationBlunt>4</armorPenetrationBlunt>
 				</li>
 			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="pphhyy_LightlessEmpyrean_Lemures"]/statBases</xpath>
+		<value>
+			<MeleeDodgeChance>0.24</MeleeDodgeChance>
+			<MeleeCritChance>0.09</MeleeCritChance>
+			<MeleeParryChance>0.14</MeleeParryChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/pphhyy's Lightless Empyrean/Patches/pphhyy's Lightless Empyrean/ThingDefs_Resources.xml
+++ b/ModPatches/pphhyy's Lightless Empyrean/Patches/pphhyy's Lightless Empyrean/ThingDefs_Resources.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="pphhyy_LightlessEmpyrean_EtherealCloth"]/statBases/StuffPower_Armor_Sharp</xpath>
+		<value>
+			<StuffPower_Armor_Sharp>0.01</StuffPower_Armor_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="pphhyy_LightlessEmpyrean_EtherealCloth"]/statBases/StuffPower_Armor_Heat</xpath>
+		<value>
+			<StuffPower_Armor_Heat>0.05</StuffPower_Armor_Heat>
+		</value>
+	</Operation>
+
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -374,6 +374,7 @@ Poleepkwa Race	|
 Possessed Weapons	|
 pphhyy's Demigryphs   |
 phynilla Expanded Mechs Scyther |
+pphhyy's Lightless Empyrean |
 pphhyy Sanguinary Animals   |
 Prestige Specialist Armours	|
 Project RimFactory - Materials |


### PR DESCRIPTION
## Additions
- Patch new animals and material from pphhyy's Lightless Empyrean.
  - New fabric is in line with basic wools.
  - Gaster is essentially a stronger megascarab.
  - Jellys are unarmored and fairly weak, but have a toxic attack.
  - The shades are basically buffed humans.

## Reasoning
- See above.

## Alternatives
- Could do a different balancing scheme.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
