### PR TITLE
Aitburst shell frag amount fix

### DIFF
--- a/Defs/Ammo/Shell/105mmHowitzer.xml
+++ b/Defs/Ammo/Shell/105mmHowitzer.xml
@@ -219,7 +219,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>40</Fragment_Large>
-					<Fragment_Small>44</Fragment_Small>
+					<Fragment_Small>65</Fragment_Small>
 				</fragments>
 				<fragAngleRange>-90~-40</fragAngleRange>
 			</li>

--- a/Defs/Ammo/Shell/81mmMortar.xml
+++ b/Defs/Ammo/Shell/81mmMortar.xml
@@ -23,7 +23,7 @@
 			<Shell_Smoke>Bullet_81mmMortarShell_Smoke</Shell_Smoke>
 			<Shell_AntigrainWarhead>Bullet_81mmMortarShell_Antigrain</Shell_AntigrainWarhead>
 			<Shell_Toxic MayRequire="Ludeon.RimWorld.Biotech">Bullet_81mmMortarShell_Tox</Shell_Toxic>
-			<Shell_Deadlife MayRequire="Ludeon.RimWorld.Anomaly">Bullet_81mmMortarShell_Deadlife</Shell_Deadlife>			
+			<Shell_Deadlife MayRequire="Ludeon.RimWorld.Anomaly">Bullet_81mmMortarShell_Deadlife</Shell_Deadlife>
 		</ammoTypes>
 		<isMortarAmmoSet>true</isMortarAmmoSet>
 	</CombatExtended.AmmoSetDef>
@@ -292,8 +292,8 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Large>12</Fragment_Large>
-					<Fragment_Small>24</Fragment_Small>
+					<Fragment_Large>23</Fragment_Large>
+					<Fragment_Small>38</Fragment_Small>
 				</fragments>
 				<fragAngleRange>-90~-48</fragAngleRange>
 			</li>
@@ -381,7 +381,7 @@
 			<explosionEffect>ExtinguisherExplosion</explosionEffect>
 			<shellingProps>
 				<damage>0</damage>
-			</shellingProps>			
+			</shellingProps>
 		</projectile>
 	</ThingDef>
 
@@ -431,7 +431,7 @@
 			<postExplosionSpawnThingDefWater>Shell_Toxic_Releasing_Water</postExplosionSpawnThingDefWater>
 			<shellingProps>
 				<damage>0.12</damage>
-			</shellingProps>			
+			</shellingProps>
 		</projectile>
 	</ThingDef>
 
@@ -455,7 +455,7 @@
 			<postExplosionSpawnThingDef>Shell_Deadlife_Releasing</postExplosionSpawnThingDef>
 			<shellingProps>
 				<damage>0</damage>
-			</shellingProps>		
+			</shellingProps>
 		</projectile>
 	</ThingDef>
 
@@ -779,59 +779,59 @@
 			<Shell_Toxic>5</Shell_Toxic>
 		</products>
 	</RecipeDef>
-  
-  <RecipeDef ParentName="AmmoRecipeBase" MayRequire="Ludeon.RimWorld.Anomaly">
-    <defName>MakeShell_Deadlife</defName>
-    <label>make 81mm deadlife mortar shells x5</label>
-    <description>Craft 5 81mm deadlife mortar shells.</description>
-    <jobString>Making 81mm deadlife mortar shells.</jobString>
-	<researchPrerequisites>
-		<li>DeadlifeDust</li>
-		<li>Mortars</li>
-	</researchPrerequisites>
-    <recipeUsers Inherit="false">
-      <li>BioferriteShaper</li>
-    </recipeUsers> 
-    <ingredients>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Steel</li>
-          </thingDefs>
-        </filter>
-        <count>42</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>ComponentIndustrial</li>
-          </thingDefs>
-        </filter>
-        <count>2</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Bioferrite</li>
-          </thingDefs>
-        </filter>
-        <count>25</count>
-      </li>
-    </ingredients>
-    <fixedIngredientFilter>
-      <thingDefs>
-        <li>Steel</li>
-        <li>Bioferrite</li>
-        <li>ComponentIndustrial</li>
-      </thingDefs>
-    </fixedIngredientFilter>
-    <products>
-      <Shell_Deadlife>5</Shell_Deadlife>
-    </products>
-    <skillRequirements>
-      <Crafting>4</Crafting>
-    </skillRequirements>
-    <workAmount>6600</workAmount>
-  </RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase" MayRequire="Ludeon.RimWorld.Anomaly">
+		<defName>MakeShell_Deadlife</defName>
+		<label>make 81mm deadlife mortar shells x5</label>
+		<description>Craft 5 81mm deadlife mortar shells.</description>
+		<jobString>Making 81mm deadlife mortar shells.</jobString>
+		<researchPrerequisites>
+			<li>DeadlifeDust</li>
+			<li>Mortars</li>
+		</researchPrerequisites>
+		<recipeUsers Inherit="false">
+			<li>BioferriteShaper</li>
+		</recipeUsers>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>42</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>2</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Bioferrite</li>
+					</thingDefs>
+				</filter>
+				<count>25</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Bioferrite</li>
+				<li>ComponentIndustrial</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Shell_Deadlife>5</Shell_Deadlife>
+		</products>
+		<skillRequirements>
+			<Crafting>4</Crafting>
+		</skillRequirements>
+		<workAmount>6600</workAmount>
+	</RecipeDef>
 
 </Defs>


### PR DESCRIPTION
## Changes

- Changed the Airburst shells to throw 1.5 times the amount of frags of normal HE shells.
- Fixed the indentation style of the files in the meantime.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit?gid=1393347070#gid=1393347070

## Reasoning

- Shells that lack an explosive component and are meant to kill with frags should not have the same, or even less in the case of 81mm shells, the frag numbers than HE shells, it's counterintuitive and makes them useless. 

## Alternatives

- Keep things as is and have yet another useless ammo type, suffer as a result.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
