### PR TITLE
additional autoloader failure notification

### DIFF
--- a/Languages/English/Keyed/AmmoContainerKeyed.xml
+++ b/Languages/English/Keyed/AmmoContainerKeyed.xml
@@ -1,23 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LanguageData>
 
-	<CE_AutoLoader_DropAmmo>Unload contents</CE_AutoLoader_DropAmmo>
-	<CE_AutoLoader_DropAmmoDesc>Unload this autoloader's contents onto the floor.</CE_AutoLoader_DropAmmoDesc>
+  <CE_AutoLoader_DropAmmo>Unload contents</CE_AutoLoader_DropAmmo>
+  <CE_AutoLoader_DropAmmoDesc>Unload this autoloader's contents onto the floor.</CE_AutoLoader_DropAmmoDesc>
 
-	<CE_AutoLoader_ForceReload>Reload turrets</CE_AutoLoader_ForceReload>
-	<CE_AutoLoader_ForceReloadDesc>Reload adjacent turrets immediately. Forbidden turrets and currently firing turrets will be ignored.</CE_AutoLoader_ForceReloadDesc>
+  <CE_AutoLoader_ForceReload>Reload turrets</CE_AutoLoader_ForceReload>
+  <CE_AutoLoader_ForceReloadDesc>Reload adjacent turrets immediately. Forbidden turrets and currently firing turrets will be ignored.</CE_AutoLoader_ForceReloadDesc>
 
-	<CE_AutoLoader_NoTurretToReload>{0} cannot find any adjacent available {1} turrets.</CE_AutoLoader_NoTurretToReload>
+  <CE_AutoLoader_Unmanned>{0} needs to be manned by an operator to function.</CE_AutoLoader_Unmanned>
+  <CE_AutoLoader_Unpowered>{0} needs power to function.</CE_AutoLoader_Unpowered>
+  <CE_AutoLoader_NoTurretToReload>{0} cannot find any adjacent available {1} turrets.</CE_AutoLoader_NoTurretToReload>
 
-	<CE_AutoLoader_ToggleReplaceOn>Ammo replacement: on</CE_AutoLoader_ToggleReplaceOn>
-	<CE_AutoLoader_ToggleReplaceDescOn>The autoloader will replace turret's current ammo with the ammo type in the loader.</CE_AutoLoader_ToggleReplaceDescOn>
+  <CE_AutoLoader_ToggleReplaceOn>Ammo replacement: on</CE_AutoLoader_ToggleReplaceOn>
+  <CE_AutoLoader_ToggleReplaceDescOn>The autoloader will replace turret's current ammo with the ammo type in the loader.</CE_AutoLoader_ToggleReplaceDescOn>
 
-	<CE_AutoLoader_ToggleReplaceOff>Ammo replacement: off</CE_AutoLoader_ToggleReplaceOff>
-	<CE_AutoLoader_ToggleReplaceDescOff>The autoloader will only reload turret with the same ammo type in the loader.</CE_AutoLoader_ToggleReplaceDescOff>
+  <CE_AutoLoader_ToggleReplaceOff>Ammo replacement: off</CE_AutoLoader_ToggleReplaceOff>
+  <CE_AutoLoader_ToggleReplaceDescOff>The autoloader will only reload turret with the same ammo type in the loader.</CE_AutoLoader_ToggleReplaceDescOff>
 
-	<CE_AutoLoader_ReloadTime>Reload time remaining: {0} seconds</CE_AutoLoader_ReloadTime>
-	<CE_AutoLoader_ShouldReplace>Ammo type replacement: {0}</CE_AutoLoader_ShouldReplace>
+  <CE_AutoLoader_ManningRequired>Require manning to operate</CE_AutoLoader_ManningRequired>
+  <CE_AutoLoader_ReloadTime>Reload time remaining: {0} seconds</CE_AutoLoader_ReloadTime>
+  <CE_AutoLoader_ShouldReplace>Ammo type replacement: {0}</CE_AutoLoader_ShouldReplace>
 
-	<CE_AutoLoaderBusy>Autoloader is reloading or being reloaded.</CE_AutoLoaderBusy>
+  <CE_AutoLoaderBusy>Autoloader is reloading or being reloaded.</CE_AutoLoaderBusy>
 
 </LanguageData>

--- a/Languages/English/Keyed/AmmoContainerKeyed.xml
+++ b/Languages/English/Keyed/AmmoContainerKeyed.xml
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LanguageData>
 
-  <CE_AutoLoader_DropAmmo>Unload contents</CE_AutoLoader_DropAmmo>
-  <CE_AutoLoader_DropAmmoDesc>Unload this autoloader's contents onto the floor.</CE_AutoLoader_DropAmmoDesc>
+	<CE_AutoLoader_DropAmmo>Unload contents</CE_AutoLoader_DropAmmo>
+	<CE_AutoLoader_DropAmmoDesc>Unload this autoloader's contents onto the floor.</CE_AutoLoader_DropAmmoDesc>
 
