### PR TITLE
More casing variables

### DIFF
--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -938,10 +938,10 @@
 		<xpath>Defs/ThingDef[defName="Gun_Minigun"]</xpath>
 		<value>
 			<li Class="CombatExtended.GunDrawExtension">
-			<DrawSize>1.00,1.00</DrawSize>
-			<DrawOffset>0.1,-0.15</DrawOffset>
-			<CasingOffset>-0.2,-0.1</CasingOffset>
-			<CasingAngleOffset>-30</CasingAngleOffset>
+				<DrawSize>1.00,1.00</DrawSize>
+				<DrawOffset>0.1,-0.15</DrawOffset>
+				<CasingOffset>-0.2,-0.1</CasingOffset>
+				<CasingAngleOffset>-30</CasingAngleOffset>
 			</li>
 		</value>
 	</Operation>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -1,1514 +1,1515 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Gun_ChargeLance"]</xpath>
-		<value>
-			<relicChance>0</relicChance>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[@Name="BaseWeaponTurret"]</xpath>
-		<value>
-			<relicChance>0</relicChance>
-		</value>
-	</Operation>
-
-	<!-- ========== Tools ========== -->
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Gun_Revolver" or defName="Gun_Autopistol" or defName="Gun_MachinePistol"]/tools</xpath>
-		<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-					<label>grip</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>2</power>
-					<cooldownTime>1.54</cooldownTime>
-					<chanceFactor>1.5</chanceFactor>
-					<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>muzzle</label>
-					<capacities>
-						<li>Poke</li>
-					</capacities>
-					<power>2</power>
-					<cooldownTime>1.54</cooldownTime>
-					<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-				</li>
-			</tools>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>
-			Defs/ThingDef[
-			defName="Gun_PumpShotgun" or
-			defName="Gun_ChainShotgun" or
-			defName="Gun_BoltActionRifle" or
-			defName="Gun_AssaultRifle" or
-			defName="Gun_SniperRifle" or
-			defName="Gun_HeavySMG" or
-			defName="Gun_IncendiaryLauncher" or
-			defName="Gun_LMG" or
-			defName="Gun_ChargeRifle"
-			]/tools
-		</xpath>
-		<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-					<label>stock</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>8</power>
-					<cooldownTime>1.55</cooldownTime>
-					<chanceFactor>1.5</chanceFactor>
-					<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>barrel</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>5</power>
-					<cooldownTime>2.02</cooldownTime>
-					<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>muzzle</label>
-					<capacities>
-						<li>Poke</li>
-					</capacities>
-					<power>8</power>
-					<cooldownTime>1.55</cooldownTime>
-					<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-				</li>
-			</tools>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Gun_TripleRocket" or defName="Gun_DoomsdayRocket"]/tools</xpath>
-		<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-					<label>barrel</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>10</power>
-					<cooldownTime>2.44</cooldownTime>
-					<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-				</li>
-			</tools>
-		</value>
-	</Operation>
-
-	<!-- ========== Revolver ========== -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_Revolver</defName>
-		<statBases>
-			<Mass>1.39</Mass>
-			<RangedWeapon_Cooldown>0.49</RangedWeapon_Cooldown>
-			<SightsEfficiency>0.7</SightsEfficiency>
-			<ShotSpread>0.18</ShotSpread>
-			<SwayFactor>1.27</SwayFactor>
-			<Bulk>2.41</Bulk>
-			<!-- <ToughnessRating>2.5</ToughnessRating> --> <!-- Base toughness rating of a weapon -->
-			<WorkToMake>7000</WorkToMake>
-		</statBases>
-		<costList>
-			<Steel>30</Steel>
-			<ComponentIndustrial>2</ComponentIndustrial>
-		</costList>
-		<Properties>
-			<recoilAmount>2.96</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_44Magnum_FMJ</defaultProjectile>
-			<warmupTime>0.6</warmupTime>
-			<range>12</range>
-			<soundCast>Shot_Revolver</soundCast>
-			<soundCastTail>GunTail_Light</soundCastTail>
-			<muzzleFlashScale>9</muzzleFlashScale>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>6</magazineSize>
-			<reloadTime>4.6</reloadTime>
-			<ammoSet>AmmoSet_44Magnum</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aiUseBurstMode>FALSE</aiUseBurstMode>
-			<aiAimMode>Snapshot</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>CE_Sidearm</li>
-			<li>CE_AI_BROOM</li>
-			<li>CE_OneHandedWeapon</li>
-		</weaponTags>
-		<researchPrerequisite>Gunsmithing</researchPrerequisite>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Gun_Revolver"]</xpath>
-		<value>
-			<li Class="CombatExtended.GunDrawExtension">
-				<DrawSize>1.00,1.00</DrawSize>
-				<DrawOffset>0.0,0.0</DrawOffset>
-			</li>
-		</value>
-	</Operation>
-
-	<!-- ========== Autopistol ========== -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_Autopistol</defName>
-		<statBases>
-			<Mass>1.11</Mass>
-			<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
-			<SightsEfficiency>0.7</SightsEfficiency>
-			<ShotSpread>0.17</ShotSpread>
-			<SwayFactor>1.07</SwayFactor>
-			<Bulk>2.10</Bulk>
-			<WorkToMake>7000</WorkToMake>
-		</statBases>
-		<costList>
-			<Steel>25</Steel>
-			<ComponentIndustrial>3</ComponentIndustrial>
-		</costList>
-		<Properties>
-			<recoilAmount>2.72</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
-			<warmupTime>0.6</warmupTime>
-			<range>12</range>
-			<soundCast>Shot_Autopistol</soundCast>
-			<soundCastTail>GunTail_Light</soundCastTail>
-			<muzzleFlashScale>9</muzzleFlashScale>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>7</magazineSize>
-			<reloadTime>4</reloadTime>
-			<ammoSet>AmmoSet_45ACP</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aiUseBurstMode>FALSE</aiUseBurstMode>
-			<aiAimMode>Snapshot</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>CE_Sidearm</li>
-			<li>CE_AI_BROOM</li>
-			<li>CE_OneHandedWeapon</li>
-		</weaponTags>
-		<researchPrerequisite>BlowbackOperation</researchPrerequisite>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Gun_Autopistol"]</xpath>
-		<value>
-			<li Class="CombatExtended.GunDrawExtension">
-				<DrawSize>0.93,0.93</DrawSize>
-				<DrawOffset>0.0,0.0</DrawOffset>
-			</li>
-		</value>
-	</Operation>
-
-	<!-- ========== Pump Shotgun ========== -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_PumpShotgun</defName>
-		<statBases>
-			<Mass>3.00</Mass>
-			<RangedWeapon_Cooldown>1.0</RangedWeapon_Cooldown>
-			<ShotSpread>0.14</ShotSpread>
-			<SwayFactor>1.20</SwayFactor>
-			<Bulk>9.0</Bulk>
-			<SightsEfficiency>1</SightsEfficiency>
-			<WorkToMake>9500</WorkToMake>
-		</statBases>
-		<costList>
-			<Steel>45</Steel>
-			<WoodLog>10</WoodLog>
-			<ComponentIndustrial>1</ComponentIndustrial>
-		</costList>
-		<Properties>
-			<recoilAmount>2.75</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
-			<warmupTime>0.6</warmupTime>
-			<range>16</range>
-			<soundCast>Shot_Shotgun</soundCast>
-			<soundCastTail>GunTail_Heavy</soundCastTail>
-			<muzzleFlashScale>9</muzzleFlashScale>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>5</magazineSize>
-			<reloadOneAtATime>true</reloadOneAtATime>
-			<reloadTime>0.85</reloadTime>
-			<ammoSet>AmmoSet_12Gauge</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aiAimMode>Snapshot</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>SimpleGun</li>
-			<li>CE_AI_BROOM</li>
-		</weaponTags>
-		<researchPrerequisite>Gunsmithing</researchPrerequisite>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Gun_PumpShotgun"]</xpath>
-		<value>
-			<li Class="CombatExtended.GunDrawExtension">
-				<DrawSize>1.03,1.25</DrawSize>
-				<DrawOffset>0.05,0.0</DrawOffset>
-			</li>
-		</value>
-	</Operation>
-
-	<!-- ========== Chain Shotgun ========== -->
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Gun_ChainShotgun"]/description</xpath>
-		<value>
-			<description>A magazine-fed semi-automatic shotgun. It has the same range as a typical shotgun, but is extraordinarily dangerous due to being semi-automatic.</description>
-		</value>
-	</Operation>
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_ChainShotgun</defName>
-		<statBases>
-			<Mass>3.50</Mass>
-			<RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
-			<ShotSpread>0.15</ShotSpread>
-			<SwayFactor>1.26</SwayFactor>
-			<Bulk>6.7</Bulk>
-			<SightsEfficiency>1</SightsEfficiency>
-			<WorkToMake>22500</WorkToMake>
-		</statBases>
-		<costList>
-			<Steel>40</Steel>
-			<ComponentIndustrial>3</ComponentIndustrial>
-			<Chemfuel>10</Chemfuel>
-		</costList>
-		<Properties>
-			<recoilAmount>2.54</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
-			<warmupTime>0.6</warmupTime>
-			<range>16</range>
-			<soundCast>Shot_Shotgun_NoRack</soundCast>
-			<soundCastTail>GunTail_Heavy</soundCastTail>
-			<muzzleFlashScale>9</muzzleFlashScale>
-			<ticksBetweenBurstShots>15</ticksBetweenBurstShots>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>8</magazineSize>
-			<reloadTime>4</reloadTime>
-			<ammoSet>AmmoSet_12Gauge</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aiAimMode>Snapshot</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>CE_AI_BROOM</li>
-		</weaponTags>
-		<researchPrerequisite>GasOperation</researchPrerequisite>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Gun_ChainShotgun"]</xpath>
-		<value>
-			<li Class="CombatExtended.GunDrawExtension">
-				<DrawSize>1.04,1.23</DrawSize>
-				<DrawOffset>0.05,-0.05</DrawOffset>
-				<CasingOffset>0,0.2</CasingOffset>
-				<CasingAngleOffset>-30</CasingAngleOffset>
-			</li>
-		</value>
-	</Operation>
-
-	<!-- ========== Bolt-action rifle ========== -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_BoltActionRifle</defName>
-		<statBases>
-			<Mass>4.19</Mass>
-			<RangedWeapon_Cooldown>1.17</RangedWeapon_Cooldown>
-			<SightsEfficiency>1</SightsEfficiency>
-			<ShotSpread>0.02</ShotSpread>
-			<SwayFactor>1.68</SwayFactor>
-			<Bulk>12.60</Bulk>
-			<WorkToMake>12000</WorkToMake>
-		</statBases>
-		<costList>
-			<Steel>55</Steel>
-			<WoodLog>15</WoodLog>
-			<ComponentIndustrial>1</ComponentIndustrial>
-		</costList>
-		<Properties>
-			<recoilAmount>2.04</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_303British_FMJ</defaultProjectile>
-			<warmupTime>1.1</warmupTime>
-			<range>55</range>
-			<soundCast>Shot_BoltActionRifle</soundCast>
-			<soundCastTail>GunTail_Heavy</soundCastTail>
-			<muzzleFlashScale>9</muzzleFlashScale>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>10</magazineSize>
-			<reloadTime>4.3</reloadTime>
-			<ammoSet>AmmoSet_303British</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aiAimMode>AimedShot</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>SimpleGun</li>
-			<li>CE_AI_SR</li>
-		</weaponTags>
-		<researchPrerequisite>Gunsmithing</researchPrerequisite>
-		<AllowWithRunAndGun>false</AllowWithRunAndGun>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Gun_BoltActionRifle"]</xpath>
-		<value>
-			<li Class="CombatExtended.GunDrawExtension">
-				<DrawSize>1.3,1.3</DrawSize>
-				<DrawOffset>0.12,0.04</DrawOffset>
-				<CasingOffset>-0.1,0.1</CasingOffset>
-			</li>
-		</value>
-	</Operation>
-
-	<!-- ========== Assault rifle ========== -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_AssaultRifle</defName>
-		<statBases>
-			<Mass>3.26</Mass>
-			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-			<SightsEfficiency>1</SightsEfficiency>
-			<ShotSpread>0.07</ShotSpread>
-			<SwayFactor>1.33</SwayFactor>
-			<Bulk>10.03</Bulk>
-			<WorkToMake>30000</WorkToMake>
-		</statBases>
-		<costList>
-			<Steel>50</Steel>
-			<ComponentIndustrial>5</ComponentIndustrial>
-			<Chemfuel>10</Chemfuel>
-		</costList>
-		<Properties>
-			<recoilAmount>1.50</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
-			<warmupTime>1.1</warmupTime>
-			<range>55</range>
-			<burstShotCount>6</burstShotCount>
-			<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
-			<soundCast>Shot_AssaultRifle</soundCast>
-			<soundCastTail>GunTail_Medium</soundCastTail>
-			<muzzleFlashScale>9</muzzleFlashScale>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>30</magazineSize>
-			<reloadTime>4</reloadTime>
-			<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aimedBurstShotCount>3</aimedBurstShotCount>
-			<aiUseBurstMode>TRUE</aiUseBurstMode>
-			<aiAimMode>AimedShot</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>CE_AI_AR</li>
-		</weaponTags>
-		<researchPrerequisite>PrecisionRifling</researchPrerequisite>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Gun_AssaultRifle"]</xpath>
-		<value>
-			<li Class="CombatExtended.GunDrawExtension">
-				<DrawSize>1.16,1.16</DrawSize>
-				<DrawOffset>0.08,0.0</DrawOffset>
-				<CasingOffset>-0.05,0</CasingOffset>
-			</li>
-		</value>
-	</Operation>
-
-	<!-- ========== Sniper rifle ========== -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_SniperRifle</defName>
-		<statBases>
-			<Mass>7.30</Mass>
-			<RangedWeapon_Cooldown>1.36</RangedWeapon_Cooldown>
-			<SightsEfficiency>2.6</SightsEfficiency>
-			<ShotSpread>0.05</ShotSpread>
-			<SwayFactor>1.35</SwayFactor>
-			<Bulk>11.92</Bulk>
-			<WorkToMake>30000</WorkToMake>
-		</statBases>
-		<costList>
-			<Steel>60</Steel>
-			<ComponentIndustrial>5</ComponentIndustrial>
-			<Chemfuel>15</Chemfuel>
-		</costList>
-		<Properties>
-			<recoilAmount>1.50</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
-			<warmupTime>1.8</warmupTime>
-			<range>75</range>
-			<soundCast>Shot_SniperRifle</soundCast>
-			<soundCastTail>GunTail_Heavy</soundCastTail>
-			<muzzleFlashScale>9</muzzleFlashScale>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>5</magazineSize>
-			<reloadTime>4</reloadTime>
-			<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aiAimMode>AimedShot</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>CE_AI_SR</li>
-			<li>Bipod_DMR</li>
-		</weaponTags>
-		<researchPrerequisite>PrecisionRifling</researchPrerequisite>
-		<AllowWithRunAndGun>false</AllowWithRunAndGun>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Gun_SniperRifle"]</xpath>
-		<value>
-			<li Class="CombatExtended.GunDrawExtension">
-				<DrawSize>1.25,1.45</DrawSize>
-				<DrawOffset>0.15,-0.05</DrawOffset>
-				<CasingOffset>-0.3,0.1</CasingOffset>
-			</li>
-		</value>
-	</Operation>
-
-	<!-- ========== Machine pistol ========== -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_MachinePistol</defName>
-		<statBases>
-			<Mass>2.84</Mass>
-			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-			<SightsEfficiency>0.7</SightsEfficiency>
-			<ShotSpread>0.16</ShotSpread>
-			<SwayFactor>1.93</SwayFactor>
-			<Bulk>2.95</Bulk>
-			<WorkToMake>24500</WorkToMake>
-		</statBases>
-		<costList>
-			<Steel>35</Steel>
-			<ComponentIndustrial>3</ComponentIndustrial>
-		</costList>
-		<Properties>
-			<recoilAmount>1.71</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
-			<warmupTime>0.6</warmupTime>
-			<range>12</range>
-			<burstShotCount>6</burstShotCount>
-			<ticksBetweenBurstShots>3</ticksBetweenBurstShots>
-			<soundCast>Shot_MachinePistol</soundCast>
-			<soundCastTail>GunTail_Light</soundCastTail>
-			<muzzleFlashScale>9</muzzleFlashScale>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>30</magazineSize>
-			<reloadTime>4</reloadTime>
-			<ammoSet>AmmoSet_45ACP</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aimedBurstShotCount>3</aimedBurstShotCount>
-			<aiUseBurstMode>FALSE</aiUseBurstMode>
-			<aiAimMode>Snapshot</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>CE_SMG</li>
-			<li>CE_AI_BROOM</li>
-			<li>CE_OneHandedWeapon</li>
-		</weaponTags>
-		<researchPrerequisite>BlowbackOperation</researchPrerequisite>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Gun_MachinePistol"]</xpath>
-		<value>
-			<li Class="CombatExtended.GunDrawExtension">
-				<DrawSize>0.84,0.84</DrawSize>
-				<DrawOffset>-0.10,-0.07</DrawOffset>
-				<CasingOffset>0.1,0.1</CasingOffset>
-				<CasingAngleOffset>-30</CasingAngleOffset>
-			</li>
-		</value>
-	</Operation>
-
-	<!-- ========== Heavy SMG ========== -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_HeavySMG</defName>
-		<statBases>
-			<Mass>2.50</Mass>
-			<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
-			<SightsEfficiency>1.00</SightsEfficiency>
-			<ShotSpread>0.14</ShotSpread>
-			<SwayFactor>0.94</SwayFactor>
-			<Bulk>4.50</Bulk>
-			<WorkToMake>24500</WorkToMake>
-		</statBases>
-		<costList>
-			<Steel>30</Steel>
-			<Chemfuel>10</Chemfuel>
-			<ComponentIndustrial>5</ComponentIndustrial>
-		</costList>
-		<Properties>
-			<recoilAmount>1.79</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
-			<warmupTime>0.6</warmupTime>
-			<range>25</range>
-			<burstShotCount>6</burstShotCount>
-			<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
-			<soundCast>Shot_HeavySMG</soundCast>
-			<soundCastTail>GunTail_Heavy</soundCastTail>
-			<muzzleFlashScale>9</muzzleFlashScale>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>25</magazineSize>
-			<reloadTime>4</reloadTime>
-			<ammoSet>AmmoSet_45ACP</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aimedBurstShotCount>3</aimedBurstShotCount>
-			<aiUseBurstMode>FALSE</aiUseBurstMode>
-			<aiAimMode>Snapshot</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>CE_SMG</li>
-			<li>CE_AI_BROOM</li>
-		</weaponTags>
-		<researchPrerequisite>BlowbackOperation</researchPrerequisite>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Gun_HeavySMG"]</xpath>
-		<value>
-			<li Class="CombatExtended.GunDrawExtension">
-				<DrawSize>0.85,0.85</DrawSize>
-				<DrawOffset>0.00,-0.03</DrawOffset>
-				<CasingOffset>0.1,0</CasingOffset>
-			</li>
-		</value>
-	</Operation>
-
-	<!-- ========== Incendiary launcher ========== -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_IncendiaryLauncher</defName>
-		<statBases>
-			<Mass>8</Mass>
-			<RangedWeapon_Cooldown>0.43</RangedWeapon_Cooldown>
-			<SightsEfficiency>1.1</SightsEfficiency>
-			<ShotSpread>0.15</ShotSpread>
-			<SwayFactor>1.8</SwayFactor>
-			<Bulk>10</Bulk>
-			<WorkToMake>35500</WorkToMake>
-		</statBases>
-		<costList>
-			<Steel>65</Steel>
-			<Plasteel>30</Plasteel>
-			<ComponentIndustrial>1</ComponentIndustrial>
-			<ComponentSpacer>1</ComponentSpacer>
-			<Chemfuel>10</Chemfuel>
-		</costList>
-		<Properties>
-			<recoilAmount>3.87</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_30x64mmFuel_Incendiary</defaultProjectile>
-			<warmupTime>1.0</warmupTime>
-			<range>40</range>
-			<soundCast>Shot_IncendiaryLauncher</soundCast>
-			<soundCastTail>GunTail_Medium</soundCastTail>
-			<muzzleFlashScale>9</muzzleFlashScale>
-			<targetParams>
-				<canTargetLocations>true</canTargetLocations>
-			</targetParams>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>5</magazineSize>
-			<reloadOneAtATime>true</reloadOneAtATime>
-			<reloadTime>0.85</reloadTime>
-			<ammoSet>AmmoSet_30x64mmFuel</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aiUseBurstMode>FALSE</aiUseBurstMode>
-			<aiAimMode>SuppressFire</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>CE_AI_AOE</li>
-			<li>EliteGun</li>
-		</weaponTags>
-		<researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
-		<AllowWithRunAndGun>false</AllowWithRunAndGun>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Gun_IncendiaryLauncher"]</xpath>
-		<value>
-			<techLevel>Spacer</techLevel>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Gun_IncendiaryLauncher"]</xpath>
-		<value>
-			<li Class="CombatExtended.GunDrawExtension">
-				<DrawSize>1.16,1.16</DrawSize>
-				<DrawOffset>0.1,-0.05</DrawOffset>
-			</li>
-		</value>
-	</Operation>
-
-	<!-- ========== LMG ========== -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_LMG</defName>
-		<statBases>
-			<Mass>8.7</Mass>
-			<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
-			<SightsEfficiency>1</SightsEfficiency>
-			<ShotSpread>0.05</ShotSpread>
-			<SwayFactor>1.37</SwayFactor>
-			<Bulk>12.9</Bulk>
-			<WorkToMake>31500</WorkToMake>
-		</statBases>
-		<costList>
-			<Steel>80</Steel>
-			<WoodLog>10</WoodLog>
-			<ComponentIndustrial>5</ComponentIndustrial>
-		</costList>
-		<Properties>
-			<recoilAmount>1.38</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_303British_FMJ</defaultProjectile>
-			<warmupTime>1.3</warmupTime>
-			<range>62</range>
-			<ticksBetweenBurstShots>7</ticksBetweenBurstShots>
-			<burstShotCount>10</burstShotCount>
-			<soundCast>Shot_CE_BattleRifle</soundCast>
-			<soundCastTail>GunTail_Medium</soundCastTail>
-			<muzzleFlashScale>9</muzzleFlashScale>
-			<targetParams>
-				<canTargetLocations>true</canTargetLocations>
-			</targetParams>
-			<recoilPattern>Mounted</recoilPattern>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>50</magazineSize>
-			<reloadTime>4.9</reloadTime>
-			<ammoSet>AmmoSet_303British</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aimedBurstShotCount>5</aimedBurstShotCount>
-			<aiUseBurstMode>FALSE</aiUseBurstMode>
-			<aiAimMode>SuppressFire</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>CE_MachineGun</li>
-			<li>CE_AI_LMG</li>
-			<li>Bipod_LMG</li>
-		</weaponTags>
-		<researchPrerequisite>GasOperation</researchPrerequisite>
-		<AllowWithRunAndGun>false</AllowWithRunAndGun>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Gun_LMG"]</xpath>
-		<value>
-			<li Class="CombatExtended.GunDrawExtension">
-				<DrawSize>1.35,1.18</DrawSize>
-				<DrawOffset>0.13,-0.03</DrawOffset>
-			</li>
-		</value>
-	</Operation>
-
-	<!-- ========== Charge rifle ========== -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_ChargeRifle</defName>
-		<statBases>
-			<Mass>3.0</Mass>
-			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-			<SightsEfficiency>1.10</SightsEfficiency>
-			<ShotSpread>0.08</ShotSpread>
-			<SwayFactor>1.20</SwayFactor>
-			<Bulk>7.00</Bulk>
-			<WorkToMake>49000</WorkToMake>
-		</statBases>
-		<costList>
-			<Steel>45</Steel>
-			<Plasteel>25</Plasteel>
-			<ComponentIndustrial>4</ComponentIndustrial>
-			<ComponentSpacer>1</ComponentSpacer>
-			<Chemfuel>10</Chemfuel>
-		</costList>
-		<Properties>
-			<recoilAmount>1.46</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_6x24mmCharged</defaultProjectile>
-			<warmupTime>1.0</warmupTime>
-			<range>55</range>
-			<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
-			<burstShotCount>6</burstShotCount>
-			<soundCast>Shot_ChargeRifle</soundCast>
-			<soundCastTail>GunTail_Medium</soundCastTail>
-			<muzzleFlashScale>9</muzzleFlashScale>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>30</magazineSize>
-			<reloadTime>4</reloadTime>
-			<ammoSet>AmmoSet_6x24mmCharged</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aimedBurstShotCount>3</aimedBurstShotCount>
-			<aiUseBurstMode>TRUE</aiUseBurstMode>
-			<aiAimMode>AimedShot</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>CE_AI_AR</li>
-			<li>AdvancedGun</li>
-		</weaponTags>
-		<researchPrerequisite>ChargedShot</researchPrerequisite>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Gun_ChargeRifle"]</xpath>
-		<value>
-			<li Class="CombatExtended.GunDrawExtension">
-				<DrawSize>1.03,1.03</DrawSize>
-				<DrawOffset>0.05,0.0</DrawOffset>
-			</li>
-		</value>
-	</Operation>
-
-	<!-- ========== Improvised turret gun ========== -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_MiniTurret</defName>
-		<statBases>
-			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-			<SightsEfficiency>1</SightsEfficiency>
-			<ShotSpread>0.07</ShotSpread>
-			<SwayFactor>0.67</SwayFactor>
-			<Mass>4</Mass>
-		</statBases>
-		<Properties>
-			<recoilAmount>1.02</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
-			<warmupTime>1.3</warmupTime>
-			<range>48</range>
-			<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
-			<burstShotCount>10</burstShotCount>
-			<soundCast>GunShotA</soundCast>
-			<soundCastTail>GunTail_Light</soundCastTail>
-			<muzzleFlashScale>9</muzzleFlashScale>
-			<recoilPattern>Mounted</recoilPattern>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>100</magazineSize>
-			<reloadTime>7.8</reloadTime>
-			<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aiAimMode>AimedShot</aiAimMode>
-			<noSnapshot>true</noSnapshot>
-			<noSingleShot>true</noSingleShot>
-		</FireModes>
-	</Operation>
-
-	<!-- ========== Minigun ========== -->
-
-	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName ="Gun_Minigun"]/weaponTags/li[.="GunHeavy"]</xpath>
-	</Operation>
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_Minigun</defName>
-		<statBases>
-			<Mass>20.00</Mass>
-			<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
-			<SightsEfficiency>1</SightsEfficiency>
-			<ShotSpread>0.06</ShotSpread>
-			<SwayFactor>3.22</SwayFactor>
-			<Bulk>10</Bulk>
-			<WorkToMake>52000</WorkToMake>
-		</statBases>
-		<costList>
-			<Steel>110</Steel>
-			<ComponentIndustrial>11</ComponentIndustrial>
-		</costList>
-		<Properties>
-			<recoilAmount>0.97</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
-			<warmupTime>2.1</warmupTime>
-			<range>62</range>
-			<burstShotCount>50</burstShotCount>
-			<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
-			<soundCast>Shot_Minigun</soundCast>
-			<soundCastTail>GunTail_Medium</soundCastTail>
-			<muzzleFlashScale>9</muzzleFlashScale>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>250</magazineSize>
-			<reloadTime>9.2</reloadTime>
-			<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aimedBurstShotCount>25</aimedBurstShotCount>
-			<aiAimMode>Snapshot</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>CE_AI_Suppressive</li>
-		</weaponTags>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Gun_Minigun"]/tools</xpath>
-		<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-					<label>barrels</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>10</power>
-					<cooldownTime>2.44</cooldownTime>
-					<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Barrels</linkedBodyPartsGroup>
-				</li>
-			</tools>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="Gun_Minigun"]/equippedStatOffsets</xpath>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Gun_Minigun"]</xpath>
-		<value>
-			<li Class="CombatExtended.GunDrawExtension">
-				<DrawSize>1.00,1.00</DrawSize>
-				<DrawOffset>0.1,-0.15</DrawOffset>
-				<CasingOffset>-0.2,0</CasingOffset>
-				<CasingAngleOffset>-30</CasingAngleOffset>
-			</li>
-		</value>
-	</Operation>
-
-	<!-- ========== Doomsday launcher ========== -->
-
-	<!-- Patch both launchers -->
-
-	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="Gun_DoomsdayRocket" or defName="Gun_TripleRocket"]/weaponTags/li[.="Gun"]</xpath>
-	</Operation>
-
-	<Operation Class="PatchOperationAttributeSet">
-		<xpath>Defs/ThingDef[defName="Gun_DoomsdayRocket" or defName="Gun_TripleRocket"]</xpath>
-		<attribute>ParentName</attribute>
-		<value>BaseMakeableGun</value>
-	</Operation>
-
-	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="Gun_DoomsdayRocket" or defName="Gun_TripleRocket"]/statBases/MarketValue</xpath>
-	</Operation>
-
-	<!-- Patch projectile -->
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Bullet_DoomsdayRocket"]/thingClass</xpath>
-		<value>
-			<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Bullet_DoomsdayRocket"]/projectile</xpath>
-		<value>
-			<projectile Class="CombatExtended.ProjectilePropertiesCE">
-				<damageDef>Bomb</damageDef>
-				<damageAmountBase>250</damageAmountBase>
-				<explosionRadius>7.8</explosionRadius>
-				<suppressionFactor>3.0</suppressionFactor>
-				<dangerFactor>2.0</dangerFactor>
-				<speed>100</speed>
-			</projectile>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/ThingDef[defName="Bullet_DoomsdayRocket"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="Bullet_DoomsdayRocket"]</xpath>
-			<value>
-				<comps />
-			</value>
-		</nomatch>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Bullet_DoomsdayRocket"]/comps</xpath>
-		<value>
-			<li Class="CombatExtended.CompProperties_Fragments">
-				<fragSpeedFactor>1</fragSpeedFactor>
-				<fragments>
-					<Fragment_Large>400</Fragment_Large>
-				</fragments>
-			</li>
-		</value>
-	</Operation>
-
-	<!-- Patch stats -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_DoomsdayRocket</defName>
-		<statBases>
-			<Mass>20.00</Mass>
-			<RangedWeapon_Cooldown>1.5</RangedWeapon_Cooldown>
-			<SightsEfficiency>2.24</SightsEfficiency>
-			<ShotSpread>0.2</ShotSpread>
-			<SwayFactor>3.24</SwayFactor>
-			<Bulk>13.0</Bulk>
-			<WorkToMake>49500</WorkToMake>
-		</statBases>
-		<costList>
-			<Steel>125</Steel>
-			<ComponentIndustrial>8</ComponentIndustrial>
-			<FSX>5</FSX>
-		</costList>
-		<Properties>
-			<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_DoomsdayRocket</defaultProjectile>
-			<warmupTime>2.1</warmupTime>
-			<range>48</range>
-			<burstShotCount>1</burstShotCount>
-			<soundCast>InfernoCannon_Fire</soundCast>
-			<soundCastTail>GunTail_Heavy</soundCastTail>
-			<onlyManualCast>true</onlyManualCast>
-			<targetParams>
-				<canTargetLocations>true</canTargetLocations>
-			</targetParams>
-			<muzzleFlashScale>14</muzzleFlashScale>
-		</Properties>
-		<FireModes>
-			<aiAimMode>AimedShot</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>CE_AI_AOE</li>
-		</weaponTags>
-		<researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
-		<AllowWithRunAndGun>false</AllowWithRunAndGun>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Gun_DoomsdayRocket"]</xpath>
-		<value>
-			<li Class="CombatExtended.GunDrawExtension">
-				<DrawSize>1.45,1.45</DrawSize>
-				<DrawOffset>-0.15,0</DrawOffset>
-			</li>
-		</value>
-	</Operation>
-
-	<!-- ========== Triple rocket launcher ========== -->
-
-	<!-- Patch projectile -->
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Bullet_Rocket"]/thingClass</xpath>
-		<value>
-			<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Bullet_Rocket"]/projectile</xpath>
-		<value>
-			<projectile Class="CombatExtended.ProjectilePropertiesCE">
-				<damageDef>Bomb</damageDef>
-				<damageAmountBase>180</damageAmountBase>
-				<explosionRadius>3.0</explosionRadius>
-				<suppressionFactor>3.0</suppressionFactor>
-				<dangerFactor>2.0</dangerFactor>
-				<speed>100</speed>
-			</projectile>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/ThingDef[defName="Bullet_Rocket"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="Bullet_Rocket"]</xpath>
-			<value>
-				<comps />
-			</value>
-		</nomatch>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Bullet_Rocket"]/comps</xpath>
-		<value>
-			<li Class="CombatExtended.CompProperties_Fragments">
-				<fragSpeedFactor>1</fragSpeedFactor>
-				<fragments>
-					<Fragment_Large>150</Fragment_Large>
-				</fragments>
-			</li>
-		</value>
-	</Operation>
-
-	<!-- Patch stats -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_TripleRocket</defName>
-		<statBases>
-			<Mass>12.00</Mass>
-			<RangedWeapon_Cooldown>1.5</RangedWeapon_Cooldown>
-			<SightsEfficiency>1</SightsEfficiency>
-			<ShotSpread>0.2</ShotSpread>
-			<SwayFactor>2.20</SwayFactor>
-			<Bulk>13.00</Bulk>
-			<WorkToMake>43000</WorkToMake>
-		</statBases>
-		<costList>
-			<Steel>90</Steel>
-			<ComponentIndustrial>7</ComponentIndustrial>
-			<FSX>3</FSX>
-		</costList>
-		<Properties>
-			<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_Rocket</defaultProjectile>
-			<warmupTime>1.9</warmupTime>
-			<range>40</range>
-			<ticksBetweenBurstShots>20</ticksBetweenBurstShots>
-			<burstShotCount>3</burstShotCount>
-			<soundCast>InfernoCannon_Fire</soundCast>
-			<soundCastTail>GunTail_Heavy</soundCastTail>
-			<onlyManualCast>true</onlyManualCast>
-			<stopBurstWithoutLos>false</stopBurstWithoutLos>
-			<interruptibleBurst>false</interruptibleBurst>
-			<targetParams>
-				<canTargetLocations>true</canTargetLocations>
-			</targetParams>
-			<muzzleFlashScale>14</muzzleFlashScale>
-		</Properties>
-		<FireModes>
-			<aiAimMode>AimedShot</aiAimMode>
-			<noSingleShot>true</noSingleShot>
-		</FireModes>
-		<weaponTags>
-			<li>CE_AI_AOE</li>
-		</weaponTags>
-		<researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
-		<AllowWithRunAndGun>false</AllowWithRunAndGun>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Gun_TripleRocket"]</xpath>
-		<value>
-			<li Class="CombatExtended.GunDrawExtension">
-				<DrawSize>1.16,1.16</DrawSize>
-				<DrawOffset>-0.25,0</DrawOffset>
-			</li>
-		</value>
-	</Operation>
-
-	<!-- ========== Heavy charge blaster ========== -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_ChargeBlasterHeavy</defName>
-		<statBases>
-			<Mass>35.00</Mass>
-			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-			<SightsEfficiency>1</SightsEfficiency>
-			<ShotSpread>0.01</ShotSpread>
-			<SwayFactor>1.33</SwayFactor>
-			<Bulk>13.00</Bulk>
-		</statBases>
-		<Properties>
-			<recoilAmount>1.08</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_12x64mmCharged</defaultProjectile>
-			<warmupTime>1.3</warmupTime>
-			<range>75</range>
-			<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
-			<burstShotCount>10</burstShotCount>
-			<soundCast>Shot_ChargeBlaster</soundCast>
-			<soundCastTail>GunTail_Heavy</soundCastTail>
-			<muzzleFlashScale>9</muzzleFlashScale>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>100</magazineSize>
-			<reloadTime>9.2</reloadTime>
-			<ammoSet>AmmoSet_12x64mmCharged</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aimedBurstShotCount>5</aimedBurstShotCount>
-			<aiAimMode>AimedShot</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>CE_AI_Suppressive</li>
-			<li>NoSwitch</li>
-		</weaponTags>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[@Name="Gun_ChargeBlasterHeavyBase"]/tools</xpath>
-		<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-					<label>barrel</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>10</power>
-					<cooldownTime>2.44</cooldownTime>
-					<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-				</li>
-			</tools>
-		</value>
-	</Operation>
-
-	<!-- ========== Inferno cannon ========== -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_InfernoCannon</defName>
-		<statBases>
-			<Mass>50.00</Mass>
-			<RangedWeapon_Cooldown>2.59</RangedWeapon_Cooldown>
-			<SightsEfficiency>1</SightsEfficiency>
-			<ShotSpread>0.01</ShotSpread>
-			<SwayFactor>0.14</SwayFactor>
-			<Bulk>20.00</Bulk>
-		</statBases>
-		<Properties>
-			<recoilAmount>3.18</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>
-			<warmupTime>4.3</warmupTime>
-			<range>86</range>
-			<burstShotCount>1</burstShotCount>
-			<soundCast>InfernoCannon_Fire</soundCast>
-			<soundCastTail>GunTail_Light</soundCastTail>
-			<muzzleFlashScale>14</muzzleFlashScale>
-			<ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
-			<minRange>5</minRange>
-			<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>1</magazineSize>
-			<AmmoGenPerMagOverride>2</AmmoGenPerMagOverride>
-			<reloadTime>1.6</reloadTime>
-			<ammoSet>AmmoSet_80x256mmFuel</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aiAimMode>AimedShot</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>CE_AI_Launcher</li>
-			<li>NoSwitch</li>
-		</weaponTags>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[@Name="Gun_InfernoCannonBase"]/tools</xpath>
-		<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-					<label>barrel</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>10</power>
-					<cooldownTime>2.44</cooldownTime>
-					<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-				</li>
-			</tools>
-		</value>
-	</Operation>
-
-	<!-- ========== Thump cannon ========== -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_ThumpCannon</defName>
-		<statBases>
-			<Mass>75.00</Mass>
-			<RangedWeapon_Cooldown>2.2</RangedWeapon_Cooldown>
-			<SightsEfficiency>1</SightsEfficiency>
-			<ShotSpread>0.01</ShotSpread>
-			<SwayFactor>0.21</SwayFactor>
-			<Bulk>20.00</Bulk>
-		</statBases>
-		<Properties>
-			<recoilAmount>0.1</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_164x284mmDemo</defaultProjectile>
-			<warmupTime>3.3</warmupTime>
-			<range>42</range>
-			<burstShotCount>1</burstShotCount>
-			<soundCast>ThumpCannon_Fire</soundCast>
-			<soundCastTail>GunTail_Heavy</soundCastTail>
-			<muzzleFlashScale>14</muzzleFlashScale>
-			<ai_AvoidFriendlyFireRadius>3</ai_AvoidFriendlyFireRadius>
-			<minRange>4</minRange>
-			<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>1</magazineSize>
-			<AmmoGenPerMagOverride>2</AmmoGenPerMagOverride>
-			<reloadTime>9.8</reloadTime>
-			<ammoSet>AmmoSet_164x284mmDemo</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aiAimMode>AimedShot</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>CE_AI_Launcher</li>
-			<li>NoSwitch</li>
-		</weaponTags>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Gun_ThumpCannon"]/tools</xpath>
-		<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-					<label>barrel</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>10</power>
-					<cooldownTime>2.44</cooldownTime>
-					<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-				</li>
-			</tools>
-		</value>
-	</Operation>
-
-	<!-- ========== Charge lance ========== -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_ChargeLance</defName>
-		<statBases>
-			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-			<SightsEfficiency>1</SightsEfficiency>
-			<ShotSpread>0.01</ShotSpread>
-			<SwayFactor>0.88</SwayFactor>
-			<Bulk>13.00</Bulk>
-		</statBases>
-		<Properties>
-			<recoilAmount>0.92</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_5x35mmCharged</defaultProjectile>
-			<warmupTime>1.3</warmupTime>
-			<range>62</range>
-			<soundCast>ChargeLance_Fire</soundCast>
-			<soundCastTail>GunTail_Heavy</soundCastTail>
-			<muzzleFlashScale>9</muzzleFlashScale>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>10</magazineSize>
-			<reloadTime>4</reloadTime>
-			<ammoSet>AmmoSet_5x35mmCharged</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aiAimMode>AimedShot</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>CE_AI_Rifle</li>
-			<li>NoSwitch</li>
-		</weaponTags>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Gun_ChargeLance"]/tools</xpath>
-		<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-					<label>barrel</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>10</power>
-					<cooldownTime>2.44</cooldownTime>
-					<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-				</li>
-			</tools>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Gun_ChargeLance"]</xpath>
-		<value>
-			<li Class="CombatExtended.ThingDefExtensionCE">
-				<MenuHidden>True</MenuHidden>
-			</li>
-		</value>
-	</Operation>
-
-	<!-- Disable for player -->
-	<Operation Class="PatchOperationAttributeSet">
-		<xpath>Defs/ThingDef[defName="Gun_ChargeLance"]</xpath>
-		<attribute>ParentName</attribute>
-		<value>BaseGun</value>
-	</Operation>
-
-	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="Gun_ChargeLance"]/costList</xpath>
-	</Operation>
-
-	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="Gun_ChargeLance"]/recipeMaker</xpath>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Gun_ChargeLance"]/statBases</xpath>
-		<value>
-			<MarketValue>1400</MarketValue>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Gun_ChargeLance"]</xpath>
-		<value>
-			<tradeability>None</tradeability>
-			<destroyOnDrop>True</destroyOnDrop>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="Gun_ChargeLance"]/weaponTags/li[contains(.,"SpacerGun")]</xpath>
-	</Operation>
-
-	<!-- ========== Needle Gun ========== -->
-
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Gun_Needle</defName>
-		<statBases>
-			<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
-			<SightsEfficiency>2.24</SightsEfficiency>
-			<ShotSpread>0.01</ShotSpread>
-			<SwayFactor>0.85</SwayFactor>
-			<Bulk>15.00</Bulk>
-		</statBases>
-		<Properties>
-			<recoilAmount>1.80</recoilAmount>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_5x50mmCaseless_Sabot</defaultProjectile>
-			<warmupTime>1.5</warmupTime>
-			<range>75</range>
-			<soundCast>Shot_NeedleGun</soundCast>
-			<soundCastTail>GunTail_Heavy</soundCastTail>
-			<muzzleFlashScale>9</muzzleFlashScale>
-		</Properties>
-		<AmmoUser>
-			<magazineSize>10</magazineSize>
-			<reloadTime>4</reloadTime>
-			<ammoSet>AmmoSet_5x50mmCaseless</ammoSet>
-		</AmmoUser>
-		<FireModes>
-			<aiAimMode>AimedShot</aiAimMode>
-		</FireModes>
-		<weaponTags>
-			<li>CE_AI_Rifle</li>
-			<li>NoSwitch</li>
-		</weaponTags>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Gun_Needle"]/tools</xpath>
-		<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-					<label>barrel</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>10</power>
-					<cooldownTime>2.44</cooldownTime>
-					<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-				</li>
-			</tools>
-		</value>
-	</Operation>
-
-	<!-- Increase Orbital Bombardment Range -->
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="OrbitalTargeterBombardment" or defName="OrbitalTargeterPowerBeam"]/verbs/li/range</xpath>
-		<value>
-			<range>60</range>
-		</value>
-	</Operation>
-
-	<!-- Remove Smoke and EMP Launchers -->
-	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="Gun_SmokeLauncher"]</xpath>
-	</Operation>
-
-	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="Gun_EmpLauncher"]</xpath>
-	</Operation>
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/ThingDef[defName="Gun_ChargeLance"]</xpath>
+    <value>
+      <relicChance>0</relicChance>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/ThingDef[@Name="BaseWeaponTurret"]</xpath>
+    <value>
+      <relicChance>0</relicChance>
+    </value>
+  </Operation>
+
+  <!-- ========== Tools ========== -->
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Gun_Revolver" or defName="Gun_Autopistol" or defName="Gun_MachinePistol"]/tools</xpath>
+    <value>
+      <tools>
+        <li Class="CombatExtended.ToolCE">
+          <label>grip</label>
+          <capacities>
+            <li>Blunt</li>
+          </capacities>
+          <power>2</power>
+          <cooldownTime>1.54</cooldownTime>
+          <chanceFactor>1.5</chanceFactor>
+          <armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+          <linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
+        </li>
+        <li Class="CombatExtended.ToolCE">
+          <label>muzzle</label>
+          <capacities>
+            <li>Poke</li>
+          </capacities>
+          <power>2</power>
+          <cooldownTime>1.54</cooldownTime>
+          <armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+          <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+        </li>
+      </tools>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>
+      Defs/ThingDef[
+      defName="Gun_PumpShotgun" or
+      defName="Gun_ChainShotgun" or
+      defName="Gun_BoltActionRifle" or
+      defName="Gun_AssaultRifle" or
+      defName="Gun_SniperRifle" or
+      defName="Gun_HeavySMG" or
+      defName="Gun_IncendiaryLauncher" or
+      defName="Gun_LMG" or
+      defName="Gun_ChargeRifle"
+      ]/tools
+    </xpath>
+    <value>
+      <tools>
+        <li Class="CombatExtended.ToolCE">
+          <label>stock</label>
+          <capacities>
+            <li>Blunt</li>
+          </capacities>
+          <power>8</power>
+          <cooldownTime>1.55</cooldownTime>
+          <chanceFactor>1.5</chanceFactor>
+          <armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+          <linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+        </li>
+        <li Class="CombatExtended.ToolCE">
+          <label>barrel</label>
+          <capacities>
+            <li>Blunt</li>
+          </capacities>
+          <power>5</power>
+          <cooldownTime>2.02</cooldownTime>
+          <armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+          <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+        </li>
+        <li Class="CombatExtended.ToolCE">
+          <label>muzzle</label>
+          <capacities>
+            <li>Poke</li>
+          </capacities>
+          <power>8</power>
+          <cooldownTime>1.55</cooldownTime>
+          <armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+          <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+        </li>
+      </tools>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Gun_TripleRocket" or defName="Gun_DoomsdayRocket"]/tools</xpath>
+    <value>
+      <tools>
+        <li Class="CombatExtended.ToolCE">
+          <label>barrel</label>
+          <capacities>
+            <li>Blunt</li>
+          </capacities>
+          <power>10</power>
+          <cooldownTime>2.44</cooldownTime>
+          <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+          <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+        </li>
+      </tools>
+    </value>
+  </Operation>
+
+  <!-- ========== Revolver ========== -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_Revolver</defName>
+    <statBases>
+      <Mass>1.39</Mass>
+      <RangedWeapon_Cooldown>0.49</RangedWeapon_Cooldown>
+      <SightsEfficiency>0.7</SightsEfficiency>
+      <ShotSpread>0.18</ShotSpread>
+      <SwayFactor>1.27</SwayFactor>
+      <Bulk>2.41</Bulk>
+      <!-- <ToughnessRating>2.5</ToughnessRating> -->
+      <!-- Base toughness rating of a weapon -->
+      <WorkToMake>7000</WorkToMake>
+    </statBases>
+    <costList>
+      <Steel>30</Steel>
+      <ComponentIndustrial>2</ComponentIndustrial>
+    </costList>
+    <Properties>
+      <recoilAmount>2.96</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_44Magnum_FMJ</defaultProjectile>
+      <warmupTime>0.6</warmupTime>
+      <range>12</range>
+      <soundCast>Shot_Revolver</soundCast>
+      <soundCastTail>GunTail_Light</soundCastTail>
+      <muzzleFlashScale>9</muzzleFlashScale>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>6</magazineSize>
+      <reloadTime>4.6</reloadTime>
+      <ammoSet>AmmoSet_44Magnum</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aiUseBurstMode>FALSE</aiUseBurstMode>
+      <aiAimMode>Snapshot</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>CE_Sidearm</li>
+      <li>CE_AI_BROOM</li>
+      <li>CE_OneHandedWeapon</li>
+    </weaponTags>
+    <researchPrerequisite>Gunsmithing</researchPrerequisite>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Gun_Revolver"]</xpath>
+    <value>
+      <li Class="CombatExtended.GunDrawExtension">
+        <DrawSize>1.00,1.00</DrawSize>
+        <DrawOffset>0.0,0.0</DrawOffset>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- ========== Autopistol ========== -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_Autopistol</defName>
+    <statBases>
+      <Mass>1.11</Mass>
+      <RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
+      <SightsEfficiency>0.7</SightsEfficiency>
+      <ShotSpread>0.17</ShotSpread>
+      <SwayFactor>1.07</SwayFactor>
+      <Bulk>2.10</Bulk>
+      <WorkToMake>7000</WorkToMake>
+    </statBases>
+    <costList>
+      <Steel>25</Steel>
+      <ComponentIndustrial>3</ComponentIndustrial>
+    </costList>
+    <Properties>
+      <recoilAmount>2.72</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
+      <warmupTime>0.6</warmupTime>
+      <range>12</range>
+      <soundCast>Shot_Autopistol</soundCast>
+      <soundCastTail>GunTail_Light</soundCastTail>
+      <muzzleFlashScale>9</muzzleFlashScale>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>7</magazineSize>
+      <reloadTime>4</reloadTime>
+      <ammoSet>AmmoSet_45ACP</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aiUseBurstMode>FALSE</aiUseBurstMode>
+      <aiAimMode>Snapshot</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>CE_Sidearm</li>
+      <li>CE_AI_BROOM</li>
+      <li>CE_OneHandedWeapon</li>
+    </weaponTags>
+    <researchPrerequisite>BlowbackOperation</researchPrerequisite>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Gun_Autopistol"]</xpath>
+    <value>
+      <li Class="CombatExtended.GunDrawExtension">
+        <DrawSize>0.93,0.93</DrawSize>
+        <DrawOffset>0.0,0.0</DrawOffset>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- ========== Pump Shotgun ========== -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_PumpShotgun</defName>
+    <statBases>
+      <Mass>3.00</Mass>
+      <RangedWeapon_Cooldown>1.0</RangedWeapon_Cooldown>
+      <ShotSpread>0.14</ShotSpread>
+      <SwayFactor>1.20</SwayFactor>
+      <Bulk>9.0</Bulk>
+      <SightsEfficiency>1</SightsEfficiency>
+      <WorkToMake>9500</WorkToMake>
+    </statBases>
+    <costList>
+      <Steel>45</Steel>
+      <WoodLog>10</WoodLog>
+      <ComponentIndustrial>1</ComponentIndustrial>
+    </costList>
+    <Properties>
+      <recoilAmount>2.75</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
+      <warmupTime>0.6</warmupTime>
+      <range>16</range>
+      <soundCast>Shot_Shotgun</soundCast>
+      <soundCastTail>GunTail_Heavy</soundCastTail>
+      <muzzleFlashScale>9</muzzleFlashScale>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>5</magazineSize>
+      <reloadOneAtATime>true</reloadOneAtATime>
+      <reloadTime>0.85</reloadTime>
+      <ammoSet>AmmoSet_12Gauge</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aiAimMode>Snapshot</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>SimpleGun</li>
+      <li>CE_AI_BROOM</li>
+    </weaponTags>
+    <researchPrerequisite>Gunsmithing</researchPrerequisite>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Gun_PumpShotgun"]</xpath>
+    <value>
+      <li Class="CombatExtended.GunDrawExtension">
+        <DrawSize>1.03,1.25</DrawSize>
+        <DrawOffset>0.05,0.0</DrawOffset>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- ========== Chain Shotgun ========== -->
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Gun_ChainShotgun"]/description</xpath>
+    <value>
+      <description>A magazine-fed semi-automatic shotgun. It has the same range as a typical shotgun, but is extraordinarily dangerous due to being semi-automatic.</description>
+    </value>
+  </Operation>
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_ChainShotgun</defName>
+    <statBases>
+      <Mass>3.50</Mass>
+      <RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
+      <ShotSpread>0.15</ShotSpread>
+      <SwayFactor>1.26</SwayFactor>
+      <Bulk>6.7</Bulk>
+      <SightsEfficiency>1</SightsEfficiency>
+      <WorkToMake>22500</WorkToMake>
+    </statBases>
+    <costList>
+      <Steel>40</Steel>
+      <ComponentIndustrial>3</ComponentIndustrial>
+      <Chemfuel>10</Chemfuel>
+    </costList>
+    <Properties>
+      <recoilAmount>2.54</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
+      <warmupTime>0.6</warmupTime>
+      <range>16</range>
+      <soundCast>Shot_Shotgun_NoRack</soundCast>
+      <soundCastTail>GunTail_Heavy</soundCastTail>
+      <muzzleFlashScale>9</muzzleFlashScale>
+      <ticksBetweenBurstShots>15</ticksBetweenBurstShots>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>8</magazineSize>
+      <reloadTime>4</reloadTime>
+      <ammoSet>AmmoSet_12Gauge</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aiAimMode>Snapshot</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>CE_AI_BROOM</li>
+    </weaponTags>
+    <researchPrerequisite>GasOperation</researchPrerequisite>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Gun_ChainShotgun"]</xpath>
+    <value>
+      <li Class="CombatExtended.GunDrawExtension">
+        <DrawSize>1.04,1.23</DrawSize>
+        <DrawOffset>0.05,-0.05</DrawOffset>
+        <CasingOffset>0,0.2</CasingOffset>
+        <CasingAngleOffset>-30</CasingAngleOffset>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- ========== Bolt-action rifle ========== -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_BoltActionRifle</defName>
+    <statBases>
+      <Mass>4.19</Mass>
+      <RangedWeapon_Cooldown>1.17</RangedWeapon_Cooldown>
+      <SightsEfficiency>1</SightsEfficiency>
+      <ShotSpread>0.02</ShotSpread>
+      <SwayFactor>1.68</SwayFactor>
+      <Bulk>12.60</Bulk>
+      <WorkToMake>12000</WorkToMake>
+    </statBases>
+    <costList>
+      <Steel>55</Steel>
+      <WoodLog>15</WoodLog>
+      <ComponentIndustrial>1</ComponentIndustrial>
+    </costList>
+    <Properties>
+      <recoilAmount>2.04</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_303British_FMJ</defaultProjectile>
+      <warmupTime>1.1</warmupTime>
+      <range>55</range>
+      <soundCast>Shot_BoltActionRifle</soundCast>
+      <soundCastTail>GunTail_Heavy</soundCastTail>
+      <muzzleFlashScale>9</muzzleFlashScale>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>10</magazineSize>
+      <reloadTime>4.3</reloadTime>
+      <ammoSet>AmmoSet_303British</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aiAimMode>AimedShot</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>SimpleGun</li>
+      <li>CE_AI_SR</li>
+    </weaponTags>
+    <researchPrerequisite>Gunsmithing</researchPrerequisite>
+    <AllowWithRunAndGun>false</AllowWithRunAndGun>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Gun_BoltActionRifle"]</xpath>
+    <value>
+      <li Class="CombatExtended.GunDrawExtension">
+        <DrawSize>1.3,1.3</DrawSize>
+        <DrawOffset>0.12,0.04</DrawOffset>
+        <CasingOffset>-0.1,0.1</CasingOffset>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- ========== Assault rifle ========== -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_AssaultRifle</defName>
+    <statBases>
+      <Mass>3.26</Mass>
+      <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+      <SightsEfficiency>1</SightsEfficiency>
+      <ShotSpread>0.07</ShotSpread>
+      <SwayFactor>1.33</SwayFactor>
+      <Bulk>10.03</Bulk>
+      <WorkToMake>30000</WorkToMake>
+    </statBases>
+    <costList>
+      <Steel>50</Steel>
+      <ComponentIndustrial>5</ComponentIndustrial>
+      <Chemfuel>10</Chemfuel>
+    </costList>
+    <Properties>
+      <recoilAmount>1.50</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+      <warmupTime>1.1</warmupTime>
+      <range>55</range>
+      <burstShotCount>6</burstShotCount>
+      <ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+      <soundCast>Shot_AssaultRifle</soundCast>
+      <soundCastTail>GunTail_Medium</soundCastTail>
+      <muzzleFlashScale>9</muzzleFlashScale>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>30</magazineSize>
+      <reloadTime>4</reloadTime>
+      <ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aimedBurstShotCount>3</aimedBurstShotCount>
+      <aiUseBurstMode>TRUE</aiUseBurstMode>
+      <aiAimMode>AimedShot</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>CE_AI_AR</li>
+    </weaponTags>
+    <researchPrerequisite>PrecisionRifling</researchPrerequisite>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Gun_AssaultRifle"]</xpath>
+    <value>
+      <li Class="CombatExtended.GunDrawExtension">
+        <DrawSize>1.16,1.16</DrawSize>
+        <DrawOffset>0.08,0.0</DrawOffset>
+        <CasingOffset>-0.05,0</CasingOffset>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- ========== Sniper rifle ========== -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_SniperRifle</defName>
+    <statBases>
+      <Mass>7.30</Mass>
+      <RangedWeapon_Cooldown>1.36</RangedWeapon_Cooldown>
+      <SightsEfficiency>2.6</SightsEfficiency>
+      <ShotSpread>0.05</ShotSpread>
+      <SwayFactor>1.35</SwayFactor>
+      <Bulk>11.92</Bulk>
+      <WorkToMake>30000</WorkToMake>
+    </statBases>
+    <costList>
+      <Steel>60</Steel>
+      <ComponentIndustrial>5</ComponentIndustrial>
+      <Chemfuel>15</Chemfuel>
+    </costList>
+    <Properties>
+      <recoilAmount>1.50</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
+      <warmupTime>1.8</warmupTime>
+      <range>75</range>
+      <soundCast>Shot_SniperRifle</soundCast>
+      <soundCastTail>GunTail_Heavy</soundCastTail>
+      <muzzleFlashScale>9</muzzleFlashScale>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>5</magazineSize>
+      <reloadTime>4</reloadTime>
+      <ammoSet>AmmoSet_762x51mmNATO</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aiAimMode>AimedShot</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>CE_AI_SR</li>
+      <li>Bipod_DMR</li>
+    </weaponTags>
+    <researchPrerequisite>PrecisionRifling</researchPrerequisite>
+    <AllowWithRunAndGun>false</AllowWithRunAndGun>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Gun_SniperRifle"]</xpath>
+    <value>
+      <li Class="CombatExtended.GunDrawExtension">
+        <DrawSize>1.25,1.45</DrawSize>
+        <DrawOffset>0.15,-0.05</DrawOffset>
+        <CasingOffset>-0.3,0.1</CasingOffset>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- ========== Machine pistol ========== -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_MachinePistol</defName>
+    <statBases>
+      <Mass>2.84</Mass>
+      <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+      <SightsEfficiency>0.7</SightsEfficiency>
+      <ShotSpread>0.16</ShotSpread>
+      <SwayFactor>1.93</SwayFactor>
+      <Bulk>2.95</Bulk>
+      <WorkToMake>24500</WorkToMake>
+    </statBases>
+    <costList>
+      <Steel>35</Steel>
+      <ComponentIndustrial>3</ComponentIndustrial>
+    </costList>
+    <Properties>
+      <recoilAmount>1.71</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
+      <warmupTime>0.6</warmupTime>
+      <range>12</range>
+      <burstShotCount>6</burstShotCount>
+      <ticksBetweenBurstShots>3</ticksBetweenBurstShots>
+      <soundCast>Shot_MachinePistol</soundCast>
+      <soundCastTail>GunTail_Light</soundCastTail>
+      <muzzleFlashScale>9</muzzleFlashScale>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>30</magazineSize>
+      <reloadTime>4</reloadTime>
+      <ammoSet>AmmoSet_45ACP</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aimedBurstShotCount>3</aimedBurstShotCount>
+      <aiUseBurstMode>FALSE</aiUseBurstMode>
+      <aiAimMode>Snapshot</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>CE_SMG</li>
+      <li>CE_AI_BROOM</li>
+      <li>CE_OneHandedWeapon</li>
+    </weaponTags>
+    <researchPrerequisite>BlowbackOperation</researchPrerequisite>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Gun_MachinePistol"]</xpath>
+    <value>
+      <li Class="CombatExtended.GunDrawExtension">
+        <DrawSize>0.84,0.84</DrawSize>
+        <DrawOffset>-0.10,-0.07</DrawOffset>
+        <CasingOffset>0.1,0.1</CasingOffset>
+        <CasingAngleOffset>-30</CasingAngleOffset>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- ========== Heavy SMG ========== -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_HeavySMG</defName>
+    <statBases>
+      <Mass>2.50</Mass>
+      <RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+      <SightsEfficiency>1.00</SightsEfficiency>
+      <ShotSpread>0.14</ShotSpread>
+      <SwayFactor>0.94</SwayFactor>
+      <Bulk>4.50</Bulk>
+      <WorkToMake>24500</WorkToMake>
+    </statBases>
+    <costList>
+      <Steel>30</Steel>
+      <Chemfuel>10</Chemfuel>
+      <ComponentIndustrial>5</ComponentIndustrial>
+    </costList>
+    <Properties>
+      <recoilAmount>1.79</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
+      <warmupTime>0.6</warmupTime>
+      <range>25</range>
+      <burstShotCount>6</burstShotCount>
+      <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+      <soundCast>Shot_HeavySMG</soundCast>
+      <soundCastTail>GunTail_Heavy</soundCastTail>
+      <muzzleFlashScale>9</muzzleFlashScale>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>25</magazineSize>
+      <reloadTime>4</reloadTime>
+      <ammoSet>AmmoSet_45ACP</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aimedBurstShotCount>3</aimedBurstShotCount>
+      <aiUseBurstMode>FALSE</aiUseBurstMode>
+      <aiAimMode>Snapshot</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>CE_SMG</li>
+      <li>CE_AI_BROOM</li>
+    </weaponTags>
+    <researchPrerequisite>BlowbackOperation</researchPrerequisite>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Gun_HeavySMG"]</xpath>
+    <value>
+      <li Class="CombatExtended.GunDrawExtension">
+        <DrawSize>0.85,0.85</DrawSize>
+        <DrawOffset>0.00,-0.03</DrawOffset>
+        <CasingOffset>0.1,0</CasingOffset>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- ========== Incendiary launcher ========== -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_IncendiaryLauncher</defName>
+    <statBases>
+      <Mass>8</Mass>
+      <RangedWeapon_Cooldown>0.43</RangedWeapon_Cooldown>
+      <SightsEfficiency>1.1</SightsEfficiency>
+      <ShotSpread>0.15</ShotSpread>
+      <SwayFactor>1.8</SwayFactor>
+      <Bulk>10</Bulk>
+      <WorkToMake>35500</WorkToMake>
+    </statBases>
+    <costList>
+      <Steel>65</Steel>
+      <Plasteel>30</Plasteel>
+      <ComponentIndustrial>1</ComponentIndustrial>
+      <ComponentSpacer>1</ComponentSpacer>
+      <Chemfuel>10</Chemfuel>
+    </costList>
+    <Properties>
+      <recoilAmount>3.87</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_30x64mmFuel_Incendiary</defaultProjectile>
+      <warmupTime>1.0</warmupTime>
+      <range>40</range>
+      <soundCast>Shot_IncendiaryLauncher</soundCast>
+      <soundCastTail>GunTail_Medium</soundCastTail>
+      <muzzleFlashScale>9</muzzleFlashScale>
+      <targetParams>
+        <canTargetLocations>true</canTargetLocations>
+      </targetParams>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>5</magazineSize>
+      <reloadOneAtATime>true</reloadOneAtATime>
+      <reloadTime>0.85</reloadTime>
+      <ammoSet>AmmoSet_30x64mmFuel</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aiUseBurstMode>FALSE</aiUseBurstMode>
+      <aiAimMode>SuppressFire</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>CE_AI_AOE</li>
+      <li>EliteGun</li>
+    </weaponTags>
+    <researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
+    <AllowWithRunAndGun>false</AllowWithRunAndGun>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/ThingDef[defName="Gun_IncendiaryLauncher"]</xpath>
+    <value>
+      <techLevel>Spacer</techLevel>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Gun_IncendiaryLauncher"]</xpath>
+    <value>
+      <li Class="CombatExtended.GunDrawExtension">
+        <DrawSize>1.16,1.16</DrawSize>
+        <DrawOffset>0.1,-0.05</DrawOffset>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- ========== LMG ========== -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_LMG</defName>
+    <statBases>
+      <Mass>8.7</Mass>
+      <RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
+      <SightsEfficiency>1</SightsEfficiency>
+      <ShotSpread>0.05</ShotSpread>
+      <SwayFactor>1.37</SwayFactor>
+      <Bulk>12.9</Bulk>
+      <WorkToMake>31500</WorkToMake>
+    </statBases>
+    <costList>
+      <Steel>80</Steel>
+      <WoodLog>10</WoodLog>
+      <ComponentIndustrial>5</ComponentIndustrial>
+    </costList>
+    <Properties>
+      <recoilAmount>1.38</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_303British_FMJ</defaultProjectile>
+      <warmupTime>1.3</warmupTime>
+      <range>62</range>
+      <ticksBetweenBurstShots>7</ticksBetweenBurstShots>
+      <burstShotCount>10</burstShotCount>
+      <soundCast>Shot_CE_BattleRifle</soundCast>
+      <soundCastTail>GunTail_Medium</soundCastTail>
+      <muzzleFlashScale>9</muzzleFlashScale>
+      <targetParams>
+        <canTargetLocations>true</canTargetLocations>
+      </targetParams>
+      <recoilPattern>Mounted</recoilPattern>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>50</magazineSize>
+      <reloadTime>4.9</reloadTime>
+      <ammoSet>AmmoSet_303British</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aimedBurstShotCount>5</aimedBurstShotCount>
+      <aiUseBurstMode>FALSE</aiUseBurstMode>
+      <aiAimMode>SuppressFire</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>CE_MachineGun</li>
+      <li>CE_AI_LMG</li>
+      <li>Bipod_LMG</li>
+    </weaponTags>
+    <researchPrerequisite>GasOperation</researchPrerequisite>
+    <AllowWithRunAndGun>false</AllowWithRunAndGun>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Gun_LMG"]</xpath>
+    <value>
+      <li Class="CombatExtended.GunDrawExtension">
+        <DrawSize>1.35,1.18</DrawSize>
+        <DrawOffset>0.13,-0.03</DrawOffset>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- ========== Charge rifle ========== -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_ChargeRifle</defName>
+    <statBases>
+      <Mass>3.0</Mass>
+      <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+      <SightsEfficiency>1.10</SightsEfficiency>
+      <ShotSpread>0.08</ShotSpread>
+      <SwayFactor>1.20</SwayFactor>
+      <Bulk>7.00</Bulk>
+      <WorkToMake>49000</WorkToMake>
+    </statBases>
+    <costList>
+      <Steel>45</Steel>
+      <Plasteel>25</Plasteel>
+      <ComponentIndustrial>4</ComponentIndustrial>
+      <ComponentSpacer>1</ComponentSpacer>
+      <Chemfuel>10</Chemfuel>
+    </costList>
+    <Properties>
+      <recoilAmount>1.46</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_6x24mmCharged</defaultProjectile>
+      <warmupTime>1.0</warmupTime>
+      <range>55</range>
+      <ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+      <burstShotCount>6</burstShotCount>
+      <soundCast>Shot_ChargeRifle</soundCast>
+      <soundCastTail>GunTail_Medium</soundCastTail>
+      <muzzleFlashScale>9</muzzleFlashScale>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>30</magazineSize>
+      <reloadTime>4</reloadTime>
+      <ammoSet>AmmoSet_6x24mmCharged</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aimedBurstShotCount>3</aimedBurstShotCount>
+      <aiUseBurstMode>TRUE</aiUseBurstMode>
+      <aiAimMode>AimedShot</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>CE_AI_AR</li>
+      <li>AdvancedGun</li>
+    </weaponTags>
+    <researchPrerequisite>ChargedShot</researchPrerequisite>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Gun_ChargeRifle"]</xpath>
+    <value>
+      <li Class="CombatExtended.GunDrawExtension">
+        <DrawSize>1.03,1.03</DrawSize>
+        <DrawOffset>0.05,0.0</DrawOffset>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- ========== Improvised turret gun ========== -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_MiniTurret</defName>
+    <statBases>
+      <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+      <SightsEfficiency>1</SightsEfficiency>
+      <ShotSpread>0.07</ShotSpread>
+      <SwayFactor>0.67</SwayFactor>
+      <Mass>4</Mass>
+    </statBases>
+    <Properties>
+      <recoilAmount>1.02</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+      <warmupTime>1.3</warmupTime>
+      <range>48</range>
+      <ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+      <burstShotCount>10</burstShotCount>
+      <soundCast>GunShotA</soundCast>
+      <soundCastTail>GunTail_Light</soundCastTail>
+      <muzzleFlashScale>9</muzzleFlashScale>
+      <recoilPattern>Mounted</recoilPattern>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>100</magazineSize>
+      <reloadTime>7.8</reloadTime>
+      <ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aiAimMode>AimedShot</aiAimMode>
+      <noSnapshot>true</noSnapshot>
+      <noSingleShot>true</noSingleShot>
+    </FireModes>
+  </Operation>
+
+  <!-- ========== Minigun ========== -->
+
+  <Operation Class="PatchOperationRemove">
+    <xpath>Defs/ThingDef[defName ="Gun_Minigun"]/weaponTags/li[.="GunHeavy"]</xpath>
+  </Operation>
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_Minigun</defName>
+    <statBases>
+      <Mass>20.00</Mass>
+      <RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
+      <SightsEfficiency>1</SightsEfficiency>
+      <ShotSpread>0.06</ShotSpread>
+      <SwayFactor>3.22</SwayFactor>
+      <Bulk>10</Bulk>
+      <WorkToMake>52000</WorkToMake>
+    </statBases>
+    <costList>
+      <Steel>110</Steel>
+      <ComponentIndustrial>11</ComponentIndustrial>
+    </costList>
+    <Properties>
+      <recoilAmount>0.97</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
+      <warmupTime>2.1</warmupTime>
+      <range>62</range>
+      <burstShotCount>50</burstShotCount>
+      <ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+      <soundCast>Shot_Minigun</soundCast>
+      <soundCastTail>GunTail_Medium</soundCastTail>
+      <muzzleFlashScale>9</muzzleFlashScale>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>250</magazineSize>
+      <reloadTime>9.2</reloadTime>
+      <ammoSet>AmmoSet_762x51mmNATO</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aimedBurstShotCount>25</aimedBurstShotCount>
+      <aiAimMode>Snapshot</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>CE_AI_Suppressive</li>
+    </weaponTags>
+  </Operation>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Gun_Minigun"]/tools</xpath>
+    <value>
+      <tools>
+        <li Class="CombatExtended.ToolCE">
+          <label>barrels</label>
+          <capacities>
+            <li>Blunt</li>
+          </capacities>
+          <power>10</power>
+          <cooldownTime>2.44</cooldownTime>
+          <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+          <linkedBodyPartsGroup>Barrels</linkedBodyPartsGroup>
+        </li>
+      </tools>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationRemove">
+    <xpath>Defs/ThingDef[defName="Gun_Minigun"]/equippedStatOffsets</xpath>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Gun_Minigun"]</xpath>
+    <value>
+      <li Class="CombatExtended.GunDrawExtension">
+        <DrawSize>1.00,1.00</DrawSize>
+        <DrawOffset>0.1,-0.15</DrawOffset>
+        <CasingOffset>-0.2,-0.1</CasingOffset>
+        <CasingAngleOffset>-30</CasingAngleOffset>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- ========== Doomsday launcher ========== -->
+
+  <!-- Patch both launchers -->
+
+  <Operation Class="PatchOperationRemove">
+    <xpath>Defs/ThingDef[defName="Gun_DoomsdayRocket" or defName="Gun_TripleRocket"]/weaponTags/li[.="Gun"]</xpath>
+  </Operation>
+
+  <Operation Class="PatchOperationAttributeSet">
+    <xpath>Defs/ThingDef[defName="Gun_DoomsdayRocket" or defName="Gun_TripleRocket"]</xpath>
+    <attribute>ParentName</attribute>
+    <value>BaseMakeableGun</value>
+  </Operation>
+
+  <Operation Class="PatchOperationRemove">
+    <xpath>Defs/ThingDef[defName="Gun_DoomsdayRocket" or defName="Gun_TripleRocket"]/statBases/MarketValue</xpath>
+  </Operation>
+
+  <!-- Patch projectile -->
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Bullet_DoomsdayRocket"]/thingClass</xpath>
+    <value>
+      <thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Bullet_DoomsdayRocket"]/projectile</xpath>
+    <value>
+      <projectile Class="CombatExtended.ProjectilePropertiesCE">
+        <damageDef>Bomb</damageDef>
+        <damageAmountBase>250</damageAmountBase>
+        <explosionRadius>7.8</explosionRadius>
+        <suppressionFactor>3.0</suppressionFactor>
+        <dangerFactor>2.0</dangerFactor>
+        <speed>100</speed>
+      </projectile>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationConditional">
+    <xpath>Defs/ThingDef[defName="Bullet_DoomsdayRocket"]/comps</xpath>
+    <nomatch Class="PatchOperationAdd">
+      <xpath>Defs/ThingDef[defName="Bullet_DoomsdayRocket"]</xpath>
+      <value>
+        <comps />
+      </value>
+    </nomatch>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/ThingDef[defName="Bullet_DoomsdayRocket"]/comps</xpath>
+    <value>
+      <li Class="CombatExtended.CompProperties_Fragments">
+        <fragSpeedFactor>1</fragSpeedFactor>
+        <fragments>
+          <Fragment_Large>400</Fragment_Large>
+        </fragments>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- Patch stats -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_DoomsdayRocket</defName>
+    <statBases>
+      <Mass>20.00</Mass>
+      <RangedWeapon_Cooldown>1.5</RangedWeapon_Cooldown>
+      <SightsEfficiency>2.24</SightsEfficiency>
+      <ShotSpread>0.2</ShotSpread>
+      <SwayFactor>3.24</SwayFactor>
+      <Bulk>13.0</Bulk>
+      <WorkToMake>49500</WorkToMake>
+    </statBases>
+    <costList>
+      <Steel>125</Steel>
+      <ComponentIndustrial>8</ComponentIndustrial>
+      <FSX>5</FSX>
+    </costList>
+    <Properties>
+      <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_DoomsdayRocket</defaultProjectile>
+      <warmupTime>2.1</warmupTime>
+      <range>48</range>
+      <burstShotCount>1</burstShotCount>
+      <soundCast>InfernoCannon_Fire</soundCast>
+      <soundCastTail>GunTail_Heavy</soundCastTail>
+      <onlyManualCast>true</onlyManualCast>
+      <targetParams>
+        <canTargetLocations>true</canTargetLocations>
+      </targetParams>
+      <muzzleFlashScale>14</muzzleFlashScale>
+    </Properties>
+    <FireModes>
+      <aiAimMode>AimedShot</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>CE_AI_AOE</li>
+    </weaponTags>
+    <researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
+    <AllowWithRunAndGun>false</AllowWithRunAndGun>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Gun_DoomsdayRocket"]</xpath>
+    <value>
+      <li Class="CombatExtended.GunDrawExtension">
+        <DrawSize>1.45,1.45</DrawSize>
+        <DrawOffset>-0.15,0</DrawOffset>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- ========== Triple rocket launcher ========== -->
+
+  <!-- Patch projectile -->
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Bullet_Rocket"]/thingClass</xpath>
+    <value>
+      <thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Bullet_Rocket"]/projectile</xpath>
+    <value>
+      <projectile Class="CombatExtended.ProjectilePropertiesCE">
+        <damageDef>Bomb</damageDef>
+        <damageAmountBase>180</damageAmountBase>
+        <explosionRadius>3.0</explosionRadius>
+        <suppressionFactor>3.0</suppressionFactor>
+        <dangerFactor>2.0</dangerFactor>
+        <speed>100</speed>
+      </projectile>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationConditional">
+    <xpath>Defs/ThingDef[defName="Bullet_Rocket"]/comps</xpath>
+    <nomatch Class="PatchOperationAdd">
+      <xpath>Defs/ThingDef[defName="Bullet_Rocket"]</xpath>
+      <value>
+        <comps />
+      </value>
+    </nomatch>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/ThingDef[defName="Bullet_Rocket"]/comps</xpath>
+    <value>
+      <li Class="CombatExtended.CompProperties_Fragments">
+        <fragSpeedFactor>1</fragSpeedFactor>
+        <fragments>
+          <Fragment_Large>150</Fragment_Large>
+        </fragments>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- Patch stats -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_TripleRocket</defName>
+    <statBases>
+      <Mass>12.00</Mass>
+      <RangedWeapon_Cooldown>1.5</RangedWeapon_Cooldown>
+      <SightsEfficiency>1</SightsEfficiency>
+      <ShotSpread>0.2</ShotSpread>
+      <SwayFactor>2.20</SwayFactor>
+      <Bulk>13.00</Bulk>
+      <WorkToMake>43000</WorkToMake>
+    </statBases>
+    <costList>
+      <Steel>90</Steel>
+      <ComponentIndustrial>7</ComponentIndustrial>
+      <FSX>3</FSX>
+    </costList>
+    <Properties>
+      <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_Rocket</defaultProjectile>
+      <warmupTime>1.9</warmupTime>
+      <range>40</range>
+      <ticksBetweenBurstShots>20</ticksBetweenBurstShots>
+      <burstShotCount>3</burstShotCount>
+      <soundCast>InfernoCannon_Fire</soundCast>
+      <soundCastTail>GunTail_Heavy</soundCastTail>
+      <onlyManualCast>true</onlyManualCast>
+      <stopBurstWithoutLos>false</stopBurstWithoutLos>
+      <interruptibleBurst>false</interruptibleBurst>
+      <targetParams>
+        <canTargetLocations>true</canTargetLocations>
+      </targetParams>
+      <muzzleFlashScale>14</muzzleFlashScale>
+    </Properties>
+    <FireModes>
+      <aiAimMode>AimedShot</aiAimMode>
+      <noSingleShot>true</noSingleShot>
+    </FireModes>
+    <weaponTags>
+      <li>CE_AI_AOE</li>
+    </weaponTags>
+    <researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
+    <AllowWithRunAndGun>false</AllowWithRunAndGun>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Gun_TripleRocket"]</xpath>
+    <value>
+      <li Class="CombatExtended.GunDrawExtension">
+        <DrawSize>1.16,1.16</DrawSize>
+        <DrawOffset>-0.25,0</DrawOffset>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- ========== Heavy charge blaster ========== -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_ChargeBlasterHeavy</defName>
+    <statBases>
+      <Mass>35.00</Mass>
+      <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+      <SightsEfficiency>1</SightsEfficiency>
+      <ShotSpread>0.01</ShotSpread>
+      <SwayFactor>1.33</SwayFactor>
+      <Bulk>13.00</Bulk>
+    </statBases>
+    <Properties>
+      <recoilAmount>1.08</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_12x64mmCharged</defaultProjectile>
+      <warmupTime>1.3</warmupTime>
+      <range>75</range>
+      <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+      <burstShotCount>10</burstShotCount>
+      <soundCast>Shot_ChargeBlaster</soundCast>
+      <soundCastTail>GunTail_Heavy</soundCastTail>
+      <muzzleFlashScale>9</muzzleFlashScale>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>100</magazineSize>
+      <reloadTime>9.2</reloadTime>
+      <ammoSet>AmmoSet_12x64mmCharged</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aimedBurstShotCount>5</aimedBurstShotCount>
+      <aiAimMode>AimedShot</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>CE_AI_Suppressive</li>
+      <li>NoSwitch</li>
+    </weaponTags>
+  </Operation>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[@Name="Gun_ChargeBlasterHeavyBase"]/tools</xpath>
+    <value>
+      <tools>
+        <li Class="CombatExtended.ToolCE">
+          <label>barrel</label>
+          <capacities>
+            <li>Blunt</li>
+          </capacities>
+          <power>10</power>
+          <cooldownTime>2.44</cooldownTime>
+          <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+          <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+        </li>
+      </tools>
+    </value>
+  </Operation>
+
+  <!-- ========== Inferno cannon ========== -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_InfernoCannon</defName>
+    <statBases>
+      <Mass>50.00</Mass>
+      <RangedWeapon_Cooldown>2.59</RangedWeapon_Cooldown>
+      <SightsEfficiency>1</SightsEfficiency>
+      <ShotSpread>0.01</ShotSpread>
+      <SwayFactor>0.14</SwayFactor>
+      <Bulk>20.00</Bulk>
+    </statBases>
+    <Properties>
+      <recoilAmount>3.18</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>
+      <warmupTime>4.3</warmupTime>
+      <range>86</range>
+      <burstShotCount>1</burstShotCount>
+      <soundCast>InfernoCannon_Fire</soundCast>
+      <soundCastTail>GunTail_Light</soundCastTail>
+      <muzzleFlashScale>14</muzzleFlashScale>
+      <ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
+      <minRange>5</minRange>
+      <ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>1</magazineSize>
+      <AmmoGenPerMagOverride>2</AmmoGenPerMagOverride>
+      <reloadTime>1.6</reloadTime>
+      <ammoSet>AmmoSet_80x256mmFuel</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aiAimMode>AimedShot</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>CE_AI_Launcher</li>
+      <li>NoSwitch</li>
+    </weaponTags>
+  </Operation>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[@Name="Gun_InfernoCannonBase"]/tools</xpath>
+    <value>
+      <tools>
+        <li Class="CombatExtended.ToolCE">
+          <label>barrel</label>
+          <capacities>
+            <li>Blunt</li>
+          </capacities>
+          <power>10</power>
+          <cooldownTime>2.44</cooldownTime>
+          <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+          <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+        </li>
+      </tools>
+    </value>
+  </Operation>
+
+  <!-- ========== Thump cannon ========== -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_ThumpCannon</defName>
+    <statBases>
+      <Mass>75.00</Mass>
+      <RangedWeapon_Cooldown>2.2</RangedWeapon_Cooldown>
+      <SightsEfficiency>1</SightsEfficiency>
+      <ShotSpread>0.01</ShotSpread>
+      <SwayFactor>0.21</SwayFactor>
+      <Bulk>20.00</Bulk>
+    </statBases>
+    <Properties>
+      <recoilAmount>0.1</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_164x284mmDemo</defaultProjectile>
+      <warmupTime>3.3</warmupTime>
+      <range>42</range>
+      <burstShotCount>1</burstShotCount>
+      <soundCast>ThumpCannon_Fire</soundCast>
+      <soundCastTail>GunTail_Heavy</soundCastTail>
+      <muzzleFlashScale>14</muzzleFlashScale>
+      <ai_AvoidFriendlyFireRadius>3</ai_AvoidFriendlyFireRadius>
+      <minRange>4</minRange>
+      <ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>1</magazineSize>
+      <AmmoGenPerMagOverride>2</AmmoGenPerMagOverride>
+      <reloadTime>9.8</reloadTime>
+      <ammoSet>AmmoSet_164x284mmDemo</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aiAimMode>AimedShot</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>CE_AI_Launcher</li>
+      <li>NoSwitch</li>
+    </weaponTags>
+  </Operation>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Gun_ThumpCannon"]/tools</xpath>
+    <value>
+      <tools>
+        <li Class="CombatExtended.ToolCE">
+          <label>barrel</label>
+          <capacities>
+            <li>Blunt</li>
+          </capacities>
+          <power>10</power>
+          <cooldownTime>2.44</cooldownTime>
+          <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+          <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+        </li>
+      </tools>
+    </value>
+  </Operation>
+
+  <!-- ========== Charge lance ========== -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_ChargeLance</defName>
+    <statBases>
+      <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+      <SightsEfficiency>1</SightsEfficiency>
+      <ShotSpread>0.01</ShotSpread>
+      <SwayFactor>0.88</SwayFactor>
+      <Bulk>13.00</Bulk>
+    </statBases>
+    <Properties>
+      <recoilAmount>0.92</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_5x35mmCharged</defaultProjectile>
+      <warmupTime>1.3</warmupTime>
+      <range>62</range>
+      <soundCast>ChargeLance_Fire</soundCast>
+      <soundCastTail>GunTail_Heavy</soundCastTail>
+      <muzzleFlashScale>9</muzzleFlashScale>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>10</magazineSize>
+      <reloadTime>4</reloadTime>
+      <ammoSet>AmmoSet_5x35mmCharged</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aiAimMode>AimedShot</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>CE_AI_Rifle</li>
+      <li>NoSwitch</li>
+    </weaponTags>
+  </Operation>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Gun_ChargeLance"]/tools</xpath>
+    <value>
+      <tools>
+        <li Class="CombatExtended.ToolCE">
+          <label>barrel</label>
+          <capacities>
+            <li>Blunt</li>
+          </capacities>
+          <power>10</power>
+          <cooldownTime>2.44</cooldownTime>
+          <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+          <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+        </li>
+      </tools>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Gun_ChargeLance"]</xpath>
+    <value>
+      <li Class="CombatExtended.ThingDefExtensionCE">
+        <MenuHidden>True</MenuHidden>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- Disable for player -->
+  <Operation Class="PatchOperationAttributeSet">
+    <xpath>Defs/ThingDef[defName="Gun_ChargeLance"]</xpath>
+    <attribute>ParentName</attribute>
+    <value>BaseGun</value>
+  </Operation>
+
+  <Operation Class="PatchOperationRemove">
+    <xpath>Defs/ThingDef[defName="Gun_ChargeLance"]/costList</xpath>
+  </Operation>
+
+  <Operation Class="PatchOperationRemove">
+    <xpath>Defs/ThingDef[defName="Gun_ChargeLance"]/recipeMaker</xpath>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/ThingDef[defName="Gun_ChargeLance"]/statBases</xpath>
+    <value>
+      <MarketValue>1400</MarketValue>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/ThingDef[defName="Gun_ChargeLance"]</xpath>
+    <value>
+      <tradeability>None</tradeability>
+      <destroyOnDrop>True</destroyOnDrop>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationRemove">
+    <xpath>Defs/ThingDef[defName="Gun_ChargeLance"]/weaponTags/li[contains(.,"SpacerGun")]</xpath>
+  </Operation>
+
+  <!-- ========== Needle Gun ========== -->
+
+  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+    <defName>Gun_Needle</defName>
+    <statBases>
+      <RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
+      <SightsEfficiency>2.24</SightsEfficiency>
+      <ShotSpread>0.01</ShotSpread>
+      <SwayFactor>0.85</SwayFactor>
+      <Bulk>15.00</Bulk>
+    </statBases>
+    <Properties>
+      <recoilAmount>1.80</recoilAmount>
+      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <hasStandardCommand>true</hasStandardCommand>
+      <defaultProjectile>Bullet_5x50mmCaseless_Sabot</defaultProjectile>
+      <warmupTime>1.5</warmupTime>
+      <range>75</range>
+      <soundCast>Shot_NeedleGun</soundCast>
+      <soundCastTail>GunTail_Heavy</soundCastTail>
+      <muzzleFlashScale>9</muzzleFlashScale>
+    </Properties>
+    <AmmoUser>
+      <magazineSize>10</magazineSize>
+      <reloadTime>4</reloadTime>
+      <ammoSet>AmmoSet_5x50mmCaseless</ammoSet>
+    </AmmoUser>
+    <FireModes>
+      <aiAimMode>AimedShot</aiAimMode>
+    </FireModes>
+    <weaponTags>
+      <li>CE_AI_Rifle</li>
+      <li>NoSwitch</li>
+    </weaponTags>
+  </Operation>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Gun_Needle"]/tools</xpath>
+    <value>
+      <tools>
+        <li Class="CombatExtended.ToolCE">
+          <label>barrel</label>
+          <capacities>
+            <li>Blunt</li>
+          </capacities>
+          <power>10</power>
+          <cooldownTime>2.44</cooldownTime>
+          <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+          <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+        </li>
+      </tools>
+    </value>
+  </Operation>
+
+  <!-- Increase Orbital Bombardment Range -->
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="OrbitalTargeterBombardment" or defName="OrbitalTargeterPowerBeam"]/verbs/li/range</xpath>
+    <value>
+      <range>60</range>
+    </value>
+  </Operation>
+
+  <!-- Remove Smoke and EMP Launchers -->
+  <Operation Class="PatchOperationRemove">
+    <xpath>Defs/ThingDef[defName="Gun_SmokeLauncher"]</xpath>
+  </Operation>
+
+  <Operation Class="PatchOperationRemove">
+    <xpath>Defs/ThingDef[defName="Gun_EmpLauncher"]</xpath>
+  </Operation>
 
 </Patch>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -1,1515 +1,1515 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 
