### PR TITLE
Updated Kurin HAR Edition patch

### DIFF
--- a/ModPatches/Kurin/Patches/Kurin/Scenario/DRNTF_Scenario.xml
+++ b/ModPatches/Kurin/Patches/Kurin/Scenario/DRNTF_Scenario.xml
@@ -25,7 +25,7 @@
 			<li Class="ScenPart_StartingThing_Defined">
 				<def>StartingThing_Defined</def>
 				<thingDef>Ammo_6x24mmCharged</thingDef>
-				<count>300</count>
+				<count>150</count>
 			</li>
 		</value>
 	</Operation>

--- a/ModPatches/Kurin/Patches/Kurin/Scenario/DRNTF_Scenario.xml
+++ b/ModPatches/Kurin/Patches/Kurin/Scenario/DRNTF_Scenario.xml
@@ -1,20 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
-	<Operation Class="PatchOperationAdd">
-	<xpath>Defs/ScenarioDef[defName="Kurin_Scenario"]/scenario/parts</xpath>
-	<value>
-		<li Class="ScenPart_StartingThing_Defined">
-			<def>StartingThing_Defined</def>
-			<thingDef>Ammo_556x45mmNATO_FMJ</thingDef>
-			<count>150</count>
-		</li>
-	</value>
-</Operation>
 
-<Operation Class="PatchOperationAdd">
-	<xpath>Defs/FactionDef[defName="Kurin_PlayerFaction"]/apparelStuffFilter/thingDefs</xpath>
-	<value>
-		<li>Steel</li>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ScenarioDef[defName="Kurin_Scenario"]/scenario/parts</xpath>
+		<value>
+			<li Class="ScenPart_StartingThing_Defined">
+				<def>StartingThing_Defined</def>
+				<thingDef>Ammo_556x45mmNATO_FMJ</thingDef>
+				<count>150</count>
+			</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/FactionDef[defName="Kurin_PlayerFaction"]/apparelStuffFilter/thingDefs</xpath>
+		<value>
+			<li>Steel</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ScenarioDef[defName="Kurin_ScenarioHard"]/scenario/parts</xpath>
+		<value>
+			<li Class="ScenPart_StartingThing_Defined">
+				<def>StartingThing_Defined</def>
+				<thingDef>Ammo_6x24mmCharged</thingDef>
+				<count>300</count>
+			</li>
+		</value>
+	</Operation>
+
 </Patch>

--- a/ModPatches/Kurin/Patches/Kurin/ThingDef_Misc/DRNTF_Apparel.xml
+++ b/ModPatches/Kurin/Patches/Kurin/ThingDef_Misc/DRNTF_Apparel.xml
@@ -66,13 +66,6 @@
 </Operation>
 
 <Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Armored_Gothic_Dress"]/equippedStatOffsets/MeleeDodgeChance</xpath>
-	<value>
-		<MeleeDodgeChance>0.2</MeleeDodgeChance>
-	</value>
-</Operation>
-
-<Operation Class="PatchOperationReplace">
 	<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Military_Uniform"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
 	<value>
 		<ShootingAccuracyPawn>0.4</ShootingAccuracyPawn>
@@ -113,9 +106,9 @@
 		]/statBases/StuffEffectMultiplierArmor </xpath>
 	<value>
 		<StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
-		<Bulk>100</Bulk>
-		<WornBulk>15</WornBulk>
-		<Mass>15</Mass>
+		<Bulk>6</Bulk>
+		<WornBulk>2</WornBulk>
+		<Mass>5</Mass>
 	</value>
 </Operation>
 
@@ -123,6 +116,79 @@
 	<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Bikini_Armor"]/equippedStatOffsets/MeleeDodgeChance</xpath>
 	<value>
 		<MeleeDodgeChance>0.6</MeleeDodgeChance>
+	</value>
+</Operation>
+
+<Operation Class="PatchOperationAdd">
+	<xpath>Defs/ThingDef[defName="Kurin_Redfox_Armor"]/statBases</xpath>
+	<value>
+		<Bulk>80</Bulk>
+		<WornBulk>15</WornBulk>
+		<Mass>40</Mass>
+		<Flammability>0</Flammability>
+	</value>
+</Operation>
+
+<Operation Class="PatchOperationAdd">
+	<xpath>Defs/ThingDef[defName="Kurin_Redfox_Armor"]/equippedStatOffsets</xpath>
+	<value>
+		<CarryWeight>60</CarryWeight>
+		<CarryBulk>10</CarryBulk>
+		<ToxicEnvironmentResistance>0.50</ToxicEnvironmentResistance>
+	</value>
+</Operation>
+
+<Operation Class="PatchOperationReplace">
+	<xpath>Defs/ThingDef[defName="Kurin_Redfox_Armor"]/statBases/MaxHitPoints</xpath>
+	<value>
+		<MaxHitPoints>500</MaxHitPoints>
+	</value>
+</Operation>
+
+
+<Operation Class="PatchOperationReplace">
+	<xpath>Defs/ThingDef[defName="Kurin_Redfox_Armor"]/statBases/ArmorRating_Sharp</xpath>
+	<value>
+		<ArmorRating_Sharp>26</ArmorRating_Sharp>
+	</value>
+</Operation>
+
+<Operation Class="PatchOperationReplace">
+	<xpath>Defs/ThingDef[defName="Kurin_Redfox_Armor"]/statBases/ArmorRating_Blunt</xpath>
+	<value>
+		<ArmorRating_Blunt>52</ArmorRating_Blunt>
+	</value>
+</Operation>
+
+<Operation Class="PatchOperationAdd">
+	<xpath>Defs/ThingDef[defName="Kurin_Waterfox_Armor"]/statBases</xpath>
+	<value>
+		<Bulk>20</Bulk>
+		<WornBulk>0.2</WornBulk>
+		<Mass>0.5</Mass>
+		<Flammability>0</Flammability>
+	</value>
+</Operation>
+
+<Operation Class="PatchOperationReplace">
+	<xpath>Defs/ThingDef[defName="Kurin_Waterfox_Armor"]/statBases/MaxHitPoints</xpath>
+	<value>
+		<MaxHitPoints>200</MaxHitPoints>
+	</value>
+</Operation>
+
+
+<Operation Class="PatchOperationReplace">
+	<xpath>Defs/ThingDef[defName="Kurin_Waterfox_Armor"]/statBases/ArmorRating_Sharp</xpath>
+	<value>
+		<ArmorRating_Sharp>2</ArmorRating_Sharp>
+	</value>
+</Operation>
+
+<Operation Class="PatchOperationReplace">
+	<xpath>Defs/ThingDef[defName="Kurin_Waterfox_Armor"]/statBases/ArmorRating_Blunt</xpath>
+	<value>
+		<ArmorRating_Blunt>4</ArmorRating_Blunt>
 	</value>
 </Operation>
 
@@ -167,11 +233,11 @@
 <Operation Class="PatchOperationReplace">
 	<xpath>Defs/ThingDef[defName="Kurin_Overhead_Bikini_Armor_Headgear"]/statBases/StuffEffectMultiplierArmor</xpath>
 	<value>
-		<StuffEffectMultiplierArmor>7.5</StuffEffectMultiplierArmor>
+		<StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>
 		<ArmorRating_Heat>0.20</ArmorRating_Heat>
-		<Bulk>5</Bulk>
-		<WornBulk>3</WornBulk>
-		<Mass>3</Mass>
+		<Bulk>2</Bulk>
+		<WornBulk>0.2</WornBulk>
+		<Mass>1</Mass>
 	</value>
 </Operation>
 
