### PR TITLE
Change access level of various fields and methods for extensibility

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -865,7 +865,7 @@ namespace CombatExtended
             return false;
         }
 
-        protected bool TryCollideWithRoof(IntVec3 cell)
+        protected virtual bool TryCollideWithRoof(IntVec3 cell)
         {
             if (!cell.Roofed(Map))
             {

--- a/Source/CombatExtended/CombatExtended/Things/Building_TurretGunCE.cs
+++ b/Source/CombatExtended/CombatExtended/Things/Building_TurretGunCE.cs
@@ -58,14 +58,14 @@ namespace CombatExtended
 
         #region Properties
         // Core properties
-        public bool Active => (powerComp == null || powerComp.PowerOn) && (dormantComp == null || dormantComp.Awake) && (initiatableComp == null || initiatableComp.Initiated);
+        public virtual bool Active => (powerComp == null || powerComp.PowerOn) && (dormantComp == null || dormantComp.Awake) && (initiatableComp == null || initiatableComp.Initiated);
         public CompEquippable GunCompEq => Gun.TryGetComp<CompEquippable>();
         public override LocalTargetInfo CurrentTarget => currentTargetInt;
         private bool WarmingUp => burstWarmupTicksLeft > 0;
         public override Verb AttackVerb => Gun == null ? null : GunCompEq.verbTracker.PrimaryVerb;
         public bool IsMannable => mannableComp != null;
         public bool PlayerControlled => (Faction == Faction.OfPlayer || MannedByColonist) && !MannedByNonColonist;
-        private bool CanSetForcedTarget => mannableComp != null && PlayerControlled;
+        protected virtual bool CanSetForcedTarget => mannableComp != null && PlayerControlled;
         private bool CanToggleHoldFire => PlayerControlled;
         public bool IsMortar => def.building.IsMortar;
         public bool IsMortarOrProjectileFliesOverhead => Projectile.projectile.flyOverhead || IsMortar;
@@ -96,7 +96,7 @@ namespace CombatExtended
             }
         }
 
-        public ThingDef Projectile
+        public virtual ThingDef Projectile
         {
             get
             {
@@ -367,7 +367,7 @@ namespace CombatExtended
             }
         }
 