-  <Operation Class="PatchOperationAdd">
-    <xpath>Defs/ThingDef[defName="Gun_ChargeLance"]</xpath>
-    <value>
-      <relicChance>0</relicChance>
-    </value>
-  </Operation>
-
-  <Operation Class="PatchOperationAdd">
-    <xpath>Defs/ThingDef[@Name="BaseWeaponTurret"]</xpath>
-    <value>
-      <relicChance>0</relicChance>
-    </value>
-  </Operation>
-
-  <!-- ========== Tools ========== -->
-
-  <Operation Class="PatchOperationReplace">
-    <xpath>Defs/ThingDef[defName="Gun_Revolver" or defName="Gun_Autopistol" or defName="Gun_MachinePistol"]/tools</xpath>
-    <value>
-      <tools>
-        <li Class="CombatExtended.ToolCE">
-          <label>grip</label>
-          <capacities>
-            <li>Blunt</li>
-          </capacities>
-          <power>2</power>
-          <cooldownTime>1.54</cooldownTime>
-          <chanceFactor>1.5</chanceFactor>
-          <armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-          <linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-        </li>
-        <li Class="CombatExtended.ToolCE">
-          <label>muzzle</label>
-          <capacities>
-            <li>Poke</li>
-          </capacities>
-          <power>2</power>
-          <cooldownTime>1.54</cooldownTime>
-          <armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-          <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-        </li>
-      </tools>
-    </value>
-  </Operation>
-
-  <Operation Class="PatchOperationReplace">
-    <xpath>
-      Defs/ThingDef[
-      defName="Gun_PumpShotgun" or
-      defName="Gun_ChainShotgun" or
-      defName="Gun_BoltActionRifle" or
-      defName="Gun_AssaultRifle" or
-      defName="Gun_SniperRifle" or
-      defName="Gun_HeavySMG" or
-      defName="Gun_IncendiaryLauncher" or
-      defName="Gun_LMG" or
-      defName="Gun_ChargeRifle"
-      ]/tools
-    </xpath>
-    <value>
-      <tools>
-        <li Class="CombatExtended.ToolCE">
-          <label>stock</label>
-          <capacities>
-            <li>Blunt</li>
-          </capacities>
-          <power>8</power>
-          <cooldownTime>1.55</cooldownTime>
-          <chanceFactor>1.5</chanceFactor>
-          <armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-          <linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-        </li>
-        <li Class="CombatExtended.ToolCE">
-          <label>barrel</label>
-          <capacities>
-            <li>Blunt</li>
-          </capacities>
-          <power>5</power>
-          <cooldownTime>2.02</cooldownTime>
-          <armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-          <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-        </li>
-        <li Class="CombatExtended.ToolCE">
-          <label>muzzle</label>
-          <capacities>
-            <li>Poke</li>
-          </capacities>
-          <power>8</power>
-          <cooldownTime>1.55</cooldownTime>
-          <armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-          <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-        </li>
-      </tools>
-    </value>
-  </Operation>
-
-  <Operation Class="PatchOperationReplace">
-    <xpath>Defs/ThingDef[defName="Gun_TripleRocket" or defName="Gun_DoomsdayRocket"]/tools</xpath>
-    <value>
-      <tools>
-        <li Class="CombatExtended.ToolCE">
-          <label>barrel</label>
-          <capacities>
-            <li>Blunt</li>
-          </capacities>
-          <power>10</power>
-          <cooldownTime>2.44</cooldownTime>
-          <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-          <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-        </li>
-      </tools>
-    </value>
-  </Operation>
-
-  <!-- ========== Revolver ========== -->
-
-  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-    <defName>Gun_Revolver</defName>
-    <statBases>
-      <Mass>1.39</Mass>
-      <RangedWeapon_Cooldown>0.49</RangedWeapon_Cooldown>
-      <SightsEfficiency>0.7</SightsEfficiency>
-      <ShotSpread>0.18</ShotSpread>
-      <SwayFactor>1.27</SwayFactor>
-      <Bulk>2.41</Bulk>
-      <!-- <ToughnessRating>2.5</ToughnessRating> -->
-      <!-- Base toughness rating of a weapon -->
-      <WorkToMake>7000</WorkToMake>
-    </statBases>
-    <costList>
-      <Steel>30</Steel>
-      <ComponentIndustrial>2</ComponentIndustrial>
-    </costList>
-    <Properties>
-      <recoilAmount>2.96</recoilAmount>
-      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
-      <hasStandardCommand>true</hasStandardCommand>
-      <defaultProjectile>Bullet_44Magnum_FMJ</defaultProjectile>
-      <warmupTime>0.6</warmupTime>
-      <range>12</range>
-      <soundCast>Shot_Revolver</soundCast>
-      <soundCastTail>GunTail_Light</soundCastTail>
-      <muzzleFlashScale>9</muzzleFlashScale>
-    </Properties>
-    <AmmoUser>
-      <magazineSize>6</magazineSize>
-      <reloadTime>4.6</reloadTime>
-      <ammoSet>AmmoSet_44Magnum</ammoSet>
-    </AmmoUser>
-    <FireModes>
-      <aiUseBurstMode>FALSE</aiUseBurstMode>
-      <aiAimMode>Snapshot</aiAimMode>
-    </FireModes>
-    <weaponTags>
-      <li>CE_Sidearm</li>
-      <li>CE_AI_BROOM</li>
-      <li>CE_OneHandedWeapon</li>
-    </weaponTags>
-    <researchPrerequisite>Gunsmithing</researchPrerequisite>
-  </Operation>
-
-  <Operation Class="PatchOperationAddModExtension">
-    <xpath>Defs/ThingDef[defName="Gun_Revolver"]</xpath>
-    <value>
-      <li Class="CombatExtended.GunDrawExtension">
-        <DrawSize>1.00,1.00</DrawSize>
-        <DrawOffset>0.0,0.0</DrawOffset>
-      </li>
-    </value>
-  </Operation>
-
-  <!-- ========== Autopistol ========== -->
-
-  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-    <defName>Gun_Autopistol</defName>
-    <statBases>
-      <Mass>1.11</Mass>
-      <RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
-      <SightsEfficiency>0.7</SightsEfficiency>
-      <ShotSpread>0.17</ShotSpread>
-      <SwayFactor>1.07</SwayFactor>
-      <Bulk>2.10</Bulk>
-      <WorkToMake>7000</WorkToMake>
-    </statBases>
-    <costList>
-      <Steel>25</Steel>
-      <ComponentIndustrial>3</ComponentIndustrial>
-    </costList>
-    <Properties>
-      <recoilAmount>2.72</recoilAmount>
-      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
-      <hasStandardCommand>true</hasStandardCommand>
-      <defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
-      <warmupTime>0.6</warmupTime>
-      <range>12</range>
-      <soundCast>Shot_Autopistol</soundCast>
-      <soundCastTail>GunTail_Light</soundCastTail>
-      <muzzleFlashScale>9</muzzleFlashScale>
-    </Properties>
-    <AmmoUser>
-      <magazineSize>7</magazineSize>
-      <reloadTime>4</reloadTime>
-      <ammoSet>AmmoSet_45ACP</ammoSet>
-    </AmmoUser>
-    <FireModes>
-      <aiUseBurstMode>FALSE</aiUseBurstMode>
-      <aiAimMode>Snapshot</aiAimMode>
-    </FireModes>
-    <weaponTags>
-      <li>CE_Sidearm</li>
-      <li>CE_AI_BROOM</li>
-      <li>CE_OneHandedWeapon</li>
-    </weaponTags>
-    <researchPrerequisite>BlowbackOperation</researchPrerequisite>
-  </Operation>
-
-  <Operation Class="PatchOperationAddModExtension">
-    <xpath>Defs/ThingDef[defName="Gun_Autopistol"]</xpath>
-    <value>
-      <li Class="CombatExtended.GunDrawExtension">
-        <DrawSize>0.93,0.93</DrawSize>
-        <DrawOffset>0.0,0.0</DrawOffset>
-      </li>
-    </value>
-  </Operation>
-
-  <!-- ========== Pump Shotgun ========== -->
-
-  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-    <defName>Gun_PumpShotgun</defName>
-    <statBases>
-      <Mass>3.00</Mass>
-      <RangedWeapon_Cooldown>1.0</RangedWeapon_Cooldown>
-      <ShotSpread>0.14</ShotSpread>
-      <SwayFactor>1.20</SwayFactor>
-      <Bulk>9.0</Bulk>
-      <SightsEfficiency>1</SightsEfficiency>
-      <WorkToMake>9500</WorkToMake>
-    </statBases>
-    <costList>
-      <Steel>45</Steel>
-      <WoodLog>10</WoodLog>
-      <ComponentIndustrial>1</ComponentIndustrial>
-    </costList>
-    <Properties>
-      <recoilAmount>2.75</recoilAmount>
-      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
-      <hasStandardCommand>true</hasStandardCommand>
-      <defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
-      <warmupTime>0.6</warmupTime>
-      <range>16</range>
-      <soundCast>Shot_Shotgun</soundCast>
-      <soundCastTail>GunTail_Heavy</soundCastTail>
-      <muzzleFlashScale>9</muzzleFlashScale>
-    </Properties>
-    <AmmoUser>
-      <magazineSize>5</magazineSize>
-      <reloadOneAtATime>true</reloadOneAtATime>
-      <reloadTime>0.85</reloadTime>
-      <ammoSet>AmmoSet_12Gauge</ammoSet>
-    </AmmoUser>
-    <FireModes>
-      <aiAimMode>Snapshot</aiAimMode>
-    </FireModes>
-    <weaponTags>
-      <li>SimpleGun</li>
-      <li>CE_AI_BROOM</li>
-    </weaponTags>
-    <researchPrerequisite>Gunsmithing</researchPrerequisite>
-  </Operation>
-
-  <Operation Class="PatchOperationAddModExtension">
-    <xpath>Defs/ThingDef[defName="Gun_PumpShotgun"]</xpath>
-    <value>
-      <li Class="CombatExtended.GunDrawExtension">
-        <DrawSize>1.03,1.25</DrawSize>
-        <DrawOffset>0.05,0.0</DrawOffset>
-      </li>
-    </value>
-  </Operation>
-
-  <!-- ========== Chain Shotgun ========== -->
-
-  <Operation Class="PatchOperationReplace">
-    <xpath>Defs/ThingDef[defName="Gun_ChainShotgun"]/description</xpath>
-    <value>
-      <description>A magazine-fed semi-automatic shotgun. It has the same range as a typical shotgun, but is extraordinarily dangerous due to being semi-automatic.</description>
-    </value>
-  </Operation>
-
-  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-    <defName>Gun_ChainShotgun</defName>
-    <statBases>
-      <Mass>3.50</Mass>
-      <RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
-      <ShotSpread>0.15</ShotSpread>
-      <SwayFactor>1.26</SwayFactor>
-      <Bulk>6.7</Bulk>
-      <SightsEfficiency>1</SightsEfficiency>
-      <WorkToMake>22500</WorkToMake>
-    </statBases>
-    <costList>
-      <Steel>40</Steel>
-      <ComponentIndustrial>3</ComponentIndustrial>
-      <Chemfuel>10</Chemfuel>
-    </costList>
-    <Properties>
-      <recoilAmount>2.54</recoilAmount>
-      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
-      <hasStandardCommand>true</hasStandardCommand>
-      <defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
-      <warmupTime>0.6</warmupTime>
-      <range>16</range>
-      <soundCast>Shot_Shotgun_NoRack</soundCast>
-      <soundCastTail>GunTail_Heavy</soundCastTail>
-      <muzzleFlashScale>9</muzzleFlashScale>
-      <ticksBetweenBurstShots>15</ticksBetweenBurstShots>
-    </Properties>
-    <AmmoUser>
-      <magazineSize>8</magazineSize>
-      <reloadTime>4</reloadTime>
-      <ammoSet>AmmoSet_12Gauge</ammoSet>
-    </AmmoUser>
-    <FireModes>
-      <aiAimMode>Snapshot</aiAimMode>
-    </FireModes>
-    <weaponTags>
-      <li>CE_AI_BROOM</li>
-    </weaponTags>
-    <researchPrerequisite>GasOperation</researchPrerequisite>
-  </Operation>
-
-  <Operation Class="PatchOperationAddModExtension">
-    <xpath>Defs/ThingDef[defName="Gun_ChainShotgun"]</xpath>
-    <value>
-      <li Class="CombatExtended.GunDrawExtension">
-        <DrawSize>1.04,1.23</DrawSize>
-        <DrawOffset>0.05,-0.05</DrawOffset>
-        <CasingOffset>0,0.2</CasingOffset>
-        <CasingAngleOffset>-30</CasingAngleOffset>
-      </li>
-    </value>
-  </Operation>
-
-  <!-- ========== Bolt-action rifle ========== -->
-
-  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-    <defName>Gun_BoltActionRifle</defName>
-    <statBases>
-      <Mass>4.19</Mass>
-      <RangedWeapon_Cooldown>1.17</RangedWeapon_Cooldown>
-      <SightsEfficiency>1</SightsEfficiency>
-      <ShotSpread>0.02</ShotSpread>
-      <SwayFactor>1.68</SwayFactor>
-      <Bulk>12.60</Bulk>
-      <WorkToMake>12000</WorkToMake>
-    </statBases>
-    <costList>
-      <Steel>55</Steel>
-      <WoodLog>15</WoodLog>
-      <ComponentIndustrial>1</ComponentIndustrial>
-    </costList>
-    <Properties>
-      <recoilAmount>2.04</recoilAmount>
-      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
-      <hasStandardCommand>true</hasStandardCommand>
-      <defaultProjectile>Bullet_303British_FMJ</defaultProjectile>
-      <warmupTime>1.1</warmupTime>
-      <range>55</range>
-      <soundCast>Shot_BoltActionRifle</soundCast>
-      <soundCastTail>GunTail_Heavy</soundCastTail>
-      <muzzleFlashScale>9</muzzleFlashScale>
-    </Properties>
-    <AmmoUser>
-      <magazineSize>10</magazineSize>
-      <reloadTime>4.3</reloadTime>
-      <ammoSet>AmmoSet_303British</ammoSet>
-    </AmmoUser>
-    <FireModes>
-      <aiAimMode>AimedShot</aiAimMode>
-    </FireModes>
-    <weaponTags>
-      <li>SimpleGun</li>
-      <li>CE_AI_SR</li>
-    </weaponTags>
-    <researchPrerequisite>Gunsmithing</researchPrerequisite>
-    <AllowWithRunAndGun>false</AllowWithRunAndGun>
-  </Operation>
-
-  <Operation Class="PatchOperationAddModExtension">
-    <xpath>Defs/ThingDef[defName="Gun_BoltActionRifle"]</xpath>
-    <value>
-      <li Class="CombatExtended.GunDrawExtension">
-        <DrawSize>1.3,1.3</DrawSize>
-        <DrawOffset>0.12,0.04</DrawOffset>
-        <CasingOffset>-0.1,0.1</CasingOffset>
-      </li>
-    </value>
-  </Operation>
-
-  <!-- ========== Assault rifle ========== -->
-
-  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-    <defName>Gun_AssaultRifle</defName>
-    <statBases>
-      <Mass>3.26</Mass>
-      <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-      <SightsEfficiency>1</SightsEfficiency>
-      <ShotSpread>0.07</ShotSpread>
-      <SwayFactor>1.33</SwayFactor>
-      <Bulk>10.03</Bulk>
-      <WorkToMake>30000</WorkToMake>
-    </statBases>
-    <costList>
-      <Steel>50</Steel>
-      <ComponentIndustrial>5</ComponentIndustrial>
-      <Chemfuel>10</Chemfuel>
-    </costList>
-    <Properties>
-      <recoilAmount>1.50</recoilAmount>
-      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
-      <hasStandardCommand>true</hasStandardCommand>
-      <defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
-      <warmupTime>1.1</warmupTime>
-      <range>55</range>
-      <burstShotCount>6</burstShotCount>
-      <ticksBetweenBurstShots>4</ticksBetweenBurstShots>
-      <soundCast>Shot_AssaultRifle</soundCast>
-      <soundCastTail>GunTail_Medium</soundCastTail>
-      <muzzleFlashScale>9</muzzleFlashScale>
-    </Properties>
-    <AmmoUser>
-      <magazineSize>30</magazineSize>
-      <reloadTime>4</reloadTime>
-      <ammoSet>AmmoSet_556x45mmNATO</ammoSet>
-    </AmmoUser>
-    <FireModes>
-      <aimedBurstShotCount>3</aimedBurstShotCount>
-      <aiUseBurstMode>TRUE</aiUseBurstMode>
-      <aiAimMode>AimedShot</aiAimMode>
-    </FireModes>
-    <weaponTags>
-      <li>CE_AI_AR</li>
-    </weaponTags>
-    <researchPrerequisite>PrecisionRifling</researchPrerequisite>
-  </Operation>
-
-  <Operation Class="PatchOperationAddModExtension">
-    <xpath>Defs/ThingDef[defName="Gun_AssaultRifle"]</xpath>
-    <value>
-      <li Class="CombatExtended.GunDrawExtension">
-        <DrawSize>1.16,1.16</DrawSize>
-        <DrawOffset>0.08,0.0</DrawOffset>
-        <CasingOffset>-0.05,0</CasingOffset>
-      </li>
-    </value>
-  </Operation>
-
-  <!-- ========== Sniper rifle ========== -->
-
-  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-    <defName>Gun_SniperRifle</defName>
-    <statBases>
-      <Mass>7.30</Mass>
-      <RangedWeapon_Cooldown>1.36</RangedWeapon_Cooldown>
-      <SightsEfficiency>2.6</SightsEfficiency>
-      <ShotSpread>0.05</ShotSpread>
-      <SwayFactor>1.35</SwayFactor>
-      <Bulk>11.92</Bulk>
-      <WorkToMake>30000</WorkToMake>
-    </statBases>
-    <costList>
-      <Steel>60</Steel>
-      <ComponentIndustrial>5</ComponentIndustrial>
-      <Chemfuel>15</Chemfuel>
-    </costList>
-    <Properties>
-      <recoilAmount>1.50</recoilAmount>
-      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
-      <hasStandardCommand>true</hasStandardCommand>
-      <defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
-      <warmupTime>1.8</warmupTime>
-      <range>75</range>
-      <soundCast>Shot_SniperRifle</soundCast>
-      <soundCastTail>GunTail_Heavy</soundCastTail>
-      <muzzleFlashScale>9</muzzleFlashScale>
-    </Properties>
-    <AmmoUser>
-      <magazineSize>5</magazineSize>
-      <reloadTime>4</reloadTime>
-      <ammoSet>AmmoSet_762x51mmNATO</ammoSet>
-    </AmmoUser>
-    <FireModes>
-      <aiAimMode>AimedShot</aiAimMode>
-    </FireModes>
-    <weaponTags>
-      <li>CE_AI_SR</li>
-      <li>Bipod_DMR</li>
-    </weaponTags>
-    <researchPrerequisite>PrecisionRifling</researchPrerequisite>
-    <AllowWithRunAndGun>false</AllowWithRunAndGun>
-  </Operation>
-
-  <Operation Class="PatchOperationAddModExtension">
-    <xpath>Defs/ThingDef[defName="Gun_SniperRifle"]</xpath>
-    <value>
-      <li Class="CombatExtended.GunDrawExtension">
-        <DrawSize>1.25,1.45</DrawSize>
-        <DrawOffset>0.15,-0.05</DrawOffset>
-        <CasingOffset>-0.3,0.1</CasingOffset>
-      </li>
-    </value>
-  </Operation>
-
-  <!-- ========== Machine pistol ========== -->
-
-  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-    <defName>Gun_MachinePistol</defName>
-    <statBases>
-      <Mass>2.84</Mass>
-      <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-      <SightsEfficiency>0.7</SightsEfficiency>
-      <ShotSpread>0.16</ShotSpread>
-      <SwayFactor>1.93</SwayFactor>
-      <Bulk>2.95</Bulk>
-      <WorkToMake>24500</WorkToMake>
-    </statBases>
-    <costList>
-      <Steel>35</Steel>
-      <ComponentIndustrial>3</ComponentIndustrial>
-    </costList>
-    <Properties>
-      <recoilAmount>1.71</recoilAmount>
-      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
-      <hasStandardCommand>true</hasStandardCommand>
-      <defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
-      <warmupTime>0.6</warmupTime>
-      <range>12</range>
-      <burstShotCount>6</burstShotCount>
-      <ticksBetweenBurstShots>3</ticksBetweenBurstShots>
-      <soundCast>Shot_MachinePistol</soundCast>
-      <soundCastTail>GunTail_Light</soundCastTail>
-      <muzzleFlashScale>9</muzzleFlashScale>
-    </Properties>
-    <AmmoUser>
-      <magazineSize>30</magazineSize>
-      <reloadTime>4</reloadTime>
-      <ammoSet>AmmoSet_45ACP</ammoSet>
-    </AmmoUser>
-    <FireModes>
-      <aimedBurstShotCount>3</aimedBurstShotCount>
-      <aiUseBurstMode>FALSE</aiUseBurstMode>
-      <aiAimMode>Snapshot</aiAimMode>
-    </FireModes>
-    <weaponTags>
-      <li>CE_SMG</li>
-      <li>CE_AI_BROOM</li>
-      <li>CE_OneHandedWeapon</li>
-    </weaponTags>
-    <researchPrerequisite>BlowbackOperation</researchPrerequisite>
-  </Operation>
-
-  <Operation Class="PatchOperationAddModExtension">
-    <xpath>Defs/ThingDef[defName="Gun_MachinePistol"]</xpath>
-    <value>
-      <li Class="CombatExtended.GunDrawExtension">
-        <DrawSize>0.84,0.84</DrawSize>
-        <DrawOffset>-0.10,-0.07</DrawOffset>
-        <CasingOffset>0.1,0.1</CasingOffset>
-        <CasingAngleOffset>-30</CasingAngleOffset>
-      </li>
-    </value>
-  </Operation>
-
-  <!-- ========== Heavy SMG ========== -->
-
-  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-    <defName>Gun_HeavySMG</defName>
-    <statBases>
-      <Mass>2.50</Mass>
-      <RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
-      <SightsEfficiency>1.00</SightsEfficiency>
-      <ShotSpread>0.14</ShotSpread>
-      <SwayFactor>0.94</SwayFactor>
-      <Bulk>4.50</Bulk>
-      <WorkToMake>24500</WorkToMake>
-    </statBases>
-    <costList>
-      <Steel>30</Steel>
-      <Chemfuel>10</Chemfuel>
-      <ComponentIndustrial>5</ComponentIndustrial>
-    </costList>
-    <Properties>
-      <recoilAmount>1.79</recoilAmount>
-      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
-      <hasStandardCommand>true</hasStandardCommand>
-      <defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
-      <warmupTime>0.6</warmupTime>
-      <range>25</range>
-      <burstShotCount>6</burstShotCount>
-      <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
-      <soundCast>Shot_HeavySMG</soundCast>
-      <soundCastTail>GunTail_Heavy</soundCastTail>
-      <muzzleFlashScale>9</muzzleFlashScale>
-    </Properties>
-    <AmmoUser>
-      <magazineSize>25</magazineSize>
-      <reloadTime>4</reloadTime>
-      <ammoSet>AmmoSet_45ACP</ammoSet>
-    </AmmoUser>
-    <FireModes>
-      <aimedBurstShotCount>3</aimedBurstShotCount>
-      <aiUseBurstMode>FALSE</aiUseBurstMode>
-      <aiAimMode>Snapshot</aiAimMode>
-    </FireModes>
-    <weaponTags>
-      <li>CE_SMG</li>
-      <li>CE_AI_BROOM</li>
-    </weaponTags>
-    <researchPrerequisite>BlowbackOperation</researchPrerequisite>
-  </Operation>
-
-  <Operation Class="PatchOperationAddModExtension">
-    <xpath>Defs/ThingDef[defName="Gun_HeavySMG"]</xpath>
-    <value>
-      <li Class="CombatExtended.GunDrawExtension">
-        <DrawSize>0.85,0.85</DrawSize>
-        <DrawOffset>0.00,-0.03</DrawOffset>
-        <CasingOffset>0.1,0</CasingOffset>
-      </li>
-    </value>
-  </Operation>
-
-  <!-- ========== Incendiary launcher ========== -->
-
-  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-    <defName>Gun_IncendiaryLauncher</defName>
-    <statBases>
-      <Mass>8</Mass>
-      <RangedWeapon_Cooldown>0.43</RangedWeapon_Cooldown>
-      <SightsEfficiency>1.1</SightsEfficiency>
-      <ShotSpread>0.15</ShotSpread>
-      <SwayFactor>1.8</SwayFactor>
-      <Bulk>10</Bulk>
-      <WorkToMake>35500</WorkToMake>
-    </statBases>
-    <costList>
-      <Steel>65</Steel>
-      <Plasteel>30</Plasteel>
-      <ComponentIndustrial>1</ComponentIndustrial>
-      <ComponentSpacer>1</ComponentSpacer>
-      <Chemfuel>10</Chemfuel>
-    </costList>
-    <Properties>
-      <recoilAmount>3.87</recoilAmount>
-      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
-      <hasStandardCommand>true</hasStandardCommand>
-      <defaultProjectile>Bullet_30x64mmFuel_Incendiary</defaultProjectile>
-      <warmupTime>1.0</warmupTime>
-      <range>40</range>
-      <soundCast>Shot_IncendiaryLauncher</soundCast>
-      <soundCastTail>GunTail_Medium</soundCastTail>
-      <muzzleFlashScale>9</muzzleFlashScale>
-      <targetParams>
-        <canTargetLocations>true</canTargetLocations>
-      </targetParams>
-    </Properties>
-    <AmmoUser>
-      <magazineSize>5</magazineSize>
-      <reloadOneAtATime>true</reloadOneAtATime>
-      <reloadTime>0.85</reloadTime>
-      <ammoSet>AmmoSet_30x64mmFuel</ammoSet>
-    </AmmoUser>
-    <FireModes>
-      <aiUseBurstMode>FALSE</aiUseBurstMode>
-      <aiAimMode>SuppressFire</aiAimMode>
-    </FireModes>
-    <weaponTags>
-      <li>CE_AI_AOE</li>
-      <li>EliteGun</li>
-    </weaponTags>
-    <researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
-    <AllowWithRunAndGun>false</AllowWithRunAndGun>
-  </Operation>
-
-  <Operation Class="PatchOperationAdd">
-    <xpath>Defs/ThingDef[defName="Gun_IncendiaryLauncher"]</xpath>
-    <value>
-      <techLevel>Spacer</techLevel>
-    </value>
-  </Operation>
-
-  <Operation Class="PatchOperationAddModExtension">
-    <xpath>Defs/ThingDef[defName="Gun_IncendiaryLauncher"]</xpath>
-    <value>
-      <li Class="CombatExtended.GunDrawExtension">
-        <DrawSize>1.16,1.16</DrawSize>
-        <DrawOffset>0.1,-0.05</DrawOffset>
-      </li>
-    </value>
-  </Operation>
-
-  <!-- ========== LMG ========== -->
-
-  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-    <defName>Gun_LMG</defName>
-    <statBases>
-      <Mass>8.7</Mass>
-      <RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
-      <SightsEfficiency>1</SightsEfficiency>
-      <ShotSpread>0.05</ShotSpread>
-      <SwayFactor>1.37</SwayFactor>
-      <Bulk>12.9</Bulk>
-      <WorkToMake>31500</WorkToMake>
-    </statBases>
-    <costList>
-      <Steel>80</Steel>
-      <WoodLog>10</WoodLog>
-      <ComponentIndustrial>5</ComponentIndustrial>
-    </costList>
-    <Properties>
-      <recoilAmount>1.38</recoilAmount>
-      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
-      <hasStandardCommand>true</hasStandardCommand>
-      <defaultProjectile>Bullet_303British_FMJ</defaultProjectile>
-      <warmupTime>1.3</warmupTime>
-      <range>62</range>
-      <ticksBetweenBurstShots>7</ticksBetweenBurstShots>
-      <burstShotCount>10</burstShotCount>
-      <soundCast>Shot_CE_BattleRifle</soundCast>
-      <soundCastTail>GunTail_Medium</soundCastTail>
-      <muzzleFlashScale>9</muzzleFlashScale>
-      <targetParams>
-        <canTargetLocations>true</canTargetLocations>
-      </targetParams>
-      <recoilPattern>Mounted</recoilPattern>
-    </Properties>
-    <AmmoUser>
-      <magazineSize>50</magazineSize>
-      <reloadTime>4.9</reloadTime>
-      <ammoSet>AmmoSet_303British</ammoSet>
-    </AmmoUser>
-    <FireModes>
-      <aimedBurstShotCount>5</aimedBurstShotCount>
-      <aiUseBurstMode>FALSE</aiUseBurstMode>
-      <aiAimMode>SuppressFire</aiAimMode>
-    </FireModes>
-    <weaponTags>
-      <li>CE_MachineGun</li>
-      <li>CE_AI_LMG</li>
-      <li>Bipod_LMG</li>
-    </weaponTags>
-    <researchPrerequisite>GasOperation</researchPrerequisite>
-    <AllowWithRunAndGun>false</AllowWithRunAndGun>
-  </Operation>
-
-  <Operation Class="PatchOperationAddModExtension">
-    <xpath>Defs/ThingDef[defName="Gun_LMG"]</xpath>
-    <value>
-      <li Class="CombatExtended.GunDrawExtension">
-        <DrawSize>1.35,1.18</DrawSize>
-        <DrawOffset>0.13,-0.03</DrawOffset>
-      </li>
-    </value>
-  </Operation>
-
-  <!-- ========== Charge rifle ========== -->
-
-  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-    <defName>Gun_ChargeRifle</defName>
-    <statBases>
-      <Mass>3.0</Mass>
-      <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-      <SightsEfficiency>1.10</SightsEfficiency>
-      <ShotSpread>0.08</ShotSpread>
-      <SwayFactor>1.20</SwayFactor>
-      <Bulk>7.00</Bulk>
-      <WorkToMake>49000</WorkToMake>
-    </statBases>
-    <costList>
-      <Steel>45</Steel>
-      <Plasteel>25</Plasteel>
-      <ComponentIndustrial>4</ComponentIndustrial>
-      <ComponentSpacer>1</ComponentSpacer>
-      <Chemfuel>10</Chemfuel>
-    </costList>
-    <Properties>
-      <recoilAmount>1.46</recoilAmount>
-      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
-      <hasStandardCommand>true</hasStandardCommand>
-      <defaultProjectile>Bullet_6x24mmCharged</defaultProjectile>
-      <warmupTime>1.0</warmupTime>
-      <range>55</range>
-      <ticksBetweenBurstShots>5</ticksBetweenBurstShots>
-      <burstShotCount>6</burstShotCount>
-      <soundCast>Shot_ChargeRifle</soundCast>
-      <soundCastTail>GunTail_Medium</soundCastTail>
-      <muzzleFlashScale>9</muzzleFlashScale>
-    </Properties>
-    <AmmoUser>
-      <magazineSize>30</magazineSize>
-      <reloadTime>4</reloadTime>
-      <ammoSet>AmmoSet_6x24mmCharged</ammoSet>
-    </AmmoUser>
-    <FireModes>
-      <aimedBurstShotCount>3</aimedBurstShotCount>
-      <aiUseBurstMode>TRUE</aiUseBurstMode>
-      <aiAimMode>AimedShot</aiAimMode>
-    </FireModes>
-    <weaponTags>
-      <li>CE_AI_AR</li>
-      <li>AdvancedGun</li>
-    </weaponTags>
-    <researchPrerequisite>ChargedShot</researchPrerequisite>
-  </Operation>
-
-  <Operation Class="PatchOperationAddModExtension">
-    <xpath>Defs/ThingDef[defName="Gun_ChargeRifle"]</xpath>
-    <value>
-      <li Class="CombatExtended.GunDrawExtension">
-        <DrawSize>1.03,1.03</DrawSize>
-        <DrawOffset>0.05,0.0</DrawOffset>
-      </li>
-    </value>
-  </Operation>
-
-  <!-- ========== Improvised turret gun ========== -->
-
-  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-    <defName>Gun_MiniTurret</defName>
-    <statBases>
-      <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-      <SightsEfficiency>1</SightsEfficiency>
-      <ShotSpread>0.07</ShotSpread>
-      <SwayFactor>0.67</SwayFactor>
-      <Mass>4</Mass>
-    </statBases>
-    <Properties>
-      <recoilAmount>1.02</recoilAmount>
-      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
-      <hasStandardCommand>true</hasStandardCommand>
-      <defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
-      <warmupTime>1.3</warmupTime>
-      <range>48</range>
-      <ticksBetweenBurstShots>5</ticksBetweenBurstShots>
-      <burstShotCount>10</burstShotCount>
-      <soundCast>GunShotA</soundCast>
-      <soundCastTail>GunTail_Light</soundCastTail>
-      <muzzleFlashScale>9</muzzleFlashScale>
-      <recoilPattern>Mounted</recoilPattern>
-    </Properties>
-    <AmmoUser>
-      <magazineSize>100</magazineSize>
-      <reloadTime>7.8</reloadTime>
-      <ammoSet>AmmoSet_556x45mmNATO</ammoSet>
-    </AmmoUser>
-    <FireModes>
-      <aiAimMode>AimedShot</aiAimMode>
-      <noSnapshot>true</noSnapshot>
-      <noSingleShot>true</noSingleShot>
-    </FireModes>
-  </Operation>
-
-  <!-- ========== Minigun ========== -->
-
-  <Operation Class="PatchOperationRemove">
-    <xpath>Defs/ThingDef[defName ="Gun_Minigun"]/weaponTags/li[.="GunHeavy"]</xpath>
-  </Operation>
-
-  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-    <defName>Gun_Minigun</defName>
-    <statBases>
-      <Mass>20.00</Mass>
-      <RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
-      <SightsEfficiency>1</SightsEfficiency>
-      <ShotSpread>0.06</ShotSpread>
-      <SwayFactor>3.22</SwayFactor>
-      <Bulk>10</Bulk>
-      <WorkToMake>52000</WorkToMake>
-    </statBases>
-    <costList>
-      <Steel>110</Steel>
-      <ComponentIndustrial>11</ComponentIndustrial>
-    </costList>
-    <Properties>
-      <recoilAmount>0.97</recoilAmount>
-      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
-      <hasStandardCommand>true</hasStandardCommand>
-      <defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
-      <warmupTime>2.1</warmupTime>
-      <range>62</range>
-      <burstShotCount>50</burstShotCount>
-      <ticksBetweenBurstShots>2</ticksBetweenBurstShots>
-      <soundCast>Shot_Minigun</soundCast>
-      <soundCastTail>GunTail_Medium</soundCastTail>
-      <muzzleFlashScale>9</muzzleFlashScale>
-    </Properties>
-    <AmmoUser>
-      <magazineSize>250</magazineSize>
-      <reloadTime>9.2</reloadTime>
-      <ammoSet>AmmoSet_762x51mmNATO</ammoSet>
-    </AmmoUser>
-    <FireModes>
-      <aimedBurstShotCount>25</aimedBurstShotCount>
-      <aiAimMode>Snapshot</aiAimMode>
-    </FireModes>
-    <weaponTags>
-      <li>CE_AI_Suppressive</li>
-    </weaponTags>
-  </Operation>
-
-  <Operation Class="PatchOperationReplace">
-    <xpath>Defs/ThingDef[defName="Gun_Minigun"]/tools</xpath>
-    <value>
-      <tools>
-        <li Class="CombatExtended.ToolCE">
-          <label>barrels</label>
-          <capacities>
-            <li>Blunt</li>
-          </capacities>
-          <power>10</power>
-          <cooldownTime>2.44</cooldownTime>
-          <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-          <linkedBodyPartsGroup>Barrels</linkedBodyPartsGroup>
-        </li>
-      </tools>
-    </value>
-  </Operation>
-
-  <Operation Class="PatchOperationRemove">
-    <xpath>Defs/ThingDef[defName="Gun_Minigun"]/equippedStatOffsets</xpath>
-  </Operation>
-
-  <Operation Class="PatchOperationAddModExtension">
-    <xpath>Defs/ThingDef[defName="Gun_Minigun"]</xpath>
-    <value>
-      <li Class="CombatExtended.GunDrawExtension">
-        <DrawSize>1.00,1.00</DrawSize>
-        <DrawOffset>0.1,-0.15</DrawOffset>
-        <CasingOffset>-0.2,-0.1</CasingOffset>
-        <CasingAngleOffset>-30</CasingAngleOffset>
-      </li>
-    </value>
-  </Operation>
-
-  <!-- ========== Doomsday launcher ========== -->
-
-  <!-- Patch both launchers -->
-
-  <Operation Class="PatchOperationRemove">
-    <xpath>Defs/ThingDef[defName="Gun_DoomsdayRocket" or defName="Gun_TripleRocket"]/weaponTags/li[.="Gun"]</xpath>
-  </Operation>
-
-  <Operation Class="PatchOperationAttributeSet">
-    <xpath>Defs/ThingDef[defName="Gun_DoomsdayRocket" or defName="Gun_TripleRocket"]</xpath>
-    <attribute>ParentName</attribute>
-    <value>BaseMakeableGun</value>
-  </Operation>
-
-  <Operation Class="PatchOperationRemove">
-    <xpath>Defs/ThingDef[defName="Gun_DoomsdayRocket" or defName="Gun_TripleRocket"]/statBases/MarketValue</xpath>
-  </Operation>
-
-  <!-- Patch projectile -->
-
-  <Operation Class="PatchOperationReplace">
-    <xpath>Defs/ThingDef[defName="Bullet_DoomsdayRocket"]/thingClass</xpath>
-    <value>
-      <thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
-    </value>
-  </Operation>
-
-  <Operation Class="PatchOperationReplace">
-    <xpath>Defs/ThingDef[defName="Bullet_DoomsdayRocket"]/projectile</xpath>
-    <value>
-      <projectile Class="CombatExtended.ProjectilePropertiesCE">
-        <damageDef>Bomb</damageDef>
-        <damageAmountBase>250</damageAmountBase>
-        <explosionRadius>7.8</explosionRadius>
-        <suppressionFactor>3.0</suppressionFactor>
-        <dangerFactor>2.0</dangerFactor>
-        <speed>100</speed>
-      </projectile>
-    </value>
-  </Operation>
-
-  <Operation Class="PatchOperationConditional">
-    <xpath>Defs/ThingDef[defName="Bullet_DoomsdayRocket"]/comps</xpath>
-    <nomatch Class="PatchOperationAdd">
-      <xpath>Defs/ThingDef[defName="Bullet_DoomsdayRocket"]</xpath>
-      <value>
-        <comps />
-      </value>
-    </nomatch>
-  </Operation>
-
-  <Operation Class="PatchOperationAdd">
-    <xpath>Defs/ThingDef[defName="Bullet_DoomsdayRocket"]/comps</xpath>
-    <value>
-      <li Class="CombatExtended.CompProperties_Fragments">
-        <fragSpeedFactor>1</fragSpeedFactor>
-        <fragments>
-          <Fragment_Large>400</Fragment_Large>
-        </fragments>
-      </li>
-    </value>
-  </Operation>
-
-  <!-- Patch stats -->
-
-  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-    <defName>Gun_DoomsdayRocket</defName>
-    <statBases>
-      <Mass>20.00</Mass>
-      <RangedWeapon_Cooldown>1.5</RangedWeapon_Cooldown>
-      <SightsEfficiency>2.24</SightsEfficiency>
-      <ShotSpread>0.2</ShotSpread>
-      <SwayFactor>3.24</SwayFactor>
-      <Bulk>13.0</Bulk>
-      <WorkToMake>49500</WorkToMake>
-    </statBases>
-    <costList>
-      <Steel>125</Steel>
-      <ComponentIndustrial>8</ComponentIndustrial>
-      <FSX>5</FSX>
-    </costList>
-    <Properties>
-      <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
-      <hasStandardCommand>true</hasStandardCommand>
-      <defaultProjectile>Bullet_DoomsdayRocket</defaultProjectile>
-      <warmupTime>2.1</warmupTime>
-      <range>48</range>
-      <burstShotCount>1</burstShotCount>
-      <soundCast>InfernoCannon_Fire</soundCast>
-      <soundCastTail>GunTail_Heavy</soundCastTail>
-      <onlyManualCast>true</onlyManualCast>
-      <targetParams>
-        <canTargetLocations>true</canTargetLocations>
-      </targetParams>
-      <muzzleFlashScale>14</muzzleFlashScale>
-    </Properties>
-    <FireModes>
-      <aiAimMode>AimedShot</aiAimMode>
-    </FireModes>
-    <weaponTags>
-      <li>CE_AI_AOE</li>
-    </weaponTags>
-    <researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
-    <AllowWithRunAndGun>false</AllowWithRunAndGun>
-  </Operation>
-
-  <Operation Class="PatchOperationAddModExtension">
-    <xpath>Defs/ThingDef[defName="Gun_DoomsdayRocket"]</xpath>
-    <value>
-      <li Class="CombatExtended.GunDrawExtension">
-        <DrawSize>1.45,1.45</DrawSize>
-        <DrawOffset>-0.15,0</DrawOffset>
-      </li>
-    </value>
-  </Operation>
-
-  <!-- ========== Triple rocket launcher ========== -->
-
-  <!-- Patch projectile -->
-
-  <Operation Class="PatchOperationReplace">
-    <xpath>Defs/ThingDef[defName="Bullet_Rocket"]/thingClass</xpath>
-    <value>
-      <thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
-    </value>
-  </Operation>
-
-  <Operation Class="PatchOperationReplace">
-    <xpath>Defs/ThingDef[defName="Bullet_Rocket"]/projectile</xpath>
-    <value>
-      <projectile Class="CombatExtended.ProjectilePropertiesCE">
-        <damageDef>Bomb</damageDef>
-        <damageAmountBase>180</damageAmountBase>
-        <explosionRadius>3.0</explosionRadius>
-        <suppressionFactor>3.0</suppressionFactor>
-        <dangerFactor>2.0</dangerFactor>
-        <speed>100</speed>
-      </projectile>
-    </value>
-  </Operation>
-
-  <Operation Class="PatchOperationConditional">
-    <xpath>Defs/ThingDef[defName="Bullet_Rocket"]/comps</xpath>
-    <nomatch Class="PatchOperationAdd">
-      <xpath>Defs/ThingDef[defName="Bullet_Rocket"]</xpath>
-      <value>
-        <comps />
-      </value>
-    </nomatch>
-  </Operation>
-
-  <Operation Class="PatchOperationAdd">
-    <xpath>Defs/ThingDef[defName="Bullet_Rocket"]/comps</xpath>
-    <value>
-      <li Class="CombatExtended.CompProperties_Fragments">
-        <fragSpeedFactor>1</fragSpeedFactor>
-        <fragments>
-          <Fragment_Large>150</Fragment_Large>
-        </fragments>
-      </li>
-    </value>
-  </Operation>
-
-  <!-- Patch stats -->
-
-  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-    <defName>Gun_TripleRocket</defName>
-    <statBases>
-      <Mass>12.00</Mass>
-      <RangedWeapon_Cooldown>1.5</RangedWeapon_Cooldown>
-      <SightsEfficiency>1</SightsEfficiency>
-      <ShotSpread>0.2</ShotSpread>
-      <SwayFactor>2.20</SwayFactor>
-      <Bulk>13.00</Bulk>
-      <WorkToMake>43000</WorkToMake>
-    </statBases>
-    <costList>
-      <Steel>90</Steel>
-      <ComponentIndustrial>7</ComponentIndustrial>
-      <FSX>3</FSX>
-    </costList>
-    <Properties>
-      <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
-      <hasStandardCommand>true</hasStandardCommand>
-      <defaultProjectile>Bullet_Rocket</defaultProjectile>
-      <warmupTime>1.9</warmupTime>
-      <range>40</range>
-      <ticksBetweenBurstShots>20</ticksBetweenBurstShots>
-      <burstShotCount>3</burstShotCount>
-      <soundCast>InfernoCannon_Fire</soundCast>
-      <soundCastTail>GunTail_Heavy</soundCastTail>
-      <onlyManualCast>true</onlyManualCast>
-      <stopBurstWithoutLos>false</stopBurstWithoutLos>
-      <interruptibleBurst>false</interruptibleBurst>
-      <targetParams>
-        <canTargetLocations>true</canTargetLocations>
-      </targetParams>
-      <muzzleFlashScale>14</muzzleFlashScale>
-    </Properties>
-    <FireModes>
-      <aiAimMode>AimedShot</aiAimMode>
-      <noSingleShot>true</noSingleShot>
-    </FireModes>
-    <weaponTags>
-      <li>CE_AI_AOE</li>
-    </weaponTags>
-    <researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
-    <AllowWithRunAndGun>false</AllowWithRunAndGun>
-  </Operation>
-
-  <Operation Class="PatchOperationAddModExtension">
-    <xpath>Defs/ThingDef[defName="Gun_TripleRocket"]</xpath>
-    <value>
-      <li Class="CombatExtended.GunDrawExtension">
-        <DrawSize>1.16,1.16</DrawSize>
-        <DrawOffset>-0.25,0</DrawOffset>
-      </li>
-    </value>
-  </Operation>
-
-  <!-- ========== Heavy charge blaster ========== -->
-
-  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-    <defName>Gun_ChargeBlasterHeavy</defName>
-    <statBases>
-      <Mass>35.00</Mass>
-      <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-      <SightsEfficiency>1</SightsEfficiency>
-      <ShotSpread>0.01</ShotSpread>
-      <SwayFactor>1.33</SwayFactor>
-      <Bulk>13.00</Bulk>
-    </statBases>
-    <Properties>
-      <recoilAmount>1.08</recoilAmount>
-      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
-      <hasStandardCommand>true</hasStandardCommand>
-      <defaultProjectile>Bullet_12x64mmCharged</defaultProjectile>
-      <warmupTime>1.3</warmupTime>
-      <range>75</range>
-      <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
-      <burstShotCount>10</burstShotCount>
-      <soundCast>Shot_ChargeBlaster</soundCast>
-      <soundCastTail>GunTail_Heavy</soundCastTail>
-      <muzzleFlashScale>9</muzzleFlashScale>
-    </Properties>
-    <AmmoUser>
-      <magazineSize>100</magazineSize>
-      <reloadTime>9.2</reloadTime>
-      <ammoSet>AmmoSet_12x64mmCharged</ammoSet>
-    </AmmoUser>
-    <FireModes>
-      <aimedBurstShotCount>5</aimedBurstShotCount>
-      <aiAimMode>AimedShot</aiAimMode>
-    </FireModes>
-    <weaponTags>
-      <li>CE_AI_Suppressive</li>
-      <li>NoSwitch</li>
-    </weaponTags>
-  </Operation>
-
-  <Operation Class="PatchOperationReplace">
-    <xpath>Defs/ThingDef[@Name="Gun_ChargeBlasterHeavyBase"]/tools</xpath>
-    <value>
-      <tools>
-        <li Class="CombatExtended.ToolCE">
-          <label>barrel</label>
-          <capacities>
-            <li>Blunt</li>
-          </capacities>
-          <power>10</power>
-          <cooldownTime>2.44</cooldownTime>
-          <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-          <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-        </li>
-      </tools>
-    </value>
-  </Operation>
-
-  <!-- ========== Inferno cannon ========== -->
-
-  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-    <defName>Gun_InfernoCannon</defName>
-    <statBases>
-      <Mass>50.00</Mass>
-      <RangedWeapon_Cooldown>2.59</RangedWeapon_Cooldown>
-      <SightsEfficiency>1</SightsEfficiency>
-      <ShotSpread>0.01</ShotSpread>
-      <SwayFactor>0.14</SwayFactor>
-      <Bulk>20.00</Bulk>
-    </statBases>
-    <Properties>
-      <recoilAmount>3.18</recoilAmount>
-      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
-      <hasStandardCommand>true</hasStandardCommand>
-      <defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>
-      <warmupTime>4.3</warmupTime>
-      <range>86</range>
-      <burstShotCount>1</burstShotCount>
-      <soundCast>InfernoCannon_Fire</soundCast>
-      <soundCastTail>GunTail_Light</soundCastTail>
-      <muzzleFlashScale>14</muzzleFlashScale>
-      <ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
-      <minRange>5</minRange>
-      <ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
-    </Properties>
-    <AmmoUser>
-      <magazineSize>1</magazineSize>
-      <AmmoGenPerMagOverride>2</AmmoGenPerMagOverride>
-      <reloadTime>1.6</reloadTime>
-      <ammoSet>AmmoSet_80x256mmFuel</ammoSet>
-    </AmmoUser>
-    <FireModes>
-      <aiAimMode>AimedShot</aiAimMode>
-    </FireModes>
-    <weaponTags>
-      <li>CE_AI_Launcher</li>
-      <li>NoSwitch</li>
-    </weaponTags>
-  </Operation>
-
-  <Operation Class="PatchOperationReplace">
-    <xpath>Defs/ThingDef[@Name="Gun_InfernoCannonBase"]/tools</xpath>
-    <value>
-      <tools>
-        <li Class="CombatExtended.ToolCE">
-          <label>barrel</label>
-          <capacities>
-            <li>Blunt</li>
-          </capacities>
-          <power>10</power>
-          <cooldownTime>2.44</cooldownTime>
-          <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-          <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-        </li>
-      </tools>
-    </value>
-  </Operation>
-
-  <!-- ========== Thump cannon ========== -->
-
-  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-    <defName>Gun_ThumpCannon</defName>
-    <statBases>
-      <Mass>75.00</Mass>
-      <RangedWeapon_Cooldown>2.2</RangedWeapon_Cooldown>
-      <SightsEfficiency>1</SightsEfficiency>
-      <ShotSpread>0.01</ShotSpread>
-      <SwayFactor>0.21</SwayFactor>
-      <Bulk>20.00</Bulk>
-    </statBases>
-    <Properties>
-      <recoilAmount>0.1</recoilAmount>
-      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
-      <hasStandardCommand>true</hasStandardCommand>
-      <defaultProjectile>Bullet_164x284mmDemo</defaultProjectile>
-      <warmupTime>3.3</warmupTime>
-      <range>42</range>
-      <burstShotCount>1</burstShotCount>
-      <soundCast>ThumpCannon_Fire</soundCast>
-      <soundCastTail>GunTail_Heavy</soundCastTail>
-      <muzzleFlashScale>14</muzzleFlashScale>
-      <ai_AvoidFriendlyFireRadius>3</ai_AvoidFriendlyFireRadius>
-      <minRange>4</minRange>
-      <ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
-    </Properties>
-    <AmmoUser>
-      <magazineSize>1</magazineSize>
-      <AmmoGenPerMagOverride>2</AmmoGenPerMagOverride>
-      <reloadTime>9.8</reloadTime>
-      <ammoSet>AmmoSet_164x284mmDemo</ammoSet>
-    </AmmoUser>
-    <FireModes>
-      <aiAimMode>AimedShot</aiAimMode>
-    </FireModes>
-    <weaponTags>
-      <li>CE_AI_Launcher</li>
-      <li>NoSwitch</li>
-    </weaponTags>
-  </Operation>
-
-  <Operation Class="PatchOperationReplace">
-    <xpath>Defs/ThingDef[defName="Gun_ThumpCannon"]/tools</xpath>
-    <value>
-      <tools>
-        <li Class="CombatExtended.ToolCE">
-          <label>barrel</label>
-          <capacities>
-            <li>Blunt</li>
-          </capacities>
-          <power>10</power>
-          <cooldownTime>2.44</cooldownTime>
-          <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-          <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-        </li>
-      </tools>
-    </value>
-  </Operation>
-
-  <!-- ========== Charge lance ========== -->
-
-  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-    <defName>Gun_ChargeLance</defName>
-    <statBases>
-      <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-      <SightsEfficiency>1</SightsEfficiency>
-      <ShotSpread>0.01</ShotSpread>
-      <SwayFactor>0.88</SwayFactor>
-      <Bulk>13.00</Bulk>
-    </statBases>
-    <Properties>
-      <recoilAmount>0.92</recoilAmount>
-      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
-      <hasStandardCommand>true</hasStandardCommand>
-      <defaultProjectile>Bullet_5x35mmCharged</defaultProjectile>
-      <warmupTime>1.3</warmupTime>
-      <range>62</range>
-      <soundCast>ChargeLance_Fire</soundCast>
-      <soundCastTail>GunTail_Heavy</soundCastTail>
-      <muzzleFlashScale>9</muzzleFlashScale>
-    </Properties>
-    <AmmoUser>
-      <magazineSize>10</magazineSize>
-      <reloadTime>4</reloadTime>
-      <ammoSet>AmmoSet_5x35mmCharged</ammoSet>
-    </AmmoUser>
-    <FireModes>
-      <aiAimMode>AimedShot</aiAimMode>
-    </FireModes>
-    <weaponTags>
-      <li>CE_AI_Rifle</li>
-      <li>NoSwitch</li>
-    </weaponTags>
-  </Operation>
-
-  <Operation Class="PatchOperationReplace">
-    <xpath>Defs/ThingDef[defName="Gun_ChargeLance"]/tools</xpath>
-    <value>
-      <tools>
-        <li Class="CombatExtended.ToolCE">
-          <label>barrel</label>
-          <capacities>
-            <li>Blunt</li>
-          </capacities>
-          <power>10</power>
-          <cooldownTime>2.44</cooldownTime>
-          <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-          <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-        </li>
-      </tools>
-    </value>
-  </Operation>
-
-  <Operation Class="PatchOperationAddModExtension">
-    <xpath>Defs/ThingDef[defName="Gun_ChargeLance"]</xpath>
-    <value>
-      <li Class="CombatExtended.ThingDefExtensionCE">
-        <MenuHidden>True</MenuHidden>
-      </li>
-    </value>
-  </Operation>
-
-  <!-- Disable for player -->
-  <Operation Class="PatchOperationAttributeSet">
-    <xpath>Defs/ThingDef[defName="Gun_ChargeLance"]</xpath>
-    <attribute>ParentName</attribute>
-    <value>BaseGun</value>
-  </Operation>
-
-  <Operation Class="PatchOperationRemove">
-    <xpath>Defs/ThingDef[defName="Gun_ChargeLance"]/costList</xpath>
-  </Operation>
-
-  <Operation Class="PatchOperationRemove">
-    <xpath>Defs/ThingDef[defName="Gun_ChargeLance"]/recipeMaker</xpath>
-  </Operation>
-
-  <Operation Class="PatchOperationAdd">
-    <xpath>Defs/ThingDef[defName="Gun_ChargeLance"]/statBases</xpath>
-    <value>
-      <MarketValue>1400</MarketValue>
-    </value>
-  </Operation>
-
-  <Operation Class="PatchOperationAdd">
-    <xpath>Defs/ThingDef[defName="Gun_ChargeLance"]</xpath>
-    <value>
-      <tradeability>None</tradeability>
-      <destroyOnDrop>True</destroyOnDrop>
-    </value>
-  </Operation>
-
-  <Operation Class="PatchOperationRemove">
-    <xpath>Defs/ThingDef[defName="Gun_ChargeLance"]/weaponTags/li[contains(.,"SpacerGun")]</xpath>
-  </Operation>
-
-  <!-- ========== Needle Gun ========== -->
-
-  <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-    <defName>Gun_Needle</defName>
-    <statBases>
-      <RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
-      <SightsEfficiency>2.24</SightsEfficiency>
-      <ShotSpread>0.01</ShotSpread>
-      <SwayFactor>0.85</SwayFactor>
-      <Bulk>15.00</Bulk>
-    </statBases>
-    <Properties>
-      <recoilAmount>1.80</recoilAmount>
-      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
-      <hasStandardCommand>true</hasStandardCommand>
-      <defaultProjectile>Bullet_5x50mmCaseless_Sabot</defaultProjectile>
-      <warmupTime>1.5</warmupTime>
-      <range>75</range>
-      <soundCast>Shot_NeedleGun</soundCast>
-      <soundCastTail>GunTail_Heavy</soundCastTail>
-      <muzzleFlashScale>9</muzzleFlashScale>
-    </Properties>
-    <AmmoUser>
-      <magazineSize>10</magazineSize>
-      <reloadTime>4</reloadTime>
-      <ammoSet>AmmoSet_5x50mmCaseless</ammoSet>
-    </AmmoUser>
-    <FireModes>
-      <aiAimMode>AimedShot</aiAimMode>
-    </FireModes>
-    <weaponTags>
-      <li>CE_AI_Rifle</li>
-      <li>NoSwitch</li>
-    </weaponTags>
-  </Operation>
-
-  <Operation Class="PatchOperationReplace">
-    <xpath>Defs/ThingDef[defName="Gun_Needle"]/tools</xpath>
-    <value>
-      <tools>
-        <li Class="CombatExtended.ToolCE">
-          <label>barrel</label>
-          <capacities>
-            <li>Blunt</li>
-          </capacities>
-          <power>10</power>
-          <cooldownTime>2.44</cooldownTime>
-          <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-          <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-        </li>
-      </tools>
-    </value>
-  </Operation>
-
-  <!-- Increase Orbital Bombardment Range -->
-  <Operation Class="PatchOperationReplace">
-    <xpath>Defs/ThingDef[defName="OrbitalTargeterBombardment" or defName="OrbitalTargeterPowerBeam"]/verbs/li/range</xpath>
-    <value>
-      <range>60</range>
-    </value>
-  </Operation>
-
-  <!-- Remove Smoke and EMP Launchers -->
-  <Operation Class="PatchOperationRemove">
-    <xpath>Defs/ThingDef[defName="Gun_SmokeLauncher"]</xpath>
-  </Operation>
-
-  <Operation Class="PatchOperationRemove">
-    <xpath>Defs/ThingDef[defName="Gun_EmpLauncher"]</xpath>
-  </Operation>
+	<Operation Class="PatchOperationAdd">
+	<xpath>Defs/ThingDef[defName="Gun_ChargeLance"]</xpath>
+		<value>
+			<relicChance>0</relicChance>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+	<xpath>Defs/ThingDef[@Name="BaseWeaponTurret"]</xpath>
+		<value>
+			<relicChance>0</relicChance>
+		</value>
+	</Operation>
+
+	<!-- ========== Tools ========== -->
+
+	<Operation Class="PatchOperationReplace">
+	<xpath>Defs/ThingDef[defName="Gun_Revolver" or defName="Gun_Autopistol" or defName="Gun_MachinePistol"]/tools</xpath>
+		<value>
+			<tools>
+			<li Class="CombatExtended.ToolCE">
+				<label>grip</label>
+				<capacities>
+				<li>Blunt</li>
+				</capacities>
+				<power>2</power>
+				<cooldownTime>1.54</cooldownTime>
+				<chanceFactor>1.5</chanceFactor>
+				<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+				<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
+			</li>
+			<li Class="CombatExtended.ToolCE">
+				<label>muzzle</label>
+				<capacities>
+				<li>Poke</li>
+				</capacities>
+				<power>2</power>
+				<cooldownTime>1.54</cooldownTime>
+				<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+				<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+			</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>
+			Defs/ThingDef[
+			defName="Gun_PumpShotgun" or
+			defName="Gun_ChainShotgun" or
+			defName="Gun_BoltActionRifle" or
+			defName="Gun_AssaultRifle" or
+			defName="Gun_SniperRifle" or
+			defName="Gun_HeavySMG" or
+			defName="Gun_IncendiaryLauncher" or
+			defName="Gun_LMG" or
+			defName="Gun_ChargeRifle"
+			]/tools
+		</xpath>
+		<value>
+			<tools>
+			<li Class="CombatExtended.ToolCE">
+				<label>stock</label>
+				<capacities>
+				<li>Blunt</li>
+				</capacities>
+				<power>8</power>
+				<cooldownTime>1.55</cooldownTime>
+				<chanceFactor>1.5</chanceFactor>
+				<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+				<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+			</li>
+			<li Class="CombatExtended.ToolCE">
+				<label>barrel</label>
+				<capacities>
+				<li>Blunt</li>
+				</capacities>
+				<power>5</power>
+				<cooldownTime>2.02</cooldownTime>
+				<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+				<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+			</li>
+			<li Class="CombatExtended.ToolCE">
+				<label>muzzle</label>
+				<capacities>
+				<li>Poke</li>
+				</capacities>
+				<power>8</power>
+				<cooldownTime>1.55</cooldownTime>
+				<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+				<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+			</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+	<xpath>Defs/ThingDef[defName="Gun_TripleRocket" or defName="Gun_DoomsdayRocket"]/tools</xpath>
+		<value>
+			<tools>
+			<li Class="CombatExtended.ToolCE">
+				<label>barrel</label>
+				<capacities>
+				<li>Blunt</li>
+				</capacities>
+				<power>10</power>
+				<cooldownTime>2.44</cooldownTime>
+				<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+				<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+			</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<!-- ========== Revolver ========== -->
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Gun_Revolver</defName>
+		<statBases>
+			<Mass>1.39</Mass>
+			<RangedWeapon_Cooldown>0.49</RangedWeapon_Cooldown>
+			<SightsEfficiency>0.7</SightsEfficiency>
+			<ShotSpread>0.18</ShotSpread>
+			<SwayFactor>1.27</SwayFactor>
+			<Bulk>2.41</Bulk>
+			<!-- <ToughnessRating>2.5</ToughnessRating> -->
+			<!-- Base toughness rating of a weapon -->
+			<WorkToMake>7000</WorkToMake>
+		</statBases>
+		<costList>
+			<Steel>30</Steel>
+			<ComponentIndustrial>2</ComponentIndustrial>
+		</costList>
+		<Properties>
+			<recoilAmount>2.96</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_44Magnum_FMJ</defaultProjectile>
+			<warmupTime>0.6</warmupTime>
+			<range>12</range>
+			<soundCast>Shot_Revolver</soundCast>
+			<soundCastTail>GunTail_Light</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>6</magazineSize>
+			<reloadTime>4.6</reloadTime>
+			<ammoSet>AmmoSet_44Magnum</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aiUseBurstMode>FALSE</aiUseBurstMode>
+			<aiAimMode>Snapshot</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>CE_Sidearm</li>
+			<li>CE_AI_BROOM</li>
+			<li>CE_OneHandedWeapon</li>
+		</weaponTags>
+		<researchPrerequisite>Gunsmithing</researchPrerequisite>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="Gun_Revolver"]</xpath>
+		<value>
+			<li Class="CombatExtended.GunDrawExtension">
+			<DrawSize>1.00,1.00</DrawSize>
+			<DrawOffset>0.0,0.0</DrawOffset>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- ========== Autopistol ========== -->
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Gun_Autopistol</defName>
+		<statBases>
+			<Mass>1.11</Mass>
+			<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
+			<SightsEfficiency>0.7</SightsEfficiency>
+			<ShotSpread>0.17</ShotSpread>
+			<SwayFactor>1.07</SwayFactor>
+			<Bulk>2.10</Bulk>
+			<WorkToMake>7000</WorkToMake>
+		</statBases>
+		<costList>
+			<Steel>25</Steel>
+			<ComponentIndustrial>3</ComponentIndustrial>
+		</costList>
+		<Properties>
+			<recoilAmount>2.72</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
+			<warmupTime>0.6</warmupTime>
+			<range>12</range>
+			<soundCast>Shot_Autopistol</soundCast>
+			<soundCastTail>GunTail_Light</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>7</magazineSize>
+			<reloadTime>4</reloadTime>
+			<ammoSet>AmmoSet_45ACP</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aiUseBurstMode>FALSE</aiUseBurstMode>
+			<aiAimMode>Snapshot</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>CE_Sidearm</li>
+			<li>CE_AI_BROOM</li>
+			<li>CE_OneHandedWeapon</li>
+		</weaponTags>
+		<researchPrerequisite>BlowbackOperation</researchPrerequisite>
+		</Operation>
+
+		<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="Gun_Autopistol"]</xpath>
+		<value>
+			<li Class="CombatExtended.GunDrawExtension">
+			<DrawSize>0.93,0.93</DrawSize>
+			<DrawOffset>0.0,0.0</DrawOffset>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- ========== Pump Shotgun ========== -->
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Gun_PumpShotgun</defName>
+		<statBases>
+			<Mass>3.00</Mass>
+			<RangedWeapon_Cooldown>1.0</RangedWeapon_Cooldown>
+			<ShotSpread>0.14</ShotSpread>
+			<SwayFactor>1.20</SwayFactor>
+			<Bulk>9.0</Bulk>
+			<SightsEfficiency>1</SightsEfficiency>
+			<WorkToMake>9500</WorkToMake>
+		</statBases>
+		<costList>
+			<Steel>45</Steel>
+			<WoodLog>10</WoodLog>
+			<ComponentIndustrial>1</ComponentIndustrial>
+		</costList>
+		<Properties>
+			<recoilAmount>2.75</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
+			<warmupTime>0.6</warmupTime>
+			<range>16</range>
+			<soundCast>Shot_Shotgun</soundCast>
+			<soundCastTail>GunTail_Heavy</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>5</magazineSize>
+			<reloadOneAtATime>true</reloadOneAtATime>
+			<reloadTime>0.85</reloadTime>
+			<ammoSet>AmmoSet_12Gauge</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aiAimMode>Snapshot</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>SimpleGun</li>
+			<li>CE_AI_BROOM</li>
+		</weaponTags>
+		<researchPrerequisite>Gunsmithing</researchPrerequisite>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="Gun_PumpShotgun"]</xpath>
+		<value>
+			<li Class="CombatExtended.GunDrawExtension">
+			<DrawSize>1.03,1.25</DrawSize>
+			<DrawOffset>0.05,0.0</DrawOffset>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- ========== Chain Shotgun ========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Gun_ChainShotgun"]/description</xpath>
+		<value>
+			<description>A magazine-fed semi-automatic shotgun. It has the same range as a typical shotgun, but is extraordinarily dangerous due to being semi-automatic.</description>
+		</value>
+	</Operation>
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Gun_ChainShotgun</defName>
+		<statBases>
+			<Mass>3.50</Mass>
+			<RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
+			<ShotSpread>0.15</ShotSpread>
+			<SwayFactor>1.26</SwayFactor>
+			<Bulk>6.7</Bulk>
+			<SightsEfficiency>1</SightsEfficiency>
+			<WorkToMake>22500</WorkToMake>
+		</statBases>
+		<costList>
+			<Steel>40</Steel>
+			<ComponentIndustrial>3</ComponentIndustrial>
+			<Chemfuel>10</Chemfuel>
+		</costList>
+		<Properties>
+			<recoilAmount>2.54</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
+			<warmupTime>0.6</warmupTime>
+			<range>16</range>
+			<soundCast>Shot_Shotgun_NoRack</soundCast>
+			<soundCastTail>GunTail_Heavy</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+			<ticksBetweenBurstShots>15</ticksBetweenBurstShots>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>8</magazineSize>
+			<reloadTime>4</reloadTime>
+			<ammoSet>AmmoSet_12Gauge</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aiAimMode>Snapshot</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>CE_AI_BROOM</li>
+		</weaponTags>
+		<researchPrerequisite>GasOperation</researchPrerequisite>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="Gun_ChainShotgun"]</xpath>
+		<value>
+			<li Class="CombatExtended.GunDrawExtension">
+			<DrawSize>1.04,1.23</DrawSize>
+			<DrawOffset>0.05,-0.05</DrawOffset>
+			<CasingOffset>0,0.2</CasingOffset>
+			<CasingAngleOffset>-30</CasingAngleOffset>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- ========== Bolt-action rifle ========== -->
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Gun_BoltActionRifle</defName>
+		<statBases>
+			<Mass>4.19</Mass>
+			<RangedWeapon_Cooldown>1.17</RangedWeapon_Cooldown>
+			<SightsEfficiency>1</SightsEfficiency>
+			<ShotSpread>0.02</ShotSpread>
+			<SwayFactor>1.68</SwayFactor>
+			<Bulk>12.60</Bulk>
+			<WorkToMake>12000</WorkToMake>
+		</statBases>
+		<costList>
+			<Steel>55</Steel>
+			<WoodLog>15</WoodLog>
+			<ComponentIndustrial>1</ComponentIndustrial>
+		</costList>
+		<Properties>
+			<recoilAmount>2.04</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_303British_FMJ</defaultProjectile>
+			<warmupTime>1.1</warmupTime>
+			<range>55</range>
+			<soundCast>Shot_BoltActionRifle</soundCast>
+			<soundCastTail>GunTail_Heavy</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>10</magazineSize>
+			<reloadTime>4.3</reloadTime>
+			<ammoSet>AmmoSet_303British</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aiAimMode>AimedShot</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>SimpleGun</li>
+			<li>CE_AI_SR</li>
+		</weaponTags>
+		<researchPrerequisite>Gunsmithing</researchPrerequisite>
+		<AllowWithRunAndGun>false</AllowWithRunAndGun>
+		</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="Gun_BoltActionRifle"]</xpath>
+		<value>
+			<li Class="CombatExtended.GunDrawExtension">
+			<DrawSize>1.3,1.3</DrawSize>
+			<DrawOffset>0.12,0.04</DrawOffset>
+			<CasingOffset>-0.1,0.1</CasingOffset>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- ========== Assault rifle ========== -->
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Gun_AssaultRifle</defName>
+		<statBases>
+			<Mass>3.26</Mass>
+			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+			<SightsEfficiency>1</SightsEfficiency>
+			<ShotSpread>0.07</ShotSpread>
+			<SwayFactor>1.33</SwayFactor>
+			<Bulk>10.03</Bulk>
+			<WorkToMake>30000</WorkToMake>
+		</statBases>
+		<costList>
+			<Steel>50</Steel>
+			<ComponentIndustrial>5</ComponentIndustrial>
+			<Chemfuel>10</Chemfuel>
+		</costList>
+		<Properties>
+			<recoilAmount>1.50</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+			<warmupTime>1.1</warmupTime>
+			<range>55</range>
+			<burstShotCount>6</burstShotCount>
+			<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+			<soundCast>Shot_AssaultRifle</soundCast>
+			<soundCastTail>GunTail_Medium</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>30</magazineSize>
+			<reloadTime>4</reloadTime>
+			<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aimedBurstShotCount>3</aimedBurstShotCount>
+			<aiUseBurstMode>TRUE</aiUseBurstMode>
+			<aiAimMode>AimedShot</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>CE_AI_AR</li>
+		</weaponTags>
+		<researchPrerequisite>PrecisionRifling</researchPrerequisite>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="Gun_AssaultRifle"]</xpath>
+		<value>
+			<li Class="CombatExtended.GunDrawExtension">
+			<DrawSize>1.16,1.16</DrawSize>
+			<DrawOffset>0.08,0.0</DrawOffset>
+			<CasingOffset>-0.05,0</CasingOffset>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- ========== Sniper rifle ========== -->
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Gun_SniperRifle</defName>
+		<statBases>
+			<Mass>7.30</Mass>
+			<RangedWeapon_Cooldown>1.36</RangedWeapon_Cooldown>
+			<SightsEfficiency>2.6</SightsEfficiency>
+			<ShotSpread>0.05</ShotSpread>
+			<SwayFactor>1.35</SwayFactor>
+			<Bulk>11.92</Bulk>
+			<WorkToMake>30000</WorkToMake>
+		</statBases>
+		<costList>
+			<Steel>60</Steel>
+			<ComponentIndustrial>5</ComponentIndustrial>
+			<Chemfuel>15</Chemfuel>
+		</costList>
+		<Properties>
+			<recoilAmount>1.50</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
+			<warmupTime>1.8</warmupTime>
+			<range>75</range>
+			<soundCast>Shot_SniperRifle</soundCast>
+			<soundCastTail>GunTail_Heavy</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>5</magazineSize>
+			<reloadTime>4</reloadTime>
+			<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aiAimMode>AimedShot</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>CE_AI_SR</li>
+			<li>Bipod_DMR</li>
+		</weaponTags>
+		<researchPrerequisite>PrecisionRifling</researchPrerequisite>
+		<AllowWithRunAndGun>false</AllowWithRunAndGun>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="Gun_SniperRifle"]</xpath>
+		<value>
+			<li Class="CombatExtended.GunDrawExtension">
+			<DrawSize>1.25,1.45</DrawSize>
+			<DrawOffset>0.15,-0.05</DrawOffset>
+			<CasingOffset>-0.3,0.1</CasingOffset>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- ========== Machine pistol ========== -->
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Gun_MachinePistol</defName>
+		<statBases>
+			<Mass>2.84</Mass>
+			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+			<SightsEfficiency>0.7</SightsEfficiency>
+			<ShotSpread>0.16</ShotSpread>
+			<SwayFactor>1.93</SwayFactor>
+			<Bulk>2.95</Bulk>
+			<WorkToMake>24500</WorkToMake>
+		</statBases>
+		<costList>
+			<Steel>35</Steel>
+			<ComponentIndustrial>3</ComponentIndustrial>
+		</costList>
+		<Properties>
+			<recoilAmount>1.71</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
+			<warmupTime>0.6</warmupTime>
+			<range>12</range>
+			<burstShotCount>6</burstShotCount>
+			<ticksBetweenBurstShots>3</ticksBetweenBurstShots>
+			<soundCast>Shot_MachinePistol</soundCast>
+			<soundCastTail>GunTail_Light</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>30</magazineSize>
+			<reloadTime>4</reloadTime>
+			<ammoSet>AmmoSet_45ACP</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aimedBurstShotCount>3</aimedBurstShotCount>
+			<aiUseBurstMode>FALSE</aiUseBurstMode>
+			<aiAimMode>Snapshot</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>CE_SMG</li>
+			<li>CE_AI_BROOM</li>
+			<li>CE_OneHandedWeapon</li>
+		</weaponTags>
+		<researchPrerequisite>BlowbackOperation</researchPrerequisite>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="Gun_MachinePistol"]</xpath>
+		<value>
+			<li Class="CombatExtended.GunDrawExtension">
+			<DrawSize>0.84,0.84</DrawSize>
+			<DrawOffset>-0.10,-0.07</DrawOffset>
+			<CasingOffset>0.1,0.1</CasingOffset>
+			<CasingAngleOffset>-30</CasingAngleOffset>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- ========== Heavy SMG ========== -->
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Gun_HeavySMG</defName>
+		<statBases>
+			<Mass>2.50</Mass>
+			<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+			<SightsEfficiency>1.00</SightsEfficiency>
+			<ShotSpread>0.14</ShotSpread>
+			<SwayFactor>0.94</SwayFactor>
+			<Bulk>4.50</Bulk>
+			<WorkToMake>24500</WorkToMake>
+		</statBases>
+		<costList>
+			<Steel>30</Steel>
+			<Chemfuel>10</Chemfuel>
+			<ComponentIndustrial>5</ComponentIndustrial>
+		</costList>
+		<Properties>
+			<recoilAmount>1.79</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
+			<warmupTime>0.6</warmupTime>
+			<range>25</range>
+			<burstShotCount>6</burstShotCount>
+			<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+			<soundCast>Shot_HeavySMG</soundCast>
+			<soundCastTail>GunTail_Heavy</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>25</magazineSize>
+			<reloadTime>4</reloadTime>
+			<ammoSet>AmmoSet_45ACP</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aimedBurstShotCount>3</aimedBurstShotCount>
+			<aiUseBurstMode>FALSE</aiUseBurstMode>
+			<aiAimMode>Snapshot</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>CE_SMG</li>
+			<li>CE_AI_BROOM</li>
+		</weaponTags>
+		<researchPrerequisite>BlowbackOperation</researchPrerequisite>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="Gun_HeavySMG"]</xpath>
+		<value>
+			<li Class="CombatExtended.GunDrawExtension">
+			<DrawSize>0.85,0.85</DrawSize>
+			<DrawOffset>0.00,-0.03</DrawOffset>
+			<CasingOffset>0.1,0</CasingOffset>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- ========== Incendiary launcher ========== -->
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Gun_IncendiaryLauncher</defName>
+		<statBases>
+			<Mass>8</Mass>
+			<RangedWeapon_Cooldown>0.43</RangedWeapon_Cooldown>
+			<SightsEfficiency>1.1</SightsEfficiency>
+			<ShotSpread>0.15</ShotSpread>
+			<SwayFactor>1.8</SwayFactor>
+			<Bulk>10</Bulk>
+			<WorkToMake>35500</WorkToMake>
+		</statBases>
+		<costList>
+			<Steel>65</Steel>
+			<Plasteel>30</Plasteel>
+			<ComponentIndustrial>1</ComponentIndustrial>
+			<ComponentSpacer>1</ComponentSpacer>
+			<Chemfuel>10</Chemfuel>
+		</costList>
+		<Properties>
+			<recoilAmount>3.87</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_30x64mmFuel_Incendiary</defaultProjectile>
+			<warmupTime>1.0</warmupTime>
+			<range>40</range>
+			<soundCast>Shot_IncendiaryLauncher</soundCast>
+			<soundCastTail>GunTail_Medium</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+			<targetParams>
+			<canTargetLocations>true</canTargetLocations>
+			</targetParams>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>5</magazineSize>
+			<reloadOneAtATime>true</reloadOneAtATime>
+			<reloadTime>0.85</reloadTime>
+			<ammoSet>AmmoSet_30x64mmFuel</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aiUseBurstMode>FALSE</aiUseBurstMode>
+			<aiAimMode>SuppressFire</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>CE_AI_AOE</li>
+			<li>EliteGun</li>
+		</weaponTags>
+		<researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
+		<AllowWithRunAndGun>false</AllowWithRunAndGun>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Gun_IncendiaryLauncher"]</xpath>
+		<value>
+			<techLevel>Spacer</techLevel>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="Gun_IncendiaryLauncher"]</xpath>
+		<value>
+			<li Class="CombatExtended.GunDrawExtension">
+			<DrawSize>1.16,1.16</DrawSize>
+			<DrawOffset>0.1,-0.05</DrawOffset>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- ========== LMG ========== -->
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Gun_LMG</defName>
+		<statBases>
+			<Mass>8.7</Mass>
+			<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
+			<SightsEfficiency>1</SightsEfficiency>
+			<ShotSpread>0.05</ShotSpread>
+			<SwayFactor>1.37</SwayFactor>
+			<Bulk>12.9</Bulk>
+			<WorkToMake>31500</WorkToMake>
+		</statBases>
+		<costList>
+			<Steel>80</Steel>
+			<WoodLog>10</WoodLog>
+			<ComponentIndustrial>5</ComponentIndustrial>
+		</costList>
+		<Properties>
+			<recoilAmount>1.38</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_303British_FMJ</defaultProjectile>
+			<warmupTime>1.3</warmupTime>
+			<range>62</range>
+			<ticksBetweenBurstShots>7</ticksBetweenBurstShots>
+			<burstShotCount>10</burstShotCount>
+			<soundCast>Shot_CE_BattleRifle</soundCast>
+			<soundCastTail>GunTail_Medium</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+			<targetParams>
+			<canTargetLocations>true</canTargetLocations>
+			</targetParams>
+			<recoilPattern>Mounted</recoilPattern>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>50</magazineSize>
+			<reloadTime>4.9</reloadTime>
+			<ammoSet>AmmoSet_303British</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aimedBurstShotCount>5</aimedBurstShotCount>
+			<aiUseBurstMode>FALSE</aiUseBurstMode>
+			<aiAimMode>SuppressFire</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>CE_MachineGun</li>
+			<li>CE_AI_LMG</li>
+			<li>Bipod_LMG</li>
+		</weaponTags>
+		<researchPrerequisite>GasOperation</researchPrerequisite>
+		<AllowWithRunAndGun>false</AllowWithRunAndGun>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="Gun_LMG"]</xpath>
+		<value>
+			<li Class="CombatExtended.GunDrawExtension">
+			<DrawSize>1.35,1.18</DrawSize>
+			<DrawOffset>0.13,-0.03</DrawOffset>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- ========== Charge rifle ========== -->
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Gun_ChargeRifle</defName>
+		<statBases>
+			<Mass>3.0</Mass>
+			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+			<SightsEfficiency>1.10</SightsEfficiency>
+			<ShotSpread>0.08</ShotSpread>
+			<SwayFactor>1.20</SwayFactor>
+			<Bulk>7.00</Bulk>
+			<WorkToMake>49000</WorkToMake>
+		</statBases>
+		<costList>
+			<Steel>45</Steel>
+			<Plasteel>25</Plasteel>
+			<ComponentIndustrial>4</ComponentIndustrial>
+			<ComponentSpacer>1</ComponentSpacer>
+			<Chemfuel>10</Chemfuel>
+		</costList>
+		<Properties>
+			<recoilAmount>1.46</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_6x24mmCharged</defaultProjectile>
+			<warmupTime>1.0</warmupTime>
+			<range>55</range>
+			<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+			<burstShotCount>6</burstShotCount>
+			<soundCast>Shot_ChargeRifle</soundCast>
+			<soundCastTail>GunTail_Medium</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>30</magazineSize>
+			<reloadTime>4</reloadTime>
+			<ammoSet>AmmoSet_6x24mmCharged</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aimedBurstShotCount>3</aimedBurstShotCount>
+			<aiUseBurstMode>TRUE</aiUseBurstMode>
+			<aiAimMode>AimedShot</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>CE_AI_AR</li>
+			<li>AdvancedGun</li>
+		</weaponTags>
+		<researchPrerequisite>ChargedShot</researchPrerequisite>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="Gun_ChargeRifle"]</xpath>
+		<value>
+			<li Class="CombatExtended.GunDrawExtension">
+			<DrawSize>1.03,1.03</DrawSize>
+			<DrawOffset>0.05,0.0</DrawOffset>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- ========== Improvised turret gun ========== -->
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Gun_MiniTurret</defName>
+		<statBases>
+			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+			<SightsEfficiency>1</SightsEfficiency>
+			<ShotSpread>0.07</ShotSpread>
+			<SwayFactor>0.67</SwayFactor>
+			<Mass>4</Mass>
+		</statBases>
+		<Properties>
+			<recoilAmount>1.02</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+			<warmupTime>1.3</warmupTime>
+			<range>48</range>
+			<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+			<burstShotCount>10</burstShotCount>
+			<soundCast>GunShotA</soundCast>
+			<soundCastTail>GunTail_Light</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+			<recoilPattern>Mounted</recoilPattern>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>100</magazineSize>
+			<reloadTime>7.8</reloadTime>
+			<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aiAimMode>AimedShot</aiAimMode>
+			<noSnapshot>true</noSnapshot>
+			<noSingleShot>true</noSingleShot>
+		</FireModes>
+	</Operation>
+
+	<!-- ========== Minigun ========== -->
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName ="Gun_Minigun"]/weaponTags/li[.="GunHeavy"]</xpath>
+	</Operation>
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Gun_Minigun</defName>
+		<statBases>
+			<Mass>20.00</Mass>
+			<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
+			<SightsEfficiency>1</SightsEfficiency>
+			<ShotSpread>0.06</ShotSpread>
+			<SwayFactor>3.22</SwayFactor>
+			<Bulk>10</Bulk>
+			<WorkToMake>52000</WorkToMake>
+		</statBases>
+		<costList>
+			<Steel>110</Steel>
+			<ComponentIndustrial>11</ComponentIndustrial>
+		</costList>
+		<Properties>
+			<recoilAmount>0.97</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
+			<warmupTime>2.1</warmupTime>
+			<range>62</range>
+			<burstShotCount>50</burstShotCount>
+			<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+			<soundCast>Shot_Minigun</soundCast>
+			<soundCastTail>GunTail_Medium</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>250</magazineSize>
+			<reloadTime>9.2</reloadTime>
+			<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aimedBurstShotCount>25</aimedBurstShotCount>
+			<aiAimMode>Snapshot</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>CE_AI_Suppressive</li>
+		</weaponTags>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Gun_Minigun"]/tools</xpath>
+		<value>
+			<tools>
+			<li Class="CombatExtended.ToolCE">
+				<label>barrels</label>
+				<capacities>
+				<li>Blunt</li>
+				</capacities>
+				<power>10</power>
+				<cooldownTime>2.44</cooldownTime>
+				<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+				<linkedBodyPartsGroup>Barrels</linkedBodyPartsGroup>
+			</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Gun_Minigun"]/equippedStatOffsets</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="Gun_Minigun"]</xpath>
+		<value>
+			<li Class="CombatExtended.GunDrawExtension">
+			<DrawSize>1.00,1.00</DrawSize>
+			<DrawOffset>0.1,-0.15</DrawOffset>
+			<CasingOffset>-0.2,-0.1</CasingOffset>
+			<CasingAngleOffset>-30</CasingAngleOffset>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- ========== Doomsday launcher ========== -->
+
+	<!-- Patch both launchers -->
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Gun_DoomsdayRocket" or defName="Gun_TripleRocket"]/weaponTags/li[.="Gun"]</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationAttributeSet">
+		<xpath>Defs/ThingDef[defName="Gun_DoomsdayRocket" or defName="Gun_TripleRocket"]</xpath>
+		<attribute>ParentName</attribute>
+		<value>BaseMakeableGun</value>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Gun_DoomsdayRocket" or defName="Gun_TripleRocket"]/statBases/MarketValue</xpath>
+	</Operation>
+
+	<!-- Patch projectile -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_DoomsdayRocket"]/thingClass</xpath>
+		<value>
+			<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_DoomsdayRocket"]/projectile</xpath>
+		<value>
+			<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bomb</damageDef>
+			<damageAmountBase>250</damageAmountBase>
+			<explosionRadius>7.8</explosionRadius>
+			<suppressionFactor>3.0</suppressionFactor>
+			<dangerFactor>2.0</dangerFactor>
+			<speed>100</speed>
+			</projectile>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="Bullet_DoomsdayRocket"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Bullet_DoomsdayRocket"]</xpath>
+			<value>
+			<comps />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Bullet_DoomsdayRocket"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_Fragments">
+			<fragSpeedFactor>1</fragSpeedFactor>
+			<fragments>
+				<Fragment_Large>400</Fragment_Large>
+			</fragments>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- Patch stats -->
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Gun_DoomsdayRocket</defName>
+		<statBases>
+			<Mass>20.00</Mass>
+			<RangedWeapon_Cooldown>1.5</RangedWeapon_Cooldown>
+			<SightsEfficiency>2.24</SightsEfficiency>
+			<ShotSpread>0.2</ShotSpread>
+			<SwayFactor>3.24</SwayFactor>
+			<Bulk>13.0</Bulk>
+			<WorkToMake>49500</WorkToMake>
+		</statBases>
+		<costList>
+			<Steel>125</Steel>
+			<ComponentIndustrial>8</ComponentIndustrial>
+			<FSX>5</FSX>
+		</costList>
+		<Properties>
+			<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_DoomsdayRocket</defaultProjectile>
+			<warmupTime>2.1</warmupTime>
+			<range>48</range>
+			<burstShotCount>1</burstShotCount>
+			<soundCast>InfernoCannon_Fire</soundCast>
+			<soundCastTail>GunTail_Heavy</soundCastTail>
+			<onlyManualCast>true</onlyManualCast>
+			<targetParams>
+			<canTargetLocations>true</canTargetLocations>
+			</targetParams>
+			<muzzleFlashScale>14</muzzleFlashScale>
+		</Properties>
+		<FireModes>
+			<aiAimMode>AimedShot</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>CE_AI_AOE</li>
+		</weaponTags>
+		<researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
+		<AllowWithRunAndGun>false</AllowWithRunAndGun>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="Gun_DoomsdayRocket"]</xpath>
+		<value>
+			<li Class="CombatExtended.GunDrawExtension">
+			<DrawSize>1.45,1.45</DrawSize>
+			<DrawOffset>-0.15,0</DrawOffset>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- ========== Triple rocket launcher ========== -->
+
+	<!-- Patch projectile -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_Rocket"]/thingClass</xpath>
+		<value>
+			<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_Rocket"]/projectile</xpath>
+		<value>
+			<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bomb</damageDef>
+			<damageAmountBase>180</damageAmountBase>
+			<explosionRadius>3.0</explosionRadius>
+			<suppressionFactor>3.0</suppressionFactor>
+			<dangerFactor>2.0</dangerFactor>
+			<speed>100</speed>
+			</projectile>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="Bullet_Rocket"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Bullet_Rocket"]</xpath>
+			<value>
+			<comps />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Bullet_Rocket"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_Fragments">
+			<fragSpeedFactor>1</fragSpeedFactor>
+			<fragments>
+				<Fragment_Large>150</Fragment_Large>
+			</fragments>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- Patch stats -->
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Gun_TripleRocket</defName>
+		<statBases>
+			<Mass>12.00</Mass>
+			<RangedWeapon_Cooldown>1.5</RangedWeapon_Cooldown>
+			<SightsEfficiency>1</SightsEfficiency>
+			<ShotSpread>0.2</ShotSpread>
+			<SwayFactor>2.20</SwayFactor>
+			<Bulk>13.00</Bulk>
+			<WorkToMake>43000</WorkToMake>
+		</statBases>
+		<costList>
+			<Steel>90</Steel>
+			<ComponentIndustrial>7</ComponentIndustrial>
+			<FSX>3</FSX>
+		</costList>
+		<Properties>
+			<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_Rocket</defaultProjectile>
+			<warmupTime>1.9</warmupTime>
+			<range>40</range>
+			<ticksBetweenBurstShots>20</ticksBetweenBurstShots>
+			<burstShotCount>3</burstShotCount>
+			<soundCast>InfernoCannon_Fire</soundCast>
+			<soundCastTail>GunTail_Heavy</soundCastTail>
+			<onlyManualCast>true</onlyManualCast>
+			<stopBurstWithoutLos>false</stopBurstWithoutLos>
+			<interruptibleBurst>false</interruptibleBurst>
+			<targetParams>
+			<canTargetLocations>true</canTargetLocations>
+			</targetParams>
+			<muzzleFlashScale>14</muzzleFlashScale>
+		</Properties>
+		<FireModes>
+			<aiAimMode>AimedShot</aiAimMode>
+			<noSingleShot>true</noSingleShot>
+		</FireModes>
+		<weaponTags>
+			<li>CE_AI_AOE</li>
+		</weaponTags>
+		<researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
+		<AllowWithRunAndGun>false</AllowWithRunAndGun>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="Gun_TripleRocket"]</xpath>
+		<value>
+			<li Class="CombatExtended.GunDrawExtension">
+			<DrawSize>1.16,1.16</DrawSize>
+			<DrawOffset>-0.25,0</DrawOffset>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- ========== Heavy charge blaster ========== -->
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Gun_ChargeBlasterHeavy</defName>
+		<statBases>
+			<Mass>35.00</Mass>
+			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+			<SightsEfficiency>1</SightsEfficiency>
+			<ShotSpread>0.01</ShotSpread>
+			<SwayFactor>1.33</SwayFactor>
+			<Bulk>13.00</Bulk>
+		</statBases>
+		<Properties>
+			<recoilAmount>1.08</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_12x64mmCharged</defaultProjectile>
+			<warmupTime>1.3</warmupTime>
+			<range>75</range>
+			<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+			<burstShotCount>10</burstShotCount>
+			<soundCast>Shot_ChargeBlaster</soundCast>
+			<soundCastTail>GunTail_Heavy</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>100</magazineSize>
+			<reloadTime>9.2</reloadTime>
+			<ammoSet>AmmoSet_12x64mmCharged</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aimedBurstShotCount>5</aimedBurstShotCount>
+			<aiAimMode>AimedShot</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>CE_AI_Suppressive</li>
+			<li>NoSwitch</li>
+		</weaponTags>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[@Name="Gun_ChargeBlasterHeavyBase"]/tools</xpath>
+		<value>
+			<tools>
+			<li Class="CombatExtended.ToolCE">
+				<label>barrel</label>
+				<capacities>
+				<li>Blunt</li>
+				</capacities>
+				<power>10</power>
+				<cooldownTime>2.44</cooldownTime>
+				<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+				<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+			</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<!-- ========== Inferno cannon ========== -->
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Gun_InfernoCannon</defName>
+		<statBases>
+			<Mass>50.00</Mass>
+			<RangedWeapon_Cooldown>2.59</RangedWeapon_Cooldown>
+			<SightsEfficiency>1</SightsEfficiency>
+			<ShotSpread>0.01</ShotSpread>
+			<SwayFactor>0.14</SwayFactor>
+			<Bulk>20.00</Bulk>
+		</statBases>
+		<Properties>
+			<recoilAmount>3.18</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>
+			<warmupTime>4.3</warmupTime>
+			<range>86</range>
+			<burstShotCount>1</burstShotCount>
+			<soundCast>InfernoCannon_Fire</soundCast>
+			<soundCastTail>GunTail_Light</soundCastTail>
+			<muzzleFlashScale>14</muzzleFlashScale>
+			<ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
+			<minRange>5</minRange>
+			<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>1</magazineSize>
+			<AmmoGenPerMagOverride>2</AmmoGenPerMagOverride>
+			<reloadTime>1.6</reloadTime>
+			<ammoSet>AmmoSet_80x256mmFuel</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aiAimMode>AimedShot</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>CE_AI_Launcher</li>
+			<li>NoSwitch</li>
+		</weaponTags>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[@Name="Gun_InfernoCannonBase"]/tools</xpath>
+		<value>
+			<tools>
+			<li Class="CombatExtended.ToolCE">
+				<label>barrel</label>
+				<capacities>
+				<li>Blunt</li>
+				</capacities>
+				<power>10</power>
+				<cooldownTime>2.44</cooldownTime>
+				<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+				<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+			</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<!-- ========== Thump cannon ========== -->
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Gun_ThumpCannon</defName>
+		<statBases>
+			<Mass>75.00</Mass>
+			<RangedWeapon_Cooldown>2.2</RangedWeapon_Cooldown>
+			<SightsEfficiency>1</SightsEfficiency>
+			<ShotSpread>0.01</ShotSpread>
+			<SwayFactor>0.21</SwayFactor>
+			<Bulk>20.00</Bulk>
+		</statBases>
+		<Properties>
+			<recoilAmount>0.1</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_164x284mmDemo</defaultProjectile>
+			<warmupTime>3.3</warmupTime>
+			<range>42</range>
+			<burstShotCount>1</burstShotCount>
+			<soundCast>ThumpCannon_Fire</soundCast>
+			<soundCastTail>GunTail_Heavy</soundCastTail>
+			<muzzleFlashScale>14</muzzleFlashScale>
+			<ai_AvoidFriendlyFireRadius>3</ai_AvoidFriendlyFireRadius>
+			<minRange>4</minRange>
+			<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>1</magazineSize>
+			<AmmoGenPerMagOverride>2</AmmoGenPerMagOverride>
+			<reloadTime>9.8</reloadTime>
+			<ammoSet>AmmoSet_164x284mmDemo</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aiAimMode>AimedShot</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>CE_AI_Launcher</li>
+			<li>NoSwitch</li>
+		</weaponTags>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Gun_ThumpCannon"]/tools</xpath>
+		<value>
+			<tools>
+			<li Class="CombatExtended.ToolCE">
+				<label>barrel</label>
+				<capacities>
+				<li>Blunt</li>
+				</capacities>
+				<power>10</power>
+				<cooldownTime>2.44</cooldownTime>
+				<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+				<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+			</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<!-- ========== Charge lance ========== -->
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Gun_ChargeLance</defName>
+		<statBases>
+			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+			<SightsEfficiency>1</SightsEfficiency>
+			<ShotSpread>0.01</ShotSpread>
+			<SwayFactor>0.88</SwayFactor>
+			<Bulk>13.00</Bulk>
+		</statBases>
+		<Properties>
+			<recoilAmount>0.92</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_5x35mmCharged</defaultProjectile>
+			<warmupTime>1.3</warmupTime>
+			<range>62</range>
+			<soundCast>ChargeLance_Fire</soundCast>
+			<soundCastTail>GunTail_Heavy</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>10</magazineSize>
+			<reloadTime>4</reloadTime>
+			<ammoSet>AmmoSet_5x35mmCharged</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aiAimMode>AimedShot</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>CE_AI_Rifle</li>
+			<li>NoSwitch</li>
+		</weaponTags>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Gun_ChargeLance"]/tools</xpath>
+		<value>
+			<tools>
+			<li Class="CombatExtended.ToolCE">
+				<label>barrel</label>
+				<capacities>
+				<li>Blunt</li>
+				</capacities>
+				<power>10</power>
+				<cooldownTime>2.44</cooldownTime>
+				<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+				<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+			</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="Gun_ChargeLance"]</xpath>
+		<value>
+			<li Class="CombatExtended.ThingDefExtensionCE">
+			<MenuHidden>True</MenuHidden>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- Disable for player -->
+	<Operation Class="PatchOperationAttributeSet">
+		<xpath>Defs/ThingDef[defName="Gun_ChargeLance"]</xpath>
+		<attribute>ParentName</attribute>
+		<value>BaseGun</value>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Gun_ChargeLance"]/costList</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Gun_ChargeLance"]/recipeMaker</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Gun_ChargeLance"]/statBases</xpath>
+		<value>
+			<MarketValue>1400</MarketValue>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Gun_ChargeLance"]</xpath>
+		<value>
+			<tradeability>None</tradeability>
+			<destroyOnDrop>True</destroyOnDrop>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Gun_ChargeLance"]/weaponTags/li[contains(.,"SpacerGun")]</xpath>
+	</Operation>
+
+	<!-- ========== Needle Gun ========== -->
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Gun_Needle</defName>
+		<statBases>
+			<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
+			<SightsEfficiency>2.24</SightsEfficiency>
+			<ShotSpread>0.01</ShotSpread>
+			<SwayFactor>0.85</SwayFactor>
+			<Bulk>15.00</Bulk>
+		</statBases>
+		<Properties>
+			<recoilAmount>1.80</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_5x50mmCaseless_Sabot</defaultProjectile>
+			<warmupTime>1.5</warmupTime>
+			<range>75</range>
+			<soundCast>Shot_NeedleGun</soundCast>
+			<soundCastTail>GunTail_Heavy</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>10</magazineSize>
+			<reloadTime>4</reloadTime>
+			<ammoSet>AmmoSet_5x50mmCaseless</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aiAimMode>AimedShot</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>CE_AI_Rifle</li>
+			<li>NoSwitch</li>
+		</weaponTags>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Gun_Needle"]/tools</xpath>
+		<value>
+			<tools>
+			<li Class="CombatExtended.ToolCE">
+				<label>barrel</label>
+				<capacities>
+				<li>Blunt</li>
+				</capacities>
+				<power>10</power>
+				<cooldownTime>2.44</cooldownTime>
+				<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+				<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+			</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<!-- Increase Orbital Bombardment Range -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="OrbitalTargeterBombardment" or defName="OrbitalTargeterPowerBeam"]/verbs/li/range</xpath>
+		<value>
+			<range>60</range>
+		</value>
+	</Operation>
+
+	<!-- Remove Smoke and EMP Launchers -->
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Gun_SmokeLauncher"]</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Gun_EmpLauncher"]</xpath>
+	</Operation>
 
 </Patch>

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -862,13 +862,13 @@ namespace CombatExtended
 
 
 