-  <CE_AutoLoader_ForceReload>Reload turrets</CE_AutoLoader_ForceReload>
-  <CE_AutoLoader_ForceReloadDesc>Reload adjacent turrets immediately. Forbidden turrets and currently firing turrets will be ignored.</CE_AutoLoader_ForceReloadDesc>
+	<CE_AutoLoader_ForceReload>Reload turrets</CE_AutoLoader_ForceReload>
+	<CE_AutoLoader_ForceReloadDesc>Reload adjacent turrets immediately. Forbidden turrets and currently firing turrets will be ignored.</CE_AutoLoader_ForceReloadDesc>
 
-  <CE_AutoLoader_Unmanned>{0} needs to be manned by an operator to function.</CE_AutoLoader_Unmanned>
-  <CE_AutoLoader_Unpowered>{0} needs power to function.</CE_AutoLoader_Unpowered>
-  <CE_AutoLoader_NoTurretToReload>{0} cannot find any adjacent available {1} turrets.</CE_AutoLoader_NoTurretToReload>
+	<CE_AutoLoader_Unmanned>{0} needs to be manned by an operator to function.</CE_AutoLoader_Unmanned>
+	<CE_AutoLoader_Unpowered>{0} needs power to function.</CE_AutoLoader_Unpowered>
+	<CE_AutoLoader_NoTurretToReload>{0} cannot find any adjacent available {1} turrets.</CE_AutoLoader_NoTurretToReload>
 
-  <CE_AutoLoader_ToggleReplaceOn>Ammo replacement: on</CE_AutoLoader_ToggleReplaceOn>
-  <CE_AutoLoader_ToggleReplaceDescOn>The autoloader will replace turret's current ammo with the ammo type in the loader.</CE_AutoLoader_ToggleReplaceDescOn>
+	<CE_AutoLoader_ToggleReplaceOn>Ammo replacement: on</CE_AutoLoader_ToggleReplaceOn>
+	<CE_AutoLoader_ToggleReplaceDescOn>The autoloader will replace turret's current ammo with the ammo type in the loader.</CE_AutoLoader_ToggleReplaceDescOn>
 
-  <CE_AutoLoader_ToggleReplaceOff>Ammo replacement: off</CE_AutoLoader_ToggleReplaceOff>
-  <CE_AutoLoader_ToggleReplaceDescOff>The autoloader will only reload turret with the same ammo type in the loader.</CE_AutoLoader_ToggleReplaceDescOff>
+	<CE_AutoLoader_ToggleReplaceOff>Ammo replacement: off</CE_AutoLoader_ToggleReplaceOff>
+	<CE_AutoLoader_ToggleReplaceDescOff>The autoloader will only reload turret with the same ammo type in the loader.</CE_AutoLoader_ToggleReplaceDescOff>
 
-  <CE_AutoLoader_ManningRequired>Require manning to operate</CE_AutoLoader_ManningRequired>
-  <CE_AutoLoader_ReloadTime>Reload time remaining: {0} seconds</CE_AutoLoader_ReloadTime>
-  <CE_AutoLoader_ShouldReplace>Ammo type replacement: {0}</CE_AutoLoader_ShouldReplace>
+	<CE_AutoLoader_ManningRequired>Require manning to operate</CE_AutoLoader_ManningRequired>
+	<CE_AutoLoader_ReloadTime>Reload time remaining: {0} seconds</CE_AutoLoader_ReloadTime>
+	<CE_AutoLoader_ShouldReplace>Ammo type replacement: {0}</CE_AutoLoader_ShouldReplace>
 
-  <CE_AutoLoaderBusy>Autoloader is reloading or being reloaded.</CE_AutoLoaderBusy>
+	<CE_AutoLoaderBusy>Autoloader is reloading or being reloaded.</CE_AutoLoaderBusy>
 
 </LanguageData>

--- a/Source/CombatExtended/CombatExtended/Building_AmmoContainerCE/Building_AutoloaderCE.cs
+++ b/Source/CombatExtended/CombatExtended/Building_AmmoContainerCE/Building_AutoloaderCE.cs
@@ -48,22 +48,21 @@ namespace CombatExtended
 
         public ModExtension_AutoLoaderGraphics graphicsExt;
 
