### PR TITLE
pphhyy Demipryphs patch update

### DIFF
--- a/ModPatches/pphhyy Demigryph/Patches/pphhyy Demigryph/Demigryph_Banners.xml
+++ b/ModPatches/pphhyy Demigryph/Patches/pphhyy Demigryph/Demigryph_Banners.xml
@@ -1,0 +1,486 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Expanded Framework</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/ThingDef[
+						defName="pphhyy_Human_DemigyryphBanner" or
+						defName="pphhyy_Human_DemigyryphHunterBanner" or
+						defName="pphhyy_Human_DemigyryphRaiderBanner" or
+						defName="pphhyy_Human_DemigyryphGildedBanner" or
+						defName="pphhyy_Human_DemigyryphChampionBanner"]
+					</xpath>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs</xpath>
+					<value>
+
+						<ThingDef ParentName="ShieldBase">
+							<defName>pphhyy_Human_DemigyryphBanner</defName>
+							<label>Demigyryph Banner</label>
+							<description>A Cavalry Banner made from Leather materials.</description>
+							<techLevel>Medieval</techLevel>
+							<graphicData>
+								<texPath>Weapons/DemigyryphBanner/DemigyryphBanner</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+							</graphicData>
+							<costStuffCount>30</costStuffCount>
+							<stuffCategories Inherit="False">
+								<li>Fabric</li>
+								<li>Leathery</li>
+							</stuffCategories>
+							<costList>
+								<WoodLog>10</WoodLog>
+							</costList>
+							<statBases>
+								<WorkToMake>6000</WorkToMake>
+								<MaxHitPoints>200</MaxHitPoints>
+								<Mass>2</Mass>
+								<Bulk>10</Bulk>
+								<WornBulk>4</WornBulk>
+								<StuffEffectMultiplierArmor>1.0</StuffEffectMultiplierArmor>
+							</statBases>
+							<recipeMaker>
+								<researchPrerequisite>Smithing</researchPrerequisite>
+								<recipeUsers>
+									<li>ElectricSmithy</li>
+									<li>FueledSmithy</li>
+									<li MayRequire="DankPyon.Medieval.Overhaul">DankPyon_Anvil</li>
+								</recipeUsers>
+							</recipeMaker>
+							<equippedStatOffsets>
+								<Suppressability>-0.25</Suppressability>
+								<PainShockThreshold>0.1</PainShockThreshold>
+								<ReloadSpeed>-0.05</ReloadSpeed>
+								<MeleeHitChance>-0.5</MeleeHitChance>
+								<ShootingAccuracyPawn>-0.25</ShootingAccuracyPawn>
+								<AimingAccuracy>-0.15</AimingAccuracy>
+								<MeleeCritChance>-0.1</MeleeCritChance>
+								<MeleeParryChance>0.5</MeleeParryChance>
+							</equippedStatOffsets>
+							<apparel>
+								<tags>
+									<li>TribalShield</li>
+								</tags>
+								<renderNodeProperties>
+									<li>
+										<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
+										<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
+										<texPath>Weapons/DemigyryphBanner/DemigyryphBanner</texPath>
+										<shaderTypeDef>CutoutComplex</shaderTypeDef>
+										<parentTagDef>ApparelBody</parentTagDef>
+										<drawData>
+											<scale>2.5</scale>
+											<defaultData>
+												<layer>80</layer>
+											</defaultData>
+											<dataEast>
+												<layer>-5</layer>
+												<offset>(0, 0, -0.1)</offset>
+												<rotationOffset>30</rotationOffset>
+											</dataEast>
+											<dataWest>
+												<rotationOffset>-30</rotationOffset>
+											</dataWest>
+											<dataNorth>
+												<layer>-5</layer>
+												<offset>(0.15, 0, -0.1)</offset>
+											</dataNorth>
+											<dataSouth>
+												<offset>(0.15, 0, -0.1)</offset>
+											</dataSouth>
+										</drawData>
+									</li>
+								</renderNodeProperties>
+							</apparel>
+							<modExtensions>
+								<li Class="CombatExtended.ShieldDefExtension">
+									<shieldCoverage>
+										<li>Hands</li>
+									</shieldCoverage>
+								</li>
+							</modExtensions>
+							<tradeTags>
+								<li>Armor</li>
+							</tradeTags>
+						</ThingDef>
+
+						<ThingDef ParentName="ShieldBase">
+							<defName>pphhyy_Human_DemigyryphHunterBanner</defName>
+							<label>Demigyryph Hunter Banner</label>
+							<description>A Cavalry Hunter Banner made from Leather materials and slain demigyphs.</description>
+							<techLevel>Medieval</techLevel>
+							<graphicData>
+								<texPath>Weapons/DemigyryphHunterBanner/DemigyryphHunterBanner</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+							</graphicData>
+							<costStuffCount>30</costStuffCount>
+							<stuffCategories Inherit="False">
+								<li>Fabric</li>
+								<li>Leathery</li>
+							</stuffCategories>
+							<costList>
+								<WoodLog>10</WoodLog>
+								<pphhyy_AnimalProduct_DemigryphClaw>1</pphhyy_AnimalProduct_DemigryphClaw>
+							</costList>
+							<statBases>
+								<WorkToMake>6000</WorkToMake>
+								<MaxHitPoints>200</MaxHitPoints>
+								<Mass>2</Mass>
+								<Bulk>10</Bulk>
+								<WornBulk>4</WornBulk>
+								<StuffEffectMultiplierArmor>1.0</StuffEffectMultiplierArmor>
+							</statBases>
+							<recipeMaker>
+								<researchPrerequisite>PlateArmor</researchPrerequisite>
+								<recipeUsers>
+									<li>ElectricSmithy</li>
+									<li>FueledSmithy</li>
+									<li MayRequire="DankPyon.Medieval.Overhaul">DankPyon_Anvil</li>
+								</recipeUsers>
+							</recipeMaker>
+							<equippedStatOffsets>
+								<Suppressability>-0.25</Suppressability>
+								<PainShockThreshold>0.1</PainShockThreshold>
+								<ReloadSpeed>-0.05</ReloadSpeed>
+								<MeleeHitChance>-0.5</MeleeHitChance>
+								<ShootingAccuracyPawn>-0.25</ShootingAccuracyPawn>
+								<AimingAccuracy>-0.15</AimingAccuracy>
+								<MeleeCritChance>-0.1</MeleeCritChance>
+								<MeleeParryChance>0.5</MeleeParryChance>
+							</equippedStatOffsets>
+							<apparel>
+								<tags>
+									<li>TribalShield</li>
+								</tags>
+								<renderNodeProperties>
+									<li>
+										<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
+										<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
+										<texPath>Weapons/DemigyryphHunterBanner/DemigyryphHunterBanner</texPath>
+										<shaderTypeDef>CutoutComplex</shaderTypeDef>
+										<parentTagDef>ApparelBody</parentTagDef>
+										<drawData>
+											<scale>2.5</scale>
+											<defaultData>
+												<layer>80</layer>
+											</defaultData>
+											<dataEast>
+												<layer>-5</layer>
+												<offset>(0, 0, -0.1)</offset>
+												<rotationOffset>30</rotationOffset>
+											</dataEast>
+											<dataWest>
+												<rotationOffset>-30</rotationOffset>
+											</dataWest>
+											<dataNorth>
+												<layer>-5</layer>
+												<offset>(0.15, 0, -0.1)</offset>
+											</dataNorth>
+											<dataSouth>
+												<offset>(0.15, 0, -0.1)</offset>
+											</dataSouth>
+										</drawData>
+									</li>
+								</renderNodeProperties>
+							</apparel>
+							<modExtensions>
+								<li Class="CombatExtended.ShieldDefExtension">
+									<shieldCoverage>
+										<li>Hands</li>
+									</shieldCoverage>
+								</li>
+							</modExtensions>
+							<tradeTags>
+								<li>Armor</li>
+							</tradeTags>
+						</ThingDef>
+
+						<ThingDef ParentName="ShieldBase">
+							<defName>pphhyy_Human_DemigyryphRaiderBanner</defName>
+							<label>Demigyryph Raider Banner</label>
+							<description>A Cavalry Raider Banner made from Leather materials and slain Foes.</description>
+							<techLevel>Medieval</techLevel>
+							<graphicData>
+								<texPath>Weapons/DemigyryphRaiderBanner/DemigyryphRaiderBanner</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+							</graphicData>
+							<costStuffCount>30</costStuffCount>
+							<stuffCategories Inherit="False">
+								<li>Fabric</li>
+								<li>Leathery</li>
+							</stuffCategories>
+							<costList>
+								<WoodLog>10</WoodLog>
+								<Skull MayRequire="Ludeon.RimWorld.Ideology">1</Skull>
+							</costList>
+							<statBases>
+								<WorkToMake>6000</WorkToMake>
+								<MaxHitPoints>200</MaxHitPoints>
+								<Mass>2</Mass>
+								<Bulk>10</Bulk>
+								<WornBulk>4</WornBulk>
+								<StuffEffectMultiplierArmor>1.0</StuffEffectMultiplierArmor>
+							</statBases>
+							<recipeMaker>
+								<researchPrerequisite>PlateArmor</researchPrerequisite>
+								<recipeUsers>
+									<li>ElectricSmithy</li>
+									<li>FueledSmithy</li>
+									<li MayRequire="DankPyon.Medieval.Overhaul">DankPyon_Anvil</li>
+								</recipeUsers>
+							</recipeMaker>
+							<equippedStatOffsets>
+								<Suppressability>-0.25</Suppressability>
+								<PainShockThreshold>0.1</PainShockThreshold>
+								<ReloadSpeed>-0.05</ReloadSpeed>
+								<MeleeHitChance>-0.5</MeleeHitChance>
+								<ShootingAccuracyPawn>-0.25</ShootingAccuracyPawn>
+								<AimingAccuracy>-0.15</AimingAccuracy>
+								<MeleeCritChance>-0.1</MeleeCritChance>
+								<MeleeParryChance>0.5</MeleeParryChance>
+							</equippedStatOffsets>
+							<apparel>
+								<tags>
+									<li>TribalShield</li>
+								</tags>
+								<renderNodeProperties>
+									<li>
+										<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
+										<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
+										<texPath>Weapons/DemigyryphRaiderBanner/DemigyryphRaiderBanner</texPath>
+										<shaderTypeDef>CutoutComplex</shaderTypeDef>
+										<parentTagDef>ApparelBody</parentTagDef>
+										<drawData>
+											<scale>2.5</scale>
+											<defaultData>
+												<layer>80</layer>
+											</defaultData>
+											<dataEast>
+												<layer>-5</layer>
+												<offset>(0, 0, -0.1)</offset>
+												<rotationOffset>30</rotationOffset>
+											</dataEast>
+											<dataWest>
+												<rotationOffset>-30</rotationOffset>
+											</dataWest>
+											<dataNorth>
+												<layer>-5</layer>
+												<offset>(0.15, 0, -0.1)</offset>
+											</dataNorth>
+											<dataSouth>
+												<offset>(0.15, 0, -0.1)</offset>
+											</dataSouth>
+										</drawData>
+									</li>
+								</renderNodeProperties>
+							</apparel>
+							<modExtensions>
+								<li Class="CombatExtended.ShieldDefExtension">
+									<shieldCoverage>
+										<li>Hands</li>
+									</shieldCoverage>
+								</li>
+							</modExtensions>
+							<tradeTags>
+								<li>Armor</li>
+							</tradeTags>
+						</ThingDef>
+
+						<ThingDef ParentName="ShieldBase">
+							<defName>pphhyy_Human_DemigyryphGildedBanner</defName>
+							<label>Demigyryph Gilded Banner</label>
+							<description>A Cavalry Gilded Banner made from Leather materials and God, wielded by wealthy knights.</description>
+							<techLevel>Medieval</techLevel>
+							<graphicData>
+								<texPath>Weapons/DemigyryphGildedBanner/DemigyryphGildedBanner</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+							</graphicData>
+							<costStuffCount>30</costStuffCount>
+							<stuffCategories Inherit="False">
+								<li>Fabric</li>
+								<li>Leathery</li>
+							</stuffCategories>
+							<costList>
+								<WoodLog>10</WoodLog>
+								<Gold>10</Gold>
+							</costList>
+							<statBases>
+								<WorkToMake>6000</WorkToMake>
+								<MaxHitPoints>200</MaxHitPoints>
+								<Mass>2</Mass>
+								<Bulk>10</Bulk>
+								<WornBulk>4</WornBulk>
+								<StuffEffectMultiplierArmor>1.0</StuffEffectMultiplierArmor>
+							</statBases>
+							<recipeMaker>
+								<researchPrerequisite>PlateArmor</researchPrerequisite>
+								<recipeUsers>
+									<li>ElectricSmithy</li>
+									<li>FueledSmithy</li>
+									<li MayRequire="DankPyon.Medieval.Overhaul">DankPyon_Anvil</li>
+								</recipeUsers>
+							</recipeMaker>
+							<equippedStatOffsets>
+								<Suppressability>-0.25</Suppressability>
+								<PainShockThreshold>0.1</PainShockThreshold>
+								<ReloadSpeed>-0.05</ReloadSpeed>
+								<MeleeHitChance>-0.5</MeleeHitChance>
+								<ShootingAccuracyPawn>-0.25</ShootingAccuracyPawn>
+								<AimingAccuracy>-0.15</AimingAccuracy>
+								<MeleeCritChance>-0.1</MeleeCritChance>
+								<MeleeParryChance>0.5</MeleeParryChance>
+							</equippedStatOffsets>
+							<apparel>
+								<tags>
+									<li>TribalShield</li>
+								</tags>
+								<renderNodeProperties>
+									<li>
+										<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
+										<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
+										<texPath>Weapons/DemigyryphGildedBanner/DemigyryphGildedBanner</texPath>
+										<shaderTypeDef>CutoutComplex</shaderTypeDef>
+										<parentTagDef>ApparelBody</parentTagDef>
+										<drawData>
+											<scale>2.5</scale>
+											<defaultData>
+												<layer>80</layer>
+											</defaultData>
+											<dataEast>
+												<layer>-5</layer>
+												<offset>(0, 0, -0.1)</offset>
+												<rotationOffset>30</rotationOffset>
+											</dataEast>
+											<dataWest>
+												<rotationOffset>-30</rotationOffset>
+											</dataWest>
+											<dataNorth>
+												<layer>-5</layer>
+												<offset>(0.15, 0, -0.1)</offset>
+											</dataNorth>
+											<dataSouth>
+												<offset>(0.15, 0, -0.1)</offset>
+											</dataSouth>
+										</drawData>
+									</li>
+								</renderNodeProperties>
+							</apparel>
+							<modExtensions>
+								<li Class="CombatExtended.ShieldDefExtension">
+									<shieldCoverage>
+										<li>Hands</li>
+									</shieldCoverage>
+								</li>
+							</modExtensions>
+							<tradeTags>
+								<li>Armor</li>
+							</tradeTags>
+						</ThingDef>
+
+						<ThingDef ParentName="ShieldBase">
+							<defName>pphhyy_Human_DemigyryphChampionBanner</defName>
+							<label>Demigyryph Champion Banner</label>
+							<description>A Cavalry Champion Banner made from Leather materials and, wielded by veteran knights.</description>
+							<techLevel>Medieval</techLevel>
+							<graphicData>
+								<texPath>Weapons/DemigyryphChampionBanner/DemigyryphChampionBanner</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+							</graphicData>
+							<costStuffCount>30</costStuffCount>
+							<stuffCategories Inherit="False">
+								<li>Fabric</li>
+								<li>Leathery</li>
+							</stuffCategories>
+							<costList>
+								<WoodLog>10</WoodLog>
+							</costList>
+							<statBases>
+								<WorkToMake>6000</WorkToMake>
+								<MaxHitPoints>200</MaxHitPoints>
+								<Mass>2</Mass>
+								<Bulk>10</Bulk>
+								<WornBulk>4</WornBulk>
+								<StuffEffectMultiplierArmor>1.0</StuffEffectMultiplierArmor>
+							</statBases>
+							<recipeMaker>
+								<researchPrerequisite>PlateArmor</researchPrerequisite>
+								<recipeUsers>
+									<li>ElectricSmithy</li>
+									<li>FueledSmithy</li>
+									<li MayRequire="DankPyon.Medieval.Overhaul">DankPyon_Anvil</li>
+								</recipeUsers>
+							</recipeMaker>
+							<equippedStatOffsets>
+								<Suppressability>-0.25</Suppressability>
+								<PainShockThreshold>0.1</PainShockThreshold>
+								<ReloadSpeed>-0.05</ReloadSpeed>
+								<MeleeHitChance>-0.5</MeleeHitChance>
+								<ShootingAccuracyPawn>-0.25</ShootingAccuracyPawn>
+								<AimingAccuracy>-0.15</AimingAccuracy>
+								<MeleeCritChance>-0.1</MeleeCritChance>
+								<MeleeParryChance>0.5</MeleeParryChance>
+							</equippedStatOffsets>
+							<apparel>
+								<tags>
+									<li>TribalShield</li>
+								</tags>
+								<renderNodeProperties>
+									<li>
+										<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
+										<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
+										<texPath>Weapons/DemigyryphChampionBanner/DemigyryphChampionBanner</texPath>
+										<shaderTypeDef>CutoutComplex</shaderTypeDef>
+										<parentTagDef>ApparelBody</parentTagDef>
+										<drawData>
+											<scale>2.5</scale>
+											<defaultData>
+												<layer>80</layer>
+											</defaultData>
+											<dataEast>
+												<layer>-5</layer>
+												<offset>(0, 0, -0.1)</offset>
+												<rotationOffset>30</rotationOffset>
+											</dataEast>
+											<dataWest>
+												<rotationOffset>-30</rotationOffset>
+											</dataWest>
+											<dataNorth>
+												<layer>-5</layer>
+												<offset>(0.15, 0, -0.1)</offset>
+											</dataNorth>
+											<dataSouth>
+												<offset>(0.15, 0, -0.1)</offset>
+											</dataSouth>
+										</drawData>
+									</li>
+								</renderNodeProperties>
+							</apparel>
+							<modExtensions>
+								<li Class="CombatExtended.ShieldDefExtension">
+									<shieldCoverage>
+										<li>Hands</li>
+									</shieldCoverage>
+								</li>
+							</modExtensions>
+							<tradeTags>
+								<li>Armor</li>
+							</tradeTags>
+						</ThingDef>
+
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/ModPatches/pphhyy Demigryph/Patches/pphhyy Demigryph/Demigryph_Banners.xml
+++ b/ModPatches/pphhyy Demigryph/Patches/pphhyy Demigryph/Demigryph_Banners.xml
@@ -9,63 +9,98 @@
 		<match Class="PatchOperationSequence">
 			<operations>
 
