### PR TITLE
Patch Biotech Expansion - Insectoid

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -68,6 +68,7 @@
 		<li IfModActive="divineDerivative.AutoWool">ModPatches/Better Wool Production</li>
 		<li IfModActive="Ushanka.BiologicalWarfare">ModPatches/BiologicalWarfare</li>
 		<li IfModActive="BiomesTeam.BiomesCore">ModPatches/Biomes Core</li>
+		<li IfModActive="biotexpans.insect">ModPatches/Biotech Expansion - Insectoid</li>
 		<li IfModActive="biotexpans.mammalia">ModPatches/Biotech Expansion - Mammalia</li>
 		<li IfModActive="biotexpans.mythic">ModPatches/Biotech Expansion - Mythic</li>
 		<li IfModActive="MrKociak.BiotechMoreMechStuffMechUpgradePod">ModPatches/Biotech Mech Stuff Elongated - Mechanoid Upgrades V2</li>

--- a/ModPatches/Biotech Expansion - Insectoid/Patches/Biotech Expansion - Insectoid/BEI_AbilityDefs_Patch.xml
+++ b/ModPatches/Biotech Expansion - Insectoid/Patches/Biotech Expansion - Insectoid/BEI_AbilityDefs_Patch.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AbilityDef[defName="BTEIst_VolatileStingLauncher" or defName="BTEIst_ToxicStingLauncher"]/verbProperties/range</xpath>
+		<value>
+			<range>21</range>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="BTEIst_ToxicSting"]/projectile</xpath>
+		<value>
+			<projectile Class="CombatExtended.ProjectilePropertiesCE">
+				<damageDef>BTEIst_ToxicStab</damageDef>
+				<speed>120</speed>
+				<damageAmountBase>5</damageAmountBase>
+				<armorPenetrationSharp>6</armorPenetrationSharp>
+				<armorPenetrationBlunt>9</armorPenetrationBlunt>
+			</projectile>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="BTEIst_ToxicStingBuffed"]/projectile</xpath>
+		<value>
+			<projectile Class="CombatExtended.ProjectilePropertiesCE">
+				<damageDef>BTEIst_ToxicStab</damageDef>
+				<speed>120</speed>
+				<damageAmountBase>10</damageAmountBase>
+				<armorPenetrationSharp>9</armorPenetrationSharp>
+				<armorPenetrationBlunt>12</armorPenetrationBlunt>
+			</projectile>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="BTEIst_VolatileSting"]/projectile</xpath>
+		<value>
+			<projectile Class="CombatExtended.ProjectilePropertiesCE">
+				<damageDef>BTEIst_VolatileStab</damageDef>
+				<speed>120</speed>
+				<damageAmountBase>1</damageAmountBase>
+				<armorPenetrationSharp>12</armorPenetrationSharp>
+				<armorPenetrationBlunt>18</armorPenetrationBlunt>
+			</projectile>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="BTEIst_ToxicStingBuffed"]/projectile</xpath>
+		<value>
+			<projectile Class="CombatExtended.ProjectilePropertiesCE">
+				<damageDef>BTEIst_ToxicStab</damageDef>
+				<speed>120</speed>
+				<damageAmountBase>2</damageAmountBase>
+				<armorPenetrationSharp>12</armorPenetrationSharp>
+				<armorPenetrationBlunt>18</armorPenetrationBlunt>
+			</projectile>
+		</value>
+	</Operation>
+</Patch>

--- a/ModPatches/Biotech Expansion - Insectoid/Patches/Biotech Expansion - Insectoid/BEI_AbilityDefs_Patch.xml
+++ b/ModPatches/Biotech Expansion - Insectoid/Patches/Biotech Expansion - Insectoid/BEI_AbilityDefs_Patch.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/AbilityDef[defName="BTEIst_VolatileStingLauncher" or defName="BTEIst_ToxicStingLauncher"]/verbProperties/range</xpath>
 		<value>
@@ -58,4 +59,5 @@
 			</projectile>
 		</value>
 	</Operation>
+
 </Patch>

