### PR TITLE
Add Anomaly to loadafter

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -55,6 +55,7 @@
 		<li>TheKingInYellow.Lope</li>
 		<li>Ludeon.RimWorld</li>
 		<li>Ludeon.RimWorld.Royalty</li>
+    <li>Ludeon.RimWorld.Anomaly</li>
 		<li>RunneLatki.RabbieRaceMod</li>
 		<li>HC.GiantRace</li>
 		<li>neronix17.fr.compilation</li>


### PR DESCRIPTION
## Additions

N/A

## Changes

Add Ludeon.RimWorld.Anomaly to loadAfter node of About.xml

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #3243

## Reasoning

Error if loaded before Anomaly. Adding to loadAfter will prevent this from happening unless user intentionally ignores defined load order.

## Alternatives

N/A

## Testing

Check tests you have performed:
- [ X ] Compiles without warnings
- [ X ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
