### PR TITLE
Update Patch for A RimWorld of Magic

### DIFF
--- a/ModPatches/A Rimworld of Magic/Defs/A Rimworld of Magic/Defs_Projectiles.xml
+++ b/ModPatches/A Rimworld of Magic/Defs/A Rimworld of Magic/Defs_Projectiles.xml
@@ -15,7 +15,7 @@
 	</ThingDef>
 
 	<ThingDef ParentName="WandBoltProjectile" Class="AbilityUser.ProjectileDef_Ability">
-		<defName>Projectile_IceWandCE</defName>
+		<defName>Projectile_CE_IceWand</defName>
 		<label>ice shard</label>
 		<graphicData>
 			<texPath>Spells/Icebolt</texPath>
@@ -29,7 +29,7 @@
 	</ThingDef>
 
 	<ThingDef ParentName="WandBoltProjectile" Class="AbilityUser.ProjectileDef_Ability">
-		<defName>Projectile_FireWandCE</defName>
+		<defName>Projectile_CE_FireWand</defName>
 		<label>fire blast</label>
 		<graphicData>
 			<texPath>Spells/seer_ring_fire</texPath>
@@ -46,7 +46,7 @@
 	</ThingDef>
 
 	<ThingDef ParentName="WandBoltProjectile" Class="AbilityUser.ProjectileDef_Ability">
-		<defName>Projectile_LightningWandCE</defName>
+		<defName>Projectile_CE_LightningWand</defName>
 		<label>lightning bolt</label>
 		<graphicData>
 			<texPath>Spells/LightningBolt</texPath>
@@ -64,7 +64,7 @@
 	</ThingDef>
 
 	<ThingDef ParentName="WandBoltProjectile" Class="AbilityUser.ProjectileDef_Ability">
-		<defName>Projectile_BlazingPowerCE</defName>
+		<defName>Projectile_CE_BlazingPower</defName>
 		<label>blazing power</label>
 		<graphicData>
 			<texPath>Spells/blazingpower</texPath>

--- a/ModPatches/A Rimworld of Magic/Defs/A Rimworld of Magic/Defs_Projectiles.xml
+++ b/ModPatches/A Rimworld of Magic/Defs/A Rimworld of Magic/Defs_Projectiles.xml
@@ -3,7 +3,7 @@
 
 	<!-- ==================== Wand Projectiles ==================== -->
 
-	<ThingDef Name="WandBoltProjectile" ParentName="Base6x24mmChargedBullet" Class="AbilityUser.ProjectileDef_Ability">
+	<ThingDef Name="WandBoltProjectile" ParentName="Base6x24mmChargedBullet" Class="AbilityUser.ProjectileDef_Ability" Abstract="true">
 		<graphicData>
 			<graphicClass>Graphic_Single</graphicClass>
 			<shaderType>TransparentPostLight</shaderType>

--- a/ModPatches/A Rimworld of Magic/Defs/A Rimworld of Magic/Defs_Projectiles.xml
+++ b/ModPatches/A Rimworld of Magic/Defs/A Rimworld of Magic/Defs_Projectiles.xml
@@ -15,7 +15,7 @@
 	</ThingDef>
 
 	<ThingDef ParentName="WandBoltProjectile" Class="AbilityUser.ProjectileDef_Ability">
-		<defName>Projectile_IceWand</defName>
+		<defName>Projectile_IceWandCE</defName>
 		<label>ice shard</label>
 		<graphicData>
 			<texPath>Spells/Icebolt</texPath>
@@ -29,7 +29,7 @@
 	</ThingDef>
 
 	<ThingDef ParentName="WandBoltProjectile" Class="AbilityUser.ProjectileDef_Ability">
-		<defName>Projectile_FireWand</defName>
+		<defName>Projectile_FireWandCE</defName>
 		<label>fire blast</label>
 		<graphicData>
 			<texPath>Spells/seer_ring_fire</texPath>
@@ -46,7 +46,7 @@
 	</ThingDef>
 
 	<ThingDef ParentName="WandBoltProjectile" Class="AbilityUser.ProjectileDef_Ability">
-		<defName>Projectile_LightningWand</defName>
+		<defName>Projectile_LightningWandCE</defName>
 		<label>lightning bolt</label>
 		<graphicData>
 			<texPath>Spells/LightningBolt</texPath>
@@ -64,7 +64,7 @@
 	</ThingDef>
 
 	<ThingDef ParentName="WandBoltProjectile" Class="AbilityUser.ProjectileDef_Ability">
-		<defName>Projectile_BlazingPower</defName>
+		<defName>Projectile_BlazingPowerCE</defName>
 		<label>blazing power</label>
 		<graphicData>
 			<texPath>Spells/blazingpower</texPath>