--- a/ModPatches/Biotech Expansion - Insectoid/Patches/Biotech Expansion - Insectoid/BEI_AbilityDefs_Patch.xml
+++ b/ModPatches/Biotech Expansion - Insectoid/Patches/Biotech Expansion - Insectoid/BEI_AbilityDefs_Patch.xml
@@ -4,7 +4,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/AbilityDef[defName="BTEIst_VolatileStingLauncher" or defName="BTEIst_ToxicStingLauncher"]/verbProperties/range</xpath>
 		<value>
-			<range>21</range>
+			<range>28</range>
 		</value>
 	</Operation>
 	

--- a/ModPatches/Biotech Expansion - Insectoid/Patches/Biotech Expansion - Insectoid/BEI_Hediffs_BodyParts.xml
+++ b/ModPatches/Biotech Expansion - Insectoid/Patches/Biotech Expansion - Insectoid/BEI_Hediffs_BodyParts.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/HediffDef[defName="BTEIst_InsectoidClaw"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>claws</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>15</power>
+					<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.22</armorPenetrationSharp>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+					<cooldownTime>1.4</cooldownTime>
+					<soundMeleeHit>MeleeHit_BionicSlash</soundMeleeHit>
+					<soundMeleeMiss>MeleeMiss_BionicSlash</soundMeleeMiss>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/GeneDef[defName="BTEIst_HardenedChitin"]/statOffsets</xpath>
+		<value>
+			<statOffsets>
+				<ArmorRating_Sharp>3</ArmorRating_Sharp>
+				<ArmorRating_Blunt>4.5</ArmorRating_Blunt>
+			</statOffsets>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/HediffDef[defName="BTEIst_Exogelatin"]/stages/li/statOffsets</xpath>
+		<value>
+			<statOffsets>
+				<ArmorRating_Sharp>3</ArmorRating_Sharp>
+				<ArmorRating_Blunt>4.5</ArmorRating_Blunt>
+			</statOffsets>
+		</value>
+	</Operation>
+</Patch>

--- a/ModPatches/Biotech Expansion - Insectoid/Patches/Biotech Expansion - Insectoid/BEI_Hediffs_BodyParts.xml
+++ b/ModPatches/Biotech Expansion - Insectoid/Patches/Biotech Expansion - Insectoid/BEI_Hediffs_BodyParts.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="BTEIst_InsectoidClaw"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
 		<value>
@@ -25,8 +26,8 @@
 		<xpath>Defs/GeneDef[defName="BTEIst_HardenedChitin"]/statOffsets</xpath>
 		<value>
 			<statOffsets>
-				<ArmorRating_Sharp>3</ArmorRating_Sharp>
-				<ArmorRating_Blunt>4.5</ArmorRating_Blunt>
+				<ArmorRating_Sharp>2.25</ArmorRating_Sharp>
+				<ArmorRating_Blunt>3.375</ArmorRating_Blunt>
 			</statOffsets>
 		</value>
 	</Operation>
@@ -35,9 +36,10 @@
 		<xpath>Defs/HediffDef[defName="BTEIst_Exogelatin"]/stages/li/statOffsets</xpath>
 		<value>
 			<statOffsets>
-				<ArmorRating_Sharp>3</ArmorRating_Sharp>
-				<ArmorRating_Blunt>4.5</ArmorRating_Blunt>
+				<ArmorRating_Sharp>2.25</ArmorRating_Sharp>
+				<ArmorRating_Blunt>3.375</ArmorRating_Blunt>
 			</statOffsets>
 		</value>
 	</Operation>
+
 </Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -132,6 +132,7 @@ Big and Small - Vampires and the Undead  |
 Big and Small - Weapons	|
 Biomes! Caverns	|
 Biomes! Core	|
+Biotech Expansion - Insectoid   |
 Biotech Expansion - Mammalia  |
 Biotech Expansion - Mythic  |
 Biotech Mech Stuff Elongated - Mechanoid Upgrades V2  |


### PR DESCRIPTION
## Additions
What it says on the tin.
## Changes
Abilities has two versions one when pawn ingested jelly one didn't, the jelly one has slightly better pen and x2 damage. the 1 and 2 damage one is a debuff that when affected pawn dies they explode.
## References

## Reasoning

## Alternatives


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
