### PR TITLE
Combat bionics and implants rebalanced

### DIFF
--- a/ModPatches/EPOE Forked Royalty DLC expansion/Patches/EPOE Forked Royalty DLC expansion/Bionics_Patch.xml
+++ b/ModPatches/EPOE Forked Royalty DLC expansion/Patches/EPOE Forked Royalty DLC expansion/Bionics_Patch.xml
@@ -11,9 +11,9 @@
 						<li>Stab</li>
 					</capacities>
 					<power>8</power>
-					<cooldownTime>1.88</cooldownTime>
-					<armorPenetrationSharp>0.04</armorPenetrationSharp>
-					<armorPenetrationBlunt>0.32</armorPenetrationBlunt>
+					<cooldownTime>1.25</cooldownTime>
+					<armorPenetrationSharp>0.15</armorPenetrationSharp>
+					<armorPenetrationBlunt>0.72</armorPenetrationBlunt>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 					<soundMeleeHit>MeleeHit_DrillArm</soundMeleeHit>
 					<soundMeleeMiss>MeleeMiss_DrillArm</soundMeleeMiss>
@@ -52,10 +52,10 @@
 					<capacities>
 						<li>Scratch</li>
 					</capacities>
-					<power>8</power>
-					<cooldownTime>0.99</cooldownTime>
-					<armorPenetrationBlunt>0.288</armorPenetrationBlunt>
-					<armorPenetrationSharp>0.58</armorPenetrationSharp>
+					<power>9</power>
+					<cooldownTime>0.74</cooldownTime>
+					<armorPenetrationBlunt>0.338</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.34</armorPenetrationSharp>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 					<soundMeleeHit>MeleeHit_BionicSlash</soundMeleeHit>
 					<soundMeleeMiss>MeleeMiss_BionicSlash</soundMeleeMiss>
@@ -82,10 +82,10 @@
 					<capacities>
 						<li>Cut</li>
 					</capacities>
-					<power>12</power>
-					<cooldownTime>1.0</cooldownTime>
-					<armorPenetrationBlunt>0.4</armorPenetrationBlunt>
-					<armorPenetrationSharp>0.3</armorPenetrationSharp>
+					<power>11</power>
+					<cooldownTime>0.8</cooldownTime>
+					<armorPenetrationBlunt>0.45</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.4</armorPenetrationSharp>
 					<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 					<soundMeleeHit>MeleeHit_BionicSlash</soundMeleeHit>
@@ -104,10 +104,10 @@
 					<capacities>
 						<li>Stab</li>
 					</capacities>
-					<power>15</power>
+					<power>13</power>
 					<cooldownTime>1.0</cooldownTime>
-					<armorPenetrationBlunt>0.75</armorPenetrationBlunt>
-					<armorPenetrationSharp>1.0</armorPenetrationSharp>
+					<armorPenetrationBlunt>1.125</armorPenetrationBlunt>
+					<armorPenetrationSharp>1.13</armorPenetrationSharp>
 					<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 					<soundMeleeHit>MeleeHit_BionicSlash</soundMeleeHit>
@@ -127,9 +127,9 @@
 						<li>Scratch</li>
 					</capacities>
 					<power>9</power>
-					<cooldownTime>1.05</cooldownTime>
-					<armorPenetrationBlunt>0.36</armorPenetrationBlunt>
-					<armorPenetrationSharp>0.36</armorPenetrationSharp>
+					<cooldownTime>0.74</cooldownTime>
+					<armorPenetrationBlunt>0.338</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.68</armorPenetrationSharp>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 					<soundMeleeHit>MeleeHit_BionicSlash</soundMeleeHit>
 					<soundMeleeMiss>MeleeMiss_BionicSlash</soundMeleeMiss>
@@ -156,10 +156,10 @@
 					<capacities>
 						<li>Cut</li>
 					</capacities>
-					<power>10</power>
-					<cooldownTime>1.1</cooldownTime>
-					<armorPenetrationBlunt>0.3</armorPenetrationBlunt>
-					<armorPenetrationSharp>0.25</armorPenetrationSharp>
+					<power>12</power>
+					<cooldownTime>0.84</cooldownTime>
+					<armorPenetrationBlunt>0.563</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.81</armorPenetrationSharp>
 					<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 					<soundMeleeHit>MeleeHit_BionicSlash</soundMeleeHit>
@@ -179,9 +179,9 @@
 						<li>Stab</li>
 					</capacities>
 					<power>15</power>
