### PR TITLE
Creepjoiner fixes

### DIFF
--- a/Anomaly/Patches/CreepjoinderDefs/Forms.xml
+++ b/Anomaly/Patches/CreepjoinderDefs/Forms.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- ========== Creepjoiner inventory fixes ========== -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/CreepJoinerFormKindDef[defName="LeatheryStranger"]/fixedInventory</xpath>
+		<value>
+			<CE_Apparel_Backpack>
+				<stuff>WoolBison</stuff>
+				<quality>Poor</quality>
+			</CE_Apparel_Backpack>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/CreepJoinerFormKindDef[defName="LeatheryStranger"]</xpath>
+		<value>
+			<inventoryOptions>
+				<subOptionsChooseOne>
+					<li>
+						<thingDef>Ammo_303British_FMJ</thingDef>
+						<countRange>20~40</countRange>
+					</li>
+				</subOptionsChooseOne>
+			</inventoryOptions>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/CreepJoinerFormKindDef[defName="DealMaker"]/fixedInventory</xpath>
+		<value>
+			<CE_Apparel_Backpack>
+				<stuff>Cloth</stuff>
+				<quality>Normal</quality>
+			</CE_Apparel_Backpack>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/CreepJoinerFormKindDef[defName="DealMaker"]</xpath>
+		<value>
+			<inventoryOptions>
+				<subOptionsChooseOne>
+					<li>
+						<thingDef>Ammo_44Magnum_FMJ</thingDef>
+						<countRange>12~24</countRange>
+					</li>
+				</subOptionsChooseOne>
+			</inventoryOptions>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/CreepJoinerFormKindDef[defName="LoneGenius"]/fixedInventory</xpath>
+		<value>
+			<CE_Apparel_Backpack>
+				<stuff>Cloth</stuff>
+				<quality>Good</quality>
+			</CE_Apparel_Backpack>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/CreepJoinerFormKindDef[defName="LoneGenius"]/fixedInventory/Gun_ChargeLance</xpath>
+		<value>
+			<Gun_ChargeRifle />
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/CreepJoinerFormKindDef[defName="LoneGenius"]</xpath>
+		<value>
+			<inventoryOptions>
+				<subOptionsChooseOne>
+					<li>
+						<thingDef>Ammo_6x24mmCharged</thingDef>
+						<countRange>60~120</countRange>
+					</li>
+				</subOptionsChooseOne>
+			</inventoryOptions>
+		</value>
+	</Operation>
+
+</Patch>

--- a/Anomaly/Patches/CreepjoinderDefs/Forms.xml
+++ b/Anomaly/Patches/CreepjoinderDefs/Forms.xml
@@ -22,6 +22,14 @@
 						<thingDef>Ammo_303British_FMJ</thingDef>
 						<countRange>20~40</countRange>
 					</li>
+					<li>
+						<thingDef>Ammo_303British_AP</thingDef>
+						<countRange>20~40</countRange>
+					</li>
+					<li>
+						<thingDef>Ammo_303British_HP</thingDef>
+						<countRange>20~40</countRange>
+					</li>										
 				</subOptionsChooseOne>
 			</inventoryOptions>
 		</value>
@@ -46,6 +54,14 @@
 						<thingDef>Ammo_44Magnum_FMJ</thingDef>
 						<countRange>12~24</countRange>
 					</li>
+					<li>
+						<thingDef>Ammo_44Magnum_AP</thingDef>
+						<countRange>12~24</countRange>
+					</li>
+					<li>
+						<thingDef>Ammo_44Magnum_HP</thingDef>
+						<countRange>12~24</countRange>
+					</li>										
 				</subOptionsChooseOne>
 			</inventoryOptions>
 		</value>
@@ -77,6 +93,10 @@
 						<thingDef>Ammo_6x24mmCharged</thingDef>
 						<countRange>60~120</countRange>
 					</li>
+					<li>
+						<thingDef>Ammo_6x24mmCharged_AP</thingDef>
+						<countRange>60~120</countRange>
+					</li>					
 				</subOptionsChooseOne>
 			</inventoryOptions>
 		</value>


### PR DESCRIPTION
## Changes

- Made sure certain creepjoiners from anomaly have backpacks to carry their weapon and its ammo.
- Made sure said creepjoiners spawn with enough ammo for their gun.
- The lone genius joiner spawns with the charge lance which was replaced with the charge rifle.

## References

- Closes #3329

## Reasoning

- Bulk cap issues.
- Creepjoiners are not like normal pawnkinds and spawn with their gun in not a traditional way (the weapons are forced items in their inventory) for CE's loadout code to assign ammo for them so patching the pawnkind itself or its parent does nothing hence the forced ammo in their inventory.
- Lances are not for the meatbags, the rifle is the closest option.

## Alternatives

- Suffer.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Spawned each joiner to see stuff working)
