### PR TITLE
Update OutsideSquishy for missed mod patches

### DIFF
--- a/ModPatches/Ancient Blade Cyborg/Patches/Ancient Blade Cyborg/Cyborg_CoveredByNaturalArmor.xml
+++ b/ModPatches/Ancient Blade Cyborg/Patches/Ancient Blade Cyborg/Cyborg_CoveredByNaturalArmor.xml
@@ -145,17 +145,4 @@
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>
-			Defs/BodyDef[defName="Cyborg"]//*[
-			def="CyborgJaw" or
-			def="CyborgNose" or
-			def="CyborgSightSensor" or
-			def="CyborgEye"]/groups
-		</xpath>
-		<value>
-			<li>OutsideSquishy</li>
-		</value>
-	</Operation>
 </Patch>

--- a/ModPatches/Antinium/Patches/Antinium/Bodies/Ant_Bodies.xml
+++ b/ModPatches/Antinium/Patches/Antinium/Bodies/Ant_Bodies.xml
@@ -43,21 +43,6 @@
 		</value>
 	</Operation>
 
-	<!-- Part squishy-ness -->
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/BodyDef[defName="Antinium"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Eye"]/groups</xpath>
-		<value>
-			<li>OutsideSquishy</li>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/BodyDef[defName="Antinium"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]/groups</xpath>
-		<value>
-			<li>OutsideSquishy</li>
-		</value>
-	</Operation>
-
 	<!-- Arm and shoulder tags-->
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="Antinium"]/corePart/parts/li[def = "Shoulder"]/parts/li[contains(./customLabel, "left arm")]/groups</xpath>

--- a/ModPatches/Aspero Race/Patches/Aspero Race/CE_Patch_Bodies.xml
+++ b/ModPatches/Aspero Race/Patches/Aspero Race/CE_Patch_Bodies.xml
@@ -104,33 +104,4 @@
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
-
-	<!-- Squishy bits -->
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/BodyDef[defName = "Aspero_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[customLabel = "right eye"]/groups</xpath>
-		<value>
-			<li>OutsideSquishy</li>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/BodyDef[defName = "Aspero_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[customLabel = "left eye"]/groups</xpath>
-		<value>
-			<li>OutsideSquishy</li>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/BodyDef[defName = "Aspero_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]/groups</xpath>
-		<value>
-			<li>OutsideSquishy</li>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/BodyDef[defName = "Aspero_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Jaw"]/groups</xpath>
-		<value>
-			<li>OutsideSquishy</li>
-		</value>
-	</Operation>
 </Patch>

--- a/ModPatches/Astoriel Legacy/Patches/Astoriel Legacy/Astoriel_Bodytype.xml
+++ b/ModPatches/Astoriel Legacy/Patches/Astoriel Legacy/Astoriel_Bodytype.xml
@@ -1,36 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 
-	<!--Outside Squishy-->
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/BodyDef[defName = "Astoriel"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[customLabel = "right eye"]/groups</xpath>
-		<value>
-			<li>OutsideSquishy</li>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/BodyDef[defName = "Astoriel"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[customLabel = "left eye"]/groups</xpath>
-		<value>
-			<li>OutsideSquishy</li>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/BodyDef[defName = "Astoriel"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]/groups</xpath>
-		<value>
-			<li>OutsideSquishy</li>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/BodyDef[defName = "Astoriel"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Jaw"]/groups</xpath>
-		<value>
-			<li>OutsideSquishy</li>
-		</value>
-	</Operation>
-
 	<!--Arm Groups-->
 
 	<Operation Class="PatchOperationAdd">

--- a/ModPatches/Biomes Caverns/Patches/Biomes Caverns/BodyDefs/Bodies_CE.xml
+++ b/ModPatches/Biomes Caverns/Patches/Biomes Caverns/BodyDefs/Bodies_CE.xml
@@ -36,17 +36,6 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>
 			Defs/BodyDef[defName="BeetleLikeWithHorn"]//*[
-			def="InsectMouth" or
-			def="Eye"]/groups
-		</xpath>
-		<value>
-			<li>OutsideSquishy</li>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>
-			Defs/BodyDef[defName="BeetleLikeWithHorn"]//*[
 			def="Body" or
 			def="Elytra" or
 			def="Pronotum" or
@@ -103,18 +92,6 @@
 		</xpath>
 		<value>
 			<groups/>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>
-			Defs/BodyDef[defName="BMT_BatBird"]//*[
-			def="AnimalJaw" or
-			def="Nose" or
-			def="Eye"]/groups
-		</xpath>
-		<value>
-			<li>OutsideSquishy</li>
 		</value>
 	</Operation>
 

--- a/ModPatches/Rim Flood/Patches/Rim Flood/CE_Flood_Bodies.xml
+++ b/ModPatches/Rim Flood/Patches/Rim Flood/CE_Flood_Bodies.xml
@@ -49,15 +49,4 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>
-			Defs/BodyDef[defName="Flood"]//*[
-			def="Nose" or
-			def="FloodMouth"]/groups
-		</xpath>
-		<value>
-			<li>OutsideSquishy</li>
-		</value>
-	</Operation>
-
 </Patch>

--- a/ModPatches/Rim Flood/Patches/Rim Flood/CE_Flood_Bodyparts.xml
+++ b/ModPatches/Rim Flood/Patches/Rim Flood/CE_Flood_Bodyparts.xml
@@ -8,4 +8,11 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/BodyPartDef[defName="FloodMouth"]/tags</xpath>
+		<value>
+			<li>OutsideSquishy</li>
+		</value>
+	</Operation>
+
 </Patch>

--- a/ModPatches/pphhyy's Lightless Empyrean/Patches/pphhyy's Lightless Empyrean/Bodies_Jellyfish.xml
+++ b/ModPatches/pphhyy's Lightless Empyrean/Patches/pphhyy's Lightless Empyrean/Bodies_Jellyfish.xml
@@ -78,7 +78,7 @@
 	<!-- ========== Set parts as squishy ========== -->
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/BodyPartDef[defName="pphhyy_LightlessEmpyrean_CnidarianTentacle" or defName="pphhyy_LightlessEmpyrean_CnidarianSensoryOrgan" or defName="AnimalJaw"]/tags</xpath>
+		<xpath>Defs/BodyPartDef[defName="pphhyy_LightlessEmpyrean_CnidarianTentacle" or defName="pphhyy_LightlessEmpyrean_CnidarianSensoryOrgan"]/tags</xpath>
 		<value>
 			<li>OutsideSquishy</li>
 		</value>


### PR DESCRIPTION
## Changes
- Removed OutsideSquishy group patches for 'Ancient Blade Cyborg', 'Antinium', 'Aspero Race', 'Astoriel Legacy', 'Biomes! Caverns', 'pphhyy's Lightless Empyrean' mods, changed OutsideSquishy from group to tag patch for 'Rim Flood'.

## References
- Closes #3260;

## Testing
- [ ] Compiles without warnings;
- [ ] Game runs without errors;
- [ ] (For compatibility patches) ...with and without patched mod loaded;
- [ ] Playtested a colony.