-					<cooldownTime>1.1</cooldownTime>
-					<armorPenetrationBlunt>0.65</armorPenetrationBlunt>
-					<armorPenetrationSharp>0.75</armorPenetrationSharp>
+					<cooldownTime>1.05</cooldownTime>
+					<armorPenetrationBlunt>1.35</armorPenetrationBlunt>
+					<armorPenetrationSharp>1.93</armorPenetrationSharp>
 					<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 					<soundMeleeHit>MeleeHit_BionicSlash</soundMeleeHit>

--- a/ModPatches/EPOE Forked/Patches/EPOE Forked/Bionics_Patch.xml
+++ b/ModPatches/EPOE Forked/Patches/EPOE Forked/Bionics_Patch.xml
@@ -10,10 +10,10 @@
 					<capacities>
 						<li>Cut</li>
 					</capacities>
-					<power>29</power>
+					<power>25</power>
 					<armorPenetrationBlunt>2.16</armorPenetrationBlunt>
 					<armorPenetrationSharp>0.87</armorPenetrationSharp>
-					<cooldownTime>1.65</cooldownTime>
+					<cooldownTime>1.45</cooldownTime>
 					<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
 					<soundMeleeHit>MeleeHit_BionicSlash</soundMeleeHit>
 					<soundMeleeMiss>MeleeMiss_BionicSlash</soundMeleeMiss>

--- a/ModPatches/EPOE Forked/Patches/EPOE Forked/Bionics_Patch.xml
+++ b/ModPatches/EPOE Forked/Patches/EPOE Forked/Bionics_Patch.xml
@@ -10,10 +10,10 @@
 					<capacities>
 						<li>Cut</li>
 					</capacities>
-					<power>23</power>
-					<armorPenetrationBlunt>1.28</armorPenetrationBlunt>
-					<armorPenetrationSharp>0.8</armorPenetrationSharp>
-					<cooldownTime>1.29</cooldownTime>
+					<power>29</power>
+					<armorPenetrationBlunt>2.16</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.87</armorPenetrationSharp>
+					<cooldownTime>1.65</cooldownTime>
 					<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
 					<soundMeleeHit>MeleeHit_BionicSlash</soundMeleeHit>
 					<soundMeleeMiss>MeleeMiss_BionicSlash</soundMeleeMiss>
@@ -23,10 +23,10 @@
 					<capacities>
 						<li>Stab</li>
 					</capacities>
-					<power>19</power>
-					<armorPenetrationBlunt>1.28</armorPenetrationBlunt>
-					<armorPenetrationSharp>2.56</armorPenetrationSharp>
-					<cooldownTime>1.29</cooldownTime>
+					<power>20</power>
+					<armorPenetrationBlunt>3.6</armorPenetrationBlunt>
+					<armorPenetrationSharp>3.6</armorPenetrationSharp>
+					<cooldownTime>1.87</cooldownTime>
 					<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
 					<soundMeleeHit>MeleeHit_BionicSlash</soundMeleeHit>
 					<soundMeleeMiss>MeleeMiss_BionicSlash</soundMeleeMiss>
@@ -46,7 +46,7 @@
 					</capacities>
 					<power>5</power>
 					<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
-					<armorPenetrationSharp>0.01</armorPenetrationSharp>
+					<armorPenetrationSharp>0.05</armorPenetrationSharp>
 					<cooldownTime>1.26</cooldownTime>
 				</li>
 			</tools>
@@ -102,7 +102,7 @@
 					</capacities>
 					<power>21</power>
 					<cooldownTime>0.89</cooldownTime>
-					<armorPenetrationSharp>0.8</armorPenetrationSharp>
+					<armorPenetrationSharp>1.6</armorPenetrationSharp>
 					<armorPenetrationBlunt>4</armorPenetrationBlunt>
 					<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
 					<soundMeleeHit>Pawn_Melee_PowerClaw_Hit</soundMeleeHit>
@@ -122,9 +122,9 @@
 						<li>Scratch</li>
 					</capacities>
 					<power>24</power>
-					<cooldownTime>0.89</cooldownTime>
-					<armorPenetrationSharp>0.96</armorPenetrationSharp>
-					<armorPenetrationBlunt>4.75</armorPenetrationBlunt>
+					<cooldownTime>0.74</cooldownTime>
+					<armorPenetrationSharp>2.31</armorPenetrationSharp>
+					<armorPenetrationBlunt>5.76</armorPenetrationBlunt>
 					<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
 					<soundMeleeHit>Pawn_Melee_PowerClaw_Hit</soundMeleeHit>
 					<soundMeleeMiss>Pawn_Melee_PowerClaw_Miss</soundMeleeMiss>

