### PR TITLE
Vehicle Framework - Component depth effected by upgrades

### DIFF
--- a/Source/VehiclesCompat/VehiclesCompat/VehicleArmorPatch.cs
+++ b/Source/VehiclesCompat/VehiclesCompat/VehicleArmorPatch.cs
@@ -214,7 +214,7 @@ namespace CombatExtended.Compatibility.VehiclesCompat
 
         public static bool TryPenetrateComponents(VehicleStatHandler stats, ref DamageInfo dinfo, List<VehicleComponent> components, VehicleComponent.VehiclePartDepth hitDepth, StringBuilder report)
         {
-            var componentsAtHitDepth = components.Where(comp => comp.props.depth == hitDepth && comp.HealthPercent > 0).OrderBy(x => Rand.Value * x.props.hitWeight);
+            var componentsAtHitDepth = components.Where(comp => comp.Depth == hitDepth && comp.HealthPercent > 0).OrderBy(x => Rand.Value * x.props.hitWeight);
             report?.AppendLine($"components=({string.Join(",", components.Select(c => c.props.label))})");
             report?.AppendLine($"hitDepth = {hitDepth}");
             report?.AppendLine($"components at hitDepth {hitDepth}: ({string.Join(",", componentsAtHitDepth.Select(comp => comp.props.label))})");


### PR DESCRIPTION
## Changes

- Component depth is now effected by upgrades

## Reasoning

- Should mean that everything from VF new upgrade system is working properly now. (Other values already correctly upgrade)

## Alternatives

- N/A

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony - Devtest with the CV90 mod changed to have tracks default as external > after armor plating upgrade they correctly changed to internal