-        public bool shouldBeOn
+        public bool shouldBeOn => ShouldBeOn();
+
+        public bool ShouldBeOn(bool failureNotify = false)
         {
-            get
+            if (manningRequiredButUnmanned)
             {
-                if (manningRequiredButUnmanned)
-                {
-                    Messages.Message(string.Format("CE_AutoLoader_Unmanned".Translate(), Label), this, MessageTypeDefOf.RejectInput, historical: false);
-                    return false;
-                }
-                if (powerRequiredButUnpowered)
-                {
-                    Messages.Message(string.Format("CE_AutoLoader_Unpowered".Translate(), Label), this, MessageTypeDefOf.RejectInput, historical: false);
-                    return false;
-                }
-                return (dormantComp == null || dormantComp.Awake) && (initiatableComp == null || initiatableComp.Initiated);
+                if (failureNotify) { Messages.Message(string.Format("CE_AutoLoader_Unmanned".Translate(), Label), this, MessageTypeDefOf.RejectInput, historical: false); }
+                return false;
             }
+            if (powerRequiredButUnpowered)
+            {
+                if (failureNotify) { Messages.Message(string.Format("CE_AutoLoader_Unpowered".Translate(), Label), this, MessageTypeDefOf.RejectInput, historical: false); }
+                return false;
+            }
+            return (dormantComp == null || dormantComp.Awake) && (initiatableComp == null || initiatableComp.Initiated);
         }
 
         public bool manningRequiredButUnmanned => mannableComp != null && !mannableComp.MannedNow;
@@ -238,17 +237,20 @@ namespace CombatExtended
                         List<Thing> adjThings = new List<Thing>();
                         GenAdjFast.AdjacentThings8Way(this, adjThings);
                         bool success = false;
-                        foreach (Thing building in adjThings)
+                        if (ShouldBeOn(true))
                         {
-                            if (building is Building_TurretGunCE turret && StartReload(turret.GetAmmo()))
+                            foreach (Thing building in adjThings)
                             {
-                                success = true;
-                                break;
+                                if (building is Building_TurretGunCE turret && StartReload(turret.GetAmmo()))
+                                {
+                                    success = true;
+                                    break;
+                                }
                             }
-                        }
-                        if (!success)
-                        {
-                            Messages.Message(string.Format("CE_AutoLoader_NoTurretToReload".Translate(), Label, CompAmmoUser.Props.ammoSet.label), this, MessageTypeDefOf.RejectInput, historical: false);
+                            if (!success)
+                            {
+                                Messages.Message(string.Format("CE_AutoLoader_NoTurretToReload".Translate(), Label, CompAmmoUser.Props.ammoSet.label), this, MessageTypeDefOf.RejectInput, historical: false);
+                            }
                         }
                     };
                     yield return reload;

--- a/Source/CombatExtended/CombatExtended/Building_AmmoContainerCE/Building_AutoloaderCE.cs
+++ b/Source/CombatExtended/CombatExtended/Building_AmmoContainerCE/Building_AutoloaderCE.cs
@@ -48,7 +48,27 @@ namespace CombatExtended
 
         public ModExtension_AutoLoaderGraphics graphicsExt;
 
-        public bool shouldBeOn => (powerComp == null || powerComp.PowerOn) && (dormantComp == null || dormantComp.Awake) && (initiatableComp == null || initiatableComp.Initiated) && (mannableComp == null || mannableComp.MannedNow);
+        public bool shouldBeOn
+        {
+            get
+            {
+                if (manningRequiredButUnmanned)
+                {
+                    Messages.Message(string.Format("CE_AutoLoader_Unmanned".Translate(), Label), this, MessageTypeDefOf.RejectInput, historical: false);
+                    return false;
+                }
+                if (powerRequiredButUnpowered)
+                {
+                    Messages.Message(string.Format("CE_AutoLoader_Unpowered".Translate(), Label), this, MessageTypeDefOf.RejectInput, historical: false);
+                    return false;
+                }
+                return (dormantComp == null || dormantComp.Awake) && (initiatableComp == null || initiatableComp.Initiated);
+            }
+        }
+
+        public bool manningRequiredButUnmanned => mannableComp != null && !mannableComp.MannedNow;
+
+        public bool powerRequiredButUnpowered => powerComp != null && !powerComp.PowerOn;
 
         public override void ExposeData()
         {
@@ -306,6 +326,10 @@ namespace CombatExtended
             if (!inspectString.NullOrEmpty())
             {
                 stringBuilder.AppendLine(inspectString);
+            }
+            if (manningRequiredButUnmanned)
+            {
+                stringBuilder.AppendLine("CE_AutoLoader_ManningRequired".Translate());
             }
             if (isActive)
             {


### PR DESCRIPTION
## Additions

Additional notification when a powered autoloader is unpowered, or a manned is unmanned.

## Reasoning

-Turned out it's not obvious a manned autoloader need to be manned. fooled me once.

## Alternatives

-AUTOLOADER ARE BROKEN!!! (not really you need to man them)

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
