### PR TITLE
Make frag grenades non-smeltable

### DIFF
--- a/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
@@ -148,12 +148,19 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Weapon_GrenadeFrag"]/smeltable</xpath>
+		<value>
+			<smeltable>false</smeltable>
+		</value>
+	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Weapon_GrenadeFrag"]</xpath>
 		<value>
 			<thingClass>CombatExtended.AmmoThing</thingClass>
 			<stackLimit>75</stackLimit>
-			<resourceReadoutPriority>First</resourceReadoutPriority>
+			<resourceReadoutPriority>First</resourceReadoutPriority>		
 		</value>
 	</Operation>
 
@@ -405,7 +412,7 @@
 		<value>
 			<thingClass>CombatExtended.AmmoThing</thingClass>
 			<stackLimit>75</stackLimit>
-			<resourceReadoutPriority>First</resourceReadoutPriority>
+			<resourceReadoutPriority>First</resourceReadoutPriority>	
 		</value>
 	</Operation>
 


### PR DESCRIPTION
## Changes
- Make frag grenades non-smeltable.

## Reasoning
Due to the crafting cost for frags and their ability to be smelted, it was possible to "profit" on steel by crafting 10 grenades for 8 steel, and then smelting them for 5 steel each. Since RW can't do fractional amounts, it's easiest to just make frags non-smeltable, like other grenades.

## Alternatives
- Could ignore the issue and leave as-is.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