--- a/ModPatches/A Rimworld of Magic/Patches/A Rimworld of Magic/Patch_Ranged.xml
+++ b/ModPatches/A Rimworld of Magic/Patches/A Rimworld of Magic/Patch_Ranged.xml
@@ -40,7 +40,7 @@
 					</capacities>
 					<power>2</power>
 					<cooldownTime>0.5</cooldownTime>
-					<armorPenetrationBlunt>.2</armorPenetrationBlunt>
+					<armorPenetrationBlunt>0.2</armorPenetrationBlunt>
 				</li>
 			</tools>
 		</value>
@@ -49,7 +49,6 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Projectile_IceWand"]</xpath>
 	</Operation>
-
 
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Projectile_FireWand"]</xpath>
@@ -67,13 +66,13 @@
 			<SwayFactor>1.01</SwayFactor>
 			<Bulk>1</Bulk>
 			<Mass>1</Mass>
-			<RangedWeapon_Cooldown>.6</RangedWeapon_Cooldown>
+			<RangedWeapon_Cooldown>0.6</RangedWeapon_Cooldown>
 		</statBases>
 		<Properties>
 			<recoilAmount>1.53</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Projectile_IceWandCE</defaultProjectile>
+			<defaultProjectile>Projectile_CE_IceWand</defaultProjectile>
 			<warmupTime>0.5</warmupTime>
 			<range>40</range>
 			<soundCast>TM_Woosh</soundCast>
@@ -93,12 +92,12 @@
 			<SwayFactor>0.10</SwayFactor>
 			<Bulk>0.5</Bulk>
 			<Mass>1</Mass>
-			<RangedWeapon_Cooldown>.3</RangedWeapon_Cooldown>
+			<RangedWeapon_Cooldown>0.3</RangedWeapon_Cooldown>
 		</statBases>
 		<Properties>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Projectile_IceWandCE</defaultProjectile>
+			<defaultProjectile>Projectile_CE_IceWand</defaultProjectile>
 			<warmupTime>0.25</warmupTime>
 			<range>40</range>
 			<soundCast>Shot_ChargeRifle</soundCast>
@@ -124,7 +123,7 @@
 			<recoilAmount>1.53</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Projectile_LightningWandCE</defaultProjectile>
+			<defaultProjectile>Projectile_CE_LightningWand</defaultProjectile>
 			<warmupTime>2.8</warmupTime>
 			<range>32</range>
 			<soundCast>TM_Thunder_OnMap</soundCast>
@@ -144,12 +143,12 @@
 			<SwayFactor>0.10</SwayFactor>
 			<Bulk>0.5</Bulk>
 			<Mass>1</Mass>
-			<RangedWeapon_Cooldown>.8</RangedWeapon_Cooldown>
+			<RangedWeapon_Cooldown>0.8</RangedWeapon_Cooldown>
 		</statBases>
 		<Properties>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Projectile_LightningWandCE</defaultProjectile>
+			<defaultProjectile>Projectile_CE_LightningWand</defaultProjectile>
 			<warmupTime>1.4</warmupTime>
 			<range>32</range>
 			<soundCast>TM_Thunder_OnMap</soundCast>
@@ -175,7 +174,7 @@
 			<recoilAmount>1.53</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Projectile_FireWandCE</defaultProjectile>
+			<defaultProjectile>Projectile_CE_FireWand</defaultProjectile>
 			<warmupTime>1.5</warmupTime>
 			<range>32</range>
 			<burstShotCount>3</burstShotCount>
@@ -197,12 +196,12 @@
 			<SwayFactor>0.10</SwayFactor>
 			<Bulk>0.5</Bulk>
 			<Mass>1</Mass>
-			<RangedWeapon_Cooldown>.95</RangedWeapon_Cooldown>
+			<RangedWeapon_Cooldown>0.95</RangedWeapon_Cooldown>
 		</statBases>
 		<Properties>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Projectile_FireWandCE</defaultProjectile>
+			<defaultProjectile>Projectile_CE_FireWand</defaultProjectile>
 			<warmupTime>0.75</warmupTime>
 			<range>32</range>
 			<burstShotCount>3</burstShotCount>
@@ -227,7 +226,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[defName= "TM_Ruunbled" or defName="TM_BlazingPowerStaff" or defName="TM_DefenderStaff"]/comps/li[@Class="CompDeflector.CompProperties_Deflector"]/DeflectVerb/defaultProjectile</xpath>
     <value>
-      <defaultProjectile>Projectile_BlazingPowerCE</defaultProjectile>
+      <defaultProjectile>Projectile_CE_BlazingPower</defaultProjectile>
     </value>
   </Operation>
 
@@ -245,7 +244,7 @@
 			<recoilAmount>1.53</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Projectile_BlazingPowerCE</defaultProjectile>
