### PR TITLE
Correct ammo gen for single use weapon with custom verb 

### DIFF
--- a/Source/CombatExtended/CombatExtended/Defs/LoadoutPropertiesExtension.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/LoadoutPropertiesExtension.cs
@@ -253,7 +253,7 @@ namespace CombatExtended
             var compAmmo = gun.TryGetComp<CompAmmoUser>();
             if (compAmmo == null || !compAmmo.UseAmmo)
             {
-                if (gun.TryGetComp<CompEquippable>().PrimaryVerb.verbProps.verbClass == typeof(Verb_ShootCEOneUse))
+                if (gun.TryGetComp<CompEquippable>().PrimaryVerb.verbProps.verbClass == typeof(Verb_ShootCEOneUse) || (gun.def.weaponTags?.Contains("CE_AmmoGen_Disposable") ?? false))
                 {
                     thingToAdd = gun.def;   // For one-time use weapons such as grenades, add duplicates instead of ammo
                 }


### PR DESCRIPTION
## Changes

-Make weapons with CE_AmmoGen_Disposable weapontag to be treated as single use during NPC loadout generation

## Reasoning

It's bill doors with his custom verb problems again. My indirect weapons' verb was coded not to fire under roof, which make them not recognized as single use weapon.

## Alternatives

Every raider show up with only one disposable LGIS launch tube (sounds like a benefit)

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (A few newly written imperial LGIS carrier pawns spawned)