@@ -185,7 +251,6 @@
 <Operation Class="PatchOperationReplace">
 	<xpath>Defs/ThingDef[defName="Kurin_Overhead_Military_Helmet"]/statBases/StuffEffectMultiplierArmor</xpath>
 	<value>
-		<StuffEffectMultiplierArmor>5.5</StuffEffectMultiplierArmor>
 		<Bulk>5</Bulk>
 		<WornBulk>3</WornBulk>
 		<Mass>3</Mass>
@@ -195,14 +260,53 @@
 <Operation Class="PatchOperationReplace">
 	<xpath>Defs/ThingDef[defName="Kurin_Overhead_Military_Helmet"]/statBases/ArmorRating_Sharp</xpath>
 	<value>
-		<ArmorRating_Sharp>4</ArmorRating_Sharp>
+		<ArmorRating_Sharp>12</ArmorRating_Sharp>
 	</value>
 </Operation>
 
 <Operation Class="PatchOperationReplace">
 	<xpath>Defs/ThingDef[defName="Kurin_Overhead_Military_Helmet"]/statBases/ArmorRating_Blunt</xpath>
 	<value>
-		<ArmorRating_Blunt>6</ArmorRating_Blunt>
+		<ArmorRating_Blunt>24</ArmorRating_Blunt>
+	</value>
+</Operation>
+
+<Operation Class="PatchOperationAdd">
+	<xpath>Defs/ThingDef[defName="Kurin_Redfox_Helmet"]/statBases</xpath>
+	<value>
+		<Bulk>5</Bulk>
+		<WornBulk>1</WornBulk>
+		<NightVisionEfficiency_Apparel>0.80</NightVisionEfficiency_Apparel>
+	</value>
+</Operation>
+
+<Operation Class="PatchOperationReplace">
+	<xpath>Defs/ThingDef[defName="Kurin_Redfox_Helmet"]/statBases/MaxHitPoints</xpath>
+	<value>
+		<MaxHitPoints>300</MaxHitPoints>
+	</value>
+</Operation>
+
+
+<Operation Class="PatchOperationReplace">
+	<xpath>Defs/ThingDef[defName="Kurin_Redfox_Helmet"]/statBases/ArmorRating_Sharp</xpath>
+	<value>
+		<ArmorRating_Sharp>12</ArmorRating_Sharp>
+	</value>
+</Operation>
+
+<Operation Class="PatchOperationReplace">
+	<xpath>Defs/ThingDef[defName="Kurin_Redfox_Helmet"]/statBases/ArmorRating_Blunt</xpath>
+	<value>
+		<ArmorRating_Blunt>24</ArmorRating_Blunt>
+	</value>
+</Operation>
+
+<Operation Class="PatchOperationAdd">
+	<xpath>Defs/ThingDef[defName="Kurin_Redfox_Helmet"]/equippedStatOffsets</xpath>
+	<value>
+		<ToxicEnvironmentResistance>0.50</ToxicEnvironmentResistance>
+		<SmokeSensitivity>-1</SmokeSensitivity>
 	</value>
 </Operation>
 

--- a/ModPatches/Kurin/Patches/Kurin/ThingDef_Misc/DRNTF_Apparel.xml
+++ b/ModPatches/Kurin/Patches/Kurin/ThingDef_Misc/DRNTF_Apparel.xml
@@ -145,7 +145,6 @@
 		</value>
 	</Operation>
 
-
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Kurin_Redfox_Armor"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
@@ -176,7 +175,6 @@
 			<MaxHitPoints>200</MaxHitPoints>
 		</value>
 	</Operation>
-
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Kurin_Waterfox_Armor"]/statBases/ArmorRating_Sharp</xpath>
@@ -286,7 +284,6 @@
 			<MaxHitPoints>300</MaxHitPoints>
 		</value>
 	</Operation>
-
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Kurin_Redfox_Helmet"]/statBases/ArmorRating_Sharp</xpath>

--- a/ModPatches/Kurin/Patches/Kurin/ThingDef_Misc/DRNTF_Apparel.xml
+++ b/ModPatches/Kurin/Patches/Kurin/ThingDef_Misc/DRNTF_Apparel.xml
@@ -2,410 +2,411 @@
 <Patch>
 	<!--========= Underwear/On Skin =========-->
 
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[@Name="Kurin_UnderwearBase" or @Name="Kurin_StockingBase"]/statBases/StuffEffectMultiplierArmor</xpath>
-	<value>
-		<Bulk>0.5</Bulk>
-		<WornBulk>0.25</WornBulk>
-		<StuffEffectMultiplierArmor>0.25</StuffEffectMultiplierArmor>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[@Name="Kurin_UnderwearBase" or @Name="Kurin_StockingBase"]/statBases/StuffEffectMultiplierArmor</xpath>
+		<value>
+			<Bulk>0.5</Bulk>
+			<WornBulk>0.25</WornBulk>
+			<StuffEffectMultiplierArmor>0.25</StuffEffectMultiplierArmor>
+		</value>
+	</Operation>
 
-<Operation Class="PatchOperationAdd">
-	<xpath>Defs/ThingDef[@Name="Kurin_ApparelBase"]/statBases</xpath>
-	<value>
-		<Bulk>1</Bulk>
-		<WornBulk>1</WornBulk>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[@Name="Kurin_ApparelBase"]/statBases</xpath>
+		<value>
+			<Bulk>1</Bulk>
+			<WornBulk>1</WornBulk>
+		</value>
+	</Operation>
 
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Shirt" or
-		defName="Kurin_OnSkin_T_Shirt" or
-		defName="Kurin_OnSkin_Hot_Pants" or
-		defName="Kurin_OnSkin_Pajamas" or
-		defName="Kurin_OnSkin_One_Piece_Dress" or
-		defName="Kurin_OnSkin_Open_Back_Knit" or
-		defName="Kurin_OnSkin_Open_Shoulder_Knit" or
-		defName="Kurin_OnSkin_Hoodie" or
-		defName="Kurin_OnSkin_Casual_Wear"
-		]/statBases/StuffEffectMultiplierArmor </xpath>
-	<value>
-		<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Shirt" or
+			defName="Kurin_OnSkin_T_Shirt" or
+			defName="Kurin_OnSkin_Hot_Pants" or
+			defName="Kurin_OnSkin_Pajamas" or
+			defName="Kurin_OnSkin_One_Piece_Dress" or
+			defName="Kurin_OnSkin_Open_Back_Knit" or
+			defName="Kurin_OnSkin_Open_Shoulder_Knit" or
+			defName="Kurin_OnSkin_Hoodie" or
+			defName="Kurin_OnSkin_Casual_Wear"
+			]/statBases/StuffEffectMultiplierArmor </xpath>
+		<value>
+			<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+		</value>
+	</Operation>
 
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Gothic_Dress" or
-		defName="Kurin_OnSkin_Nun_Dress" or
-		defName="Kurin_OnSkin_Work_Jumpsuit" or
-		defName="Kurin_OnSkin_Traditional_Simple_Dress" or
-		defName="Kurin_OnSkin_Traditional_Fancy_Dress" or
-		defName="Kurin_OnSkin_Traditional_Luxury_Dress" or
-		defName="Kurin_OnSkin_Cute_Dress" or
-		defName="Kurin_OnSkin_Seductive_White_Dress" or
-		defName="Kurin_OnSkin_Seductive_Black_Dress"
-		]/statBases/StuffEffectMultiplierArmor </xpath>
-	<value>
-		<StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Gothic_Dress" or
+			defName="Kurin_OnSkin_Nun_Dress" or
+			defName="Kurin_OnSkin_Work_Jumpsuit" or
+			defName="Kurin_OnSkin_Traditional_Simple_Dress" or
+			defName="Kurin_OnSkin_Traditional_Fancy_Dress" or
+			defName="Kurin_OnSkin_Traditional_Luxury_Dress" or
+			defName="Kurin_OnSkin_Cute_Dress" or
+			defName="Kurin_OnSkin_Seductive_White_Dress" or
+			defName="Kurin_OnSkin_Seductive_Black_Dress"
+			]/statBases/StuffEffectMultiplierArmor </xpath>
+		<value>
+			<StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>
+		</value>
+	</Operation>
 
