### PR TITLE
chore(load-folder): Add continued version of DD House Sanguin & Elves

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -95,7 +95,7 @@
 		<li IfModActive="Van.DATools">ModPatches/Dark Ages - Medieval Tools</li>
 		<li IfModActive="nilchei.darkestnightsksteam">ModPatches/Darkest Night SK Steam</li>
 		<li IfModActive="DevDesigner.Elves,DevDesigner.Elves.continued">ModPatches/DD Elves</li>
-		<li IfModActive="DevDesigner.Blood,DevDesigner.Blood.continued">ModPatches/DD House Sanguin</li>
+		<li IfModActive="finch.blood">ModPatches/DD House Sanguin</li>
 		<li IfModActive="DetVisor.EnergyWeapons">ModPatches/Det&apos;s Energy Weapons</li>
 		<li IfModActive="ATK.DevilstrandAnimals">ModPatches/Devilstrand Animals</li>
 		<li IfModActive="GarbageDayIsHereToStay.DevilstrandColourBundle.GDIHTSDSCB">ModPatches/Devilstrand Colour Bundle</li>

--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -94,10 +94,8 @@
 		<li IfModActive="Mlie.CyberneticWarfare">ModPatches/Cybernetic Warfare and Special Weapons</li>
 		<li IfModActive="Van.DATools">ModPatches/Dark Ages - Medieval Tools</li>
 		<li IfModActive="nilchei.darkestnightsksteam">ModPatches/Darkest Night SK Steam</li>
-		<li IfModActive="DevDesigner.Elves">ModPatches/DD Elves</li>
-		<li IfModActive="DevDesigner.Elves.continued">ModPatches/DD Elves</li>
-		<li IfModActive="DevDesigner.Blood">ModPatches/DD House Sanguin</li>
-		<li IfModActive="DevDesigner.Blood.continued">ModPatches/DD House Sanguin</li>
+		<li IfModActive="DevDesigner.Elves,DevDesigner.Elves.continued">ModPatches/DD Elves</li>
+		<li IfModActive="DevDesigner.Blood,DevDesigner.Blood.continued">ModPatches/DD House Sanguin</li>
 		<li IfModActive="DetVisor.EnergyWeapons">ModPatches/Det&apos;s Energy Weapons</li>
 		<li IfModActive="ATK.DevilstrandAnimals">ModPatches/Devilstrand Animals</li>
 		<li IfModActive="GarbageDayIsHereToStay.DevilstrandColourBundle.GDIHTSDSCB">ModPatches/Devilstrand Colour Bundle</li>

--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -95,7 +95,7 @@
 		<li IfModActive="Van.DATools">ModPatches/Dark Ages - Medieval Tools</li>
 		<li IfModActive="nilchei.darkestnightsksteam">ModPatches/Darkest Night SK Steam</li>
 		<li IfModActive="DevDesigner.Elves,DevDesigner.Elves.continued">ModPatches/DD Elves</li>
-		<li IfModActive="finch.blood">ModPatches/DD House Sanguin</li>
+		<li IfModActive="DevDesigner.Blood,finch.blood">ModPatches/DD House Sanguin</li>
 		<li IfModActive="DetVisor.EnergyWeapons">ModPatches/Det&apos;s Energy Weapons</li>
 		<li IfModActive="ATK.DevilstrandAnimals">ModPatches/Devilstrand Animals</li>
 		<li IfModActive="GarbageDayIsHereToStay.DevilstrandColourBundle.GDIHTSDSCB">ModPatches/Devilstrand Colour Bundle</li>

--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -95,7 +95,9 @@
 		<li IfModActive="Van.DATools">ModPatches/Dark Ages - Medieval Tools</li>
 		<li IfModActive="nilchei.darkestnightsksteam">ModPatches/Darkest Night SK Steam</li>
 		<li IfModActive="DevDesigner.Elves">ModPatches/DD Elves</li>
+		<li IfModActive="DevDesigner.Elves.continued">ModPatches/DD Elves</li>
 		<li IfModActive="DevDesigner.Blood">ModPatches/DD House Sanguin</li>
+		<li IfModActive="DevDesigner.Blood.continued">ModPatches/DD House Sanguin</li>
 		<li IfModActive="DetVisor.EnergyWeapons">ModPatches/Det&apos;s Energy Weapons</li>
 		<li IfModActive="ATK.DevilstrandAnimals">ModPatches/Devilstrand Animals</li>
 		<li IfModActive="GarbageDayIsHereToStay.DevilstrandColourBundle.GDIHTSDSCB">ModPatches/Devilstrand Colour Bundle</li>


### PR DESCRIPTION
## Additions

- Add continued version of both DD Elves & DD House Sanguin in LoadFolders to apply correct patches

## Changes

Nothing.

## References

## Reasoning

Why did you choose to implement things this way, e.g.
- Adding instead of replacing to keep v1.4 running nad be able to remove it easily when/if both mod are updated by the original mod author

## Alternatives

Could have copy/paste complete DD patch folders but that would have been combersome

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [X] Game runs without errors
- [X] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