--- a/Patches/Core/HediffDefs/Hediffs_Local_AddedParts.xml
+++ b/Patches/Core/HediffDefs/Hediffs_Local_AddedParts.xml
@@ -67,7 +67,7 @@
 					</capacities>
 					<power>21</power>
 					<cooldownTime>0.89</cooldownTime>
-					<armorPenetrationSharp>0.8</armorPenetrationSharp>
+					<armorPenetrationSharp>1.6</armorPenetrationSharp>
 					<armorPenetrationBlunt>4</armorPenetrationBlunt>
 					<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
 					<soundMeleeHit>Pawn_Melee_PowerClaw_Hit</soundMeleeHit>

--- a/Royalty/Patches/HeDiffDefs/Hediffs_Implants.xml
+++ b/Royalty/Patches/HeDiffDefs/Hediffs_Implants.xml
@@ -13,9 +13,9 @@
 						<li>Stab</li>
 					</capacities>
 					<power>8</power>
-					<cooldownTime>1.88</cooldownTime>
-					<armorPenetrationSharp>0.04</armorPenetrationSharp>
-					<armorPenetrationBlunt>0.32</armorPenetrationBlunt>
+					<cooldownTime>1.5</cooldownTime>
+					<armorPenetrationSharp>0.1</armorPenetrationSharp>
+					<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 					<soundMeleeHit>MeleeHit_DrillArm</soundMeleeHit>
 					<soundMeleeMiss>MeleeMiss_DrillArm</soundMeleeMiss>
@@ -55,9 +55,9 @@
 						<li>Scratch</li>
 					</capacities>
 					<power>7</power>
-					<cooldownTime>1.19</cooldownTime>
-					<armorPenetrationBlunt>0.2</armorPenetrationBlunt>
-					<armorPenetrationSharp>0.2</armorPenetrationSharp>
+					<cooldownTime>0.93</cooldownTime>
+					<armorPenetrationBlunt>0.26</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.216</armorPenetrationSharp>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 					<soundMeleeHit>MeleeHit_BionicSlash</soundMeleeHit>
 					<soundMeleeMiss>MeleeMiss_BionicSlash</soundMeleeMiss>
@@ -75,10 +75,10 @@
 					<capacities>
 						<li>Cut</li>
 					</capacities>
-					<power>8</power>
+					<power>9</power>
 					<cooldownTime>1.19</cooldownTime>
-					<armorPenetrationBlunt>0.2</armorPenetrationBlunt>
-					<armorPenetrationSharp>0.18</armorPenetrationSharp>
+					<armorPenetrationBlunt>0.288</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.26</armorPenetrationSharp>
 					<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 					<soundMeleeHit>MeleeHit_BionicSlash</soundMeleeHit>
@@ -98,9 +98,9 @@
 						<li>Stab</li>
 					</capacities>
 					<power>13</power>
-					<cooldownTime>1.18</cooldownTime>
-					<armorPenetrationBlunt>0.576</armorPenetrationBlunt>
-					<armorPenetrationSharp>0.58</armorPenetrationSharp>
+					<cooldownTime>1.25</cooldownTime>
+					<armorPenetrationBlunt>0.72</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.72</armorPenetrationSharp>
 					<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 					<soundMeleeHit>MeleeHit_BionicSlash</soundMeleeHit>
@@ -139,10 +139,10 @@
 					<capacities>
 						<li>ScratchToxic</li>
 					</capacities>
-					<power>7</power>
-					<cooldownTime>1.19</cooldownTime>
-					<armorPenetrationBlunt>0.2</armorPenetrationBlunt>
-					<armorPenetrationSharp>0.2</armorPenetrationSharp>
+					<power>8</power>
+					<cooldownTime>0.99</cooldownTime>
+					<armorPenetrationBlunt>0.288</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.15</armorPenetrationSharp>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 					<soundMeleeHit>MeleeHit_BionicSlash</soundMeleeHit>
 					<soundMeleeMiss>MeleeMiss_BionicSlash</soundMeleeMiss>


### PR DESCRIPTION
## Changes

- Tweaked the vanilla, Royalty DLC and EPOE-Forked's combat bionics and implants.

## References

- https://docs.google.com/spreadsheets/d/11e6FkTQvZiJpq7DpXUk9JSXBSq9enrx0DQhTTJ2xH7c/edit?gid=647442519#gid=647442519

## Reasoning

- They are all anemic when it comes to armor penetration, this helps a decent amount without making them imbalanced. The advanced parts in EPOE swing faster than the normal versions and the scyther versions are faster and heavier tools, the player is spending scyther blades to make them but they lack the bonuses that come with advanced parts so it balances out.

## Alternatives

- Suffer the waste of resources and time.
- MOAR?!

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