-<!--========= Onskin Armor =========-->
+	<!--========= Onskin Armor =========-->
 
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Armored_Gothic_Dress" or
-		defName="Kurin_OnSkin_Military_Uniform"
-		]/statBases/StuffEffectMultiplierArmor </xpath>
-	<value>
-		<StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
-		<Bulk>24</Bulk>
-		<WornBulk>10</WornBulk>
-		<Mass>6</Mass>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Armored_Gothic_Dress" or
+			defName="Kurin_OnSkin_Military_Uniform"
+			]/statBases/StuffEffectMultiplierArmor </xpath>
+		<value>
+			<StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
+			<Bulk>24</Bulk>
+			<WornBulk>10</WornBulk>
+			<Mass>6</Mass>
+		</value>
+	</Operation>
 
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Military_Uniform"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
-	<value>
-		<ShootingAccuracyPawn>0.4</ShootingAccuracyPawn>
-		<AimingAccuracy>0.2</AimingAccuracy>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Military_Uniform"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
+		<value>
+			<ShootingAccuracyPawn>0.4</ShootingAccuracyPawn>
+			<AimingAccuracy>0.2</AimingAccuracy>
+		</value>
+	</Operation>
 
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Armored_Gothic_Dress"]/statBases/ArmorRating_Sharp</xpath>
-	<value>
-		<ArmorRating_Sharp>1.75</ArmorRating_Sharp>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Armored_Gothic_Dress"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>1.75</ArmorRating_Sharp>
+		</value>
+	</Operation>
 
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Armored_Gothic_Dress"]/statBases/ArmorRating_Blunt</xpath>
-	<value>
-		<ArmorRating_Blunt>2.30</ArmorRating_Blunt>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Armored_Gothic_Dress"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>2.30</ArmorRating_Blunt>
+		</value>
+	</Operation>
 
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Military_Uniform"]/statBases/ArmorRating_Sharp</xpath>
-	<value>
-		<ArmorRating_Sharp>2.25</ArmorRating_Sharp>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Military_Uniform"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>2.25</ArmorRating_Sharp>
+		</value>
+	</Operation>
 
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Military_Uniform"]/statBases/ArmorRating_Blunt</xpath>
-	<value>
-		<ArmorRating_Blunt>3.05</ArmorRating_Blunt>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Military_Uniform"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>3.05</ArmorRating_Blunt>
+		</value>
+	</Operation>
 
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Bikini_Armor"
-		]/statBases/StuffEffectMultiplierArmor </xpath>
-	<value>
-		<StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
-		<Bulk>6</Bulk>
-		<WornBulk>2</WornBulk>
-		<Mass>5</Mass>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Bikini_Armor"
+			]/statBases/StuffEffectMultiplierArmor </xpath>
+		<value>
+			<StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
+			<Bulk>6</Bulk>
+			<WornBulk>2</WornBulk>
+			<Mass>5</Mass>
+		</value>
+	</Operation>
 
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Bikini_Armor"]/equippedStatOffsets/MeleeDodgeChance</xpath>
-	<value>
-		<MeleeDodgeChance>0.6</MeleeDodgeChance>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Bikini_Armor"]/equippedStatOffsets/MeleeDodgeChance</xpath>
+		<value>
+			<MeleeDodgeChance>0.6</MeleeDodgeChance>
+		</value>
+	</Operation>
 
-<Operation Class="PatchOperationAdd">
-	<xpath>Defs/ThingDef[defName="Kurin_Redfox_Armor"]/statBases</xpath>
-	<value>
-		<Bulk>80</Bulk>
-		<WornBulk>15</WornBulk>
-		<Mass>40</Mass>
-		<Flammability>0</Flammability>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Kurin_Redfox_Armor"]/statBases</xpath>
+		<value>
+			<Bulk>80</Bulk>
+			<WornBulk>15</WornBulk>
+			<Mass>40</Mass>
+			<Flammability>0</Flammability>
+		</value>
+	</Operation>
 
-<Operation Class="PatchOperationAdd">
-	<xpath>Defs/ThingDef[defName="Kurin_Redfox_Armor"]/equippedStatOffsets</xpath>
-	<value>
-		<CarryWeight>60</CarryWeight>
-		<CarryBulk>10</CarryBulk>
-		<ToxicEnvironmentResistance>0.50</ToxicEnvironmentResistance>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Kurin_Redfox_Armor"]/equippedStatOffsets</xpath>
+		<value>
+			<CarryWeight>60</CarryWeight>
+			<CarryBulk>10</CarryBulk>
+			<ToxicEnvironmentResistance>0.50</ToxicEnvironmentResistance>
+		</value>
+	</Operation>
 
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_Redfox_Armor"]/statBases/MaxHitPoints</xpath>
-	<value>
-		<MaxHitPoints>500</MaxHitPoints>
-	</value>
-</Operation>
-
-
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_Redfox_Armor"]/statBases/ArmorRating_Sharp</xpath>
-	<value>
-		<ArmorRating_Sharp>26</ArmorRating_Sharp>
-	</value>
-</Operation>
-
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_Redfox_Armor"]/statBases/ArmorRating_Blunt</xpath>
-	<value>
-		<ArmorRating_Blunt>52</ArmorRating_Blunt>
-	</value>
-</Operation>
-
-<Operation Class="PatchOperationAdd">
-	<xpath>Defs/ThingDef[defName="Kurin_Waterfox_Armor"]/statBases</xpath>
-	<value>
-		<Bulk>20</Bulk>
-		<WornBulk>0.2</WornBulk>
-		<Mass>0.5</Mass>
-		<Flammability>0</Flammability>
-	</value>
-</Operation>
-
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_Waterfox_Armor"]/statBases/MaxHitPoints</xpath>
-	<value>
-		<MaxHitPoints>200</MaxHitPoints>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_Redfox_Armor"]/statBases/MaxHitPoints</xpath>
+		<value>
+			<MaxHitPoints>500</MaxHitPoints>
+		</value>
+	</Operation>
 
 
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_Waterfox_Armor"]/statBases/ArmorRating_Sharp</xpath>
-	<value>
-		<ArmorRating_Sharp>2</ArmorRating_Sharp>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_Redfox_Armor"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>26</ArmorRating_Sharp>
+		</value>
+	</Operation>
 
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_Waterfox_Armor"]/statBases/ArmorRating_Blunt</xpath>
-	<value>
-		<ArmorRating_Blunt>4</ArmorRating_Blunt>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_Redfox_Armor"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>52</ArmorRating_Blunt>
+		</value>
+	</Operation>
 