-				<li Class="PatchOperationRemove">
-					<xpath>Defs/ThingDef[
-						defName="pphhyy_Human_DemigyryphBanner" or
-						defName="pphhyy_Human_DemigyryphHunterBanner" or
-						defName="pphhyy_Human_DemigyryphRaiderBanner" or
-						defName="pphhyy_Human_DemigyryphGildedBanner" or
-						defName="pphhyy_Human_DemigyryphChampionBanner"]
-					</xpath>
+				<!-- Flag Base -->
+
+				<li Class="PatchOperationAttributeSet">
+					<xpath>Defs/ThingDef[@Name="pphhyy_Demigryph_BannerBase"]</xpath>
+					<attribute>ParentName</attribute>
+					<value>ArmorSmithableBase</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="pphhyy_Demigryph_BannerBase"]/thingClass</xpath>
+					<value>
+						<thingClass>CombatExtended.Apparel_Shield</thingClass>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="pphhyy_Demigryph_BannerBase"]/apparel</xpath>
+					<value>
+						<apparel>
+							<countsAsClothingForNudity>false</countsAsClothingForNudity>
+							<careIfWornByCorpse>false</careIfWornByCorpse>
+							<bodyPartGroups>
+								<li>LeftHand</li>
+							</bodyPartGroups>
+							<layers>
+								<li>Shield</li>
+							</layers>
+						</apparel>
+						<tradeTags>
+							<li>Armor</li>
+						</tradeTags>
+					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs</xpath>
+					<xpath>Defs/ThingDef[@Name="pphhyy_Demigryph_BannerBase"]/equippedStatOffsets</xpath>
 					<value>
+						<ReloadSpeed>-0.15</ReloadSpeed>
+						<MeleeHitChance>-0.85</MeleeHitChance>
+						<ShootingAccuracyPawn>-0.1</ShootingAccuracyPawn>
+						<AimingAccuracy>-0.06</AimingAccuracy>
+						<MeleeCritChance>-0.03</MeleeCritChance>
+					</value>
+				</li>
 
-						<ThingDef ParentName="ShieldBase">
-							<defName>pphhyy_Human_DemigyryphBanner</defName>
-							<label>Demigyryph Banner</label>
-							<description>A Cavalry Banner made from Leather materials.</description>
-							<techLevel>Medieval</techLevel>
-							<graphicData>
-								<texPath>Weapons/DemigyryphBanner/DemigyryphBanner</texPath>
-								<graphicClass>Graphic_Single</graphicClass>
-							</graphicData>
-							<costStuffCount>30</costStuffCount>
-							<stuffCategories Inherit="False">
-								<li>Fabric</li>
-								<li>Leathery</li>
-							</stuffCategories>
-							<costList>
-								<WoodLog>10</WoodLog>
-							</costList>
-							<statBases>
-								<WorkToMake>6000</WorkToMake>
-								<MaxHitPoints>200</MaxHitPoints>
-								<Mass>2</Mass>
-								<Bulk>10</Bulk>
-								<WornBulk>4</WornBulk>
-								<StuffEffectMultiplierArmor>1.0</StuffEffectMultiplierArmor>
-							</statBases>
-							<recipeMaker>
-								<researchPrerequisite>Smithing</researchPrerequisite>
-								<recipeUsers>
-									<li>ElectricSmithy</li>
-									<li>FueledSmithy</li>
-									<li MayRequire="DankPyon.Medieval.Overhaul">DankPyon_Anvil</li>
-								</recipeUsers>
-							</recipeMaker>
-							<equippedStatOffsets>
-								<Suppressability>-0.25</Suppressability>
-								<PainShockThreshold>0.1</PainShockThreshold>
-								<ReloadSpeed>-0.05</ReloadSpeed>
-								<MeleeHitChance>-0.5</MeleeHitChance>
-								<ShootingAccuracyPawn>-0.25</ShootingAccuracyPawn>
-								<AimingAccuracy>-0.15</AimingAccuracy>
-								<MeleeCritChance>-0.1</MeleeCritChance>
-								<MeleeParryChance>0.5</MeleeParryChance>
-							</equippedStatOffsets>
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/ThingDef[@Name="pphhyy_Demigryph_BannerBase"]/tools</xpath>
+				</li>
+
+				<!-- All Banners -->
+<!--
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/ThingDef[
+					defName="pphhyy_Human_DemigyryphBanner" or
+					defName="pphhyy_Human_DemigyryphRaiderBanner" or
+					defName="pphhyy_Human_DemigyryphGildedBanner" or
+					defName="pphhyy_Human_DemigyryphHunterBanner" or
+					defName="pphhyy_Human_DemigyryphChampionBanner"
+					]/comps/li[@Class="VFECore.CompProperties_Shield"]</xpath>
+				</li>
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/ThingDef[
+					defName="pphhyy_Human_DemigyryphBanner" or
+					defName="pphhyy_Human_DemigyryphRaiderBanner" or
+					defName="pphhyy_Human_DemigyryphGildedBanner" or
+					defName="pphhyy_Human_DemigyryphHunterBanner" or
+					defName="pphhyy_Human_DemigyryphChampionBanner"
+					]</xpath>
+					<value>
+						<li Class="CombatExtended.ShieldDefExtension">
+							<shieldCoverage>
+								<li>Hands</li>
+							</shieldCoverage>
+						</li>
+					</value>
+				</li>
+-->
+				<!-- Demigyryph Banner -->
+<!--
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphBanner"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>	
+						<Bulk>10</Bulk>
+						<WornBulk>4</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphBanner"]</xpath>
+					<value>
 							<apparel>
 								<tags>
 									<li>TribalShield</li>
@@ -101,62 +136,23 @@
 									</li>
 								</renderNodeProperties>
 							</apparel>
-							<modExtensions>
-								<li Class="CombatExtended.ShieldDefExtension">
-									<shieldCoverage>
-										<li>Hands</li>
-									</shieldCoverage>
-								</li>
-							</modExtensions>
-							<tradeTags>
-								<li>Armor</li>
-							</tradeTags>
-						</ThingDef>
+					</value>
+				</li>
+-->
+				<!-- Hunter Banner -->
+<!--
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphHunterBanner"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>	
+						<Bulk>10</Bulk>
+						<WornBulk>4</WornBulk>
+					</value>
+				</li>
 
-						<ThingDef ParentName="ShieldBase">
-							<defName>pphhyy_Human_DemigyryphHunterBanner</defName>
-							<label>Demigyryph Hunter Banner</label>
-							<description>A Cavalry Hunter Banner made from Leather materials and slain demigyphs.</description>
-							<techLevel>Medieval</techLevel>
-							<graphicData>
-								<texPath>Weapons/DemigyryphHunterBanner/DemigyryphHunterBanner</texPath>
-								<graphicClass>Graphic_Single</graphicClass>
-							</graphicData>
-							<costStuffCount>30</costStuffCount>
-							<stuffCategories Inherit="False">
-								<li>Fabric</li>
-								<li>Leathery</li>
-							</stuffCategories>
-							<costList>
-								<WoodLog>10</WoodLog>
-								<pphhyy_AnimalProduct_DemigryphClaw>1</pphhyy_AnimalProduct_DemigryphClaw>
-							</costList>
-							<statBases>
-								<WorkToMake>6000</WorkToMake>
-								<MaxHitPoints>200</MaxHitPoints>
-								<Mass>2</Mass>
-								<Bulk>10</Bulk>
-								<WornBulk>4</WornBulk>
-								<StuffEffectMultiplierArmor>1.0</StuffEffectMultiplierArmor>
-							</statBases>
-							<recipeMaker>
-								<researchPrerequisite>PlateArmor</researchPrerequisite>
-								<recipeUsers>
-									<li>ElectricSmithy</li>
-									<li>FueledSmithy</li>
-									<li MayRequire="DankPyon.Medieval.Overhaul">DankPyon_Anvil</li>
-								</recipeUsers>
-							</recipeMaker>
-							<equippedStatOffsets>
-								<Suppressability>-0.25</Suppressability>
-								<PainShockThreshold>0.1</PainShockThreshold>
-								<ReloadSpeed>-0.05</ReloadSpeed>
-								<MeleeHitChance>-0.5</MeleeHitChance>
-								<ShootingAccuracyPawn>-0.25</ShootingAccuracyPawn>
-								<AimingAccuracy>-0.15</AimingAccuracy>
-								<MeleeCritChance>-0.1</MeleeCritChance>
-								<MeleeParryChance>0.5</MeleeParryChance>
-							</equippedStatOffsets>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphHunterBanner"]</xpath>
+					<value>
 							<apparel>
 								<tags>
 									<li>TribalShield</li>
