### PR TITLE
Add null check for weapon tags in recoil function.

### DIFF
--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -811,7 +811,7 @@ namespace CombatExtended
 
                 if (handheld)
                 {
-                    if (weaponDef.weaponTags.Contains("CE_OneHandedWeapon"))
+                    if (weaponDef.weaponTags != null && weaponDef.weaponTags.Contains("CE_OneHandedWeapon"))
                     {
                         recoil /= 3;
                         muzzleJumpModifier *= 1.5f;


### PR DESCRIPTION
## Changes

-Fix Rimworld of Magic wand rendering error.

## References

- Closes #[ISSUE_NUMBER]

## Reasoning
-Bugfix

## Alternatives
  - Suffer

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