-<!--========= Hats =========-->
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Kurin_Waterfox_Armor"]/statBases</xpath>
+		<value>
+			<Bulk>20</Bulk>
+			<WornBulk>0.2</WornBulk>
+			<Mass>0.5</Mass>
+			<Flammability>0</Flammability>
+		</value>
+	</Operation>
 
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_Overhead_Winter_Hat" or
-		defName="Kurin_Overhead_Summer_Hat" or
-		defName="Kurin_Overhead_Casual_Hair_Pin"
-		]/statBases/StuffEffectMultiplierArmor </xpath>
-	<value>
-		<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
-	</value>
-</Operation>
-
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_Overhead_Gothic_Hair_Pin" or
-		defName="Kurin_Overhead_Traditional_Hair_Pin" or
-		defName="Kurin_Overhead_Cute_Hair_Pin"
-		]/statBases/StuffEffectMultiplierArmor </xpath>
-	<value>
-		<StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>
-	</value>
-</Operation>
-
-<!--========= Overhead Armor =========-->
-
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_Overhead_Goggles"]/statBases/ArmorRating_Sharp</xpath>
-	<value>
-		<ArmorRating_Sharp>4</ArmorRating_Sharp>
-	</value>
-</Operation>
-
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_Overhead_Goggles"]/statBases/ArmorRating_Blunt</xpath>
-	<value>
-		<ArmorRating_Blunt>6</ArmorRating_Blunt>
-	</value>
-</Operation>
-
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_Overhead_Bikini_Armor_Headgear"]/statBases/StuffEffectMultiplierArmor</xpath>
-	<value>
-		<StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>
-		<ArmorRating_Heat>0.20</ArmorRating_Heat>
-		<Bulk>2</Bulk>
-		<WornBulk>0.2</WornBulk>
-		<Mass>1</Mass>
-	</value>
-</Operation>
-
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_Overhead_Bikini_Armor_Headgear"]/equippedStatOffsets/MeleeDodgeChance</xpath>
-	<value>
-		<MeleeDodgeChance>0.2</MeleeDodgeChance>
-	</value>
-</Operation>
-
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_Overhead_Military_Helmet"]/statBases/StuffEffectMultiplierArmor</xpath>
-	<value>
-		<Bulk>5</Bulk>
-		<WornBulk>3</WornBulk>
-		<Mass>3</Mass>
-	</value>
-</Operation>
-
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_Overhead_Military_Helmet"]/statBases/ArmorRating_Sharp</xpath>
-	<value>
-		<ArmorRating_Sharp>12</ArmorRating_Sharp>
-	</value>
-</Operation>
-
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_Overhead_Military_Helmet"]/statBases/ArmorRating_Blunt</xpath>
-	<value>
-		<ArmorRating_Blunt>24</ArmorRating_Blunt>
-	</value>
-</Operation>
-
-<Operation Class="PatchOperationAdd">
-	<xpath>Defs/ThingDef[defName="Kurin_Redfox_Helmet"]/statBases</xpath>
-	<value>
-		<Bulk>5</Bulk>
-		<WornBulk>1</WornBulk>
-		<NightVisionEfficiency_Apparel>0.80</NightVisionEfficiency_Apparel>
-	</value>
-</Operation>
-
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_Redfox_Helmet"]/statBases/MaxHitPoints</xpath>
-	<value>
-		<MaxHitPoints>300</MaxHitPoints>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_Waterfox_Armor"]/statBases/MaxHitPoints</xpath>
+		<value>
+			<MaxHitPoints>200</MaxHitPoints>
+		</value>
+	</Operation>
 
 
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_Redfox_Helmet"]/statBases/ArmorRating_Sharp</xpath>
-	<value>
-		<ArmorRating_Sharp>12</ArmorRating_Sharp>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_Waterfox_Armor"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>2</ArmorRating_Sharp>
+		</value>
+	</Operation>
 
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_Redfox_Helmet"]/statBases/ArmorRating_Blunt</xpath>
-	<value>
-		<ArmorRating_Blunt>24</ArmorRating_Blunt>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_Waterfox_Armor"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>4</ArmorRating_Blunt>
+		</value>
+	</Operation>
 
-<Operation Class="PatchOperationAdd">
-	<xpath>Defs/ThingDef[defName="Kurin_Redfox_Helmet"]/equippedStatOffsets</xpath>
-	<value>
-		<ToxicEnvironmentResistance>0.50</ToxicEnvironmentResistance>
-		<SmokeSensitivity>-1</SmokeSensitivity>
-	</value>
-</Operation>
+	<!--========= Hats =========-->
 
-<!--========= Middle Apparel =========-->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_Overhead_Winter_Hat" or
+			defName="Kurin_Overhead_Summer_Hat" or
+			defName="Kurin_Overhead_Casual_Hair_Pin"
+			]/statBases/StuffEffectMultiplierArmor </xpath>
+		<value>
+			<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+		</value>
+	</Operation>
 
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_Middle_Body_Armor"]/statBases/StuffEffectMultiplierArmor</xpath>
-	<value>
-		<StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>
-		<Bulk>5</Bulk>
-		<WornBulk>3</WornBulk>
-		<Mass>13</Mass>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_Overhead_Gothic_Hair_Pin" or
+			defName="Kurin_Overhead_Traditional_Hair_Pin" or
+			defName="Kurin_Overhead_Cute_Hair_Pin"
+			]/statBases/StuffEffectMultiplierArmor </xpath>
+		<value>
+			<StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>
+		</value>
+	</Operation>
 
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_Middle_Body_Armor"]/statBases/MaxHitPoints</xpath>
-	<value>
-		<MaxHitPoints>125</MaxHitPoints>
-	</value>
-</Operation>
+	<!--========= Overhead Armor =========-->
 
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_Middle_Body_Armor"]/statBases/WorkToMake</xpath>
-	<value>
-		<WorkToMake>9000</WorkToMake>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_Overhead_Goggles"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>4</ArmorRating_Sharp>
+		</value>
+	</Operation>
 
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_Middle_Body_Armor"]/stuffCategories</xpath>
-	<value>
-		<stuffCategories>
-			<li>Steeled</li>
-		</stuffCategories>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_Overhead_Goggles"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>6</ArmorRating_Blunt>
+		</value>
+	</Operation>
 
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_Middle_Body_Armor"]/costList</xpath>
-	<value>
-		<costList>
-			<Cloth>30</Cloth>
-		</costList>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_Overhead_Bikini_Armor_Headgear"]/statBases/StuffEffectMultiplierArmor</xpath>
+		<value>
+			<StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>
+			<ArmorRating_Heat>0.20</ArmorRating_Heat>
+			<Bulk>2</Bulk>
+			<WornBulk>0.2</WornBulk>
+			<Mass>1</Mass>
+		</value>
+	</Operation>
 
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_Middle_Body_Armor"]/costStuffCount</xpath>
-	<value>
-		<costStuffCount>90</costStuffCount>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_Overhead_Bikini_Armor_Headgear"]/equippedStatOffsets/MeleeDodgeChance</xpath>
+		<value>
+			<MeleeDodgeChance>0.2</MeleeDodgeChance>
+		</value>
+	</Operation>
 
-<Operation Class="PatchOperationAdd">
-	<xpath>Defs/ThingDef[defName="Kurin_Middle_Body_Armor"]/apparel</xpath>
-	<value>
-		<bodyPartGroups>
-			<li>Torso</li>
-			<li>Neck</li>
-			<li>Shoulders</li>
-		</bodyPartGroups>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_Overhead_Military_Helmet"]/statBases/StuffEffectMultiplierArmor</xpath>
+		<value>
+			<Bulk>5</Bulk>
+			<WornBulk>3</WornBulk>
+			<Mass>3</Mass>
+		</value>
+	</Operation>
 