@@ -165,7 +161,7 @@
 									<li>
 										<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
 										<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
-										<texPath>Weapons/DemigyryphHunterBanner/DemigyryphHunterBanner</texPath>
+										<texPath>Weapons/DemigyryphBanner/DemigyryphBanner</texPath>
 										<shaderTypeDef>CutoutComplex</shaderTypeDef>
 										<parentTagDef>ApparelBody</parentTagDef>
 										<drawData>
@@ -192,62 +188,23 @@
 									</li>
 								</renderNodeProperties>
 							</apparel>
-							<modExtensions>
-								<li Class="CombatExtended.ShieldDefExtension">
-									<shieldCoverage>
-										<li>Hands</li>
-									</shieldCoverage>
-								</li>
-							</modExtensions>
-							<tradeTags>
-								<li>Armor</li>
-							</tradeTags>
-						</ThingDef>
+					</value>
+				</li>
+-->
+				<!-- Raider Banner -->
+<!--
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphRaiderBanner"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>	
+						<Bulk>10</Bulk>
+						<WornBulk>4</WornBulk>
+					</value>
+				</li>
 
-						<ThingDef ParentName="ShieldBase">
-							<defName>pphhyy_Human_DemigyryphRaiderBanner</defName>
-							<label>Demigyryph Raider Banner</label>
-							<description>A Cavalry Raider Banner made from Leather materials and slain Foes.</description>
-							<techLevel>Medieval</techLevel>
-							<graphicData>
-								<texPath>Weapons/DemigyryphRaiderBanner/DemigyryphRaiderBanner</texPath>
-								<graphicClass>Graphic_Single</graphicClass>
-							</graphicData>
-							<costStuffCount>30</costStuffCount>
-							<stuffCategories Inherit="False">
-								<li>Fabric</li>
-								<li>Leathery</li>
-							</stuffCategories>
-							<costList>
-								<WoodLog>10</WoodLog>
-								<Skull MayRequire="Ludeon.RimWorld.Ideology">1</Skull>
-							</costList>
-							<statBases>
-								<WorkToMake>6000</WorkToMake>
-								<MaxHitPoints>200</MaxHitPoints>
-								<Mass>2</Mass>
-								<Bulk>10</Bulk>
-								<WornBulk>4</WornBulk>
-								<StuffEffectMultiplierArmor>1.0</StuffEffectMultiplierArmor>
-							</statBases>
-							<recipeMaker>
-								<researchPrerequisite>PlateArmor</researchPrerequisite>
-								<recipeUsers>
-									<li>ElectricSmithy</li>
-									<li>FueledSmithy</li>
-									<li MayRequire="DankPyon.Medieval.Overhaul">DankPyon_Anvil</li>
-								</recipeUsers>
-							</recipeMaker>
-							<equippedStatOffsets>
-								<Suppressability>-0.25</Suppressability>
-								<PainShockThreshold>0.1</PainShockThreshold>
-								<ReloadSpeed>-0.05</ReloadSpeed>
-								<MeleeHitChance>-0.5</MeleeHitChance>
-								<ShootingAccuracyPawn>-0.25</ShootingAccuracyPawn>
-								<AimingAccuracy>-0.15</AimingAccuracy>
-								<MeleeCritChance>-0.1</MeleeCritChance>
-								<MeleeParryChance>0.5</MeleeParryChance>
-							</equippedStatOffsets>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphRaiderBanner"]</xpath>
+					<value>
 							<apparel>
 								<tags>
 									<li>TribalShield</li>
@@ -283,202 +240,113 @@
 									</li>
 								</renderNodeProperties>
 							</apparel>
-							<modExtensions>
-								<li Class="CombatExtended.ShieldDefExtension">
-									<shieldCoverage>
-										<li>Hands</li>
-									</shieldCoverage>
-								</li>
-							</modExtensions>
-							<tradeTags>
-								<li>Armor</li>
-							</tradeTags>
-						</ThingDef>
-
-						<ThingDef ParentName="ShieldBase">
-							<defName>pphhyy_Human_DemigyryphGildedBanner</defName>
-							<label>Demigyryph Gilded Banner</label>
-							<description>A Cavalry Gilded Banner made from Leather materials and God, wielded by wealthy knights.</description>
-							<techLevel>Medieval</techLevel>
-							<graphicData>
-								<texPath>Weapons/DemigyryphGildedBanner/DemigyryphGildedBanner</texPath>
-								<graphicClass>Graphic_Single</graphicClass>
-							</graphicData>
-							<costStuffCount>30</costStuffCount>
-							<stuffCategories Inherit="False">
-								<li>Fabric</li>
-								<li>Leathery</li>
-							</stuffCategories>
-							<costList>
-								<WoodLog>10</WoodLog>
-								<Gold>10</Gold>
-							</costList>
-							<statBases>
-								<WorkToMake>6000</WorkToMake>
-								<MaxHitPoints>200</MaxHitPoints>
-								<Mass>2</Mass>
-								<Bulk>10</Bulk>
-								<WornBulk>4</WornBulk>
-								<StuffEffectMultiplierArmor>1.0</StuffEffectMultiplierArmor>
-							</statBases>
-							<recipeMaker>
-								<researchPrerequisite>PlateArmor</researchPrerequisite>
-								<recipeUsers>
-									<li>ElectricSmithy</li>
-									<li>FueledSmithy</li>
-									<li MayRequire="DankPyon.Medieval.Overhaul">DankPyon_Anvil</li>
-								</recipeUsers>
-							</recipeMaker>
-							<equippedStatOffsets>
-								<Suppressability>-0.25</Suppressability>
-								<PainShockThreshold>0.1</PainShockThreshold>
-								<ReloadSpeed>-0.05</ReloadSpeed>
-								<MeleeHitChance>-0.5</MeleeHitChance>
-								<ShootingAccuracyPawn>-0.25</ShootingAccuracyPawn>
-								<AimingAccuracy>-0.15</AimingAccuracy>
-								<MeleeCritChance>-0.1</MeleeCritChance>
-								<MeleeParryChance>0.5</MeleeParryChance>
-							</equippedStatOffsets>
-							<apparel>
-								<tags>
-									<li>TribalShield</li>
-								</tags>
-								<renderNodeProperties>
-									<li>
-										<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
-										<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
-										<texPath>Weapons/DemigyryphGildedBanner/DemigyryphGildedBanner</texPath>
-										<shaderTypeDef>CutoutComplex</shaderTypeDef>
-										<parentTagDef>ApparelBody</parentTagDef>
-										<drawData>
-											<scale>2.5</scale>
-											<defaultData>
-												<layer>80</layer>
-											</defaultData>
-											<dataEast>
-												<layer>-5</layer>
-												<offset>(0, 0, -0.1)</offset>
-												<rotationOffset>30</rotationOffset>
-											</dataEast>
-											<dataWest>
-												<rotationOffset>-30</rotationOffset>
-											</dataWest>
-											<dataNorth>
-												<layer>-5</layer>
-												<offset>(0.15, 0, -0.1)</offset>
-											</dataNorth>
-											<dataSouth>
-												<offset>(0.15, 0, -0.1)</offset>
-											</dataSouth>
-										</drawData>
-									</li>
-								</renderNodeProperties>
-							</apparel>
-							<modExtensions>
-								<li Class="CombatExtended.ShieldDefExtension">
-									<shieldCoverage>
-										<li>Hands</li>
-									</shieldCoverage>
-								</li>
-							</modExtensions>
-							<tradeTags>
-								<li>Armor</li>
-							</tradeTags>
-						</ThingDef>
-
-						<ThingDef ParentName="ShieldBase">
-							<defName>pphhyy_Human_DemigyryphChampionBanner</defName>
-							<label>Demigyryph Champion Banner</label>
-							<description>A Cavalry Champion Banner made from Leather materials and, wielded by veteran knights.</description>
-							<techLevel>Medieval</techLevel>
-							<graphicData>
-								<texPath>Weapons/DemigyryphChampionBanner/DemigyryphChampionBanner</texPath>
-								<graphicClass>Graphic_Single</graphicClass>
-							</graphicData>
-							<costStuffCount>30</costStuffCount>
-							<stuffCategories Inherit="False">
-								<li>Fabric</li>
-								<li>Leathery</li>
-							</stuffCategories>
-							<costList>
-								<WoodLog>10</WoodLog>
-							</costList>
-							<statBases>
-								<WorkToMake>6000</WorkToMake>
-								<MaxHitPoints>200</MaxHitPoints>
-								<Mass>2</Mass>
-								<Bulk>10</Bulk>
-								<WornBulk>4</WornBulk>
-								<StuffEffectMultiplierArmor>1.0</StuffEffectMultiplierArmor>
-							</statBases>
-							<recipeMaker>
-								<researchPrerequisite>PlateArmor</researchPrerequisite>
-								<recipeUsers>
-									<li>ElectricSmithy</li>
-									<li>FueledSmithy</li>
-									<li MayRequire="DankPyon.Medieval.Overhaul">DankPyon_Anvil</li>
-								</recipeUsers>
-							</recipeMaker>
-							<equippedStatOffsets>
-								<Suppressability>-0.25</Suppressability>
-								<PainShockThreshold>0.1</PainShockThreshold>
-								<ReloadSpeed>-0.05</ReloadSpeed>
-								<MeleeHitChance>-0.5</MeleeHitChance>
-								<ShootingAccuracyPawn>-0.25</ShootingAccuracyPawn>
-								<AimingAccuracy>-0.15</AimingAccuracy>
-								<MeleeCritChance>-0.1</MeleeCritChance>
-								<MeleeParryChance>0.5</MeleeParryChance>
-							</equippedStatOffsets>
-							<apparel>
-								<tags>
-									<li>TribalShield</li>
-								</tags>
-								<renderNodeProperties>
-									<li>
-										<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
-										<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
-										<texPath>Weapons/DemigyryphChampionBanner/DemigyryphChampionBanner</texPath>
-										<shaderTypeDef>CutoutComplex</shaderTypeDef>
-										<parentTagDef>ApparelBody</parentTagDef>
-										<drawData>
-											<scale>2.5</scale>
-											<defaultData>
-												<layer>80</layer>
-											</defaultData>
-											<dataEast>
-												<layer>-5</layer>
-												<offset>(0, 0, -0.1)</offset>
-												<rotationOffset>30</rotationOffset>
-											</dataEast>
-											<dataWest>
-												<rotationOffset>-30</rotationOffset>
-											</dataWest>
-											<dataNorth>
-												<layer>-5</layer>
-												<offset>(0.15, 0, -0.1)</offset>
-											</dataNorth>
-											<dataSouth>
-												<offset>(0.15, 0, -0.1)</offset>
-											</dataSouth>
-										</drawData>
-									</li>
-								</renderNodeProperties>
-							</apparel>
-							<modExtensions>
-								<li Class="CombatExtended.ShieldDefExtension">
-									<shieldCoverage>
-										<li>Hands</li>
-									</shieldCoverage>
-								</li>
-							</modExtensions>
-							<tradeTags>
-								<li>Armor</li>
-							</tradeTags>
-						</ThingDef>
-
+					</value>
+				</li>
+-->
+				<!-- Gilded Banner -->
+<!--
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphGildedBanner"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>	
+						<Bulk>10</Bulk>
+						<WornBulk>4</WornBulk>
 					</value>
 				</li>
 
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphGildedBanner"]</xpath>
+					<value>
+							<apparel>
+								<tags>
+									<li>TribalShield</li>
+								</tags>
+								<renderNodeProperties>
+									<li>
+										<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
+										<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
+										<texPath>Weapons/DemigyryphRaiderBanner/DemigyryphRaiderBanner</texPath>
+										<shaderTypeDef>CutoutComplex</shaderTypeDef>
+										<parentTagDef>ApparelBody</parentTagDef>
+										<drawData>
+											<scale>2.5</scale>
+											<defaultData>
+												<layer>80</layer>
+											</defaultData>
+											<dataEast>
+												<layer>-5</layer>
+												<offset>(0, 0, -0.1)</offset>
+												<rotationOffset>30</rotationOffset>
+											</dataEast>
+											<dataWest>
+												<rotationOffset>-30</rotationOffset>
+											</dataWest>
+											<dataNorth>
+												<layer>-5</layer>
+												<offset>(0.15, 0, -0.1)</offset>
+											</dataNorth>
+											<dataSouth>
+												<offset>(0.15, 0, -0.1)</offset>
+											</dataSouth>
+										</drawData>
+									</li>
+								</renderNodeProperties>
+							</apparel>
+					</value>
+				</li>
+-->
+				<!-- Champion Banner -->
+<!--
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphChampionBanner"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>	
+						<Bulk>10</Bulk>
+						<WornBulk>4</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphChampionBanner"]</xpath>
+					<value>
+							<apparel>
+								<tags>
+									<li>TribalShield</li>
+								</tags>
+								<renderNodeProperties>
+									<li>
+										<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
+										<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
+										<texPath>Weapons/DemigyryphRaiderBanner/DemigyryphRaiderBanner</texPath>
+										<shaderTypeDef>CutoutComplex</shaderTypeDef>
+										<parentTagDef>ApparelBody</parentTagDef>
+										<drawData>
+											<scale>2.5</scale>
+											<defaultData>
+												<layer>80</layer>
+											</defaultData>
+											<dataEast>
+												<layer>-5</layer>
+												<offset>(0, 0, -0.1)</offset>
+												<rotationOffset>30</rotationOffset>
+											</dataEast>
+											<dataWest>
+												<rotationOffset>-30</rotationOffset>
+											</dataWest>
+											<dataNorth>
+												<layer>-5</layer>
+												<offset>(0.15, 0, -0.1)</offset>
+											</dataNorth>
+											<dataSouth>
+												<offset>(0.15, 0, -0.1)</offset>
+											</dataSouth>
+										</drawData>
+									</li>
+								</renderNodeProperties>
+							</apparel>
+					</value>
+				</li>
+-->
 			</operations>
 		</match>
 	</Operation>

