### PR TITLE
walker mech natural armor HP update

### DIFF
--- a/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Medium.xml
+++ b/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Medium.xml
@@ -211,7 +211,7 @@
 		<xpath>Defs/ThingDef[defName="Mech_Scorcher"]/comps</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
-				<Durability>850</Durability>
+				<Durability>1000</Durability>
 				<Regenerates>true</Regenerates>
 				<RegenInterval>1250</RegenInterval>
 				<RegenValue>5</RegenValue>
@@ -223,7 +223,7 @@
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
 				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>85</MaxOverHeal>
+				<MaxOverHeal>100</MaxOverHeal>
 				<MinArmorPct>0.75</MinArmorPct>
 			</li>
 		</value>

--- a/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
+++ b/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
@@ -343,7 +343,7 @@
 		<xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedLancer"]/comps</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
-				<Durability>860</Durability>
+				<Durability>1000</Durability>
 				<Regenerates>true</Regenerates>
 				<RegenInterval>1250</RegenInterval>
 				<RegenValue>5</RegenValue>
@@ -355,7 +355,7 @@
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
 				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>86</MaxOverHeal>
+				<MaxOverHeal>100</MaxOverHeal>
 				<MinArmorPct>0.75</MinArmorPct>
 			</li>
 		</value>
@@ -570,7 +570,7 @@
 		<xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedKnight"]/comps</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
-				<Durability>860</Durability>
+				<Durability>1000</Durability>
 				<Regenerates>true</Regenerates>
 				<RegenInterval>1250</RegenInterval>
 				<RegenValue>5</RegenValue>
@@ -582,7 +582,7 @@
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
 				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>86</MaxOverHeal>
+				<MaxOverHeal>100</MaxOverHeal>
 				<MinArmorPct>0.75</MinArmorPct>
 			</li>
 		</value>

--- a/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid_PlayerControlled.xml
+++ b/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid_PlayerControlled.xml
@@ -298,7 +298,7 @@
 					<xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedLancer_PlayerControlled"]/comps</xpath>
 					<value>
 						<li Class="CombatExtended.CompProperties_ArmorDurability">
-							<Durability>860</Durability>
+							<Durability>1000</Durability>
 							<Regenerates>true</Regenerates>
 							<RegenInterval>1250</RegenInterval>
 							<RegenValue>5</RegenValue>
@@ -310,7 +310,7 @@
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
 							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>86</MaxOverHeal>
+							<MaxOverHeal>100</MaxOverHeal>
 							<MinArmorPct>0.75</MinArmorPct>
 						</li>
 					</value>
@@ -537,7 +537,7 @@
 					<xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedKnight_PlayerControlled"]/comps</xpath>
 					<value>
 						<li Class="CombatExtended.CompProperties_ArmorDurability">
-							<Durability>860</Durability>
+							<Durability>1000</Durability>
 							<Regenerates>true</Regenerates>
 							<RegenInterval>1250</RegenInterval>
 							<RegenValue>5</RegenValue>
@@ -549,7 +549,7 @@
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
 							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>86</MaxOverHeal>
+							<MaxOverHeal>100</MaxOverHeal>
 							<MinArmorPct>0.75</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -367,7 +367,7 @@
 		<xpath>Defs/ThingDef[defName="VFE_Mech_Lancer"]/comps</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
-				<Durability>860</Durability>
+				<Durability>1000</Durability>
 				<Regenerates>true</Regenerates>
 				<RegenInterval>1250</RegenInterval>
 				<RegenValue>5</RegenValue>
@@ -379,7 +379,7 @@
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
 				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>86</MaxOverHeal>
+				<MaxOverHeal>100</MaxOverHeal>
 				<MinArmorPct>0.75</MinArmorPct>
 			</li>
 		</value>
@@ -594,7 +594,7 @@
 		<xpath>Defs/ThingDef[defName="VFE_Mech_Knight"]/comps</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
-				<Durability>860</Durability>
+				<Durability>1000</Durability>
 				<Regenerates>true</Regenerates>
 				<RegenInterval>1250</RegenInterval>
 				<RegenValue>5</RegenValue>
@@ -606,7 +606,7 @@
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
 				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>86</MaxOverHeal>
+				<MaxOverHeal>100</MaxOverHeal>
 				<MinArmorPct>0.75</MinArmorPct>
 			</li>
 		</value>

--- a/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid_PlayerControlled.xml
+++ b/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid_PlayerControlled.xml
@@ -205,7 +205,7 @@
 					<xpath>Defs/ThingDef[defName="VFE_Mech_Knight_PlayerControlled"]/comps</xpath>
 					<value>
 						<li Class="CombatExtended.CompProperties_ArmorDurability">
-							<Durability>860</Durability>
+							<Durability>1000</Durability>
 							<Regenerates>true</Regenerates>
 							<RegenInterval>1250</RegenInterval>
 							<RegenValue>5</RegenValue>
@@ -217,7 +217,7 @@
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
 							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>86</MaxOverHeal>
+							<MaxOverHeal>100</MaxOverHeal>
 							<MinArmorPct>0.75</MinArmorPct>
 						</li>
 					</value>

--- a/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
@@ -437,7 +437,7 @@
 		<xpath>Defs/ThingDef[defName="Mech_Lancer"]/comps</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
-				<Durability>860</Durability>
+				<Durability>1000</Durability>
 				<Regenerates>true</Regenerates>
 				<RegenInterval>1250</RegenInterval>
 				<RegenValue>5</RegenValue>
@@ -449,7 +449,7 @@
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
 				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>86</MaxOverHeal>
+				<MaxOverHeal>100</MaxOverHeal>
 				<MinArmorPct>0.75</MinArmorPct>
 				<!-- <MinArmorValueSharp>10</MinArmorValueSharp>
 				<MinArmorValueBlunt>22</MinArmorValueBlunt>


### PR DESCRIPTION
## Changes

- Updated the natural armor HP of the mechs that received 1.0 HP scaling in #3137.

## Reasoning

- Forgor.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