-        static Vector3 CasingOffsetRotated(GunDrawExtension ext, float shotRotation)
+        static Vector3 CasingOffsetRotated(GunDrawExtension ext, float shotRotation, bool flip)
         {
             if (ext == null || ext.CasingOffset == Vector2.zero)
             {
                 return Vector3.zero;
             }
-            return (new Vector3(ext.CasingOffset.x, 0, ext.CasingOffset.y) + RandomOriginOffset(ext.CasingOffsetRandomRange)).RotatedBy(shotRotation);
+            return (new Vector3(flip ? -ext.CasingOffset.x : ext.CasingOffset.x, 0, ext.CasingOffset.y) + RandomOriginOffset(ext.CasingOffsetRandomRange)).RotatedBy(shotRotation);
         }
 
         //No need to null check as the function calling it already handled it
@@ -925,7 +925,7 @@ namespace CombatExtended
             //Extension overrides
             if (extension != null)
             {
-                creationData.spawnPosition += CasingOffsetRotated(extension, shotRotation);
+                creationData.spawnPosition += CasingOffsetRotated(extension, shotRotation, flip);
                 casingAngleOffset = extension.CasingAngleOffset;
 
                 if (extension.AdvancedCasingVariables)

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -845,13 +845,13 @@ namespace CombatExtended
         #endregion Misc
 
         #region MoteThrower
-        public static void GenerateAmmoCasings(ProjectilePropertiesCE projProps, Vector3 drawPosition, Map map, float shotRotation = -180f, float recoilAmount = 2f, bool fromPawn = false, float casingAngleOffset = 0)
+        public static void GenerateAmmoCasings(ProjectilePropertiesCE projProps, Vector3 drawPosition, Map map, float shotRotation = -180f, float recoilAmount = 2f, bool fromPawn = false, GunDrawExtension extension = null)
         {
             if (projProps.dropsCasings)
             {
                 if (Controller.settings.ShowCasings)
                 {
-                    ThrowEmptyCasing(drawPosition, map, DefDatabase<FleckDef>.GetNamed(projProps.casingMoteDefname), recoilAmount, shotRotation, 1f, fromPawn, casingAngleOffset);
+                    ThrowEmptyCasing(drawPosition, map, DefDatabase<FleckDef>.GetNamed(projProps.casingMoteDefname), recoilAmount, shotRotation, 1f, fromPawn, extension);
                 }
                 if (Controller.settings.CreateCasingsFilth)
                 {
@@ -861,7 +861,28 @@ namespace CombatExtended
         }
 
 
-        public static void ThrowEmptyCasing(Vector3 loc, Map map, FleckDef casingFleckDef, float recoilAmount, float shotRotation, float size = 1f, bool fromPawn = false, float casingAngleOffset = 0)
+
+        static Vector3 CasingOffsetRotated(GunDrawExtension ext, float shotRotation)
+        {
+            if (ext == null || ext.CasingOffset == Vector2.zero)
+            {
+                return Vector3.zero;
+            }
+            return (new Vector3(ext.CasingOffset.x, 0, ext.CasingOffset.y) + RandomOriginOffset(ext.CasingOffsetRandomRange)).RotatedBy(shotRotation);
+        }
+
+        //No need to null check as the function calling it already handled it
+        static Vector3 RandomOriginOffset(Vector2 randRange)
+        {
+            if (randRange.y == 0 && randRange.x == 0)
+            {
+                return Vector3.zero;
+            }
+            return new Vector3(Rand.Range(-randRange.x, randRange.x), 0, Rand.Range(-randRange.y, randRange.y));
+        }
+
+
+        public static void ThrowEmptyCasing(Vector3 loc, Map map, FleckDef casingFleckDef, float recoilAmount, float shotRotation, float size = 1f, bool fromPawn = false, GunDrawExtension extension = null)
         {
             if (!loc.ShouldSpawnMotesAt(map) || map.moteCounter.SaturatedLowPriority)
             {
@@ -894,9 +915,48 @@ namespace CombatExtended
             {
                 flip = true;
             }
-            creationData.velocityAngle = flip ? shotRotation - 90 - casingAngleOffset + randomAngle : shotRotation + 90 + casingAngleOffset + randomAngle;
+
+
             creationData.rotation = (flip ? shotRotation - 90 : shotRotation + 90) + Rand.Range(-3f, 4f);
             creationData.rotationRate = (float)Rand.Range(-150, 150) / recoilAmount;
+
+
+            float casingAngleOffset = 0;
+            //Extension overrides
+            if (extension != null)
+            {
+                creationData.spawnPosition += CasingOffsetRotated(extension, shotRotation);
+                casingAngleOffset = extension.CasingAngleOffset;
+
+                if (extension.AdvancedCasingVariables)
+                {
+                    casingAngleOffset += extension.CasingAngleOffsetRange.RandomInRange;
+
+                    if (extension.CasingLifeTimeOverrideRange.min > 0)
+                    {
+                        creationData.airTimeLeft = extension.CasingLifeTimeOverrideRange.RandomInRange;
+                    }
+                    else if (extension.CasingLifeTimeMultiplier > 0)
+                    {
+                        creationData.airTimeLeft *= extension.CasingLifeTimeMultiplier;
+                    }
+
+                    if (extension.CasingSpeedOverrideRange.min > 0)
+                    {
+                        creationData.velocitySpeed = extension.CasingSpeedOverrideRange.RandomInRange;
+                    }
+                    else if (extension.CasingSpeedMultiplier > 0)
+                    {
+                        creationData.velocitySpeed *= extension.CasingSpeedMultiplier;
+                    }
+                }
+
+                creationData.scale *= extension.CasingSizeOffset;
+
+                creationData.rotation += Rand.Range(-extension.CasingRotationRandomRange, extension.CasingRotationRandomRange);
+            }
+
+            creationData.velocityAngle = flip ? shotRotation - 90 - casingAngleOffset + randomAngle : shotRotation + 90 + casingAngleOffset + randomAngle;
             map.flecks.CreateFleck(creationData);
             Rand.PopState();
         }

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -861,7 +861,7 @@ namespace CombatExtended
         }
 
 
-
+        //Don't use it when frompawn since pawn gun draw harmony patch handled it.
         static Vector3 CasingOffsetRotated(GunDrawExtension ext, float shotRotation, bool flip)
         {
             if (ext == null || ext.CasingOffset == Vector2.zero)
@@ -917,7 +917,7 @@ namespace CombatExtended
             }
 
 
-            creationData.rotation = (flip ? shotRotation - 90 : shotRotation + 90) + Rand.Range(-3f, 4f);
+            creationData.rotation = (flip ? shotRotation + 90 : shotRotation + 90) + Rand.Range(-3f, 4f);
             creationData.rotationRate = (float)Rand.Range(-150, 150) / recoilAmount;
 
 
@@ -925,7 +925,14 @@ namespace CombatExtended
             //Extension overrides
             if (extension != null)
             {
-                creationData.spawnPosition += CasingOffsetRotated(extension, shotRotation, flip);
+                if (fromPawn)
+                {
+                    creationData.spawnPosition += RandomOriginOffset(extension.CasingOffsetRandomRange).RotatedBy(shotRotation);
+                }
+                else
+                {
+                    creationData.spawnPosition += CasingOffsetRotated(extension, shotRotation, flip);
+                }
                 casingAngleOffset = extension.CasingAngleOffset;
 
                 if (extension.AdvancedCasingVariables)

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -875,6 +875,14 @@ namespace CombatExtended
             FleckCreationData creationData = FleckMaker.GetDataStatic(loc, map, casingFleckDef);
             creationData.velocitySpeed = Rand.Range(1.5f, 2f) * recoilAmount;
             creationData.airTimeLeft = Rand.Range(1f, 1.5f) / creationData.velocitySpeed;
+
+            //Just in case a super low recoil caused the airtimeleft to be super high.
+            if (creationData.airTimeLeft > 1.5f)
+            {
+                creationData.airTimeLeft = Rand.Range(1f, 1.5f);
+            }
+
+
             creationData.scale = Rand.Range(0.5f, 0.3f) * size;
             creationData.spawnPosition = loc;
             int randomAngle = Rand.Range(-20, 20);

--- a/Source/CombatExtended/CombatExtended/Defs/GunDrawExtension.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/GunDrawExtension.cs
@@ -15,6 +15,7 @@ namespace CombatExtended
 
         public Vector2 CasingOffset = Vector2.zero;
         public float CasingAngleOffset = 0;
-
+        public FloatRange CasingRotationOffsetRange = new FloatRange(0, 0);
+        public float CasingSpeedOverride = -1;
     }
 }

--- a/Source/CombatExtended/CombatExtended/Defs/GunDrawExtension.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/GunDrawExtension.cs
@@ -13,9 +13,26 @@ namespace CombatExtended
         public int recoilTick = -1;
         public float muzzleJumpModifier = -1;
 
+        //Angle: eject direction
+        //Rotation: casing's orientation
+
         public Vector2 CasingOffset = Vector2.zero;
         public float CasingAngleOffset = 0;
-        public FloatRange CasingRotationOffsetRange = new FloatRange(0, 0);
-        public float CasingSpeedOverride = -1;
+
+        public bool AdvancedCasingVariables = false;
+
+        public FloatRange CasingAngleOffsetRange = new FloatRange(0, 0);
+        public float CasingLifeTimeMultiplier = -1;
+        //having a min value below 0 disables lifetime override range. Override disables multiplier
+        public FloatRange CasingLifeTimeOverrideRange = new FloatRange(-1, 1);
+
+        public float CasingSpeedMultiplier = -1;
+        public FloatRange CasingSpeedOverrideRange = new FloatRange(-1, 1);
+
+        public float CasingSizeOffset = 1;
+
+        //for edge cases (read: Phalanx or Type-1130, where casings fell from a deflector chute)
+        public Vector2 CasingOffsetRandomRange = Vector2.zero;
+        public float CasingRotationRandomRange = 0;
     }
 }

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -394,7 +394,7 @@ namespace CombatExtended
             //Drop casings
             if (VerbPropsCE.ejectsCasings)
             {
-                CE_Utility.GenerateAmmoCasings(projectilePropsCE, fromPawn ? drawPos : caster.DrawPos + CasingOffsetRotated(ext), caster.Map, AimAngle + ext.CasingRotationOffsetRange.RandomInRange, ext.CasingSpeedOverride >= 0 ? ext.CasingSpeedOverride : VerbPropsCE.recoilAmount, fromPawn: fromPawn, casingAngleOffset: EquipmentSource?.def.GetModExtension<GunDrawExtension>()?.CasingAngleOffset ?? 0);
+                CE_Utility.GenerateAmmoCasings(projectilePropsCE, fromPawn ? drawPos : caster.DrawPos, caster.Map, AimAngle, VerbPropsCE.recoilAmount, fromPawn: fromPawn, extension: ext);
             }
             // This needs to here for weapons without magazine to ensure their last shot plays sounds
             if (CompAmmo != null && !CompAmmo.HasMagazine && CompAmmo.UseAmmo)