--- a/ModPatches/pphhyy Demigryph/Patches/pphhyy Demigryph/Demigryph_Banners.xml
+++ b/ModPatches/pphhyy Demigryph/Patches/pphhyy Demigryph/Demigryph_Banners.xml
@@ -10,28 +10,21 @@
 			<operations>
 
 				<!-- Flag Base -->
-
 				<li Class="PatchOperationAttributeSet">
 					<xpath>Defs/ThingDef[@Name="pphhyy_Demigryph_BannerBase"]</xpath>
 					<attribute>ParentName</attribute>
 					<value>ArmorSmithableBase</value>
 				</li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[@Name="pphhyy_Demigryph_BannerBase"]/thingClass</xpath>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[@Name="pphhyy_Demigryph_BannerBase"]</xpath>
 					<value>
-						<thingClass>CombatExtended.Apparel_Shield</thingClass>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[@Name="pphhyy_Demigryph_BannerBase"]/apparel</xpath>
-					<value>
+						<thingClass>CombatExtended.Apparel_Shield</thingClass>					
 						<apparel>
 							<countsAsClothingForNudity>false</countsAsClothingForNudity>
 							<careIfWornByCorpse>false</careIfWornByCorpse>
 							<bodyPartGroups>
-								<li>LeftHand</li>
+								<li>LeftShoulder</li>
 							</bodyPartGroups>
 							<layers>
 								<li>Shield</li>
@@ -43,8 +36,8 @@
 					</value>
 				</li>
 
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[@Name="pphhyy_Demigryph_BannerBase"]/equippedStatOffsets</xpath>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="pphhyy_Demigryph_BannerBase"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
 					<value>
 						<ReloadSpeed>-0.15</ReloadSpeed>
 						<MeleeHitChance>-0.85</MeleeHitChance>
@@ -59,7 +52,7 @@
 				</li>
 
 				<!-- All Banners -->
-<!--
+
 				<li Class="PatchOperationRemove">
 					<xpath>Defs/ThingDef[
 					defName="pphhyy_Human_DemigyryphBanner" or
@@ -86,11 +79,11 @@
 						</li>
 					</value>
 				</li>
--->
+
 				<!-- Demigyryph Banner -->
-<!--
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphBanner"]/statBases/StuffEffectMultiplierArmor</xpath>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphBanner"]/statBases</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>	
 						<Bulk>10</Bulk>
@@ -101,48 +94,49 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphBanner"]</xpath>
 					<value>
-							<apparel>
-								<tags>
-									<li>TribalShield</li>
-								</tags>
-								<renderNodeProperties>
-									<li>
-										<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
-										<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
-										<texPath>Weapons/DemigyryphBanner/DemigyryphBanner</texPath>
-										<shaderTypeDef>CutoutComplex</shaderTypeDef>
-										<parentTagDef>ApparelBody</parentTagDef>
-										<drawData>
-											<scale>2.5</scale>
-											<defaultData>
-												<layer>80</layer>
-											</defaultData>
-											<dataEast>
-												<layer>-5</layer>
-												<offset>(0, 0, -0.1)</offset>
-												<rotationOffset>30</rotationOffset>
-											</dataEast>
-											<dataWest>
-												<rotationOffset>-30</rotationOffset>
-											</dataWest>
-											<dataNorth>
-												<layer>-5</layer>
-												<offset>(0.15, 0, -0.1)</offset>
-											</dataNorth>
-											<dataSouth>
-												<offset>(0.15, 0, -0.1)</offset>
-											</dataSouth>
-										</drawData>
-									</li>
-								</renderNodeProperties>
-							</apparel>
+						<apparel>
+							<tags>
+								<li>TribalShield</li>
+							</tags>
+							<renderNodeProperties>
+								<li>
+									<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
+									<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
+									<texPath>Weapons/DemigyryphBanner/DemigyryphBanner</texPath>
+									<shaderTypeDef>CutoutComplex</shaderTypeDef>
+									<parentTagDef>ApparelBody</parentTagDef>
+									<drawData>
+										<scale>1.3</scale>
+										<defaultData>
+											<layer>80</layer>
+										</defaultData>
+										<dataEast>
+											<layer>-5</layer>
+											<offset>(0.35, 0, 0.2)</offset>
+											<rotationOffset>30</rotationOffset>
+										</dataEast>
+										<dataWest>
+											<rotationOffset>-30</rotationOffset>
+											<offset>(-0.35, 0, 0.2)</offset>
+										</dataWest>
+										<dataNorth>
+											<layer>-5</layer>
+											<offset>(0.15, 0, 0.2)</offset>
+										</dataNorth>
+										<dataSouth>
+											<offset>(0.2, 0, 0.2)</offset>
+										</dataSouth>
+									</drawData>
+								</li>
+							</renderNodeProperties>
+						</apparel>
 					</value>
 				</li>
--->
+
 				<!-- Hunter Banner -->
-<!--
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphHunterBanner"]/statBases/StuffEffectMultiplierArmor</xpath>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphHunterBanner"]/statBases</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>	
 						<Bulk>10</Bulk>
@@ -161,28 +155,29 @@
 									<li>
 										<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
 										<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
-										<texPath>Weapons/DemigyryphBanner/DemigyryphBanner</texPath>
+										<texPath>Weapons/DemigyryphHunterBanner/DemigyryphHunterBanner</texPath>
 										<shaderTypeDef>CutoutComplex</shaderTypeDef>
 										<parentTagDef>ApparelBody</parentTagDef>
 										<drawData>
-											<scale>2.5</scale>
+											<scale>1.3</scale>
 											<defaultData>
 												<layer>80</layer>
 											</defaultData>
 											<dataEast>
 												<layer>-5</layer>
-												<offset>(0, 0, -0.1)</offset>
+												<offset>(0.35, 0, 0.2)</offset>
 												<rotationOffset>30</rotationOffset>
 											</dataEast>
 											<dataWest>
 												<rotationOffset>-30</rotationOffset>
+												<offset>(-0.35, 0, 0.2)</offset>
 											</dataWest>
 											<dataNorth>
 												<layer>-5</layer>
-												<offset>(0.15, 0, -0.1)</offset>
+												<offset>(0.15, 0, 0.2)</offset>
 											</dataNorth>
 											<dataSouth>
-												<offset>(0.15, 0, -0.1)</offset>
+												<offset>(0.2, 0, 0.2)</offset>
 											</dataSouth>
 										</drawData>
 									</li>
@@ -190,11 +185,11 @@
 							</apparel>
 					</value>
 				</li>
--->
+
 				<!-- Raider Banner -->
-<!--
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphRaiderBanner"]/statBases/StuffEffectMultiplierArmor</xpath>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphRaiderBanner"]/statBases</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>	
 						<Bulk>10</Bulk>
@@ -217,24 +212,25 @@
 										<shaderTypeDef>CutoutComplex</shaderTypeDef>
 										<parentTagDef>ApparelBody</parentTagDef>
 										<drawData>
-											<scale>2.5</scale>
+											<scale>1.3</scale>
 											<defaultData>
 												<layer>80</layer>
 											</defaultData>
 											<dataEast>
 												<layer>-5</layer>
-												<offset>(0, 0, -0.1)</offset>
+												<offset>(0.35, 0, 0.2)</offset>
 												<rotationOffset>30</rotationOffset>
 											</dataEast>
 											<dataWest>
 												<rotationOffset>-30</rotationOffset>
+												<offset>(-0.35, 0, 0.2)</offset>
 											</dataWest>
 											<dataNorth>
 												<layer>-5</layer>
-												<offset>(0.15, 0, -0.1)</offset>
+												<offset>(0.15, 0, 0.2)</offset>
 											</dataNorth>
 											<dataSouth>
-												<offset>(0.15, 0, -0.1)</offset>
+												<offset>(0.2, 0, 0.2)</offset>
 											</dataSouth>
 										</drawData>
 									</li>
@@ -242,11 +238,11 @@
 							</apparel>
 					</value>
 				</li>
--->
+
 				<!-- Gilded Banner -->
-<!--
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphGildedBanner"]/statBases/StuffEffectMultiplierArmor</xpath>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphGildedBanner"]/statBases</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>	
 						<Bulk>10</Bulk>
@@ -265,28 +261,29 @@
 									<li>
 										<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
 										<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
-										<texPath>Weapons/DemigyryphRaiderBanner/DemigyryphRaiderBanner</texPath>
+										<texPath>Weapons/DemigyryphGildedBanner/DemigyryphGildedBanner</texPath>
 										<shaderTypeDef>CutoutComplex</shaderTypeDef>
 										<parentTagDef>ApparelBody</parentTagDef>
 										<drawData>
-											<scale>2.5</scale>
+											<scale>1.3</scale>
 											<defaultData>
 												<layer>80</layer>
 											</defaultData>
 											<dataEast>
 												<layer>-5</layer>
-												<offset>(0, 0, -0.1)</offset>
+												<offset>(0.35, 0, 0.2)</offset>
 												<rotationOffset>30</rotationOffset>
 											</dataEast>
 											<dataWest>
 												<rotationOffset>-30</rotationOffset>
+												<offset>(-0.35, 0, 0.2)</offset>
 											</dataWest>
 											<dataNorth>
 												<layer>-5</layer>
-												<offset>(0.15, 0, -0.1)</offset>
+												<offset>(0.15, 0, 0.2)</offset>
 											</dataNorth>
 											<dataSouth>
-												<offset>(0.15, 0, -0.1)</offset>
+												<offset>(0.2, 0, 0.2)</offset>
 											</dataSouth>
 										</drawData>
 									</li>
@@ -294,11 +291,11 @@
 							</apparel>
 					</value>
 				</li>
--->
+
 				<!-- Champion Banner -->
-<!--
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphChampionBanner"]/statBases/StuffEffectMultiplierArmor</xpath>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphChampionBanner"]/statBases</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>	
 						<Bulk>10</Bulk>
@@ -317,28 +314,29 @@
 									<li>
 										<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
 										<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
-										<texPath>Weapons/DemigyryphRaiderBanner/DemigyryphRaiderBanner</texPath>
+										<texPath>Weapons/DemigyryphChampionBanner/DemigyryphChampionBanner</texPath>
 										<shaderTypeDef>CutoutComplex</shaderTypeDef>
 										<parentTagDef>ApparelBody</parentTagDef>
 										<drawData>
-											<scale>2.5</scale>
+											<scale>1.3</scale>
 											<defaultData>
 												<layer>80</layer>
 											</defaultData>
 											<dataEast>
 												<layer>-5</layer>
-												<offset>(0, 0, -0.1)</offset>
+												<offset>(0.35, 0, 0.2)</offset>
 												<rotationOffset>30</rotationOffset>
 											</dataEast>
 											<dataWest>
 												<rotationOffset>-30</rotationOffset>
+												<offset>(-0.35, 0, 0.2)</offset>
 											</dataWest>
 											<dataNorth>
 												<layer>-5</layer>
-												<offset>(0.15, 0, -0.1)</offset>
+												<offset>(0.15, 0, 0.2)</offset>
 											</dataNorth>
 											<dataSouth>
-												<offset>(0.15, 0, -0.1)</offset>
+												<offset>(0.2, 0, 0.2)</offset>
 											</dataSouth>
 										</drawData>
 									</li>
@@ -346,7 +344,7 @@
 							</apparel>
 					</value>
 				</li>
--->
+
 			</operations>
 		</match>
 	</Operation>

