### PR TITLE
Key autopatcher mod menu entries

### DIFF
--- a/Languages/English/Keyed/ModMenu.xml
+++ b/Languages/English/Keyed/ModMenu.xml
@@ -111,18 +111,18 @@
 	<CE_Settings_VerboseAutopatcher_Desc>This will enable verbose logging of the autopatcher</CE_Settings_VerboseAutopatcher_Desc>			
 
 	<CE_Settings_ApparelAutopatcher_Title>Enable apparel autopatcher</CE_Settings_ApparelAutopatcher_Title>
-	<CE_Settings_ApparelAutopatcher_Desc>This will enable the apparel autopatcher.</CE_Settings_ApparelAutopatcher_Desc>
+	<CE_Settings_ApparelAutopatcher_Desc>Attempt to apply an appropriate apparel preset to the armor values of unpatched apparel.</CE_Settings_ApparelAutopatcher_Desc>
 
 	<CE_Settings_RaceAutopatcher_Title>Enable race autopatcher</CE_Settings_RaceAutopatcher_Title>
-	<CE_Settings_RaceAutopatcher_Desc>This will enable the race autopatcher.</CE_Settings_RaceAutopatcher_Desc>
+	<CE_Settings_RaceAutopatcher_Desc>The autopatcher will apply a preset to unpatched races to allow basic functionality.</CE_Settings_RaceAutopatcher_Desc>
 
 	<CE_Settings_WeaponAutopatcher_Title>Enable weapon autopatcher</CE_Settings_WeaponAutopatcher_Title>
-	<CE_Settings_WeaponAutopatcher_Desc>This will enable the weapon autopatcher.</CE_Settings_WeaponAutopatcher_Desc>
+	<CE_Settings_WeaponAutopatcher_Desc>Attempt to apply an appropriate weapon preset to unpatched ranged weapons.</CE_Settings_WeaponAutopatcher_Desc>
 
-	<CE_Settings_ToughnessAutopatcher_Title>Enable weapon autopatcher</CE_Settings_ToughnessAutopatcher_Title>
-	<CE_Settings_ToughnessAutopatcher_Desc>This will enable the weapon toughness autopatcher.</CE_Settings_ToughnessAutopatcher_Desc>
+	<CE_Settings_ToughnessAutopatcher_Title>Enable weapon toughness autopatcher</CE_Settings_ToughnessAutopatcher_Title>
+	<CE_Settings_ToughnessAutopatcher_Desc>Apply an automatically calculated toughness stat to weapons, which affects how much damage they recieve when used in melee.</CE_Settings_ToughnessAutopatcher_Desc>
 
 	<CE_Settings_PawnkindAutopatcher_Title>Enable pawnkind autopatcher</CE_Settings_PawnkindAutopatcher_Title>
-	<CE_Settings_PawnkindAutopatcher_Desc>This will enable the pawnkind toughness autopatcher.</CE_Settings_PawnkindAutopatcher_Desc>
+	<CE_Settings_PawnkindAutopatcher_Desc>Give unpatched pawnkinds equipped with a patched ranged weapon a small amount of ammunition.</CE_Settings_PawnkindAutopatcher_Desc>
 
 </LanguageData>

--- a/Languages/English/Keyed/ModMenu.xml
+++ b/Languages/English/Keyed/ModMenu.xml
@@ -105,4 +105,24 @@
 	<CE_Settings_PatchArmorDamage_Title>Use New Vehicle Armor</CE_Settings_PatchArmorDamage_Title>
 	<CE_Settings_PatchArmorDamage_Desc>Vehicle Armor reduces damage based on relative values, but can be penetrated by high AP attacks..</CE_Settings_PatchArmorDamage_Desc>
 
