### PR TITLE
Rah's Vanilla Turrets Expanded Patch Update

### DIFF
--- a/ModPatches/Rah's Vanilla Turrets Expansion/Patches/Rah's Vanilla Turrets Expansion/Patch_Buildings_Security.xml
+++ b/ModPatches/Rah's Vanilla Turrets Expansion/Patches/Rah's Vanilla Turrets Expansion/Patch_Buildings_Security.xml
@@ -582,29 +582,6 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[
-			defName="VulcanCannon" or
-			defName="VulcanCannonManned" or
-			defName="ChargeCannon"
-			]/passability </xpath>
-		<value>
-			<!-- Turrets must be passable to allow reloading -->
-			<passability>PassThroughOnly</passability>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[
-			defName="VulcanCannon" or
-			defName="VulcanCannonManned" or
-			defName="ChargeCannon"
-			] </xpath>
-		<value>
-			<!-- Workaround to replace passability=Impassable -->
-			<pathCost>200</pathCost>
-		</value>
-	</Operation>
 
 	<!-- ========== Devastator Mortar ========== -->
 


### PR DESCRIPTION
## Additions

## Changes

- Removed patches for VulcanCannon, VulcanCannonManned, ChargeCannon that change their passability and pathCost

## References

## Reasoning

- These turrets are no longer impassable in the base mod, making the patches unnecessary, and also causing errors due to targeting nonexistant <passability> node on those defs.

## Alternatives

## Testing

Check tests you have performed:
- [ X ] Compiles without warnings
- [ X ] Game runs without errors
- [ X ] (For compatibility patches) ...with and without patched mod loaded
- [ X ] Playtested a colony (specify how long) - spawned the turrets in question, forced a pawn to walk through them, forced pawns to reload them, forced them to fire on a target