@@ -424,16 +424,6 @@ namespace CombatExtended
                 return CompAmmo.Notify_PostShotFired();
             }
             return true;
-        }
-
-        Vector3 CasingOffsetRotated(GunDrawExtension ext)
-        {
-            if (ext == null || ext.CasingOffset == Vector2.zero)
-            {
-                return Vector3.zero;
-            }
-            return new Vector3(ext.CasingOffset.x, 0, ext.CasingOffset.y).RotatedBy(AimAngle);
-
         }
         #endregion
     }

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -394,7 +394,7 @@ namespace CombatExtended
             //Drop casings
             if (VerbPropsCE.ejectsCasings)
             {
-                CE_Utility.GenerateAmmoCasings(projectilePropsCE, fromPawn ? drawPos : caster.DrawPos + CasingOffsetRotated(ext), caster.Map, AimAngle, VerbPropsCE.recoilAmount, fromPawn: fromPawn, casingAngleOffset: EquipmentSource?.def.GetModExtension<GunDrawExtension>()?.CasingAngleOffset ?? 0);
+                CE_Utility.GenerateAmmoCasings(projectilePropsCE, fromPawn ? drawPos : caster.DrawPos + CasingOffsetRotated(ext), caster.Map, AimAngle + ext.CasingRotationOffsetRange.RandomInRange, ext.CasingSpeedOverride >= 0 ? ext.CasingSpeedOverride : VerbPropsCE.recoilAmount, fromPawn: fromPawn, casingAngleOffset: EquipmentSource?.def.GetModExtension<GunDrawExtension>()?.CasingAngleOffset ?? 0);
             }
             // This needs to here for weapons without magazine to ensure their last shot plays sounds
             if (CompAmmo != null && !CompAmmo.HasMagazine && CompAmmo.UseAmmo)


### PR DESCRIPTION
## Changes
Added a celling for casing lifetime, so that slow casings don't keep falling for too long.

A metric load of variables that will be enabled if AdvancedCasingVariables is true in gundrawext, including random ranges for casing eject angle, casing rotation, random spawn offset range. And multipliers and overrides for casing lifetime and speed.

## Reasoning

-Deal with very-very edge case
-Prevent guns with too low recoil from behaving weird.
-Extra fine tuning freedom
-Most logic locked behind AdvancedCasingVariables so they don't burden most weapons too much.

## Alternatives

-Suffer

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (fiddling with most guns and my beloved CIWS turret)
