### PR TITLE
Fix typo in Contraband.xml

### DIFF
--- a/ModPatches/Vanilla Factions Expanded - Deserters/Patches/Vanilla Factions Expanded - Deserters/Contraband.xml
+++ b/ModPatches/Vanilla Factions Expanded - Deserters/Patches/Vanilla Factions Expanded - Deserters/Contraband.xml
@@ -45,7 +45,7 @@
 		<mods>
 			<li>Combat Extended Guns</li>
 		</mods>
-		<match Class="PatchOperationReplace">
+		<match Class="PatchOperationAddModExtension">
 			<xpath>Defs/ThingDef[defName="CE_Gun_ChargeSniperRifle"]</xpath>
 			<value>
 				<li Class="VFED.ContrabandExtension">


### PR DESCRIPTION
## Changes

fix typo that removes change sniper rifle when deserters is loaded


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (few days)