--- a/ModPatches/pphhyy Demigryph/Patches/pphhyy Demigryph/Demigryph_Shields.xml
+++ b/ModPatches/pphhyy Demigryph/Patches/pphhyy Demigryph/Demigryph_Shields.xml
@@ -1,0 +1,495 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Expanded Framework</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/ThingDef[
+						defName="pphhyy_Human_DemigyryphShield" or
+						defName="pphhyy_Human_DemigyryphRaiderShield" or
+						defName="pphhyy_Human_DemigyryphGildedShield" or
+						defName="pphhyy_Human_DemigyryphHunterShield" or
+						defName="pphhyy_Human_DemigyryphChampionShield"]
+					</xpath>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs</xpath>
+					<value>
+
+						<ThingDef ParentName="ShieldBase">
+							<defName>pphhyy_Human_DemigyryphShield</defName>
+							<label>Demigyryph Shield</label>
+							<description>A Cavalry shield made from metal materials.</description>
+							<techLevel>Medieval</techLevel>
+							<graphicData>
+								<texPath>Weapons/DemigyryphShield/DemigyryphShield</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+							</graphicData>
+							<costStuffCount>30</costStuffCount>
+							<stuffCategories>
+								<li>Metallic</li>
+							</stuffCategories>
+							<statBases>
+								<WorkToMake>6000</WorkToMake>
+								<MaxHitPoints>200</MaxHitPoints>
+								<Mass>10</Mass>
+								<Bulk>12</Bulk>
+								<WornBulk>8</WornBulk>
+								<StuffEffectMultiplierArmor>7.0</StuffEffectMultiplierArmor>
+							</statBases>
+							<recipeMaker>
+								<researchPrerequisite>Smithing</researchPrerequisite>
+								<recipeUsers>
+									<li>ElectricSmithy</li>
+									<li>FueledSmithy</li>
+									<li MayRequire="DankPyon.Medieval.Overhaul">DankPyon_Anvil</li>
+								</recipeUsers>
+							</recipeMaker>
+							<equippedStatOffsets>
+								<ReloadSpeed>-0.2</ReloadSpeed>
+								<MeleeHitChance>-1</MeleeHitChance>
+								<ShootingAccuracyPawn>-0.15</ShootingAccuracyPawn>
+								<AimingAccuracy>-0.08</AimingAccuracy>
+								<Suppressability>-0.25</Suppressability>
+								<MeleeCritChance>-0.05</MeleeCritChance>
+								<MeleeParryChance>1.0</MeleeParryChance>
+							</equippedStatOffsets>
+							<apparel>
+								<tags>
+									<li>pphhyy_DemigyryphShield</li>
+									<li>DemigyryphShield</li>
+								</tags>
+								<renderNodeProperties>
+									<li>
+										<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
+										<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
+										<texPath>Weapons/DemigyryphShield/DemigyryphShield</texPath>
+										<shaderTypeDef>CutoutComplex</shaderTypeDef>
+										<parentTagDef>ApparelBody</parentTagDef>
+										<drawData>
+											<scale>0.6</scale>
+											<defaultData>
+												<layer>80</layer>
+											</defaultData>
+											<dataEast>
+												<layer>-5</layer>
+												<offset>(0, 0, -0.1)</offset>
+												<rotationOffset>30</rotationOffset>
+											</dataEast>
+											<dataWest>
+												<rotationOffset>-30</rotationOffset>
+											</dataWest>
+											<dataNorth>
+												<layer>-5</layer>
+												<offset>(0.15, 0, -0.1)</offset>
+											</dataNorth>
+											<dataSouth>
+												<offset>(0.15, 0, -0.1)</offset>
+											</dataSouth>
+										</drawData>
+									</li>
+								</renderNodeProperties>
+							</apparel>
+							<modExtensions>
+								<li Class="CombatExtended.ShieldDefExtension">
+									<shieldCoverage>
+										<li>Hands</li>
+										<li>Arms</li>
+										<li>Shoulders</li>
+										<li>Torso</li>
+										<li>Neck</li>
+									</shieldCoverage>
+								</li>
+							</modExtensions>
+							<tradeTags>
+								<li>Armor</li>
+							</tradeTags>
+						</ThingDef>
+
+						<ThingDef ParentName="ShieldBase">
+							<defName>pphhyy_Human_DemigyryphRaiderShield</defName>
+							<label>Demigyryph Raider Shield</label>
+							<description>A Cavalry shield made from metal materials and skulls, perfect for Raider knights.</description>
+							<techLevel>Medieval</techLevel>
+							<graphicData>
+								<texPath>Weapons/DemigyryphRaiderShield/DemigyryphRaiderShield</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+							</graphicData>
+							<costStuffCount>50</costStuffCount>
+							<stuffCategories>
+								<li>Metallic</li>
+							</stuffCategories>
+							<costList>
+								<Skull MayRequire="Ludeon.RimWorld.Ideology">2</Skull>
+							</costList>
+							<statBases>
+								<WorkToMake>8000</WorkToMake>
+								<MaxHitPoints>300</MaxHitPoints>
+								<Mass>12</Mass>
+								<Bulk>12</Bulk>
+								<WornBulk>8</WornBulk>
+								<StuffEffectMultiplierArmor>8.0</StuffEffectMultiplierArmor>
+							</statBases>
+							<recipeMaker>
+								<researchPrerequisite>PlateArmor</researchPrerequisite>
+								<recipeUsers>
+									<li>ElectricSmithy</li>
+									<li>FueledSmithy</li>
+									<li MayRequire="DankPyon.Medieval.Overhaul">DankPyon_Anvil</li>
+								</recipeUsers>
+							</recipeMaker>
+							<equippedStatOffsets>
+								<ReloadSpeed>-0.2</ReloadSpeed>
+								<MeleeHitChance>-1</MeleeHitChance>
+								<ShootingAccuracyPawn>-0.15</ShootingAccuracyPawn>
+								<AimingAccuracy>-0.08</AimingAccuracy>
+								<Suppressability>-0.25</Suppressability>
+								<MeleeCritChance>-0.05</MeleeCritChance>
+								<MeleeParryChance>1.0</MeleeParryChance>
+							</equippedStatOffsets>
+							<apparel>
+								<tags>
+									<li>pphhyy_DemigyryphShield</li>
+									<li>DemigyryphRaiderShield</li>
+								</tags>
+								<renderNodeProperties>
+									<li>
+										<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
+										<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
+										<texPath>Weapons/DemigyryphRaiderShield/DemigyryphRaiderShield</texPath>
+										<shaderTypeDef>CutoutComplex</shaderTypeDef>
+										<parentTagDef>ApparelBody</parentTagDef>
+										<drawData>
+											<scale>0.6</scale>
+											<defaultData>
+												<layer>80</layer>
+											</defaultData>
+											<dataEast>
+												<layer>-5</layer>
+												<offset>(0, 0, -0.1)</offset>
+												<rotationOffset>30</rotationOffset>
+											</dataEast>
+											<dataWest>
+												<rotationOffset>-30</rotationOffset>
+											</dataWest>
+											<dataNorth>
+												<layer>-5</layer>
+												<offset>(0.15, 0, -0.1)</offset>
+											</dataNorth>
+											<dataSouth>
+												<offset>(0.15, 0, -0.1)</offset>
+											</dataSouth>
+										</drawData>
+									</li>
+								</renderNodeProperties>
+							</apparel>
+							<modExtensions>
+								<li Class="CombatExtended.ShieldDefExtension">
+									<shieldCoverage>
+										<li>Hands</li>
+										<li>Arms</li>
+										<li>Shoulders</li>
+										<li>Torso</li>
+										<li>Neck</li>
+									</shieldCoverage>
+								</li>
+							</modExtensions>
+							<tradeTags>
+								<li>Armor</li>
+							</tradeTags>
+						</ThingDef>
+
+						<ThingDef ParentName="ShieldBase">
+							<defName>pphhyy_Human_DemigyryphGildedShield</defName>
+							<label>Demigyryph Gilded Shield</label>
+							<description>A Cavalry shield made from metal materials and gold, worn by wealthy Knights to desplay status.</description>
+							<techLevel>Medieval</techLevel>
+							<graphicData>
+								<texPath>Weapons/DemigyryphGildedShield/DemigyryphGildedShield</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+							</graphicData>
+							<costStuffCount>50</costStuffCount>
+							<stuffCategories>
+								<li>Metallic</li>
+							</stuffCategories>
+							<costList>
+								<Gold>15</Gold>
+							</costList>
+							<statBases>
+								<WorkToMake>8000</WorkToMake>
+								<MaxHitPoints>300</MaxHitPoints>
+								<Mass>12</Mass>
+								<Bulk>12</Bulk>
+								<WornBulk>8</WornBulk>
+								<StuffEffectMultiplierArmor>8.0</StuffEffectMultiplierArmor>
+							</statBases>
+							<recipeMaker>
+								<researchPrerequisite>PlateArmor</researchPrerequisite>
+								<recipeUsers>
+									<li>ElectricSmithy</li>
+									<li>FueledSmithy</li>
+									<li MayRequire="DankPyon.Medieval.Overhaul">DankPyon_Anvil</li>
+								</recipeUsers>
+							</recipeMaker>
+							<equippedStatOffsets>
+								<SocialImpact>0.25</SocialImpact>
+								<ReloadSpeed>-0.2</ReloadSpeed>
+								<MeleeHitChance>-1</MeleeHitChance>
+								<ShootingAccuracyPawn>-0.15</ShootingAccuracyPawn>
+								<AimingAccuracy>-0.08</AimingAccuracy>
+								<Suppressability>-0.25</Suppressability>
+								<MeleeCritChance>-0.05</MeleeCritChance>
+								<MeleeParryChance>1.0</MeleeParryChance>
+							</equippedStatOffsets>
+							<apparel>
+								<tags>
+									<li>pphhyy_DemigyryphShield</li>
+									<li>DemigyryphGildedShield</li>
+								</tags>
+								<renderNodeProperties>
+									<li>
+										<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
+										<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
+										<texPath>Weapons/DemigyryphGildedShield/DemigyryphGildedShield</texPath>
+										<shaderTypeDef>CutoutComplex</shaderTypeDef>
+										<parentTagDef>ApparelBody</parentTagDef>
+										<drawData>
+											<scale>0.6</scale>
+											<defaultData>
+												<layer>80</layer>
+											</defaultData>
+											<dataEast>
+												<layer>-5</layer>
+												<offset>(0, 0, -0.1)</offset>
+												<rotationOffset>30</rotationOffset>
+											</dataEast>
+											<dataWest>
+												<rotationOffset>-30</rotationOffset>
+											</dataWest>
+											<dataNorth>
+												<layer>-5</layer>
+												<offset>(0.15, 0, -0.1)</offset>
+											</dataNorth>
+											<dataSouth>
+												<offset>(0.15, 0, -0.1)</offset>
+											</dataSouth>
+										</drawData>
+									</li>
+								</renderNodeProperties>
+							</apparel>
+							<modExtensions>
+								<li Class="CombatExtended.ShieldDefExtension">
+									<shieldCoverage>
+										<li>Hands</li>
+										<li>Arms</li>
+										<li>Shoulders</li>
+										<li>Torso</li>
+										<li>Neck</li>
+									</shieldCoverage>
+								</li>
+							</modExtensions>
+							<tradeTags>
+								<li>Armor</li>
+							</tradeTags>
+						</ThingDef>
+
+						<ThingDef ParentName="ShieldBase">
+							<defName>pphhyy_Human_DemigyryphHunterShield</defName>
+							<label>Demigyryph Hunter Shield</label>
+							<description>A Cavalry shield made from metal materials and Demigryph Trophies.</description>
+							<techLevel>Medieval</techLevel>
+							<graphicData>
+								<texPath>Weapons/DemigyryphHunterShield/DemigyryphHunterShield</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+							</graphicData>
+							<costStuffCount>50</costStuffCount>
+							<stuffCategories>
+								<li>Metallic</li>
+							</stuffCategories>
+							<costList>
+								<pphhyy_AnimalProduct_DemigryphClaw>4</pphhyy_AnimalProduct_DemigryphClaw>
+							</costList>
+							<statBases>
+								<WorkToMake>10000</WorkToMake>
+								<MaxHitPoints>400</MaxHitPoints>
+								<Mass>12</Mass>
+								<Bulk>12</Bulk>
+								<WornBulk>8</WornBulk>
+								<StuffEffectMultiplierArmor>8.0</StuffEffectMultiplierArmor>
+							</statBases>
+							<recipeMaker>
+								<researchPrerequisite>PlateArmor</researchPrerequisite>
+								<recipeUsers>
+									<li>ElectricSmithy</li>
+									<li>FueledSmithy</li>
+									<li MayRequire="DankPyon.Medieval.Overhaul">DankPyon_Anvil</li>
+								</recipeUsers>
+							</recipeMaker>
+							<equippedStatOffsets>
+								<ReloadSpeed>-0.2</ReloadSpeed>
+								<MeleeHitChance>-1</MeleeHitChance>
+								<ShootingAccuracyPawn>-0.15</ShootingAccuracyPawn>
+								<AimingAccuracy>-0.08</AimingAccuracy>
+								<Suppressability>-0.25</Suppressability>
+								<MeleeCritChance>-0.05</MeleeCritChance>
+								<MeleeParryChance>1.0</MeleeParryChance>
+							</equippedStatOffsets>
+							<apparel>
+								<tags>
+									<li>pphhyy_DemigyryphShield</li>
+									<li>DemigyryphHunterShield</li>
+								</tags>
+								<renderNodeProperties>
+									<li>
+										<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
+										<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
+										<texPath>Weapons/DemigyryphHunterShield/DemigyryphHunterShield</texPath>
+										<shaderTypeDef>CutoutComplex</shaderTypeDef>
+										<parentTagDef>ApparelBody</parentTagDef>
+										<drawData>
+											<scale>0.6</scale>
+											<defaultData>
+												<layer>80</layer>
+											</defaultData>
+											<dataEast>
+												<layer>-5</layer>
+												<offset>(0, 0, -0.1)</offset>
+												<rotationOffset>30</rotationOffset>
+											</dataEast>
+											<dataWest>
+												<rotationOffset>-30</rotationOffset>
+											</dataWest>
+											<dataNorth>
+												<layer>-5</layer>
+												<offset>(0.15, 0, -0.1)</offset>
+											</dataNorth>
+											<dataSouth>
+												<offset>(0.15, 0, -0.1)</offset>
+											</dataSouth>
+										</drawData>
+									</li>
+								</renderNodeProperties>
+							</apparel>
+							<modExtensions>
+								<li Class="CombatExtended.ShieldDefExtension">
+									<shieldCoverage>
+										<li>Hands</li>
+										<li>Arms</li>
+										<li>Shoulders</li>
+										<li>Torso</li>
+										<li>Neck</li>
+									</shieldCoverage>
+								</li>
+							</modExtensions>
+							<tradeTags>
+								<li>Armor</li>
+							</tradeTags>
+						</ThingDef>
+
+						<ThingDef ParentName="ShieldBase">
+							<defName>pphhyy_Human_DemigyryphChampionShield</defName>
+							<label>Demigyryph Champion Shield</label>
+							<description>A Cavalry shield made from metal materials, worn by veteran demigryph knights.</description>
+							<techLevel>Medieval</techLevel>
+							<graphicData>
+								<texPath>Weapons/DemigyryphChampionShield/DemigyryphChampionShield</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+							</graphicData>
+							<costStuffCount>50</costStuffCount>
+							<stuffCategories>
+								<li>Metallic</li>
+							</stuffCategories>
+							<statBases>
+								<WorkToMake>8000</WorkToMake>
+								<MaxHitPoints>300</MaxHitPoints>
+								<Mass>12</Mass>
+								<Bulk>12</Bulk>
+								<WornBulk>8</WornBulk>
+								<StuffEffectMultiplierArmor>8.0</StuffEffectMultiplierArmor>
+							</statBases>
+							<recipeMaker>
+								<researchPrerequisite>PlateArmor</researchPrerequisite>
+								<recipeUsers>
+									<li>ElectricSmithy</li>
+									<li>FueledSmithy</li>
+									<li MayRequire="DankPyon.Medieval.Overhaul">DankPyon_Anvil</li>
+								</recipeUsers>
+							</recipeMaker>
+							<equippedStatOffsets>
+								<PainShockThreshold>0.10</PainShockThreshold>
+								<SocialImpact>0.25</SocialImpact>
+								<ReloadSpeed>-0.2</ReloadSpeed>
+								<MeleeHitChance>-1</MeleeHitChance>
+								<ShootingAccuracyPawn>-0.15</ShootingAccuracyPawn>
+								<AimingAccuracy>-0.08</AimingAccuracy>
+								<Suppressability>-0.25</Suppressability>
+								<MeleeCritChance>-0.05</MeleeCritChance>
+								<MeleeParryChance>1.0</MeleeParryChance>
+							</equippedStatOffsets>
+							<apparel>
+								<tags>
+									<li>pphhyy_DemigyryphShield</li>
+									<li>DemigyryphChampionShield</li>
+								</tags>
+								<renderNodeProperties>
+									<li>
+										<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
+										<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
+										<texPath>Weapons/DemigyryphChampionShield/DemigyryphChampionShield</texPath>
+										<shaderTypeDef>CutoutComplex</shaderTypeDef>
+										<parentTagDef>ApparelBody</parentTagDef>
+										<drawData>
+											<scale>0.6</scale>
+											<defaultData>
+												<layer>80</layer>
+											</defaultData>
+											<dataEast>
+												<layer>-5</layer>
+												<offset>(0, 0, -0.1)</offset>
+												<rotationOffset>30</rotationOffset>
+											</dataEast>
+											<dataWest>
+												<rotationOffset>-30</rotationOffset>
+											</dataWest>
+											<dataNorth>
+												<layer>-5</layer>
+												<offset>(0.15, 0, -0.1)</offset>
+											</dataNorth>
+											<dataSouth>
+												<offset>(0.15, 0, -0.1)</offset>
+											</dataSouth>
+										</drawData>
+									</li>
+								</renderNodeProperties>
+							</apparel>
+							<modExtensions>
+								<li Class="CombatExtended.ShieldDefExtension">
+									<shieldCoverage>
+										<li>Hands</li>
+										<li>Arms</li>
+										<li>Shoulders</li>
+										<li>Torso</li>
+										<li>Neck</li>
+									</shieldCoverage>
+								</li>
+							</modExtensions>
+							<tradeTags>
+								<li>Armor</li>
+							</tradeTags>
+						</ThingDef>
+
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/ModPatches/pphhyy Demigryph/Patches/pphhyy Demigryph/Demigryph_Shields.xml
+++ b/ModPatches/pphhyy Demigryph/Patches/pphhyy Demigryph/Demigryph_Shields.xml
@@ -47,17 +47,15 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[@Name="pphhyy_Demigryph_ShieldBase"]/equippedStatOffsets</xpath>
+					<xpath>Defs/ThingDef[@Name="pphhyy_Demigryph_ShieldBase"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
 					<value>
-						<equippedStatOffsets>
-							<ReloadSpeed>-0.2</ReloadSpeed>
-							<MeleeHitChance>-1</MeleeHitChance>
-							<ShootingAccuracyPawn>-0.15</ShootingAccuracyPawn>
-							<AimingAccuracy>-0.08</AimingAccuracy>
-							<Suppressability>-0.25</Suppressability>
-							<MeleeCritChance>-0.05</MeleeCritChance>
-							<MeleeParryChance>1.0</MeleeParryChance>
-						</equippedStatOffsets>
+						<ReloadSpeed>-0.2</ReloadSpeed>
+						<MeleeHitChance>-1</MeleeHitChance>
+						<ShootingAccuracyPawn>-0.15</ShootingAccuracyPawn>
+						<AimingAccuracy>-0.08</AimingAccuracy>
+						<Suppressability>-0.25</Suppressability>
+						<MeleeCritChance>-0.05</MeleeCritChance>
+						<MeleeParryChance>1.0</MeleeParryChance>
 					</value>
 				</li>
 
@@ -74,6 +72,7 @@
 				</li>
 
 				<!-- All Shields -->
+
 				<li Class="PatchOperationRemove">
 					<xpath>Defs/ThingDef[
 					defName="pphhyy_Human_DemigyryphShield" or
@@ -106,8 +105,9 @@
 				</li>
 
 				<!-- Demigyryph Shield -->
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphShield"]/statBases/StuffEffectMultiplierArmor</xpath>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphShield"]/statBases</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>7</StuffEffectMultiplierArmor>	
 						<Bulk>12</Bulk>
@@ -145,10 +145,10 @@
 										</dataWest>
 										<dataNorth>
 											<layer>-5</layer>
-											<offset>(0.15, 0, -0.1)</offset>
+											<offset>(0.15, 0, -0.15)</offset>
 										</dataNorth>
 										<dataSouth>
-											<offset>(0.15, 0, -0.1)</offset>
+											<offset>(0.15, 0, -0.15)</offset>
 										</dataSouth>
 									</drawData>
 								</li>
@@ -158,19 +158,14 @@
 				</li>
 
 				<!-- Raider Shield -->
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphRaiderShield"]/statBases/StuffEffectMultiplierArmor</xpath>
-					<value>
-						<StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>	
-						<Bulk>12</Bulk>
-						<WornBulk>8</WornBulk>
-					</value>
-				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphRaiderShield"]/statBases/Mass</xpath>
 					<value>
 						<Mass>3</Mass>
+						<StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>	
+						<Bulk>12</Bulk>
+						<WornBulk>8</WornBulk>						
 					</value>
 				</li>
 
@@ -204,10 +199,10 @@
 										</dataWest>
 										<dataNorth>
 											<layer>-5</layer>
-											<offset>(0.15, 0, -0.1)</offset>
+											<offset>(0.15, 0, -0.15)</offset>
 										</dataNorth>
 										<dataSouth>
-											<offset>(0.15, 0, -0.1)</offset>
+											<offset>(0.15, 0, -0.15)</offset>
 										</dataSouth>
 									</drawData>
 								</li>
@@ -217,12 +212,6 @@
 				</li>
 
 				<!-- Gilded Shield -->
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphGildedShield"]/statBases/StuffEffectMultiplierArmor</xpath>
-					<value>
-						<StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>	
-					</value>
-				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphGildedShield"]/statBases/Mass</xpath>
@@ -230,6 +219,7 @@
 						<Mass>3</Mass>
 						<Bulk>12</Bulk>
 						<WornBulk>8</WornBulk>
+						<StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>	
 					</value>
 				</li>
 
@@ -263,10 +253,10 @@
 										</dataWest>
 										<dataNorth>
 											<layer>-5</layer>
-											<offset>(0.15, 0, -0.1)</offset>
+											<offset>(0.15, 0, -0.15)</offset>
 										</dataNorth>
 										<dataSouth>
-											<offset>(0.15, 0, -0.1)</offset>
+											<offset>(0.15, 0, -0.15)</offset>
 										</dataSouth>
 									</drawData>
 								</li>
@@ -276,12 +266,6 @@
 				</li>
 
 				<!-- Hunter Shield -->
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphHunterShield"]/statBases/StuffEffectMultiplierArmor</xpath>
-					<value>
-						<StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>	
-					</value>
-				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphHunterShield"]/statBases/Mass</xpath>
@@ -289,6 +273,7 @@
 						<Mass>3.5</Mass>
 						<Bulk>12</Bulk>
 						<WornBulk>8</WornBulk>
+						<StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>	
 					</value>
 				</li>
 
@@ -322,10 +307,10 @@
 										</dataWest>
 										<dataNorth>
 											<layer>-5</layer>
-											<offset>(0.15, 0, -0.1)</offset>
+											<offset>(0.15, 0, -0.15)</offset>
 										</dataNorth>
 										<dataSouth>
-											<offset>(0.15, 0, -0.1)</offset>
+											<offset>(0.15, 0, -0.15)</offset>
 										</dataSouth>
 									</drawData>
 								</li>
@@ -335,12 +320,6 @@
 				</li>
 
 				<!-- Champion Shield -->
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphChampionShield"]/statBases/StuffEffectMultiplierArmor</xpath>
-					<value>
-						<StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>	
-					</value>
-				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphChampionShield"]/statBases/Mass</xpath>
@@ -348,6 +327,7 @@
 						<Mass>3.5</Mass>
 						<Bulk>12</Bulk>
 						<WornBulk>8</WornBulk>
+						<StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>	
 					</value>
 				</li>
 
@@ -381,10 +361,10 @@
 										</dataWest>
 										<dataNorth>
 											<layer>-5</layer>
-											<offset>(0.15, 0, -0.1)</offset>
+											<offset>(0.15, 0, -0.15)</offset>
 										</dataNorth>
 										<dataSouth>
-											<offset>(0.15, 0, -0.1)</offset>
+											<offset>(0.15, 0, -0.15)</offset>
 										</dataSouth>
 									</drawData>
 								</li>

--- a/ModPatches/pphhyy Demigryph/Patches/pphhyy Demigryph/Demigryph_Shields.xml
+++ b/ModPatches/pphhyy Demigryph/Patches/pphhyy Demigryph/Demigryph_Shields.xml
@@ -9,482 +9,387 @@
 		<match Class="PatchOperationSequence">
 			<operations>
 
+				<!-- Shield Base -->
+				<li Class="PatchOperationAttributeSet">
+					<xpath>Defs/ThingDef[@Name="pphhyy_Demigryph_ShieldBase"]</xpath>
+					<attribute>ParentName</attribute>
+					<value>ArmorSmithableBase</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="pphhyy_Demigryph_ShieldBase"]/thingClass</xpath>
+					<value>
+						<thingClass>CombatExtended.Apparel_Shield</thingClass>
+						<thingCategories>
+							<li>Shields</li>
+						</thingCategories>
+						<storedConceptLearnOpportunity>CE_Shields</storedConceptLearnOpportunity>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="pphhyy_Demigryph_ShieldBase"]/apparel</xpath>
+					<value>
+						<apparel>
+							<countsAsClothingForNudity>false</countsAsClothingForNudity>
+							<careIfWornByCorpse>false</careIfWornByCorpse>
+							<bodyPartGroups>
+								<li>LeftShoulder</li>
+							</bodyPartGroups>
+							<layers>
+								<li>Shield</li>
+							</layers>
+						</apparel>
+						<tradeTags>
+							<li>Armor</li>
+						</tradeTags>						
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="pphhyy_Demigryph_ShieldBase"]/equippedStatOffsets</xpath>
+					<value>
+						<equippedStatOffsets>
+							<ReloadSpeed>-0.2</ReloadSpeed>
+							<MeleeHitChance>-1</MeleeHitChance>
+							<ShootingAccuracyPawn>-0.15</ShootingAccuracyPawn>
+							<AimingAccuracy>-0.08</AimingAccuracy>
+							<Suppressability>-0.25</Suppressability>
+							<MeleeCritChance>-0.05</MeleeCritChance>
+							<MeleeParryChance>1.0</MeleeParryChance>
+						</equippedStatOffsets>
+					</value>
+				</li>
+
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/ThingDef[@Name="pphhyy_Demigryph_ShieldBase"]/tools</xpath>
+				</li>
+
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/ThingDef[@Name="pphhyy_Demigryph_ShieldBase"]/weaponTags</xpath>
+				</li>
+
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/ThingDef[@Name="pphhyy_Demigryph_ShieldBase"]/equippedAngleOffset</xpath>
+				</li>
+
+				<!-- All Shields -->
 				<li Class="PatchOperationRemove">
 					<xpath>Defs/ThingDef[
-						defName="pphhyy_Human_DemigyryphShield" or
-						defName="pphhyy_Human_DemigyryphRaiderShield" or
-						defName="pphhyy_Human_DemigyryphGildedShield" or
-						defName="pphhyy_Human_DemigyryphHunterShield" or
-						defName="pphhyy_Human_DemigyryphChampionShield"]
-					</xpath>
+					defName="pphhyy_Human_DemigyryphShield" or
+					defName="pphhyy_Human_DemigyryphRaiderShield" or
+					defName="pphhyy_Human_DemigyryphGildedShield" or
+					defName="pphhyy_Human_DemigyryphHunterShield" or
+					defName="pphhyy_Human_DemigyryphChampionShield"
+					]/comps/li[@Class="VFECore.CompProperties_Shield"]</xpath>
+				</li>
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/ThingDef[
+					defName="pphhyy_Human_DemigyryphShield" or
+					defName="pphhyy_Human_DemigyryphRaiderShield" or
+					defName="pphhyy_Human_DemigyryphGildedShield" or
+					defName="pphhyy_Human_DemigyryphHunterShield" or
+					defName="pphhyy_Human_DemigyryphChampionShield"
+					]</xpath>
+					<value>
+						<li Class="CombatExtended.ShieldDefExtension">
+							<shieldCoverage>
+								<li>Hands</li>
+								<li>Arms</li>
+								<li>Shoulders</li>
+								<li>Torso</li>
+								<li>Neck</li>
+							</shieldCoverage>
+						</li>
+					</value>
+				</li>
+
+				<!-- Demigyryph Shield -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphShield"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>7</StuffEffectMultiplierArmor>	
+						<Bulk>12</Bulk>
+						<WornBulk>8</WornBulk>
+					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs</xpath>
+					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphShield"]</xpath>
 					<value>
