### PR TITLE
Patch fence gate height

### DIFF
--- a/Patches/Core/ThingDefs_Buildings/Buildings_Structure.xml
+++ b/Patches/Core/ThingDefs_Buildings/Buildings_Structure.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- ========== Fence Gate ========== -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="FenceGate"]</xpath>
+		<value>
+			<fillPercent>0.5</fillPercent>
+		</value>
+	</Operation>
+
+</Patch>


### PR DESCRIPTION
## Additions
- Add a patch for the fence gate fill percent, reducing its height from 3.5m to 0.88m.

## References
- Closes #3297 

## Reasoning
-  The gate inherits `<fillPercent>1</fillPercent>` from vanilla `DoorBase`, making it 3.5m tall. This is the same height as a regular door and is, obviously, a little silly. Setting the value to 0.5 gives it an appropriate amount of cover--a bit taller than a fence, but shorter than a sandbag.

## Alternatives
- Could leave as-is, or use a different value.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
