### PR TITLE
CG HEDP ammo ammoClass fix and misc housekeeping

### DIFF
--- a/Defs/Ammo/Rocket/84x246mmR.xml
+++ b/Defs/Ammo/Rocket/84x246mmR.xml
@@ -155,6 +155,7 @@
 			<Bulk>7.31</Bulk>
 		</statBases>
 		<ammoClass>BuckShot</ammoClass>
+		<generateAllowChance>0.5</generateAllowChance>
 		<comps>
 			<li Class="CompProperties_Explosive">
 				<damageAmountBase>20</damageAmountBase>
@@ -430,8 +431,8 @@
 			<!-- Originally 1100 flechettes are present, changed to 50 buffed projectile -->
 			<armorPenetrationSharp>5</armorPenetrationSharp>
 			<armorPenetrationBlunt>18</armorPenetrationBlunt>
-			<spreadMult>26.7</spreadMult>
-			<!-- x3 the normal spread -->
+			<spreadMult>17.8</spreadMult>
+			<!-- x2 the normal spread -->
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rocket/84x246mmR.xml
+++ b/Defs/Ammo/Rocket/84x246mmR.xml
@@ -122,7 +122,7 @@
 			<Mass>3.3</Mass>
 			<Bulk>8.35</Bulk>
 		</statBases>
-		<ammoClass>GrenadeHE</ammoClass>
+		<ammoClass>GrenadeHEDP</ammoClass>
 		<detonateProjectile>Bullet_84x246mmR_HEDP</detonateProjectile>
 	</ThingDef>
 


### PR DESCRIPTION
## Changes

- What it says on the tin, the HEDP ammo types didn't have the correct ammoClass of GrenadeHEDP.
- Made the Canister ammo type's spread tighter, the base spread of the weapon is rather high resulting it a final spread being too much. The ammo type is less likely to spawn on NPCs too.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Works)