-
-						<ThingDef ParentName="ShieldBase">
-							<defName>pphhyy_Human_DemigyryphShield</defName>
-							<label>Demigyryph Shield</label>
-							<description>A Cavalry shield made from metal materials.</description>
-							<techLevel>Medieval</techLevel>
-							<graphicData>
-								<texPath>Weapons/DemigyryphShield/DemigyryphShield</texPath>
-								<graphicClass>Graphic_Single</graphicClass>
-							</graphicData>
-							<costStuffCount>30</costStuffCount>
-							<stuffCategories>
-								<li>Metallic</li>
-							</stuffCategories>
-							<statBases>
-								<WorkToMake>6000</WorkToMake>
-								<MaxHitPoints>200</MaxHitPoints>
-								<Mass>10</Mass>
-								<Bulk>12</Bulk>
-								<WornBulk>8</WornBulk>
-								<StuffEffectMultiplierArmor>7.0</StuffEffectMultiplierArmor>
-							</statBases>
-							<recipeMaker>
-								<researchPrerequisite>Smithing</researchPrerequisite>
-								<recipeUsers>
-									<li>ElectricSmithy</li>
-									<li>FueledSmithy</li>
-									<li MayRequire="DankPyon.Medieval.Overhaul">DankPyon_Anvil</li>
-								</recipeUsers>
-							</recipeMaker>
-							<equippedStatOffsets>
-								<ReloadSpeed>-0.2</ReloadSpeed>
-								<MeleeHitChance>-1</MeleeHitChance>
-								<ShootingAccuracyPawn>-0.15</ShootingAccuracyPawn>
-								<AimingAccuracy>-0.08</AimingAccuracy>
-								<Suppressability>-0.25</Suppressability>
-								<MeleeCritChance>-0.05</MeleeCritChance>
-								<MeleeParryChance>1.0</MeleeParryChance>
-							</equippedStatOffsets>
-							<apparel>
-								<tags>
-									<li>pphhyy_DemigyryphShield</li>
-									<li>DemigyryphShield</li>
-								</tags>
-								<renderNodeProperties>
-									<li>
-										<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
-										<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
-										<texPath>Weapons/DemigyryphShield/DemigyryphShield</texPath>
-										<shaderTypeDef>CutoutComplex</shaderTypeDef>
-										<parentTagDef>ApparelBody</parentTagDef>
-										<drawData>
-											<scale>0.6</scale>
-											<defaultData>
-												<layer>80</layer>
-											</defaultData>
-											<dataEast>
-												<layer>-5</layer>
-												<offset>(0, 0, -0.1)</offset>
-												<rotationOffset>30</rotationOffset>
-											</dataEast>
-											<dataWest>
-												<rotationOffset>-30</rotationOffset>
-											</dataWest>
-											<dataNorth>
-												<layer>-5</layer>
-												<offset>(0.15, 0, -0.1)</offset>
-											</dataNorth>
-											<dataSouth>
-												<offset>(0.15, 0, -0.1)</offset>
-											</dataSouth>
-										</drawData>
-									</li>
-								</renderNodeProperties>
-							</apparel>
-							<modExtensions>
-								<li Class="CombatExtended.ShieldDefExtension">
-									<shieldCoverage>
-										<li>Hands</li>
-										<li>Arms</li>
-										<li>Shoulders</li>
-										<li>Torso</li>
-										<li>Neck</li>
-									</shieldCoverage>
+						<apparel>
+							<tags>
+								<li>pphhyy_DemigyryphShield</li>
+								<li>DemigyryphShield</li>
+							</tags>
+							<renderNodeProperties>
+								<li>
+									<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
+									<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
+									<texPath>Weapons/DemigyryphShield/DemigyryphShield</texPath>
+									<shaderTypeDef>CutoutComplex</shaderTypeDef>
+									<parentTagDef>ApparelBody</parentTagDef>
+									<drawData>
+										<scale>0.6</scale>
+										<defaultData>
+											<layer>80</layer>
+										</defaultData>
+										<dataEast>
+											<layer>-5</layer>
+											<offset>(0, 0, -0.1)</offset>
+											<rotationOffset>30</rotationOffset>
+										</dataEast>
+										<dataWest>
+											<rotationOffset>-30</rotationOffset>
+										</dataWest>
+										<dataNorth>
+											<layer>-5</layer>
+											<offset>(0.15, 0, -0.1)</offset>
+										</dataNorth>
+										<dataSouth>
+											<offset>(0.15, 0, -0.1)</offset>
+										</dataSouth>
+									</drawData>
 								</li>