-<!--========= Shell Apparel =========-->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_Overhead_Military_Helmet"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>12</ArmorRating_Sharp>
+		</value>
+	</Operation>
 
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_Shell_Cardigan" or
-		defName="Kurin_Shell_Duster" or
-		defName="Kurin_Shell_Winter_Padding"
-		]/statBases/StuffEffectMultiplierArmor </xpath>
-	<value>
-		<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_Overhead_Military_Helmet"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>24</ArmorRating_Blunt>
+		</value>
+	</Operation>
 
-<Operation Class="PatchOperationAdd">
-	<xpath>Defs/ThingDef[defName="Kurin_Shell_Cardigan" or
-		defName="Kurin_Shell_Duster" or
-		defName="Kurin_Shell_Winter_Padding"]/statBases </xpath>
-	<value>
-		<Bulk>7.5</Bulk>
-		<WornBulk>1</WornBulk>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Kurin_Redfox_Helmet"]/statBases</xpath>
+		<value>
+			<Bulk>5</Bulk>
+			<WornBulk>1</WornBulk>
+			<NightVisionEfficiency_Apparel>0.80</NightVisionEfficiency_Apparel>
+		</value>
+	</Operation>
 
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Traditional_Coat"]/statBases/StuffEffectMultiplierArmor</xpath>
-	<value>
-		<StuffEffectMultiplierArmor>6.25</StuffEffectMultiplierArmor>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_Redfox_Helmet"]/statBases/MaxHitPoints</xpath>
+		<value>
+			<MaxHitPoints>300</MaxHitPoints>
+		</value>
+	</Operation>
 
-<Operation Class="PatchOperationAdd">
-	<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Traditional_Coat"]/statBases</xpath>
-	<value>
-		<Bulk>7.5</Bulk>
-		<WornBulk>1.5</WornBulk>
-	</value>
-</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_Redfox_Helmet"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>12</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_Redfox_Helmet"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>24</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Kurin_Redfox_Helmet"]/equippedStatOffsets</xpath>
+		<value>
+			<ToxicEnvironmentResistance>0.50</ToxicEnvironmentResistance>
+			<SmokeSensitivity>-1</SmokeSensitivity>
+		</value>
+	</Operation>
+
+	<!--========= Middle Apparel =========-->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_Middle_Body_Armor"]/statBases/StuffEffectMultiplierArmor</xpath>
+		<value>
+			<StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>
+			<Bulk>5</Bulk>
+			<WornBulk>3</WornBulk>
+			<Mass>13</Mass>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_Middle_Body_Armor"]/statBases/MaxHitPoints</xpath>
+		<value>
+			<MaxHitPoints>125</MaxHitPoints>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_Middle_Body_Armor"]/statBases/WorkToMake</xpath>
+		<value>
+			<WorkToMake>9000</WorkToMake>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_Middle_Body_Armor"]/stuffCategories</xpath>
+		<value>
+			<stuffCategories>
+				<li>Steeled</li>
+			</stuffCategories>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_Middle_Body_Armor"]/costList</xpath>
+		<value>
+			<costList>
+				<Cloth>30</Cloth>
+			</costList>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_Middle_Body_Armor"]/costStuffCount</xpath>
+		<value>
+			<costStuffCount>90</costStuffCount>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Kurin_Middle_Body_Armor"]/apparel</xpath>
+		<value>
+			<bodyPartGroups>
+				<li>Torso</li>
+				<li>Neck</li>
+				<li>Shoulders</li>
+			</bodyPartGroups>
+		</value>
+	</Operation>
+
+	<!--========= Shell Apparel =========-->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_Shell_Cardigan" or
+			defName="Kurin_Shell_Duster" or
+			defName="Kurin_Shell_Winter_Padding"
+			]/statBases/StuffEffectMultiplierArmor </xpath>
+		<value>
+			<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Kurin_Shell_Cardigan" or
+			defName="Kurin_Shell_Duster" or
+			defName="Kurin_Shell_Winter_Padding"]/statBases </xpath>
+		<value>
+			<Bulk>7.5</Bulk>
+			<WornBulk>1</WornBulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Traditional_Coat"]/statBases/StuffEffectMultiplierArmor</xpath>
+		<value>
+			<StuffEffectMultiplierArmor>6.25</StuffEffectMultiplierArmor>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Traditional_Coat"]/statBases</xpath>
+		<value>
+			<Bulk>7.5</Bulk>
+			<WornBulk>1.5</WornBulk>
+		</value>
+	</Operation>
+
 </Patch>

--- a/ModPatches/Kurin/Patches/Kurin/ThingDef_Misc/DRNTF_Weapon.xml
+++ b/ModPatches/Kurin/Patches/Kurin/ThingDef_Misc/DRNTF_Weapon.xml
@@ -2,401 +2,396 @@
 <Patch>
 	<!--========= Rifle : K2 as a Basis =========-->
 
