### PR TITLE
Patch Deployable Turrets

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -600,5 +600,6 @@
 		<li IfModActive="det.boglegs">ModPatches/Det's Xenotypes - Boglegs</li>		
 		<li IfModActive="Nemonian.MY2.Beta">ModPatches/Moyo 2</li>
 		<li IfModActive="polonium.RorenRaceMod">ModPatches/Roren Race</li>
+		<li IfModActive="Pal5k.DeployableTurret">ModPatches/Deployable Turret</li>		
 	</v1.5>
 </loadFolders>

--- a/ModPatches/Deployable Turret/Patches/Deployable Turret/Patch_MicroTurret.xml
+++ b/ModPatches/Deployable Turret/Patches/Deployable Turret/Patch_MicroTurret.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- ========== Gunslinger Arm ========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/HediffDef[defName="GunslingerArm"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>fist</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>7</power>
+					<cooldownTime>0.83</cooldownTime>
+					<armorPenetrationBlunt>2.80</armorPenetrationBlunt>
+					<soundMeleeHit>MeleeHit_BionicPunch</soundMeleeHit>
+					<soundMeleeMiss>MeleeMiss_BionicPunch</soundMeleeMiss>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<!-- ========== Micro turret Pack ========== -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_PackDeployableMicroTurret"]/statBases</xpath>
+		<value>
+			<Bulk>10</Bulk>
+			<WornBulk>2</WornBulk>
+		</value>
+	</Operation>
+
+	<!-- ========== Micro-turret ========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="DeployableMicroTurret"]/thingClass</xpath>
+		<value>
+			<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="DeployableMicroTurret"]/statBases</xpath>
+		<value>
+			<AimingAccuracy>0.20</AimingAccuracy>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="DeployableMicroTurret"]/statBases/ShootingAccuracyTurret</xpath>
+		<value>
+			<ShootingAccuracyTurret>0.4</ShootingAccuracyTurret>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="DeployableMicroTurret"]/fillPercent</xpath>
+		<value>
+			<fillPercent>0.85</fillPercent>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="DeployableMicroTurret"]/building/turretBurstCooldownTime</xpath>
+		<value>
+			<turretBurstCooldownTime>1.0</turretBurstCooldownTime>
+		</value>
+	</Operation>
+
+	<!-- ========== Micro=turret gun ========== -->
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Gun_MicroTurret</defName>
+		<statBases>
+			<RangedWeapon_Cooldown>0.5</RangedWeapon_Cooldown>
+			<SightsEfficiency>1</SightsEfficiency>
+			<ShotSpread>0.17</ShotSpread>
+			<SwayFactor>0.63</SwayFactor>
+		</statBases>
+		<Properties>
+			<recoilAmount>1.55</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+			<warmupTime>1.6</warmupTime>
+			<range>32</range>
+			<ticksBetweenBurstShots>8</ticksBetweenBurstShots>
+			<burstShotCount>10</burstShotCount>
+			<soundCast>GunShotA</soundCast>
+			<soundCastTail>GunTail_Light</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+			<recoilPattern>Mounted</recoilPattern>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>30</magazineSize>
+			<reloadTime>7.8</reloadTime>
+			<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aiAimMode>AimedShot</aiAimMode>
+			<noSnapshot>true</noSnapshot>
+			<noSingleShot>true</noSingleShot>
+		</FireModes>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Deployable Turret/Patches/Deployable Turret/Patch_MicroTurret.xml
+++ b/ModPatches/Deployable Turret/Patches/Deployable Turret/Patch_MicroTurret.xml
@@ -83,7 +83,7 @@
 			<recoilAmount>1.55</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+			<defaultProjectile>Bullet_556x45mmNATO_FMJ_SB</defaultProjectile>
 			<warmupTime>1.6</warmupTime>
 			<range>32</range>
 			<ticksBetweenBurstShots>8</ticksBetweenBurstShots>
@@ -96,7 +96,7 @@
 		<AmmoUser>
 			<magazineSize>30</magazineSize>
 			<reloadTime>7.8</reloadTime>
-			<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+			<ammoSet>AmmoSet_556x45mmNATO_SB</ammoSet>
 		</AmmoUser>
 		<FireModes>
 			<aiAimMode>AimedShot</aiAimMode>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -166,6 +166,7 @@ Cybernetic Warfare and Special Weapons (Continued)  |
 Dark Ages : Medieval Tools  |
 Darkest Night SK Steam	|
 Darkest Rim: Apparel	|
+Deployable Turret   |
 Det's Energy Weapons    |
 Det's Xenotypes - Boglegs   |
 Devilstrand Animals |


### PR DESCRIPTION
## Additions
- Patch for Deployable Turret mod.
  - Gunslinger arm is patched as a slightly weaker archotech arm, as in base mod.
  - Because it is so cheap and spammable (though temporary), the micro turret is a crappier version of the Anomaly tactical turret, stats-wise. It has less range, RoF, and mag capacity, and higher recoil and sway. It also uses the low velocity variant of 5.56.

## Reasoning
See above.

## Alternatives
- Difference balance choices.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
