### PR TITLE
Sanguophage spine stats tweak

### DIFF
--- a/Biotech/Patches/AbilityDefs/Abilities_Biotech.xml
+++ b/Biotech/Patches/AbilityDefs/Abilities_Biotech.xml
@@ -16,9 +16,9 @@
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
 				<damageDef>RangedStab</damageDef>
 				<speed>30</speed>
-				<damageAmountBase>20</damageAmountBase>
-				<armorPenetrationSharp>6</armorPenetrationSharp>
-				<armorPenetrationBlunt>8</armorPenetrationBlunt>
+				<damageAmountBase>15</damageAmountBase>
+				<armorPenetrationSharp>14</armorPenetrationSharp>
+				<armorPenetrationBlunt>21</armorPenetrationBlunt>
 			</projectile>
 		</value>
 	</Operation>


### PR DESCRIPTION
## Changes

- Adjusted the Sanguophage piercing spine projectile to be more potent in terms of AP, 14mm and 21MPa to be exact.

## Reasoning

- It's extremely anemic for something that is supposed to be a charge lance shot in extremely close range that only fires 5 projectiles before needing to be "reloaded" under perfect conditions and if no other ability is even used. The current values are based one a plasteel bolt weighing 250 grams. It can do something to a normal composite vest after a couple shots now.
- Same thing that is happening to the Anomaly patch rebalancing, have to make things work as they are intended to be for space magic creatures, not what realistically might make sense.

## Alternatives

- Suffer.
- Can go even higher, it lowers the chances of the change getting approved even more.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