-<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-	<defName>Kurin_Gun_Assault_Rifle</defName>
-	<statBases>
-		<SightsEfficiency>1.00</SightsEfficiency>
-		<ShotSpread>0.07</ShotSpread>
-		<SwayFactor>1.31</SwayFactor>
-		<Bulk>8.30</Bulk>
-		<Mass>3.26</Mass>
-		<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-	</statBases>
-
-	<Properties>
-		<recoilAmount>1.50</recoilAmount>
-		<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-		<hasStandardCommand>true</hasStandardCommand>
-		<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
-		<warmupTime>1.1</warmupTime>
-		<burstShotCount>6</burstShotCount>
-		<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
-		<range>48</range>
-		<soundCast>Kurin_Shot_Tactical_Rifle</soundCast>
-		<soundCastTail>GunTail_Medium</soundCastTail>
-		<muzzleFlashScale>9</muzzleFlashScale>
-	</Properties>
-
-	<AmmoUser>
-		<magazineSize>30</magazineSize>
-		<reloadTime>4</reloadTime>
-		<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
-	</AmmoUser>
-	<FireModes>
-		<aimedBurstShotCount>3</aimedBurstShotCount>
-		<aiUseBurstMode>TRUE</aiUseBurstMode>
-	</FireModes>
-</Operation>
-
-<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-	<defName>Kurin_Gun_Sniper_Rifle</defName>
-	<statBases>
-		<SightsEfficiency>2.36</SightsEfficiency>
-		<ShotSpread>0.07</ShotSpread>
-		<SwayFactor>1.50</SwayFactor>
-		<Bulk>8.30</Bulk>
-		<Mass>3.78</Mass>
-		<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-	</statBases>
-
-	<Properties>
-		<recoilAmount>1.39</recoilAmount>
-		<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-		<hasStandardCommand>true</hasStandardCommand>
-		<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
-		<warmupTime>1.4</warmupTime>
-		<burstShotCount>6</burstShotCount>
-		<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
-		<range>62</range>
-		<soundCast>Kurin_Shot_Tactical_Rifle</soundCast>
-		<soundCastTail>GunTail_Medium</soundCastTail>
-		<muzzleFlashScale>9</muzzleFlashScale>
-	</Properties>
-
-	<AmmoUser>
-		<magazineSize>30</magazineSize>
-		<reloadTime>4</reloadTime>
-		<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
-	</AmmoUser>
-	<FireModes>
-		<aimedBurstShotCount>3</aimedBurstShotCount>
-		<aiUseBurstMode>TRUE</aiUseBurstMode>
-	</FireModes>
-</Operation>
-
-<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-	<defName>Kurin_Gun_Shotgun</defName>
-	<statBases>
-		<SightsEfficiency>1</SightsEfficiency>
-		<ShotSpread>0.14</ShotSpread>
-		<SwayFactor>1.51</SwayFactor>
-		<Bulk>9.60</Bulk>
-		<Mass>5.45</Mass>
-		<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
-	</statBases>
-
-	<Properties>
-		<recoilAmount>2.04</recoilAmount>
-		<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-		<hasStandardCommand>true</hasStandardCommand>
-		<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
-		<burstShotCount>3</burstShotCount>
-		<ticksBetweenBurstShots>9</ticksBetweenBurstShots>
-		<warmupTime>0.6</warmupTime>
-		<range>16</range>
-		<soundCast>Kurin_Shot_Shotgun</soundCast>
-		<soundCastTail>GunTail_Heavy</soundCastTail>
-		<muzzleFlashScale>9</muzzleFlashScale>
-	</Properties>
-
-	<AmmoUser>
-		<magazineSize>12</magazineSize>
-		<reloadTime>4</reloadTime>
-		<ammoSet>AmmoSet_12Gauge</ammoSet>
-	</AmmoUser>
-	<FireModes>
-		<aimedBurstShotCount>2</aimedBurstShotCount>
-		<aiAimMode>Snapshot</aiAimMode>
-	</FireModes>
-</Operation>
-
-<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-	<defName>Kurin_Gun_Carbine</defName>
-	<statBases>
-		<SightsEfficiency>1</SightsEfficiency>
-		<ShotSpread>0.14</ShotSpread>
-		<SwayFactor>0.94</SwayFactor>
-		<Bulk>5.00</Bulk>
-		<Mass>3</Mass>
-		<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
-	</statBases>
-
-	<Properties>
-		<recoilAmount>1.70</recoilAmount>
-		<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-		<hasStandardCommand>true</hasStandardCommand>
-		<defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
-		<burstShotCount>6</burstShotCount>
-		<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
-		<warmupTime>0.6</warmupTime>
-		<range>25</range>
-		<soundCast>Kurin_Shot_Tactical_Rifle</soundCast>
-		<soundCastTail>GunTail_Medium</soundCastTail>
-		<muzzleFlashScale>9</muzzleFlashScale>
-	</Properties>
-
-	<AmmoUser>
-		<magazineSize>30</magazineSize>
-		<reloadTime>3.5</reloadTime>
-		<ammoSet>AmmoSet_45ACP</ammoSet>
-	</AmmoUser>
-	<FireModes>
-		<aimedBurstShotCount>3</aimedBurstShotCount>
-		<aiAimMode>Snapshot</aiAimMode>
-	</FireModes>
-</Operation>
-
-<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-	<defName>Kurin_Gun_Charge_Shotgun</defName>
-	<statBases>
-		<SightsEfficiency>1.10</SightsEfficiency>
-		<ShotSpread>0.14</ShotSpread>
-		<SwayFactor>1.15</SwayFactor>
-		<Mass>4.0</Mass>
-		<Bulk>8.50</Bulk>
-		<RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
-	</statBases>
-
-	<Properties>
-		<recoilAmount>2.68</recoilAmount>
-		<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-		<hasStandardCommand>true</hasStandardCommand>
-		<defaultProjectile>Bullet_12GaugeCharged</defaultProjectile>
-		<warmupTime>0.5</warmupTime>
-		<range>16</range>
-		<soundCast>Kurin_Shot_Charge_Shotgun</soundCast>
-		<soundCastTail>GunTail_Heavy</soundCastTail>
-		<muzzleFlashScale>9</muzzleFlashScale>
-	</Properties>
-
-	<AmmoUser>
-		<magazineSize>16</magazineSize>
-		<reloadTime>4</reloadTime>
-		<ammoSet>AmmoSet_12GaugeCharged</ammoSet>
-	</AmmoUser>
-	<FireModes>
-		<aimedBurstShotCount>3</aimedBurstShotCount>
-		<aiAimMode>Snapshot</aiAimMode>
-	</FireModes>
-</Operation>
-
-<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-	<defName>Kurin_Gun_Charge_Rifle</defName>
-	<statBases>
-		<SightsEfficiency>1.1</SightsEfficiency>
-		<ShotSpread>0.06</ShotSpread>
-		<SwayFactor>1.42</SwayFactor>
-		<Bulk>9.00</Bulk>
-		<Mass>4.00</Mass>
-		<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
-	</statBases>
-
-	<Properties>
-		<recoilAmount>1.92</recoilAmount>
-		<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-		<hasStandardCommand>true</hasStandardCommand>
-		<defaultProjectile>Bullet_6x24mmCharged</defaultProjectile>
-		<burstShotCount>5</burstShotCount>
-		<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
-		<warmupTime>1.1</warmupTime>
-		<range>55</range>
-		<soundCast>Kurin_Shot_Charge_Rifle</soundCast>
-		<soundCastTail>GunTail_Medium</soundCastTail>
-		<muzzleFlashScale>9</muzzleFlashScale>
-	</Properties>
-
-	<AmmoUser>
-		<magazineSize>35</magazineSize>
-		<reloadTime>4.5</reloadTime>
-		<ammoSet>AmmoSet_6x24mmCharged</ammoSet>
-	</AmmoUser>
-	<FireModes>
-		<aimedBurstShotCount>3</aimedBurstShotCount>
-		<aiAimMode>Snapshot</aiAimMode>
-	</FireModes>
-</Operation>
-
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_Gun_Assault_Rifle" or defName="Kurin_Gun_Charge_Shotgun" or defName="Kurin_Gun_Charge_Rifle" or
-		defName="Kurin_Gun_Sniper_Rifle" or defName="Kurin_Gun_Shotgun" or defName="Kurin_Gun_Carbine"]/tools </xpath>
-	<value>
-		<tools>
-			<li Class="CombatExtended.ToolCE">
-				<label>stock</label>
-				<capacities>
-					<li>Blunt</li>
-				</capacities>
-				<power>8</power>
-				<cooldownTime>1.55</cooldownTime>
-				<chanceFactor>1.5</chanceFactor>
-				<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-				<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-			</li>
-			<li Class="CombatExtended.ToolCE">
-				<label>barrel</label>
-				<capacities>
-					<li>Blunt</li>
-				</capacities>
-				<power>5</power>
-				<cooldownTime>2.02</cooldownTime>
-				<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-				<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-			</li>
-			<li Class="CombatExtended.ToolCE">
-				<label>muzzle</label>
-				<capacities>
-					<li>Poke</li>
-				</capacities>
-				<power>8</power>
-				<cooldownTime>1.55</cooldownTime>
-				<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-				<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-			</li>
-		</tools>
-	</value>
-</Operation>
-
-<!--========= Ceremonial Sword : Changed to Zweihandler Clone =========-->
-
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_MeleeWeapon_Ceremonial_Sword"]/tools</xpath>
-	<value>
-		<tools>
-			<li Class="CombatExtended.ToolCE">
-				<label>handle</label>
-				<capacities>
-					<li>Poke</li>
-				</capacities>
-				<power>5</power>
-				<cooldownTime>2.01</cooldownTime>
-				<armorPenetrationBlunt>1.6</armorPenetrationBlunt>
-				<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
-			</li>
-			<li Class="CombatExtended.ToolCE">
-				<label>point</label>
-				<capacities>
-					<li>Stab</li>
-				</capacities>
-				<power>60</power>
-				<cooldownTime>2.01</cooldownTime>
-				<chanceFactor>1.165</chanceFactor>
-				<armorPenetrationBlunt>1.6</armorPenetrationBlunt>
-				<armorPenetrationSharp>0.89</armorPenetrationSharp>
-				<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
-			</li>
-			<li Class="CombatExtended.ToolCE">
-				<label>edge</label>
-				<capacities>
-					<li>Cut</li>
-				</capacities>
-				<power>47</power>
-				<cooldownTime>3.12</cooldownTime>
-				<chanceFactor>1.165</chanceFactor>
-				<armorPenetrationBlunt>3.6</armorPenetrationBlunt>
-				<armorPenetrationSharp>0.4</armorPenetrationSharp>
-				<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
-			</li>
-		</tools>
-	</value>
-</Operation>
-
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_MeleeWeapon_Ceremonial_Sword"]/statBases</xpath>
-	<value>
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Kurin_Gun_Assault_Rifle</defName>
 		<statBases>