-							</modExtensions>
-							<tradeTags>
-								<li>Armor</li>
-							</tradeTags>
-						</ThingDef>
+							</renderNodeProperties>
+						</apparel>
+					</value>
+				</li>
 
-						<ThingDef ParentName="ShieldBase">
-							<defName>pphhyy_Human_DemigyryphRaiderShield</defName>
-							<label>Demigyryph Raider Shield</label>
-							<description>A Cavalry shield made from metal materials and skulls, perfect for Raider knights.</description>
-							<techLevel>Medieval</techLevel>
-							<graphicData>
-								<texPath>Weapons/DemigyryphRaiderShield/DemigyryphRaiderShield</texPath>
-								<graphicClass>Graphic_Single</graphicClass>
-							</graphicData>
-							<costStuffCount>50</costStuffCount>
-							<stuffCategories>
-								<li>Metallic</li>
-							</stuffCategories>
-							<costList>
-								<Skull MayRequire="Ludeon.RimWorld.Ideology">2</Skull>
-							</costList>
-							<statBases>
-								<WorkToMake>8000</WorkToMake>
-								<MaxHitPoints>300</MaxHitPoints>
-								<Mass>12</Mass>
-								<Bulk>12</Bulk>
-								<WornBulk>8</WornBulk>
-								<StuffEffectMultiplierArmor>8.0</StuffEffectMultiplierArmor>
-							</statBases>
-							<recipeMaker>
-								<researchPrerequisite>PlateArmor</researchPrerequisite>
-								<recipeUsers>
-									<li>ElectricSmithy</li>
-									<li>FueledSmithy</li>
-									<li MayRequire="DankPyon.Medieval.Overhaul">DankPyon_Anvil</li>
-								</recipeUsers>
-							</recipeMaker>
-							<equippedStatOffsets>
-								<ReloadSpeed>-0.2</ReloadSpeed>
-								<MeleeHitChance>-1</MeleeHitChance>
-								<ShootingAccuracyPawn>-0.15</ShootingAccuracyPawn>
-								<AimingAccuracy>-0.08</AimingAccuracy>
-								<Suppressability>-0.25</Suppressability>
-								<MeleeCritChance>-0.05</MeleeCritChance>
-								<MeleeParryChance>1.0</MeleeParryChance>
-							</equippedStatOffsets>
-							<apparel>
-								<tags>
-									<li>pphhyy_DemigyryphShield</li>
-									<li>DemigyryphRaiderShield</li>
-								</tags>
-								<renderNodeProperties>
-									<li>
-										<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
-										<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
-										<texPath>Weapons/DemigyryphRaiderShield/DemigyryphRaiderShield</texPath>
-										<shaderTypeDef>CutoutComplex</shaderTypeDef>
-										<parentTagDef>ApparelBody</parentTagDef>
-										<drawData>
-											<scale>0.6</scale>
-											<defaultData>
-												<layer>80</layer>
-											</defaultData>
-											<dataEast>
-												<layer>-5</layer>
-												<offset>(0, 0, -0.1)</offset>
-												<rotationOffset>30</rotationOffset>
-											</dataEast>
-											<dataWest>
-												<rotationOffset>-30</rotationOffset>
-											</dataWest>
-											<dataNorth>
-												<layer>-5</layer>
-												<offset>(0.15, 0, -0.1)</offset>
-											</dataNorth>
-											<dataSouth>
-												<offset>(0.15, 0, -0.1)</offset>
-											</dataSouth>
-										</drawData>
-									</li>
-								</renderNodeProperties>
-							</apparel>
-							<modExtensions>
-								<li Class="CombatExtended.ShieldDefExtension">
-									<shieldCoverage>
-										<li>Hands</li>
-										<li>Arms</li>
-										<li>Shoulders</li>
-										<li>Torso</li>
-										<li>Neck</li>
-									</shieldCoverage>
+				<!-- Raider Shield -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphRaiderShield"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>	
+						<Bulk>12</Bulk>
+						<WornBulk>8</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphRaiderShield"]/statBases/Mass</xpath>
+					<value>
+						<Mass>3</Mass>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphRaiderShield"]</xpath>
+					<value>
+						<apparel>
+							<tags>
+								<li>pphhyy_DemigyryphShield</li>
+								<li>DemigyryphRaiderShield</li>
+							</tags>
+							<renderNodeProperties>
+								<li>
+									<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
+									<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
+									<texPath>Weapons/DemigyryphRaiderShield/DemigyryphRaiderShield</texPath>
+									<shaderTypeDef>CutoutComplex</shaderTypeDef>
+									<parentTagDef>ApparelBody</parentTagDef>
+									<drawData>
+										<scale>0.6</scale>
+										<defaultData>
+											<layer>80</layer>
+										</defaultData>
+										<dataEast>
+											<layer>-5</layer>
+											<offset>(0, 0, -0.1)</offset>
+											<rotationOffset>30</rotationOffset>
+										</dataEast>
+										<dataWest>
+											<rotationOffset>-30</rotationOffset>
+										</dataWest>
+										<dataNorth>
+											<layer>-5</layer>
+											<offset>(0.15, 0, -0.1)</offset>
+										</dataNorth>
+										<dataSouth>
+											<offset>(0.15, 0, -0.1)</offset>
+										</dataSouth>
+									</drawData>
 								</li>
-							</modExtensions>
-							<tradeTags>
-								<li>Armor</li>
-							</tradeTags>
-						</ThingDef>
+							</renderNodeProperties>
+						</apparel>
+					</value>
+				</li>
 
-						<ThingDef ParentName="ShieldBase">
-							<defName>pphhyy_Human_DemigyryphGildedShield</defName>
-							<label>Demigyryph Gilded Shield</label>
-							<description>A Cavalry shield made from metal materials and gold, worn by wealthy Knights to desplay status.</description>
-							<techLevel>Medieval</techLevel>
-							<graphicData>
-								<texPath>Weapons/DemigyryphGildedShield/DemigyryphGildedShield</texPath>
-								<graphicClass>Graphic_Single</graphicClass>
-							</graphicData>
-							<costStuffCount>50</costStuffCount>
-							<stuffCategories>
-								<li>Metallic</li>
-							</stuffCategories>
-							<costList>
-								<Gold>15</Gold>
-							</costList>
-							<statBases>
-								<WorkToMake>8000</WorkToMake>
-								<MaxHitPoints>300</MaxHitPoints>
-								<Mass>12</Mass>
-								<Bulk>12</Bulk>
-								<WornBulk>8</WornBulk>
-								<StuffEffectMultiplierArmor>8.0</StuffEffectMultiplierArmor>
-							</statBases>
-							<recipeMaker>
-								<researchPrerequisite>PlateArmor</researchPrerequisite>
-								<recipeUsers>
-									<li>ElectricSmithy</li>
-									<li>FueledSmithy</li>
-									<li MayRequire="DankPyon.Medieval.Overhaul">DankPyon_Anvil</li>
-								</recipeUsers>
-							</recipeMaker>
-							<equippedStatOffsets>
-								<SocialImpact>0.25</SocialImpact>
-								<ReloadSpeed>-0.2</ReloadSpeed>
-								<MeleeHitChance>-1</MeleeHitChance>
-								<ShootingAccuracyPawn>-0.15</ShootingAccuracyPawn>
-								<AimingAccuracy>-0.08</AimingAccuracy>
-								<Suppressability>-0.25</Suppressability>
-								<MeleeCritChance>-0.05</MeleeCritChance>
-								<MeleeParryChance>1.0</MeleeParryChance>
-							</equippedStatOffsets>
-							<apparel>
-								<tags>
-									<li>pphhyy_DemigyryphShield</li>
-									<li>DemigyryphGildedShield</li>
-								</tags>
-								<renderNodeProperties>
-									<li>
-										<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
-										<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
-										<texPath>Weapons/DemigyryphGildedShield/DemigyryphGildedShield</texPath>
-										<shaderTypeDef>CutoutComplex</shaderTypeDef>
-										<parentTagDef>ApparelBody</parentTagDef>
-										<drawData>
-											<scale>0.6</scale>
-											<defaultData>
-												<layer>80</layer>
-											</defaultData>
-											<dataEast>
-												<layer>-5</layer>
-												<offset>(0, 0, -0.1)</offset>
-												<rotationOffset>30</rotationOffset>
-											</dataEast>
-											<dataWest>
-												<rotationOffset>-30</rotationOffset>
-											</dataWest>
-											<dataNorth>
-												<layer>-5</layer>
-												<offset>(0.15, 0, -0.1)</offset>
-											</dataNorth>
-											<dataSouth>
-												<offset>(0.15, 0, -0.1)</offset>
-											</dataSouth>
-										</drawData>
-									</li>
-								</renderNodeProperties>
-							</apparel>
-							<modExtensions>
-								<li Class="CombatExtended.ShieldDefExtension">
-									<shieldCoverage>
-										<li>Hands</li>
-										<li>Arms</li>
-										<li>Shoulders</li>
-										<li>Torso</li>
-										<li>Neck</li>
-									</shieldCoverage>
+				<!-- Gilded Shield -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphGildedShield"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>	
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphGildedShield"]/statBases/Mass</xpath>
+					<value>
+						<Mass>3</Mass>
+						<Bulk>12</Bulk>
+						<WornBulk>8</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphGildedShield"]</xpath>
+					<value>
+						<apparel>
+							<tags>
+								<li>pphhyy_DemigyryphShield</li>
+								<li>DemigyryphGildedShield</li>
+							</tags>
+							<renderNodeProperties>
+								<li>
+									<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
+									<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
+									<texPath>Weapons/DemigyryphGildedShield/DemigyryphGildedShield</texPath>
+									<shaderTypeDef>CutoutComplex</shaderTypeDef>
+									<parentTagDef>ApparelBody</parentTagDef>
+									<drawData>
+										<scale>0.6</scale>
+										<defaultData>
+											<layer>80</layer>
+										</defaultData>
+										<dataEast>
+											<layer>-5</layer>
+											<offset>(0, 0, -0.1)</offset>
+											<rotationOffset>30</rotationOffset>
+										</dataEast>
+										<dataWest>
+											<rotationOffset>-30</rotationOffset>
+										</dataWest>
+										<dataNorth>
+											<layer>-5</layer>
+											<offset>(0.15, 0, -0.1)</offset>
+										</dataNorth>
+										<dataSouth>
+											<offset>(0.15, 0, -0.1)</offset>
+										</dataSouth>
+									</drawData>
 								</li>
