### PR TITLE
RH2 Faction - VOID small patch cleanup

### DIFF
--- a/ModPatches/RH2 Faction - VOID/Patches/RH2 Faction - VOID/Items_Drugs/Alcohol_RedWine.xml
+++ b/ModPatches/RH2 Faction - VOID/Patches/RH2 Faction - VOID/Items_Drugs/Alcohol_RedWine.xml
@@ -5,6 +5,7 @@
 		<xpath>Defs/ThingDef[defName="RH_RedWine"]/statBases</xpath>
 		<value>
 			<Bulk>1.5</Bulk>
+      <MeleeCounterParryBonus>0.33</MeleeCounterParryBonus>
 		</value>
 	</Operation>
 
@@ -33,13 +34,6 @@
 					<linkedBodyPartsGroup>Neck</linkedBodyPartsGroup>
 				</li>
 			</tools>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="RH_RedWine"]/statBases</xpath>
-		<value>
-			<MeleeCounterParryBonus>0.33</MeleeCounterParryBonus>
 		</value>
 	</Operation>
 


### PR DESCRIPTION
## Additions

## Changes

- Combine two PatchOperationAdd operations targeting the same def's (RH_RedWine) statBases into one operation

## References

## Reasoning

- cleaner this way
- might save a millisecond per startup

## Alternatives

- leave as-is

## Testing

Check tests you have performed:
- [ X ] Compiles without warnings
- [ X ] Game runs without errors
- [ X ] (For compatibility patches) ...with and without patched mod loaded
- [ X ] Playtested a colony (specify how long) - spawned the Wine, checked Info Card shows Bulk and MeleeCounterParryBonus values are as expected, and bonked a raider with it
