### PR TITLE
Fix Royalty's warhammer stats

### DIFF
--- a/Royalty/Patches/ThingDefs_Misc/Weapons_RoyaltyMelee.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Weapons_RoyaltyMelee.xml
@@ -75,9 +75,9 @@
 						<li>Poke</li>
 					</capacities>
 					<power>4</power>
-					<cooldownTime>1.78</cooldownTime>
+					<cooldownTime>1.89</cooldownTime>
 					<chanceFactor>0.10</chanceFactor>
-					<armorPenetrationBlunt>1.000</armorPenetrationBlunt>
+					<armorPenetrationBlunt>1.25</armorPenetrationBlunt>
 					<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
 				</li>
 				<li Class="CombatExtended.ToolCE">
@@ -85,9 +85,9 @@
 					<capacities>
 						<li>Blunt</li>
 					</capacities>
-					<power>22</power>
-					<cooldownTime>2.36</cooldownTime>
-					<armorPenetrationBlunt>11.76</armorPenetrationBlunt>
+					<power>27</power>
+					<cooldownTime>2.45</cooldownTime>
+					<armorPenetrationBlunt>11.25</armorPenetrationBlunt>
 					<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
 				</li>
 			</tools>


### PR DESCRIPTION
## Changes

- What it says on the tin, it had inaccurate stats according to the spreadsheet data.

## References

- https://docs.google.com/spreadsheets/d/11e6FkTQvZiJpq7DpXUk9JSXBSq9enrx0DQhTTJ2xH7c/edit?gid=647442519#gid=647442519

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