-							</modExtensions>
-							<tradeTags>
-								<li>Armor</li>
-							</tradeTags>
-						</ThingDef>
+							</renderNodeProperties>
+						</apparel>
+					</value>
+				</li>
 
-						<ThingDef ParentName="ShieldBase">
-							<defName>pphhyy_Human_DemigyryphHunterShield</defName>
-							<label>Demigyryph Hunter Shield</label>
-							<description>A Cavalry shield made from metal materials and Demigryph Trophies.</description>
-							<techLevel>Medieval</techLevel>
-							<graphicData>
-								<texPath>Weapons/DemigyryphHunterShield/DemigyryphHunterShield</texPath>
-								<graphicClass>Graphic_Single</graphicClass>
-							</graphicData>
-							<costStuffCount>50</costStuffCount>
-							<stuffCategories>
-								<li>Metallic</li>
-							</stuffCategories>
-							<costList>
-								<pphhyy_AnimalProduct_DemigryphClaw>4</pphhyy_AnimalProduct_DemigryphClaw>
-							</costList>
-							<statBases>
-								<WorkToMake>10000</WorkToMake>
-								<MaxHitPoints>400</MaxHitPoints>
-								<Mass>12</Mass>
-								<Bulk>12</Bulk>
-								<WornBulk>8</WornBulk>
-								<StuffEffectMultiplierArmor>8.0</StuffEffectMultiplierArmor>
-							</statBases>
-							<recipeMaker>
-								<researchPrerequisite>PlateArmor</researchPrerequisite>
-								<recipeUsers>
-									<li>ElectricSmithy</li>
-									<li>FueledSmithy</li>
-									<li MayRequire="DankPyon.Medieval.Overhaul">DankPyon_Anvil</li>
-								</recipeUsers>
-							</recipeMaker>
-							<equippedStatOffsets>
-								<ReloadSpeed>-0.2</ReloadSpeed>
-								<MeleeHitChance>-1</MeleeHitChance>
-								<ShootingAccuracyPawn>-0.15</ShootingAccuracyPawn>
-								<AimingAccuracy>-0.08</AimingAccuracy>
-								<Suppressability>-0.25</Suppressability>
-								<MeleeCritChance>-0.05</MeleeCritChance>
-								<MeleeParryChance>1.0</MeleeParryChance>
-							</equippedStatOffsets>
-							<apparel>
-								<tags>
-									<li>pphhyy_DemigyryphShield</li>
-									<li>DemigyryphHunterShield</li>
-								</tags>
-								<renderNodeProperties>
-									<li>
-										<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
-										<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
-										<texPath>Weapons/DemigyryphHunterShield/DemigyryphHunterShield</texPath>
-										<shaderTypeDef>CutoutComplex</shaderTypeDef>
-										<parentTagDef>ApparelBody</parentTagDef>
-										<drawData>
-											<scale>0.6</scale>
-											<defaultData>
-												<layer>80</layer>
-											</defaultData>
-											<dataEast>
-												<layer>-5</layer>
-												<offset>(0, 0, -0.1)</offset>
-												<rotationOffset>30</rotationOffset>
-											</dataEast>
-											<dataWest>
-												<rotationOffset>-30</rotationOffset>
-											</dataWest>
-											<dataNorth>
-												<layer>-5</layer>
-												<offset>(0.15, 0, -0.1)</offset>
-											</dataNorth>
-											<dataSouth>
-												<offset>(0.15, 0, -0.1)</offset>
-											</dataSouth>
-										</drawData>
-									</li>
-								</renderNodeProperties>
-							</apparel>
-							<modExtensions>
-								<li Class="CombatExtended.ShieldDefExtension">
-									<shieldCoverage>
-										<li>Hands</li>
-										<li>Arms</li>
-										<li>Shoulders</li>
-										<li>Torso</li>
-										<li>Neck</li>
-									</shieldCoverage>
+				<!-- Hunter Shield -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphHunterShield"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>	
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphHunterShield"]/statBases/Mass</xpath>
+					<value>
+						<Mass>3.5</Mass>
+						<Bulk>12</Bulk>
+						<WornBulk>8</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphHunterShield"]</xpath>
+					<value>
+						<apparel>
+							<tags>
+								<li>pphhyy_DemigyryphShield</li>
+								<li>DemigyryphHunterShield</li>
+							</tags>
+							<renderNodeProperties>
+								<li>
+									<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
+									<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
+									<texPath>Weapons/DemigyryphHunterShield/DemigyryphHunterShield</texPath>
+									<shaderTypeDef>CutoutComplex</shaderTypeDef>
+									<parentTagDef>ApparelBody</parentTagDef>
+									<drawData>
+										<scale>0.6</scale>
+										<defaultData>
+											<layer>80</layer>
+										</defaultData>
+										<dataEast>
+											<layer>-5</layer>
+											<offset>(0, 0, -0.1)</offset>
+											<rotationOffset>30</rotationOffset>
+										</dataEast>
+										<dataWest>
+											<rotationOffset>-30</rotationOffset>
+										</dataWest>
+										<dataNorth>
+											<layer>-5</layer>
+											<offset>(0.15, 0, -0.1)</offset>
+										</dataNorth>
+										<dataSouth>
+											<offset>(0.15, 0, -0.1)</offset>
+										</dataSouth>
+									</drawData>
 								</li>
-							</modExtensions>
-							<tradeTags>
-								<li>Armor</li>
-							</tradeTags>
-						</ThingDef>
+							</renderNodeProperties>
+						</apparel>
+					</value>
+				</li>
 
-						<ThingDef ParentName="ShieldBase">
-							<defName>pphhyy_Human_DemigyryphChampionShield</defName>
-							<label>Demigyryph Champion Shield</label>
-							<description>A Cavalry shield made from metal materials, worn by veteran demigryph knights.</description>
-							<techLevel>Medieval</techLevel>
-							<graphicData>
-								<texPath>Weapons/DemigyryphChampionShield/DemigyryphChampionShield</texPath>
-								<graphicClass>Graphic_Single</graphicClass>
-							</graphicData>
-							<costStuffCount>50</costStuffCount>
-							<stuffCategories>
-								<li>Metallic</li>
-							</stuffCategories>
-							<statBases>
-								<WorkToMake>8000</WorkToMake>
-								<MaxHitPoints>300</MaxHitPoints>
-								<Mass>12</Mass>
-								<Bulk>12</Bulk>
-								<WornBulk>8</WornBulk>
-								<StuffEffectMultiplierArmor>8.0</StuffEffectMultiplierArmor>
-							</statBases>
-							<recipeMaker>
-								<researchPrerequisite>PlateArmor</researchPrerequisite>
-								<recipeUsers>
-									<li>ElectricSmithy</li>
-									<li>FueledSmithy</li>
-									<li MayRequire="DankPyon.Medieval.Overhaul">DankPyon_Anvil</li>
-								</recipeUsers>
-							</recipeMaker>
-							<equippedStatOffsets>
-								<PainShockThreshold>0.10</PainShockThreshold>
-								<SocialImpact>0.25</SocialImpact>
-								<ReloadSpeed>-0.2</ReloadSpeed>
-								<MeleeHitChance>-1</MeleeHitChance>
-								<ShootingAccuracyPawn>-0.15</ShootingAccuracyPawn>
-								<AimingAccuracy>-0.08</AimingAccuracy>
-								<Suppressability>-0.25</Suppressability>
-								<MeleeCritChance>-0.05</MeleeCritChance>
-								<MeleeParryChance>1.0</MeleeParryChance>
-							</equippedStatOffsets>
-							<apparel>
-								<tags>
-									<li>pphhyy_DemigyryphShield</li>
-									<li>DemigyryphChampionShield</li>
-								</tags>
-								<renderNodeProperties>
-									<li>
-										<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
-										<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
-										<texPath>Weapons/DemigyryphChampionShield/DemigyryphChampionShield</texPath>
-										<shaderTypeDef>CutoutComplex</shaderTypeDef>
-										<parentTagDef>ApparelBody</parentTagDef>
-										<drawData>
-											<scale>0.6</scale>
-											<defaultData>
-												<layer>80</layer>
-											</defaultData>
-											<dataEast>
-												<layer>-5</layer>
-												<offset>(0, 0, -0.1)</offset>
-												<rotationOffset>30</rotationOffset>
-											</dataEast>
-											<dataWest>
-												<rotationOffset>-30</rotationOffset>
-											</dataWest>
-											<dataNorth>
-												<layer>-5</layer>
-												<offset>(0.15, 0, -0.1)</offset>
-											</dataNorth>
-											<dataSouth>
-												<offset>(0.15, 0, -0.1)</offset>
-											</dataSouth>
-										</drawData>
-									</li>
-								</renderNodeProperties>
-							</apparel>
-							<modExtensions>
-								<li Class="CombatExtended.ShieldDefExtension">
-									<shieldCoverage>
-										<li>Hands</li>
-										<li>Arms</li>
-										<li>Shoulders</li>
-										<li>Torso</li>
-										<li>Neck</li>
-									</shieldCoverage>
+				<!-- Champion Shield -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphChampionShield"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>	
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphChampionShield"]/statBases/Mass</xpath>
+					<value>
+						<Mass>3.5</Mass>
+						<Bulk>12</Bulk>
+						<WornBulk>8</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="pphhyy_Human_DemigyryphChampionShield"]</xpath>
+					<value>
+						<apparel>
+							<tags>
+								<li>pphhyy_DemigyryphShield</li>
+								<li>DemigyryphChampionShield</li>
+							</tags>
+							<renderNodeProperties>
+								<li>
+									<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
+									<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
+									<texPath>Weapons/DemigyryphChampionShield/DemigyryphChampionShield</texPath>
+									<shaderTypeDef>CutoutComplex</shaderTypeDef>
+									<parentTagDef>ApparelBody</parentTagDef>
+									<drawData>
+										<scale>0.6</scale>
+										<defaultData>
+											<layer>80</layer>
+										</defaultData>
+										<dataEast>
+											<layer>-5</layer>
+											<offset>(0, 0, -0.1)</offset>
+											<rotationOffset>30</rotationOffset>
+										</dataEast>
+										<dataWest>
+											<rotationOffset>-30</rotationOffset>
+										</dataWest>
+										<dataNorth>
+											<layer>-5</layer>
+											<offset>(0.15, 0, -0.1)</offset>
+										</dataNorth>
+										<dataSouth>
+											<offset>(0.15, 0, -0.1)</offset>
+										</dataSouth>
+									</drawData>
 								</li>
-							</modExtensions>
-							<tradeTags>
-								<li>Armor</li>
-							</tradeTags>
-						</ThingDef>
-
+							</renderNodeProperties>
+						</apparel>
 					</value>
 				</li>
 


### PR DESCRIPTION
## Changes

- Patched the banners and shields added by the mod.

## Reasoning

- Both the banners and shields are converted to CE's shields, the banners have a melee attack that knocks back the target which is not compatible with CE and was left out.
- There a slight issue with the textures, the mod's textures are set up in a way that CE somehow does not recognize their masking style as they have all the directions/faces and as a result the textures don't take the color of the material they are made out of, maybe the code needs more work to recognize them?

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Enough testing to see them working as intended)