-			<WorkToMake>25000</WorkToMake>
-			<Mass>3.2</Mass>
-			<Bulk>12</Bulk>
-			<MeleeCounterParryBonus>0.59</MeleeCounterParryBonus>
+			<SightsEfficiency>1.00</SightsEfficiency>
+			<ShotSpread>0.07</ShotSpread>
+			<SwayFactor>1.31</SwayFactor>
+			<Bulk>8.30</Bulk>
+			<Mass>3.26</Mass>
+			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 		</statBases>
-	</value>
-</Operation>
+		<Properties>
+			<recoilAmount>1.50</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+			<warmupTime>1.1</warmupTime>
+			<burstShotCount>6</burstShotCount>
+			<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+			<range>48</range>
+			<soundCast>Kurin_Shot_Tactical_Rifle</soundCast>
+			<soundCastTail>GunTail_Medium</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>30</magazineSize>
+			<reloadTime>4</reloadTime>
+			<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aimedBurstShotCount>3</aimedBurstShotCount>
+			<aiUseBurstMode>TRUE</aiUseBurstMode>
+		</FireModes>
+	</Operation>
 
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_MeleeWeapon_Ceremonial_Sword"]/costStuffCount</xpath>
-	<value>
-		<costStuffCount>150</costStuffCount>
-	</value>
-</Operation>
-
-<Operation Class="PatchOperationAdd">
-	<xpath>Defs/ThingDef[defName="Kurin_MeleeWeapon_Ceremonial_Sword"]</xpath>
-	<value>
-		<equippedStatOffsets>
-			<MeleeCritChance>0.08</MeleeCritChance>
-			<MeleeParryChance>0.5</MeleeParryChance>
-			<MeleeDodgeChance>0.5</MeleeDodgeChance>
-		</equippedStatOffsets>
-	</value>
-</Operation>
-
-<!--========= Surigum : Changed to Dagger, thrown property removed =========-->
-
-<Operation Class="PatchOperationAdd">
-	<xpath>Defs/ThingDef[defName="Kurin_Gun_Surigum"]</xpath>
-	<value>
-		<equippedStatOffsets>
-			<MeleeCritChance>0.5</MeleeCritChance>
-			<MeleeParryChance>0.15</MeleeParryChance>
-			<MeleeDodgeChance>0.05</MeleeDodgeChance>
-		</equippedStatOffsets>
-	</value>
-</Operation>
-
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_Gun_Surigum"]/statBases</xpath>
-	<value>
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Kurin_Gun_Sniper_Rifle</defName>
 		<statBases>
-			<WorkToMake>8000</WorkToMake>
-			<Mass>0.4</Mass>
-			<Bulk>1</Bulk>
-			<MeleeCounterParryBonus>0.15</MeleeCounterParryBonus>
+			<SightsEfficiency>2.36</SightsEfficiency>
+			<ShotSpread>0.07</ShotSpread>
+			<SwayFactor>1.50</SwayFactor>
+			<Bulk>8.30</Bulk>
+			<Mass>3.78</Mass>
+			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 		</statBases>
-	</value>
-</Operation>
+		<Properties>
+			<recoilAmount>1.39</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+			<warmupTime>1.4</warmupTime>
+			<burstShotCount>6</burstShotCount>
+			<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+			<range>62</range>
+			<soundCast>Kurin_Shot_Tactical_Rifle</soundCast>
+			<soundCastTail>GunTail_Medium</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>30</magazineSize>
+			<reloadTime>4</reloadTime>
+			<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aimedBurstShotCount>3</aimedBurstShotCount>
+			<aiUseBurstMode>TRUE</aiUseBurstMode>
+		</FireModes>
+	</Operation>
 
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="Kurin_Gun_Surigum"]/tools</xpath>
-	<value>
-		<tools>
-			<li Class="CombatExtended.ToolCE">
-				<label>handle</label>
-				<capacities>
-					<li>Poke</li>
-				</capacities>
-				<power>1</power>
-				<cooldownTime>1.26</cooldownTime>
-				<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
-				<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
-			</li>
-			<li Class="CombatExtended.ToolCE">
-				<label>blade</label>
-				<capacities>
-					<li>Cut</li>
-				</capacities>
-				<power>10</power>
-				<cooldownTime>1.18</cooldownTime>
-				<armorPenetrationBlunt>0.36</armorPenetrationBlunt>
-				<armorPenetrationSharp>0.32</armorPenetrationSharp>
-				<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
-			</li>
-			<li Class="CombatExtended.ToolCE">
-				<label>point</label>
-				<capacities>
-					<li>Stab</li>
-				</capacities>
-				<power>11</power>
-				<cooldownTime>1.26</cooldownTime>
-				<chanceFactor>1.33</chanceFactor>
-				<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
-				<armorPenetrationSharp>0.42</armorPenetrationSharp>
-				<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
-			</li>
-		</tools>
-	</value>
-</Operation>
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Kurin_Gun_Shotgun</defName>
+		<statBases>
+			<SightsEfficiency>1</SightsEfficiency>
+			<ShotSpread>0.14</ShotSpread>
+			<SwayFactor>1.51</SwayFactor>
+			<Bulk>9.60</Bulk>
+			<Mass>5.45</Mass>
+			<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
+		</statBases>
+		<Properties>
+			<recoilAmount>2.04</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
+			<burstShotCount>3</burstShotCount>
+			<ticksBetweenBurstShots>9</ticksBetweenBurstShots>
+			<warmupTime>0.6</warmupTime>
+			<range>16</range>
+			<soundCast>Kurin_Shot_Shotgun</soundCast>
+			<soundCastTail>GunTail_Heavy</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>12</magazineSize>
+			<reloadTime>4</reloadTime>
+			<ammoSet>AmmoSet_12Gauge</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aimedBurstShotCount>2</aimedBurstShotCount>
+			<aiAimMode>Snapshot</aiAimMode>
+		</FireModes>
+	</Operation>
 