+	<!-- ========== Autopatcher settings ========== -->
+
+	<CE_Settings_VerboseAutopatcher_Title>Enable autopatcher verbose logging</CE_Settings_VerboseAutopatcher_Title>
+	<CE_Settings_VerboseAutopatcher_Desc>This will enable verbose logging of the autopatcher</CE_Settings_VerboseAutopatcher_Desc>			
+
+	<CE_Settings_ApparelAutopatcher_Title>Enable apparel autopatcher</CE_Settings_ApparelAutopatcher_Title>
+	<CE_Settings_ApparelAutopatcher_Desc>This will enable the apparel autopatcher.</CE_Settings_ApparelAutopatcher_Desc>
+
+	<CE_Settings_RaceAutopatcher_Title>Enable race autopatcher</CE_Settings_RaceAutopatcher_Title>
+	<CE_Settings_RaceAutopatcher_Desc>This will enable the race autopatcher.</CE_Settings_RaceAutopatcher_Desc>
+
+	<CE_Settings_WeaponAutopatcher_Title>Enable weapon autopatcher</CE_Settings_WeaponAutopatcher_Title>
+	<CE_Settings_WeaponAutopatcher_Desc>This will enable the weapon autopatcher.</CE_Settings_WeaponAutopatcher_Desc>
+
+	<CE_Settings_ToughnessAutopatcher_Title>Enable weapon autopatcher</CE_Settings_ToughnessAutopatcher_Title>
+	<CE_Settings_ToughnessAutopatcher_Desc>This will enable the weapon toughness autopatcher.</CE_Settings_ToughnessAutopatcher_Desc>
+
+	<CE_Settings_PawnkindAutopatcher_Title>Enable pawnkind autopatcher</CE_Settings_PawnkindAutopatcher_Title>
+	<CE_Settings_PawnkindAutopatcher_Desc>This will enable the pawnkind toughness autopatcher.</CE_Settings_PawnkindAutopatcher_Desc>
+
 </LanguageData>

--- a/Source/CombatExtended/CombatExtended/Settings.cs
+++ b/Source/CombatExtended/CombatExtended/Settings.cs
@@ -255,13 +255,13 @@ namespace CombatExtended
             Text.Font = GameFont.Small;
             list.Gap();
 
-            list.CheckboxLabeled("Enable autopatcher verbose logging", ref debugAutopatcherLogger, "This will enable verbose logging of the autopatcher.");
+            list.CheckboxLabeled("CE_Settings_VerboseAutopatcher_Title".Translate(), ref debugAutopatcherLogger, "CE_Settings_VerboseAutopatcher_Desc".Translate());
 
-            list.CheckboxLabeled("Enable apparel autopatcher", ref enableApparelAutopatcher, "This will enable the apparel autopatcher.");
-            list.CheckboxLabeled("Enable race autopatcher", ref enableRaceAutopatcher, "This will enable the race autopatcher.");
-            list.CheckboxLabeled("Enable weapon autopatcher", ref enableWeaponAutopatcher, "This will enable the weapon autopatcher.");
-            list.CheckboxLabeled("Enable weapon toughness autopatcher", ref enableWeaponToughnessAutopatcher, "This will enable the weapon toughness autopatcher.");
-            list.CheckboxLabeled("Enable PawnKind autopatcher", ref enablePawnKindAutopatcher, "This will enable the PawnKind autopatcher.");
+            list.CheckboxLabeled("CE_Settings_ApparelAutopatcher_Title".Translate(), ref enableApparelAutopatcher, "CE_Settings_ApparelAutopatcher_Desc".Translate());
+            list.CheckboxLabeled("CE_Settings_RaceAutopatcher_Title".Translate(), ref enableRaceAutopatcher, "CE_Settings_RaceAutopatcher_Desc".Translate());
+            list.CheckboxLabeled("CE_Settings_WeaponAutopatcher_Title".Translate(), ref enableWeaponAutopatcher, "CE_Settings_WeaponAutopatcher_Desc".Translate());
+            list.CheckboxLabeled("CE_Settings_ToughnessAutopatcher_Title".Translate(), ref enableWeaponToughnessAutopatcher, "CE_Settings_ToughnessAutopatcher_Desc".Translate());
+            list.CheckboxLabeled("CE_Settings_PawnkindAutopatcher_Title".Translate(), ref enablePawnKindAutopatcher, "CE_Settings_PawnkindAutopatcher_Desc".Translate());
 
             // Do ammo settings
             list.NewColumn();


### PR DESCRIPTION
## Additions
- Add translation keys for autopatcher mod menu settings.

## Changes
- Expand some autopatcher descriptions to actually provide some details about their functionality.

## Reasoning
- Requested, and it's the proper way to do it.

## Alternatives
- Continue to espouse the primacy of the anglosphere.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
