### PR TITLE
Cook-off explosion radius fix

### DIFF
--- a/Defs/Ammo/Advanced/164x284mmDemoShell.xml
+++ b/Defs/Ammo/Advanced/164x284mmDemoShell.xml
@@ -53,7 +53,7 @@
 				<explosiveRadius>1</explosiveRadius>
 				<damageAmountBase>18</damageAmountBase>
 				<explosiveDamageType>Thermobaric</explosiveDamageType>
-				<explosiveExpandPerStackcount>0.10</explosiveExpandPerStackcount>
+				<explosiveExpandPerStackcount>0.25</explosiveExpandPerStackcount>
 				<startWickHitPointsPercent>0.33</startWickHitPointsPercent>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 				<explodeOnKilled>True</explodeOnKilled>

--- a/Defs/Ammo/Generic/Mech.xml
+++ b/Defs/Ammo/Generic/Mech.xml
@@ -135,7 +135,7 @@
 				<explosiveRadius>1</explosiveRadius>
 				<damageAmountBase>18</damageAmountBase>
 				<explosiveDamageType>Thermobaric</explosiveDamageType>
-				<explosiveExpandPerStackcount>0.10</explosiveExpandPerStackcount>
+				<explosiveExpandPerStackcount>0.25</explosiveExpandPerStackcount>
 				<startWickHitPointsPercent>0.33</startWickHitPointsPercent>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 				<explodeOnKilled>True</explodeOnKilled>

--- a/Defs/Ammo/Medieval/CannonBall.xml
+++ b/Defs/Ammo/Medieval/CannonBall.xml
@@ -115,7 +115,7 @@
 				<damageAmountBase>25</damageAmountBase>
 				<explosiveRadius>1.0</explosiveRadius>
 				<explosiveDamageType>Bomb</explosiveDamageType>
-				<explosiveExpandPerStackcount>0.033</explosiveExpandPerStackcount>
+				<explosiveExpandPerStackcount>1.0</explosiveExpandPerStackcount>
 				<startWickOnDamageTaken>
 					<li>Bomb</li>
 					<li>Flame</li>

--- a/Defs/Ammo/Modded/Warhammer 40k/PlasmaCannon.xml
+++ b/Defs/Ammo/Modded/Warhammer 40k/PlasmaCannon.xml
@@ -85,7 +85,7 @@
 			<li Class="CompProperties_Explosive">
 				<explosiveRadius>0.5</explosiveRadius>
 				<explosiveDamageType>Bomb</explosiveDamageType>
-				<explosiveExpandPerStackcount>0.033</explosiveExpandPerStackcount>
+				<explosiveExpandPerStackcount>1.0</explosiveExpandPerStackcount>
 				<startWickHitPointsPercent>0.33</startWickHitPointsPercent>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 				<explodeOnKilled>True</explodeOnKilled>

--- a/Defs/Ammo/Rocket/84x246mmR.xml
+++ b/Defs/Ammo/Rocket/84x246mmR.xml
@@ -160,7 +160,7 @@
 				<damageAmountBase>20</damageAmountBase>
 				<explosiveRadius>1.0</explosiveRadius>
 				<explosiveDamageType>Bomb</explosiveDamageType>
-				<explosiveExpandPerStackcount>0.033</explosiveExpandPerStackcount>
+				<explosiveExpandPerStackcount>1.0</explosiveExpandPerStackcount>
 				<startWickOnDamageTaken>
 					<li>Bomb</li>
 				</startWickOnDamageTaken>

--- a/Defs/Ammo/Rocket/90mmRecoilless.xml
+++ b/Defs/Ammo/Rocket/90mmRecoilless.xml
@@ -72,7 +72,7 @@
 				<damageAmountBase>25</damageAmountBase>
 				<explosiveRadius>1.0</explosiveRadius>
 				<explosiveDamageType>Bomb</explosiveDamageType>
-				<explosiveExpandPerStackcount>0.033</explosiveExpandPerStackcount>
+				<explosiveExpandPerStackcount>1.0</explosiveExpandPerStackcount>
 				<startWickOnDamageTaken>
 					<li>Bomb</li>
 				</startWickOnDamageTaken>

--- a/Defs/ThingDefs_Items/Items_Resource_Ammo.xml
+++ b/Defs/ThingDefs_Items/Items_Resource_Ammo.xml
@@ -31,7 +31,7 @@
 				<damageAmountBase>2</damageAmountBase>
 				<explosiveRadius>0.9</explosiveRadius>
 				<explosiveDamageType>PrometheumFlame</explosiveDamageType>
-				<explosiveExpandPerStackcount>0.027</explosiveExpandPerStackcount>
+				<explosiveExpandPerStackcount>0.5</explosiveExpandPerStackcount>
 				<startWickOnDamageTaken>
 					<li>Flame</li>
 				</startWickOnDamageTaken>
@@ -72,7 +72,7 @@
 			<li Class="CompProperties_Explosive">
 				<explosiveRadius>0.9</explosiveRadius>
 				<explosiveDamageType>Bomb</explosiveDamageType>
-				<explosiveExpandPerStackcount>0.033</explosiveExpandPerStackcount>
+				<explosiveExpandPerStackcount>1.0</explosiveExpandPerStackcount>
 				<startWickOnDamageTaken>
 					<li>Bomb</li>
 					<li>Flame</li>


### PR DESCRIPTION
## Changes

- Fixed the cook-off explosion size scaling for certain items.

## Reasoning

- Somewhere along the line between #1522 and now, there was a behind the scenes change to the cook-off explosion size scaling, most likely the `explosiveExpandPerStackcount` node, that changed how certain items behaved when cooked off. Most importantly Prometheum, FSX and Chemfuel itself which went from a huge 12 tile explosion to a mere 4 tiles. The new values mean that FSX and other bomb-like items explode in the same radius as before, being 5 tiles. Same thing but slightly smaller for Prometheum.

## Alternatives

- Cringe at the puny explosions?

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