-        public void TryStartShootSomething(bool canBeginBurstImmediately)    // Added ammo check and use verb warmup time instead of turret's
+        public virtual void TryStartShootSomething(bool canBeginBurstImmediately)    // Added ammo check and use verb warmup time instead of turret's
         {
             // Check for ammo first
             if (!Spawned
@@ -417,7 +417,7 @@ namespace CombatExtended
             burstWarmupTicksLeft = 1;
         }
 
-        public LocalTargetInfo TryFindNewTarget()    // Core method
+        public virtual LocalTargetInfo TryFindNewTarget()    // Core method
         {
             IAttackTargetSearcher attackTargetSearcher = this.TargSearcher();
             Faction faction = attackTargetSearcher.Thing.Faction;
@@ -484,7 +484,7 @@ namespace CombatExtended
             return true;
         }
 
-        public void BeginBurst()                     // Added handling for ticksUntilAutoReload
+        public virtual void BeginBurst()                     // Added handling for ticksUntilAutoReload
         {
             ticksUntilAutoReload = minTicksBeforeAutoReload;
             if (AttackVerb is Verb_ShootMortarCE shootMortar)
@@ -784,7 +784,7 @@ namespace CombatExtended
         [Compatibility.Multiplayer.SyncMethod]
         private void SyncedResetForcedTarget() => ResetForcedTarget();
 
-        public void ResetForcedTarget()                // Core method
+        public virtual void ResetForcedTarget()                // Core method
         {
             this.targetingWorldMap = false;
             this.forcedTarget = LocalTargetInfo.Invalid;

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -30,7 +30,7 @@ namespace CombatExtended
 
         // Targeting factors
         private float estimatedTargDist = -1;           // Stores estimate target distance for each burst, so each burst shot uses the same
-        private int numShotsFired = 0;                  // Stores how many shots were fired for purposes of recoil
+        protected int numShotsFired = 0;                  // Stores how many shots were fired for purposes of recoil
 
         // Angle in Vector2(degrees, radians)        
         protected Vector2 newTargetLoc = new Vector2(0, 0);
@@ -54,7 +54,7 @@ namespace CombatExtended
 
         private bool shootingAtDowned = false;
         private LocalTargetInfo lastTarget = null;
-        private IntVec3 lastTargetPos = IntVec3.Invalid;
+        protected IntVec3 lastTargetPos = IntVec3.Invalid;
 
         protected float lastShotAngle;
         protected float lastShotRotation;
@@ -62,7 +62,7 @@ namespace CombatExtended
         protected float? storedShotReduction = null;
         protected ShootLine? lastShootLine;
         protected bool repeating = false;
-        private bool doRetarget = true;
+        protected bool doRetarget = true;
 
         #endregion
 
@@ -129,7 +129,7 @@ namespace CombatExtended
                 return shotSpeed;
             }
         }
-        public float ShotHeight => (new CollisionVertical(caster)).shotHeight;
+        public virtual float ShotHeight => (new CollisionVertical(caster)).shotHeight;
         private Vector3 ShotSource
         {
             get
@@ -1166,7 +1166,7 @@ namespace CombatExtended
             return explosionRadiusForDisplay;
         }
 
-        private float GetMinCollisionDistance(float targetDistance)
+        protected float GetMinCollisionDistance(float targetDistance)
         {
             var shortRangeMinCollisionDistance = 1.5f;
             var longRangeMinCollisionDistMult = 0.2f;
@@ -1319,7 +1319,7 @@ namespace CombatExtended
         }
 
         // Added targetThing to parameters so we can calculate its height
-        private bool CanHitCellFromCellIgnoringRange(Vector3 shotSource, IntVec3 targetLoc, Thing targetThing = null)
+        protected virtual bool CanHitCellFromCellIgnoringRange(Vector3 shotSource, IntVec3 targetLoc, Thing targetThing = null)
         {
             // Vanilla checks
             if (verbProps.mustCastOnOpenGround && (!targetLoc.Standable(caster.Map) || caster.Map.thingGrid.CellContains(targetLoc, ThingCategory.Pawn)))

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootMortarCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootMortarCE.cs
@@ -38,7 +38,7 @@ namespace CombatExtended
         private int destinationTile;
         private int globalDistance;
         private Vector3 direction;
-        private int numShotsFired;
+        private new int numShotsFired;
 
         public override void ExposeData()
         {


### PR DESCRIPTION
## Changes

**Verb_LaunchProjectileCE**
- `numShotsFired` | private int > protected int
- `lastTargetPos` | private IntVec3 > protected IntVec3
- `doRetarget` | private bool > protected bool
- `ShotHeight` | public float > public virtual float
- `GetMinCollisionDistance` | private float > protected float
- `CanHitCellFromCellIgnoringRange` | private bool > protected virtual bool

**Verb_ShootMortarCE**
- `numShotsFired` | private int > private new int 

**ProjectileCE**
- `TryCollideWithRoof` | protected bool > protected virtual bool

**Building_TurretGunCE**
- `Active` | public bool > public virtual bool
- `CanSetForcedTarget` | private bool > protected virtual bool
- `Projectile` | public ThingDef > public virtual ThingDef
- `TryStartShootSomething` | public void > public virtual void
- `TryFindNewTarget` | public LocalTargetInfo > public virtual LocalTargetInfo
- `BeginBurst` | public void > public virtual void
- `ResetForcedTarget` | public void > public virtual void 

## Reasoning

- Allows for access/overriding of various fields/methods in classes extend `Building_TurretGunCE` `ProjectileCE` and `Verb_LaunchProjectileCE`
- Needed for SOS2 Ground defense mode turrets

## Alternatives

- Could leave it how it is currently but that would make extending the functionality to support things like special turrets and verbs for SOS2 harder

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
