### PR TITLE
Thermobaric CG ammo recipe output fix

### DIFF
--- a/Defs/Ammo/Rocket/84x246mmR.xml
+++ b/Defs/Ammo/Rocket/84x246mmR.xml
@@ -581,7 +581,7 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_84x246mmR_HEAT>5</Ammo_84x246mmR_HEAT>
+			<Ammo_84x246mmR_Thermobaric>5</Ammo_84x246mmR_Thermobaric>
 		</products>
 	</RecipeDef>
 


### PR DESCRIPTION
## Changes

- What it says on the tin, it had the incorrect output of HEAT ammo.

## Alternatives

- Suffer...

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
