### PR TITLE
Militors Balance Adjustments

### DIFF
--- a/Biotech/Patches/ThingDefs_Misc/Weapons/RangedMechanoid_Light.xml
+++ b/Biotech/Patches/ThingDefs_Misc/Weapons/RangedMechanoid_Light.xml
@@ -51,10 +51,10 @@
 			<Bulk>7.00</Bulk>
 		</statBases>
 		<Properties>
-			<recoilAmount>2.22</recoilAmount>
+			<recoilAmount>2.42</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_410Bore_Buck_SB</defaultProjectile>
+			<defaultProjectile>Bullet_410Bore_Buck</defaultProjectile>
 			<warmupTime>0.8</warmupTime>
 			<range>14</range>
 			<soundCast>Shot_Shotgun_NoRack</soundCast>
@@ -64,7 +64,7 @@
 		<AmmoUser>
 			<magazineSize>6</magazineSize>
 			<reloadTime>4.9</reloadTime>
-			<ammoSet>AmmoSet_410Bore_SB</ammoSet>
+			<ammoSet>AmmoSet_410Bore</ammoSet>
 		</AmmoUser>
 		<FireModes>
 			<aiAimMode>Snapshot</aiAimMode>

--- a/Biotech/Patches/ThingDefs_Misc/Weapons/RangedMechanoid_Light.xml
+++ b/Biotech/Patches/ThingDefs_Misc/Weapons/RangedMechanoid_Light.xml
@@ -44,17 +44,17 @@
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>Gun_MiniShotgun</defName>
 		<statBases>
-			<RangedWeapon_Cooldown>0.4</RangedWeapon_Cooldown>
+			<RangedWeapon_Cooldown>0.6</RangedWeapon_Cooldown>
 			<SightsEfficiency>1</SightsEfficiency>
 			<ShotSpread>0.15</ShotSpread>
 			<SwayFactor>0.53</SwayFactor>
 			<Bulk>7.00</Bulk>
 		</statBases>
 		<Properties>
-			<recoilAmount>2.42</recoilAmount>
+			<recoilAmount>2.22</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_410Bore_Buck</defaultProjectile>
+			<defaultProjectile>Bullet_410Bore_Buck_SB</defaultProjectile>
 			<warmupTime>0.8</warmupTime>
 			<range>14</range>
 			<soundCast>Shot_Shotgun_NoRack</soundCast>
@@ -62,9 +62,9 @@
 			<muzzleFlashScale>6</muzzleFlashScale>
 		</Properties>
 		<AmmoUser>
-			<magazineSize>8</magazineSize>
+			<magazineSize>6</magazineSize>
 			<reloadTime>4.9</reloadTime>
-			<ammoSet>AmmoSet_410Bore</ammoSet>
+			<ammoSet>AmmoSet_410Bore_SB</ammoSet>
 		</AmmoUser>
 		<FireModes>
 			<aiAimMode>Snapshot</aiAimMode>

--- a/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Light.xml
+++ b/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Light.xml
@@ -170,6 +170,7 @@
 			<MeleeCritChance>0.05</MeleeCritChance>
 			<MeleeParryChance>0.05</MeleeParryChance>
 			<MaxHitPoints>150</MaxHitPoints>
+			<NightVisionEfficiency>0.4</NightVisionEfficiency>
 		</value>
 	</Operation>
 

--- a/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Light.xml
+++ b/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Light.xml
@@ -164,8 +164,8 @@
 		<value>
 			<ArmorRating_Blunt>4</ArmorRating_Blunt>
 			<ArmorRating_Sharp>2.5</ArmorRating_Sharp>
-			<AimingAccuracy>1.0</AimingAccuracy>
-			<ShootingAccuracyPawn>1.0</ShootingAccuracyPawn>
+			<AimingAccuracy>0.6</AimingAccuracy>
+			<ShootingAccuracyPawn>0.769</ShootingAccuracyPawn> <!-- Equivalent to a Level 5 Shooter -->
 			<MeleeDodgeChance>0.13</MeleeDodgeChance>
 			<MeleeCritChance>0.05</MeleeCritChance>
 			<MeleeParryChance>0.05</MeleeParryChance>


### PR DESCRIPTION
## Changes
**Militor Mech**
- Reduce the militor's Aiming Accuracy from 1 to 0.6. This is better than the mini-turret (0.25) but worse than the lancer (1.7).
- Reduce the militor's Shooting Accuracy from 1 to 0.769. This gives the militor weapon handling comparable to a (healthy) Level 5 shooter. Previously, it was equivalent to a Level 8 shooter.
- Reduce night vision from 80% (inherited) to 40%.

**Mini-Shotgun**
- Reduced the mini-shotgun's ammo capacity from 8 to 6.
- Increase the mini-shotgun's cooldown from 0.4 to 0.6.

## Reasoning

**Militor Mech**
The militor is a low-tier, swarm-style combat mech. It's patched combat power (60) is equal to a tribal berserker or 1.5 manhunting tortoises. While carrying a shotgun is always going to be an advantage in the early game before armor becomes more of a factor, the militor is currently punching too far above its weight class, with weapon handling equivalent to a better-than-average shooter. 

The 80% night vision it was inheriting from `BaseMech` was likely an oversight, as that's entirely too high for something this cheap to have--especially in the player's hands.

**Mini-Shotgun**
The mini-shotgun still fires 3-inch .410 shells. The 6-round capacity is generous, whereas the 8-round capacity was just too much for such a compact weapon. The cooldown was increased so that the militor can't dump quite as much DPS onto a target.

## Alternatives
- Could leave as-is.
- Could set balance to some other level, such as increasing their combat power.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
