### PR TITLE
Fix Piercing Spine

### DIFF
--- a/Biotech/Patches/AbilityDefs/Abilities_Biotech.xml
+++ b/Biotech/Patches/AbilityDefs/Abilities_Biotech.xml
@@ -7,12 +7,35 @@
 		<xpath>Defs/AbilityDef[defName="PiercingSpine"]/verbProperties/range</xpath>
 		<value>
 			<range>5.9</range>
+			<ai_IsWeapon>false</ai_IsWeapon>
+			<defaultProjectile>PiercingSpine</defaultProjectile>
 		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AbilityDef[defName="PiercingSpine"]/verbProperties/verbClass</xpath>
+		<value>
+			<verbClass>CombatExtended.Verb_LaunchProjectileStaticCE</verbClass>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AbilityDef[defName="PiercingSpine"]/verbProperties/verbClass</xpath>
+		<value>
+			<verbClass>CombatExtended.Verb_LaunchProjectileStaticCE</verbClass>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationAttributeSet">
+		<xpath>Defs/AbilityDef[defName="PiercingSpine"]/verbProperties</xpath>
+		<attribute>Class</attribute>
+		<value>CombatExtended.VerbPropertiesCE</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PiercingSpine"]/projectile</xpath>
 		<value>
+			<thingClass>CombatExtended.BulletCE</thingClass>
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
 				<damageDef>RangedStab</damageDef>
 				<speed>30</speed>


### PR DESCRIPTION

## Changes

Makes the biotech piercing spine ability use CE static launch projectile, changes the projectile to use the CE class. This should fix its interactions with CE armor.

Also pls buff, I suggest 40/20 penetration with 24 damage (megaspider stab). Sangophages are harder to aquire than bugs on average, the attack is practically melee anyway. 

## Reasoning

We have the tools and ability to do this now thanks to the anomaly verb stuff that was required. Now we can actually make it interact with CE armor like a normal CE projectile meaning it can now actually penetrate armor using CE logic rather than vanilla logic.

## Alternatives

Leave as vanilla implementation since the damn thing is useless with its current stats anyway.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