+			<defaultProjectile>Projectile_CE_BlazingPower</defaultProjectile>
 			<warmupTime>0.5</warmupTime>
 			<range>40</range>
 			<soundCast>TM_Woosh</soundCast>
@@ -274,7 +273,7 @@
 			<recoilAmount>1.53</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Projectile_BlazingPowerCE</defaultProjectile>
+			<defaultProjectile>Projectile_CE_BlazingPower</defaultProjectile>
 			<warmupTime>1</warmupTime>
 			<range>40</range>
 			<soundCast>TM_Woosh</soundCast>

--- a/ModPatches/A Rimworld of Magic/Patches/A Rimworld of Magic/Patch_Ranged.xml
+++ b/ModPatches/A Rimworld of Magic/Patches/A Rimworld of Magic/Patch_Ranged.xml
@@ -73,7 +73,7 @@
 			<recoilAmount>1.53</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Projectile_IceWand</defaultProjectile>
+			<defaultProjectile>Projectile_IceWandCE</defaultProjectile>
 			<warmupTime>0.5</warmupTime>
 			<range>40</range>
 			<soundCast>TM_Woosh</soundCast>
@@ -98,7 +98,7 @@
 		<Properties>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Projectile_IceWand</defaultProjectile>
+			<defaultProjectile>Projectile_IceWandCE</defaultProjectile>
 			<warmupTime>0.25</warmupTime>
 			<range>40</range>
 			<soundCast>Shot_ChargeRifle</soundCast>
@@ -124,7 +124,7 @@
 			<recoilAmount>1.53</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Projectile_LightningWand</defaultProjectile>
+			<defaultProjectile>Projectile_LightningWandCE</defaultProjectile>
 			<warmupTime>2.8</warmupTime>
 			<range>32</range>
 			<soundCast>TM_Thunder_OnMap</soundCast>
@@ -149,7 +149,7 @@
 		<Properties>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Projectile_LightningWand</defaultProjectile>
+			<defaultProjectile>Projectile_LightningWandCE</defaultProjectile>
 			<warmupTime>1.4</warmupTime>
 			<range>32</range>
 			<soundCast>TM_Thunder_OnMap</soundCast>
@@ -175,7 +175,7 @@
 			<recoilAmount>1.53</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Projectile_FireWand</defaultProjectile>
+			<defaultProjectile>Projectile_FireWandCE</defaultProjectile>
 			<warmupTime>1.5</warmupTime>
 			<range>32</range>
 			<burstShotCount>3</burstShotCount>
@@ -202,7 +202,7 @@
 		<Properties>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Projectile_FireWand</defaultProjectile>
+			<defaultProjectile>Projectile_FireWandCE</defaultProjectile>
 			<warmupTime>0.75</warmupTime>
 			<range>32</range>
 			<burstShotCount>3</burstShotCount>
@@ -224,6 +224,13 @@
 		<xpath>Defs/ThingDef[defName="TM_DefenderStaff" or defName="TM_BlazingPowerStaff"]/verbs/li[verbClass="TorannMagic.Weapon.Verb_BlazingPower"]</xpath>
 	</Operation>
 
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName= "TM_Ruunbled" or defName="TM_BlazingPowerStaff" or defName="TM_DefenderStaff"]/comps/li[@Class="CompDeflector.CompProperties_Deflector"]/DeflectVerb/defaultProjectile</xpath>
+    <value>
+      <defaultProjectile>Projectile_BlazingPowerCE</defaultProjectile>
+    </value>
+  </Operation>
+
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>TM_DefenderStaff</defName>
 		<statBases>
@@ -238,7 +245,7 @@
 			<recoilAmount>1.53</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Projectile_BlazingPower</defaultProjectile>
+			<defaultProjectile>Projectile_BlazingPowerCE</defaultProjectile>
 			<warmupTime>0.5</warmupTime>
 			<range>40</range>
 			<soundCast>TM_Woosh</soundCast>
@@ -267,7 +274,7 @@
 			<recoilAmount>1.53</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Projectile_BlazingPower</defaultProjectile>
+			<defaultProjectile>Projectile_BlazingPowerCE</defaultProjectile>
 			<warmupTime>1</warmupTime>
 			<range>40</range>
 			<soundCast>TM_Woosh</soundCast>


### PR DESCRIPTION
## Additions

## Changes

- Changed defNames for the CE projectiles, so they are not removed by the PatchOperationRemove targeting the defName of the original projectiles


## References

Links to the associated issues or other related pull requests, e.g.
- Closes #3301

## Reasoning


## Alternatives

## Testing

Check tests you have performed:
- [ X ] Compiles without warnings
- [ X ] Game runs without errors
- [ X ] (For compatibility patches) ...with and without patched mod loaded
- [ X ] Playtested a colony (specify how long) - large raid
