### PR TITLE
Ranged weapon cooldown quality factor

### DIFF
--- a/Patches/Core/Stats/Stats.xml
+++ b/Patches/Core/Stats/Stats.xml
@@ -401,7 +401,46 @@
 		</value>
 	</Operation>
 
-	<!-- Tweak the Ranged Weapon Damage Multiplier -->
+	<!-- Ranged weapon cooldown quality factor  -->
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/StatDef[defName="RangedWeapon_DamageMultiplier"]/parts</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/StatDef[defName="RangedWeapon_DamageMultiplier"]</xpath>
+			<value>
+				<parts>
+					<li Class="StatPart_Quality">
+						<factorAwful>1.1</factorAwful>
+						<factorPoor>1.05</factorPoor>
+						<factorNormal>1</factorNormal>
+						<factorGood>1</factorGood>
+						<factorExcellent>0.95</factorExcellent>
+						<factorMasterwork>0.9</factorMasterwork>
+						<factorLegendary>0.8</factorLegendary>
+					</li>
+				</parts>
+			</value>
+		</nomatch>
+		<match Class="PatchOperationReplace">
+			<xpath>Defs/StatDef[defName="RangedWeapon_DamageMultiplier"]/parts</xpath>
+			<value>
+				<parts>
+					<li Class="StatPart_Quality">
+						<factorAwful>1.1</factorAwful>
+						<factorPoor>1.05</factorPoor>
+						<factorNormal>1</factorNormal>
+						<factorGood>1</factorGood>
+						<factorExcellent>0.95</factorExcellent>
+						<factorMasterwork>0.9</factorMasterwork>
+						<factorLegendary>0.8</factorLegendary>
+					</li>
+				</parts>
+			</value>
+		</match>
+	</Operation>
+
+	<!-- Tweak the ranged weapon damage multiplier -->
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/StatDef[defName="RangedWeapon_DamageMultiplier"]/parts</xpath>
 		<value>
@@ -420,6 +459,7 @@
 	</Operation>
 
 	<!-- Melee DPS -->
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/StatDef[defName="MeleeWeapon_AverageDPS"]/workerClass</xpath>
 		<value>
@@ -435,6 +475,7 @@
 	</Operation>
 
 	<!-- Melee AP -->
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/StatDef[defName="MeleeWeapon_AverageArmorPenetration"]/workerClass</xpath>
 		<value>

--- a/Patches/Core/Stats/Stats.xml
+++ b/Patches/Core/Stats/Stats.xml
@@ -404,9 +404,9 @@
 	<!-- Ranged weapon cooldown quality factor  -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/StatDef[defName="RangedWeapon_DamageMultiplier"]/parts</xpath>
+		<xpath>Defs/StatDef[defName="RangedWeapon_Cooldown"]/parts</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/StatDef[defName="RangedWeapon_DamageMultiplier"]</xpath>
+			<xpath>Defs/StatDef[defName="RangedWeapon_Cooldown"]</xpath>
 			<value>
 				<parts>
 					<li Class="StatPart_Quality">
@@ -422,7 +422,7 @@
 			</value>
 		</nomatch>
 		<match Class="PatchOperationReplace">
-			<xpath>Defs/StatDef[defName="RangedWeapon_DamageMultiplier"]/parts</xpath>
+			<xpath>Defs/StatDef[defName="RangedWeapon_Cooldown"]/parts</xpath>
 			<value>
 				<parts>
 					<li Class="StatPart_Quality">


### PR DESCRIPTION
## Changes

- Made ranged weapon cooldown be affected by quality.

## Reasoning

- Ranged weapon cooldown is considered the time it takes for a gun's action to cycle so the change is made to simulate the action being of a better or worse quality resulting in quicker and slows cycles.
- Numbers are not final, made sense to be this much considering the common values for cooldown.

## Alternatives

- Leave as is.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Works)
