### PR TITLE
VFE - Security: Hide Raider Arty Again

### DIFF
--- a/ModPatches/Vanilla Furniture Expanded - Security/Defs/Vanilla Furniture Expanded - Security/NewRaiderArtillery.xml
+++ b/ModPatches/Vanilla Furniture Expanded - Security/Defs/Vanilla Furniture Expanded - Security/NewRaiderArtillery.xml
@@ -65,6 +65,7 @@
 				</filter>
 			</defaultStorageSettings>
 		</building>
+		<designationCategory inherit="false" />
 		<uiIconPath>Things/Building/Artillery/TurretArtillery_MenuIcon</uiIconPath>
 		<uiIconScale>0.9</uiIconScale>
 		<constructionSkillPrerequisite>5</constructionSkillPrerequisite>

--- a/ModPatches/Vanilla Furniture Expanded - Security/Defs/Vanilla Furniture Expanded - Security/NewRaiderArtillery.xml
+++ b/ModPatches/Vanilla Furniture Expanded - Security/Defs/Vanilla Furniture Expanded - Security/NewRaiderArtillery.xml
@@ -29,7 +29,7 @@
 		<interactionCellOffset>(0,0,-2)</interactionCellOffset>
 		<hasInteractionCell>true</hasInteractionCell>
 		<size>(3,3)</size>
-		<!-- <designationCategory /> -->
+		<designationCategory Inherit="False"/>
 		<rotatable>true</rotatable>
 		<stealable>false</stealable>
 		<stuffCategories>
@@ -65,7 +65,6 @@
 				</filter>
 			</defaultStorageSettings>
 		</building>
-		<designationCategory inherit="false" />
 		<uiIconPath>Things/Building/Artillery/TurretArtillery_MenuIcon</uiIconPath>
 		<uiIconScale>0.9</uiIconScale>
 		<constructionSkillPrerequisite>5</constructionSkillPrerequisite>
@@ -73,7 +72,8 @@
 			<li Class="CombatExtended.ThingDefExtensionCE">
 				<MenuHidden>True</MenuHidden>
 			</li>
-		</modExtensions>		
+		</modExtensions>
+		<researchPrerequisites Inherit="False"/>
 	</ThingDef>
 
 	<ThingDef ParentName="BaseArtilleryWeapon">


### PR DESCRIPTION
## Changes
- Set the raider artillery to have no designation category, so that it doesn't appear as buildable to the player.

## Reasoning
- This was previously accomplished via CE's `MenuHidden`, but that currently appears to be broken. As a result, players can see the raider arty after researching mortars (for reasons that are unclear to me--removing the research pre-req doesn't make it stop).

## Alternatives
- Fix `MenuHidden` (we need to do this anyway).

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
