### PR TITLE
Fix Kurin HAR patch from breaking CE apparel wearability.

### DIFF
--- a/ModPatches/Kurin/Patches/Kurin/ThingDefs_Races/Race_DRNTF.xml
+++ b/ModPatches/Kurin/Patches/Kurin/ThingDefs_Races/Race_DRNTF.xml
@@ -97,7 +97,7 @@
 </Operation>
 
 <Operation Class="PatchOperationAdd">
-	<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Kurin_Race"]/alienRace/raceRestriction/apparelList</xpath>
+	<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Kurin_Race"]/alienRace/raceRestriction/whiteApparelList</xpath>
 	<value>
 		<li>CE_Apparel_TacVest</li>
 		<li>CE_Apparel_Backpack</li>


### PR DESCRIPTION

## Changes

Fixes an issue with patch causing no races other than Kurin to be able to wear backpacks if the Kurin HAR edition mod is loaded

## Reasoning

It's a old patch maybe? It's not clear why it was done like this in the first place and was probably something from back when HAR alien race defs were different.

## Alternatives

Actually check this patch is working as a whole since it throws a ton of errors on start-up.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