-<Operation Class="PatchOperationRemove">
-	<xpath>Defs/ThingDef[defName="Kurin_Gun_Surigum"]/verbs</xpath>
-</Operation>
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Kurin_Gun_Carbine</defName>
+		<statBases>
+			<SightsEfficiency>1</SightsEfficiency>
+			<ShotSpread>0.14</ShotSpread>
+			<SwayFactor>0.94</SwayFactor>
+			<Bulk>5.00</Bulk>
+			<Mass>3</Mass>
+			<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
+		</statBases>
+		<Properties>
+			<recoilAmount>1.70</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
+			<burstShotCount>6</burstShotCount>
+			<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+			<warmupTime>0.6</warmupTime>
+			<range>25</range>
+			<soundCast>Kurin_Shot_Tactical_Rifle</soundCast>
+			<soundCastTail>GunTail_Medium</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>30</magazineSize>
+			<reloadTime>3.5</reloadTime>
+			<ammoSet>AmmoSet_45ACP</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aimedBurstShotCount>3</aimedBurstShotCount>
+			<aiAimMode>Snapshot</aiAimMode>
+		</FireModes>
+	</Operation>
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Kurin_Gun_Charge_Shotgun</defName>
+		<statBases>
+			<SightsEfficiency>1.10</SightsEfficiency>
+			<ShotSpread>0.14</ShotSpread>
+			<SwayFactor>1.15</SwayFactor>
+			<Mass>4.0</Mass>
+			<Bulk>8.50</Bulk>
+			<RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
+		</statBases>
+		<Properties>
+			<recoilAmount>2.68</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_12GaugeCharged</defaultProjectile>
+			<warmupTime>0.5</warmupTime>
+			<range>16</range>
+			<soundCast>Kurin_Shot_Charge_Shotgun</soundCast>
+			<soundCastTail>GunTail_Heavy</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>16</magazineSize>
+			<reloadTime>4</reloadTime>
+			<ammoSet>AmmoSet_12GaugeCharged</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aimedBurstShotCount>3</aimedBurstShotCount>
+			<aiAimMode>Snapshot</aiAimMode>
+		</FireModes>
+	</Operation>
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Kurin_Gun_Charge_Rifle</defName>
+		<statBases>
+			<SightsEfficiency>1.1</SightsEfficiency>
+			<ShotSpread>0.06</ShotSpread>
+			<SwayFactor>1.42</SwayFactor>
+			<Bulk>9.00</Bulk>
+			<Mass>4.00</Mass>
+			<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+		</statBases>
+		<Properties>
+			<recoilAmount>1.92</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_6x24mmCharged</defaultProjectile>
+			<burstShotCount>5</burstShotCount>
+			<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+			<warmupTime>1.1</warmupTime>
+			<range>55</range>
+			<soundCast>Kurin_Shot_Charge_Rifle</soundCast>
+			<soundCastTail>GunTail_Medium</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>35</magazineSize>
+			<reloadTime>4.5</reloadTime>
+			<ammoSet>AmmoSet_6x24mmCharged</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aimedBurstShotCount>3</aimedBurstShotCount>
+			<aiAimMode>Snapshot</aiAimMode>
+		</FireModes>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[
+			defName="Kurin_Gun_Assault_Rifle" or
+			defName="Kurin_Gun_Charge_Shotgun" or
+			defName="Kurin_Gun_Charge_Rifle" or
+			defName="Kurin_Gun_Sniper_Rifle" or
+			defName="Kurin_Gun_Shotgun" or
+			defName="Kurin_Gun_Carbine"
+			]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>stock</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>8</power>
+					<cooldownTime>1.55</cooldownTime>
+					<chanceFactor>1.5</chanceFactor>
+					<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>barrel</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>5</power>
+					<cooldownTime>2.02</cooldownTime>
+					<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>muzzle</label>
+					<capacities>
+						<li>Poke</li>
+					</capacities>
+					<power>8</power>
+					<cooldownTime>1.55</cooldownTime>
+					<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<!--========= Ceremonial Sword : Changed to Zweihandler Clone =========-->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_MeleeWeapon_Ceremonial_Sword"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>handle</label>
+					<capacities>
+						<li>Poke</li>
+					</capacities>
+					<power>5</power>
+					<cooldownTime>2.01</cooldownTime>
+					<armorPenetrationBlunt>1.6</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>point</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>60</power>
+					<cooldownTime>2.01</cooldownTime>
+					<chanceFactor>1.165</chanceFactor>
+					<armorPenetrationBlunt>1.6</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.89</armorPenetrationSharp>
+					<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>edge</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>47</power>
+					<cooldownTime>3.12</cooldownTime>
+					<chanceFactor>1.165</chanceFactor>
+					<armorPenetrationBlunt>3.6</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.4</armorPenetrationSharp>
+					<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_MeleeWeapon_Ceremonial_Sword"]/statBases</xpath>
+		<value>
+			<statBases>
+				<WorkToMake>25000</WorkToMake>
+				<Mass>3.2</Mass>
+				<Bulk>12</Bulk>
+				<MeleeCounterParryBonus>0.59</MeleeCounterParryBonus>
+			</statBases>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_MeleeWeapon_Ceremonial_Sword"]/costStuffCount</xpath>
+		<value>
+			<costStuffCount>150</costStuffCount>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Kurin_MeleeWeapon_Ceremonial_Sword"]</xpath>
+		<value>
+			<equippedStatOffsets>
+				<MeleeCritChance>0.08</MeleeCritChance>
+				<MeleeParryChance>0.5</MeleeParryChance>
+				<MeleeDodgeChance>0.5</MeleeDodgeChance>
+			</equippedStatOffsets>
+		</value>
+	</Operation>
+
+	<!--========= Surigum : Changed to Dagger, thrown property removed =========-->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Kurin_Gun_Surigum"]</xpath>
+		<value>
+			<equippedStatOffsets>
+				<MeleeCritChance>0.5</MeleeCritChance>
+				<MeleeParryChance>0.15</MeleeParryChance>
+				<MeleeDodgeChance>0.05</MeleeDodgeChance>
+			</equippedStatOffsets>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_Gun_Surigum"]/statBases</xpath>
+		<value>
+			<statBases>
+				<WorkToMake>8000</WorkToMake>
+				<Mass>0.4</Mass>
+				<Bulk>1</Bulk>
+				<MeleeCounterParryBonus>0.15</MeleeCounterParryBonus>
+			</statBases>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Kurin_Gun_Surigum"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>handle</label>
+					<capacities>
+						<li>Poke</li>
+					</capacities>
+					<power>1</power>
+					<cooldownTime>1.26</cooldownTime>
+					<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>blade</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>10</power>
+					<cooldownTime>1.18</cooldownTime>
+					<armorPenetrationBlunt>0.36</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.32</armorPenetrationSharp>
+					<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>point</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>11</power>
+					<cooldownTime>1.26</cooldownTime>
+					<chanceFactor>1.33</chanceFactor>
+					<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.42</armorPenetrationSharp>
+					<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Kurin_Gun_Surigum"]/verbs</xpath>
+	</Operation>
+	
 </Patch>


### PR DESCRIPTION
## Additions

- Added patches for new Kurin HAR Edition weapons; Kurin Carbin, Kurin Shotgun, Kurin Charge Rifle and Kurin Charge Shotgun. They're made slightly stronger than CE variants to reflect their higher costs.
- Added patches for Kurin Redfox Armor and Kurin Redfox Helmet. They're made similar to Power Armor.

## Changes

- Removed melee dodge chance patch for Kurin Armored Gothic Dress as that stat is also removed in Kurin HAR Edition; that armor is now a psycaster armor in Kurin HAR Edition.
- Nerfed Kurin Military Helmet and Kurin Bikini Armor. Both of these had way too high of a material multiplier. Now they are more in line with the stats of the original mod.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (For a few hours; on-going)
