### PR TITLE
Feral / Federation Partial Armor + Tweaks

### DIFF
--- a/ModPatches/Rimsenal Federation/Defs/Rimsenal Federation/FederationShellingResponse.xml
+++ b/ModPatches/Rimsenal Federation/Defs/Rimsenal Federation/FederationShellingResponse.xml
@@ -1,0 +1,37 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+	<CombatExtended.ShellingResponseDef ParentName="ShellingPreset_UltraBase">
+		<defName>CE_ShellingPreset_Federation</defName>
+		<defaultShellingPropability>0.7</defaultShellingPropability>
+		<defaultRaidPropability>0.05</defaultRaidPropability>
+		<defaultRaidMTBDays>1</defaultRaidMTBDays>
+		<projectiles Inherit="False">
+			<li>
+				<projectile>Bullet_Federation_PlasmaCluster</projectile>
+				<points>250</points>
+				<weight>0.75</weight>
+			</li>
+			<li>
+				<projectile>Bullet_Federation_PlasmaBlast</projectile>
+				<points>100</points>
+				<weight>0.10</weight>
+			</li>
+		</projectiles>
+		<worldObjects Inherit="False">
+			<li>
+				<worldObject>Settlement</worldObject>
+				<shellingPropability>1</shellingPropability>
+				<raidPropability>0.2</raidPropability>
+				<raidMTBDays>0.5</raidMTBDays>
+			</li>
+			<li>
+				<worldObject>Site</worldObject>
+				<shellingPropability>0.6</shellingPropability>
+				<raidPropability>0.05</raidPropability>
+				<raidMTBDays>1</raidMTBDays>
+			</li>
+		</worldObjects>
+	</CombatExtended.ShellingResponseDef>
+
+</Defs>

--- a/ModPatches/Rimsenal Federation/Defs/Rimsenal Federation/ThingDefs_Misc/Ammo_Fed.xml
+++ b/ModPatches/Rimsenal Federation/Defs/Rimsenal Federation/ThingDefs_Misc/Ammo_Fed.xml
@@ -127,8 +127,6 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Smoke</damageDef>
 			<soundExplode>Explosion_OpticBurst</soundExplode>
-			<damageAmountBase>0</damageAmountBase>
-			<explosionRadius>0.9</explosionRadius>
 			<speed>0</speed>
 			<flyOverhead>true</flyOverhead>
 			<dropsCasings>false</dropsCasings>
@@ -433,7 +431,7 @@
 	<!-- ==========  Crucible Carbine Projectile =========== -->
 
 	<ThingDef ParentName="BaseOpticBoltCE">
-		<defName>Bullet_CrucibleCarbine</defName>
+		<defName>Bullet_CrucibleCarbine_CE</defName>
 		<label>energy bolt</label>
 		<graphicData>
 			<texPath>Things/Projectile/Mlaser</texPath>
@@ -443,4 +441,5 @@
 			<damageAmountBase>10</damageAmountBase>
 		</projectile>
 	</ThingDef>
+
 </Defs>

--- a/ModPatches/Rimsenal Federation/Defs/Rimsenal Federation/ThingDefs_Misc/Ammo_Fed.xml
+++ b/ModPatches/Rimsenal Federation/Defs/Rimsenal Federation/ThingDefs_Misc/Ammo_Fed.xml
@@ -1,9 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
 
+	<!-- ==========  Bases =========== -->
+	
+	<ThingDef Name="BaseOpticBoltCE" ParentName="BaseBulletCE" Abstract="true">
+		<label>energy bolt</label>
+		<graphicData>
+			<texPath>Things/Projectile/Mlaser</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Optic</damageDef>
+			<speed>100</speed>
+			<dropsCasings>false</dropsCasings>
+		</projectile>
+	</ThingDef>
+	
+	<ThingDef Name="BaseCrucibleBoltCE" ParentName="BaseBulletCE" Abstract="true">
+		<label>energy bolt</label>
+		<graphicData>
+			<texPath>Things/Projectile/Cruciblebolt</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Crucible</damageDef>
+			<speed>100</speed>
+			<dropsCasings>false</dropsCasings>
+		</projectile>
+	</ThingDef>
+	
+	<ThingDef Name="BasePlasmaBombCE" ParentName="BaseExplosiveBullet" Abstract="true">
+		<label>plasma sphere</label>
+		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+		<graphicData>
+			<texPath>Things/Projectile/Plasma</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<suppressionFactor>6.0</suppressionFactor>
+			<dangerFactor>4.0</dangerFactor>
+			<damageDef>Plasma</damageDef>
+			<speed>16</speed>
+			<dropsCasings>false</dropsCasings>
+		</projectile>
+	</ThingDef>
+	
 	<!-- ==========  Harvester Cannon =========== -->
 
-	<ThingDef ParentName="Base40x365mmBoforsBullet">
+	<ThingDef ParentName="BaseOpticBoltCE">
 		<defName>Bullet_HarvesterCannon</defName>
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		<label>energy bolt</label>
@@ -12,12 +56,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>Optic</damageDef>
-			<speed>106</speed>
-			<dropsCasings>false</dropsCasings>
-			<damageAmountBase>12</damageAmountBase>
-			<armorPenetrationBlunt>5</armorPenetrationBlunt>
-			<armorPenetrationSharp>14</armorPenetrationSharp>
+			<damageAmountBase>36</damageAmountBase>
 			<explosionRadius>1</explosionRadius>
 		</projectile>
 	</ThingDef>
@@ -39,8 +78,6 @@
 			<flyOverhead>true</flyOverhead>
 			<dropsCasings>false</dropsCasings>
 			<damageAmountBase>25</damageAmountBase>
-			<armorPenetrationBlunt>5</armorPenetrationBlunt>
-			<armorPenetrationSharp>14</armorPenetrationSharp>
 			<explosionRadius>2.5</explosionRadius>
 			<gravityFactor>5</gravityFactor>
 		</projectile>
@@ -48,7 +85,7 @@
 
 	<!-- ==========  Crucible Cannon Projectile =========== -->
 
-	<ThingDef ParentName="Base40x365mmBoforsBullet">
+	<ThingDef ParentName="BaseCrucibleBoltCE">
 		<defName>Bullet_CrucibleCannon_CE</defName>
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		<label>energy bolt</label>
@@ -57,22 +94,16 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>Optic</damageDef>
-			<speed>98</speed>
-			<dropsCasings>false</dropsCasings>
-			<damageAmountBase>20</damageAmountBase>
-			<armorPenetrationBlunt>5</armorPenetrationBlunt>
-			<armorPenetrationSharp>20</armorPenetrationSharp>
-			<explosionRadius>1</explosionRadius>
+			<damageAmountBase>40</damageAmountBase>
+			<explosionRadius>0.9</explosionRadius>
 		</projectile>
 	</ThingDef>
 
 	<!-- ==========  Mech Plasma Bombard Projectile =========== -->
 
-	<ThingDef ParentName="BaseExplosiveBullet">
+	<ThingDef ParentName="BasePlasmaBombCE">
 		<defName>Bullet_PlasmaMechBombard</defName>
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
-		<label>energy bolt</label>
 		<graphicData>
 			<texPath>Things/Projectile/MFlux</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -80,18 +111,17 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Plasma</damageDef>
-			<speed>63</speed>
+			<speed>8</speed>
+			<gravityFactor>0.01</gravityFactor>
 			<dropsCasings>false</dropsCasings>
-			<damageAmountBase>50</damageAmountBase>
-			<armorPenetrationBlunt>5</armorPenetrationBlunt>
-			<armorPenetrationSharp>14</armorPenetrationSharp>
+			<damageAmountBase>120</damageAmountBase>
 			<explosionRadius>4</explosionRadius>
 		</projectile>
 	</ThingDef>
 
 	<!-- ==========  Plasma Rifle Projectile =========== -->
 
-	<ThingDef ParentName="Base556x45mmNATOBullet">
+	<ThingDef ParentName="BasePlasmaBombCE">
 		<defName>Bullet_PlasmaRifle_Fed</defName>
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		<label>plasma sphere</label>
@@ -101,11 +131,10 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Plasma</damageDef>
-			<speed>54</speed>
+			<speed>20</speed>
+			<gravityFactor>0.01</gravityFactor>
 			<dropsCasings>false</dropsCasings>
-			<damageAmountBase>25</damageAmountBase>
-			<armorPenetrationBlunt>5</armorPenetrationBlunt>
-			<armorPenetrationSharp>16</armorPenetrationSharp>
+			<damageAmountBase>30</damageAmountBase>
 			<explosionRadius>1.5</explosionRadius>
 		</projectile>
 	</ThingDef>
@@ -133,7 +162,7 @@
 
 	<!-- ==========  Auxiliary Pistol Projectile =========== -->
 
-	<ThingDef ParentName="Base45ACPBullet">
+	<ThingDef ParentName="BaseOpticBoltCE">
 		<defName>Bullet_AuxiliaryPistol</defName>
 		<label>energy bolt</label>
 		<graphicData>
@@ -141,18 +170,13 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>Optic</damageDef>
-			<speed>90</speed>
-			<dropsCasings>false</dropsCasings>
 			<damageAmountBase>8</damageAmountBase>
-			<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
-			<armorPenetrationSharp>8</armorPenetrationSharp>
 		</projectile>
 	</ThingDef>
 
 	<!-- ==========  Makeshift Crucible Rifle Projectile =========== -->
 
-	<ThingDef ParentName="Base556x45mmNATOBullet">
+	<ThingDef ParentName="BaseOpticBoltCE">
 		<defName>Bullet_MakeshiftCrucibleRifle</defName>
 		<label>energy bolt</label>
 		<graphicData>
@@ -164,52 +188,52 @@
 			<speed>90</speed>
 			<dropsCasings>false</dropsCasings>
 			<damageAmountBase>13</damageAmountBase>
-			<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
-			<armorPenetrationSharp>10</armorPenetrationSharp>
 		</projectile>
 	</ThingDef>
 
 	<!-- ==========  Crucible Rifle Projectile =========== -->
 
-	<ThingDef ParentName="Base556x45mmNATOBullet">
+	<ThingDef ParentName="BaseCrucibleBoltCE">
 		<defName>Bullet_CrucibleRifle</defName>
-		<label>energy bolt</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>12</damageAmountBase>
+		</projectile>
+	</ThingDef>
+	
+	<ThingDef ParentName="BaseOpticBoltCE">
+		<defName>Bullet_CrucibleRifleAD</defName>
 		<graphicData>
 			<texPath>Things/Projectile/Laser</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>Optic</damageDef>
-			<speed>90</speed>
-			<dropsCasings>false</dropsCasings>
 			<damageAmountBase>12</damageAmountBase>
-			<armorPenetrationBlunt>3</armorPenetrationBlunt>
-			<armorPenetrationSharp>12</armorPenetrationSharp>
 		</projectile>
 	</ThingDef>
 
 	<!-- ==========  Crucible Pistol Projectile =========== -->
-
-	<ThingDef ParentName="Base45ACPBullet">
+	
+	<ThingDef ParentName="BaseCrucibleBoltCE">
 		<defName>Bullet_CruciblePistol</defName>
-		<label>energy bolt</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>10</damageAmountBase>
+		</projectile>
+	</ThingDef>
+	
+	<ThingDef ParentName="BaseOpticBoltCE">
+		<defName>Bullet_CruciblePistolAD</defName>
 		<graphicData>
 			<texPath>Things/Projectile/Laser</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>Optic</damageDef>
-			<speed>90</speed>
-			<dropsCasings>false</dropsCasings>
 			<damageAmountBase>10</damageAmountBase>
-			<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
-			<armorPenetrationSharp>10</armorPenetrationSharp>
 		</projectile>
 	</ThingDef>
 
 	<!-- ==========  Heat Cannon Projectile =========== -->
 
-	<ThingDef ParentName="Base40x365mmBoforsBullet">
+	<ThingDef ParentName="BaseOpticBoltCE">
 		<defName>Bullet_HeatCannon</defName>
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		<label>heat bolt</label>
@@ -222,35 +246,34 @@
 			<damageDef>Flame</damageDef>
 			<speed>90</speed>
 			<dropsCasings>false</dropsCasings>
-			<damageAmountBase>5</damageAmountBase>
-			<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-			<armorPenetrationSharp>9</armorPenetrationSharp>
+			<damageAmountBase>12</damageAmountBase>
 			<explosionRadius>0.5</explosionRadius>
 		</projectile>
 	</ThingDef>
 
 	<!-- ==========  Crucible Precision Rifle Projectile =========== -->
-
-	<ThingDef ParentName="Base556x45mmNATOBullet">
+	
+	<ThingDef ParentName="BaseCrucibleBoltCE">
 		<defName>Bullet_CruciblePrecisionRifle</defName>
-		<label>energy bolt</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>20</damageAmountBase>
+		</projectile>
+	</ThingDef>
+	
+	<ThingDef ParentName="BaseOpticBoltCE">
+		<defName>Bullet_CruciblePrecisionRifleAD</defName>
 		<graphicData>
 			<texPath>Things/Projectile/Laser</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>Optic</damageDef>
-			<speed>90</speed>
-			<dropsCasings>false</dropsCasings>
 			<damageAmountBase>20</damageAmountBase>
-			<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
-			<armorPenetrationSharp>10</armorPenetrationSharp>
 		</projectile>
 	</ThingDef>
 
 	<!-- ==========  Plasma Caster Projectile =========== -->
 
-	<ThingDef ParentName="Base40x365mmBoforsBullet">
+	<ThingDef ParentName="BasePlasmaBombCE">
 		<defName>Bullet_PlasmaCaster</defName>
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		<label>plasma sphere</label>
@@ -261,18 +284,17 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Plasma</damageDef>
-			<speed>32</speed>
+			<speed>8</speed>
+			<gravityFactor>0.01</gravityFactor>
 			<dropsCasings>false</dropsCasings>
-			<damageAmountBase>25</damageAmountBase>
-			<armorPenetrationBlunt>30</armorPenetrationBlunt>
-			<armorPenetrationSharp>8</armorPenetrationSharp>
-			<explosionRadius>2.5</explosionRadius>
+			<damageAmountBase>75</damageAmountBase>
+			<explosionRadius>3.5</explosionRadius>
 		</projectile>
 	</ThingDef>
 
 	<!-- ==========  Plasma Bomb Projectile =========== -->
 
-	<ThingDef ParentName="Base40x365mmBoforsBullet">
+	<ThingDef ParentName="BasePlasmaBombCE">
 		<defName>Bullet_PlasmaBomb</defName>
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		<label>plasma bomb</label>
@@ -294,20 +316,15 @@
 
 	<!-- ==========  Crucible Carbine Projectile =========== -->
 
-	<ThingDef ParentName="Base556x45mmNATOBullet">
+	<ThingDef ParentName="BaseOpticBoltCE">
 		<defName>Bullet_CrucibleCarbine</defName>
 		<label>energy bolt</label>
 		<graphicData>
-			<texPath>Things/Projectile/Laser</texPath>
+			<texPath>Things/Projectile/Mlaser</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>Optic</damageDef>
-			<speed>90</speed>
-			<dropsCasings>false</dropsCasings>
-			<damageAmountBase>8</damageAmountBase>
-			<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-			<armorPenetrationSharp>9</armorPenetrationSharp>
+			<damageAmountBase>10</damageAmountBase>
 		</projectile>
 	</ThingDef>
 </Defs>

--- a/ModPatches/Rimsenal Federation/Defs/Rimsenal Federation/ThingDefs_Misc/Ammo_Fed.xml
+++ b/ModPatches/Rimsenal Federation/Defs/Rimsenal Federation/ThingDefs_Misc/Ammo_Fed.xml
@@ -35,6 +35,7 @@
 		<graphicData>
 			<texPath>Things/Projectile/Plasma</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
+			<shaderType>TransparentPostLight</shaderType>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<suppressionFactor>6.0</suppressionFactor>
@@ -61,7 +62,7 @@
 		</projectile>
 	</ThingDef>
 
-	<!-- ==========  Plasma Bombard Projectile =========== -->
+	<!-- ==========  Plasma Artillery Projectile =========== -->
 
 	<ThingDef ParentName="BaseExplosiveBullet">
 		<defName>Bullet_PlasmaTurretBombard</defName>
@@ -77,9 +78,98 @@
 			<speed>0</speed>
 			<flyOverhead>true</flyOverhead>
 			<dropsCasings>false</dropsCasings>
-			<damageAmountBase>25</damageAmountBase>
+			<damageAmountBase>30</damageAmountBase>
+			<explosionRadius>2.5</explosionRadius>
+			<gravityFactor>2.5</gravityFactor>
+			<pelletCount>10</pelletCount>
+			<spreadMult>10</spreadMult>
+			<shellingProps>
+				<tilesPerTick>0.10</tilesPerTick>
+				<range>30</range>
+			</shellingProps>
+		</projectile>
+	</ThingDef>
+	
+	<ThingDef ParentName="BaseExplosiveBullet">
+		<defName>Bullet_Federation_PlasmaBlast</defName>
+		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+		<label>energy bolt</label>
+		<graphicData>
+			<texPath>Things/Projectile/MFlux</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<shaderType>TransparentPostLight</shaderType>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Plasma</damageDef>
+			<speed>0</speed>
+			<flyOverhead>true</flyOverhead>
+			<dropsCasings>false</dropsCasings>
+			<damageAmountBase>120</damageAmountBase>
+			<explosionRadius>4</explosionRadius>
+			<gravityFactor>5</gravityFactor>
+			<shellingProps>
+				<tilesPerTick>0.005</tilesPerTick>
+				<range>50</range>
+				<iconPath>Things/Projectile/MFlux</iconPath>
+			</shellingProps>
+		</projectile>
+	</ThingDef>
+	
+	<ThingDef ParentName="BaseExplosiveBullet">
+		<defName>Bullet_Federation_PlasmaCluster</defName>
+		<thingClass>CombatExtended.ProjectileCE_HeightFuse</thingClass>
+		<label>energy bolt</label>
+		<graphicData>
+			<texPath>Things/Projectile/MFlux</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<shaderType>TransparentPostLight</shaderType>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Smoke</damageDef>
+			<soundExplode>Explosion_OpticBurst</soundExplode>
+			<damageAmountBase>0</damageAmountBase>
+			<explosionRadius>0.9</explosionRadius>
+			<speed>0</speed>
+			<flyOverhead>true</flyOverhead>
+			<dropsCasings>false</dropsCasings>
+			<damageAmountBase>0</damageAmountBase>
 			<explosionRadius>2.5</explosionRadius>
 			<gravityFactor>5</gravityFactor>
+			<aimHeightOffset>11</aimHeightOffset>
+			<shellingProps>
+				<tilesPerTick>0.005</tilesPerTick>
+				<range>50</range>
+				<damage>0.46</damage>
+				<iconPath>Things/Projectile/MFlux</iconPath>
+			</shellingProps>
+		</projectile>
+		<comps>
+			<li Class="CombatExtended.CompProperties_Fragments">
+				<fragments>
+					<Bullet_Federation_PlasmaSub>15</Bullet_Federation_PlasmaSub>
+				</fragments>
+				<fragAngleRange>-90~-10</fragAngleRange>
+			</li>
+		</comps>
+	</ThingDef>
+	
+	<ThingDef ParentName="BaseExplosiveBullet">
+		<defName>Bullet_Federation_PlasmaSub</defName>
+		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+		<label>energy bolt</label>
+		<graphicData>
+			<texPath>Things/Projectile/Plasma</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<shaderType>TransparentPostLight</shaderType>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Plasma</damageDef>
+			<speed>3</speed>
+			<flyOverhead>true</flyOverhead>
+			<dropsCasings>false</dropsCasings>
+			<damageAmountBase>30</damageAmountBase>
+			<explosionRadius>2.5</explosionRadius>
+			<gravityFactor>0.01</gravityFactor>
 		</projectile>
 	</ThingDef>
 
@@ -94,8 +184,8 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>40</damageAmountBase>
-			<explosionRadius>0.9</explosionRadius>
+			<damageAmountBase>36</damageAmountBase>
+			<explosionRadius>1</explosionRadius>
 		</projectile>
 	</ThingDef>
 
@@ -116,6 +206,10 @@
 			<dropsCasings>false</dropsCasings>
 			<damageAmountBase>120</damageAmountBase>
 			<explosionRadius>4</explosionRadius>
+			<shellingProps>
+				<tilesPerTick>0.01</tilesPerTick>
+				<range>45</range>
+			</shellingProps>
 		</projectile>
 	</ThingDef>
 
@@ -135,7 +229,7 @@
 			<gravityFactor>0.01</gravityFactor>
 			<dropsCasings>false</dropsCasings>
 			<damageAmountBase>30</damageAmountBase>
-			<explosionRadius>1.5</explosionRadius>
+			<explosionRadius>2.1</explosionRadius>
 		</projectile>
 	</ThingDef>
 
@@ -271,10 +365,32 @@
 		</projectile>
 	</ThingDef>
 
-	<!-- ==========  Plasma Caster Projectile =========== -->
+	<!-- ========== Plasma Caster Projectile =========== -->
 
 	<ThingDef ParentName="BasePlasmaBombCE">
 		<defName>Bullet_PlasmaCaster</defName>
+		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+		<label>plasma sphere</label>
+		<graphicData>
+			<texPath>Things/Projectile/Plasma</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Plasma</damageDef>
+			<speed>20</speed>
+			<gravityFactor>0.01</gravityFactor>
+			<dropsCasings>false</dropsCasings>
+			<damageAmountBase>25</damageAmountBase>
+			<explosionRadius>2.1</explosionRadius>
+			<pelletCount>4</pelletCount>
+			<spreadMult>4.45</spreadMult>
+		</projectile>
+	</ThingDef>
+
+	<!-- ========== Federation Plasma Caster Projectile =========== -->
+
+	<ThingDef ParentName="BasePlasmaBombCE">
+		<defName>Bullet_PlasmaCaster_Fed</defName>
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		<label>plasma sphere</label>
 		<graphicData>
@@ -287,7 +403,7 @@
 			<speed>8</speed>
 			<gravityFactor>0.01</gravityFactor>
 			<dropsCasings>false</dropsCasings>
-			<damageAmountBase>75</damageAmountBase>
+			<damageAmountBase>90</damageAmountBase>
 			<explosionRadius>3.5</explosionRadius>
 		</projectile>
 	</ThingDef>

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/Factions_Federation.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/Factions_Federation.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- ========== Custom shelling response for mechs ========== -->
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/FactionDef[defName="FPC"]</xpath>
+		<value>
+			<li Class="CombatExtended.FactionDefExtensionCE">
+				<shellingResponse>CE_ShellingPreset_Federation</shellingResponse>
+			</li>
+			<li Class="CombatExtended.WorldObjectHealthExtension">
+				<chanceToNegateDamage>0.2</chanceToNegateDamage>
+			</li>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_Apparel.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_Apparel.xml
@@ -180,6 +180,13 @@
 			<li>StrappedHead</li>
 		</value>
 	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_JudicatorH"]/apparel</xpath>
+		<value>
+			<parentTagDef>ApparelHead</parentTagDef>
+		</value>
+	</Operation>
 
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="Apparel_JudicatorH"]</xpath>
@@ -369,6 +376,13 @@
 			<li>StrappedHead</li>
 		</value>
 	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_MarksmanGearH"]/apparel</xpath>
+		<value>
+			<parentTagDef>ApparelHead</parentTagDef>
+		</value>
+	</Operation>
 
 	<!-- ========== Unity Guard Armor =========== -->
 	<Operation Class="PatchOperationAdd">
@@ -476,6 +490,13 @@
 		<value>
 			<li>OnHead</li>
 			<li>StrappedHead</li>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_UGHelmet"]/apparel</xpath>
+		<value>
+			<parentTagDef>ApparelHead</parentTagDef>
 		</value>
 	</Operation>
 

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_DamageDefs.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_DamageDefs.xml
@@ -1,16 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/DamageDef[defName="Optic"]</xpath>
-		<value>
-			<li Class="CombatExtended.DamageDefExtensionCE">
-				<isAmbientDamage>true</isAmbientDamage>
-			</li>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/DamageDef[defName="Plasma"]</xpath>
+		<xpath>Defs/DamageDef[
+		defName="Optic" or
+		defName="Crucible" or
+		defName="Plasma"
+		]</xpath>
 		<value>
 			<li Class="CombatExtended.DamageDefExtensionCE">
 				<isAmbientDamage>true</isAmbientDamage>

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_Explosives.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_Explosives.xml
@@ -221,4 +221,28 @@
 			</ThingDef>
 		</value>
 	</Operation>
+	
+	<!-- ========== Tools + Tradetag ========== -->
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="AD_FedPlasmaGrenades" or defName="AD_PBomb"]</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>Body</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>2</power>
+					<cooldownTime>1.75</cooldownTime>
+					<armorPenetrationBlunt>1.0</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Base</linkedBodyPartsGroup>
+				</li>
+			</tools>
+			<tradeTags Inherit="False">
+				<li>CE_MediumAmmo</li>
+			</tradeTags>
+			<allowedArchonexusCount>5</allowedArchonexusCount>
+		</value>
+	</Operation>
 </Patch>

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_MechWeapons.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_MechWeapons.xml
@@ -53,5 +53,9 @@
 			<aimedBurstShotCount>5</aimedBurstShotCount>
 			<aiAimMode>AimedShot</aiAimMode>
 		</FireModes>
+		<AmmoUser>
+			<magazineSize>52</magazineSize>
+			<reloadTime>9.2</reloadTime>
+		</AmmoUser>		
 	</Operation>
 </Patch>

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_MechWeapons.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_MechWeapons.xml
@@ -20,6 +20,7 @@
 			<soundCast>RS_ShotHarmonizer</soundCast>
 			<muzzleFlashScale>17</muzzleFlashScale>
 			<soundCastTail>GunTail_Heavy</soundCastTail>
+			<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
 		</Properties>
 		<FireModes>
 			<aiAimMode>AimedShot</aiAimMode>
@@ -35,7 +36,7 @@
 			<SwayFactor>1.21</SwayFactor>
 			<Bulk>28.00</Bulk>
 			<Mass>24.00</Mass>
-			<RangedWeapon_Cooldown>8</RangedWeapon_Cooldown>
+			<RangedWeapon_Cooldown>1.6</RangedWeapon_Cooldown>
 		</statBases>
 		<Properties>
 			<recoilAmount>1.18</recoilAmount>

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_MechWeapons.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_MechWeapons.xml
@@ -66,10 +66,6 @@
 		<FireModes>
 			<aimedBurstShotCount>5</aimedBurstShotCount>
 			<aiAimMode>AimedShot</aiAimMode>
-		</FireModes>
-		<AmmoUser>
-			<magazineSize>52</magazineSize>
-			<reloadTime>9.2</reloadTime>
-		</AmmoUser>		
+		</FireModes>	
 	</Operation>
 </Patch>

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_MechWeapons.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_MechWeapons.xml
@@ -9,19 +9,26 @@
 			<SwayFactor>0.91</SwayFactor>
 			<Bulk>30</Bulk>
 			<Mass>25</Mass>
-			<RangedWeapon_Cooldown>5</RangedWeapon_Cooldown>
+			<RangedWeapon_Cooldown>2.6</RangedWeapon_Cooldown>
 		</statBases>
 		<Properties>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_PlasmaMechBombard</defaultProjectile>
-			<warmupTime>4</warmupTime>
-			<range>56</range>
+			<warmupTime>4.55</warmupTime>
+			<range>44</range>
 			<soundCast>RS_ShotHarmonizer</soundCast>
 			<muzzleFlashScale>17</muzzleFlashScale>
 			<soundCastTail>GunTail_Heavy</soundCastTail>
 			<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
+			<targetParams>
+				<canTargetLocations>true</canTargetLocations>
+			</targetParams>
 		</Properties>
+		<AmmoUser>
+			<magazineSize>3</magazineSize>
+			<reloadTime>10</reloadTime>
+		</AmmoUser>
 		<FireModes>
 			<aiAimMode>AimedShot</aiAimMode>
 		</FireModes>
@@ -36,19 +43,26 @@
 			<SwayFactor>1.21</SwayFactor>
 			<Bulk>28.00</Bulk>
 			<Mass>24.00</Mass>
-			<RangedWeapon_Cooldown>1.6</RangedWeapon_Cooldown>
+			<RangedWeapon_Cooldown>0.4</RangedWeapon_Cooldown>
 		</statBases>
 		<Properties>
-			<recoilAmount>1.18</recoilAmount>
+			<recoilAmount>0.54</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_CrucibleCannon_CE</defaultProjectile>
-			<warmupTime>2.6</warmupTime>
+			<warmupTime>1.7</warmupTime>
 			<burstShotCount>13</burstShotCount>
 			<ticksBetweenBurstShots>22</ticksBetweenBurstShots>
 			<range>75</range>
 			<soundCast>RS_ShotCR</soundCast>
+			<targetParams>
+				<canTargetLocations>true</canTargetLocations>
+			</targetParams>
 		</Properties>
+		<AmmoUser>
+			<magazineSize>65</magazineSize>
+			<reloadTime>8</reloadTime>
+		</AmmoUser>
 		<FireModes>
 			<aimedBurstShotCount>5</aimedBurstShotCount>
 			<aiAimMode>AimedShot</aiAimMode>

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_MeleeWeapons.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_MeleeWeapons.xml
@@ -23,8 +23,8 @@
 						<li>Blunt</li>
 					</capacities>
 					<power>15</power>
-					<cooldownTime>0.63</cooldownTime>
-					<armorPenetrationBlunt>5.625</armorPenetrationBlunt>
+					<cooldownTime>0.95</cooldownTime>
+					<armorPenetrationBlunt>25.625</armorPenetrationBlunt>
 					<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
 				</li>
 			</tools>

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_RangedWeapons.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_RangedWeapons.xml
@@ -220,7 +220,7 @@
 			<recoilAmount>1.56</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_CrucibleRifle</defaultProjectile>
+			<defaultProjectile>Bullet_CrucibleRifleAD</defaultProjectile>
 			<warmupTime>1.1</warmupTime>
 			<burstShotCount>6</burstShotCount>
 			<ticksBetweenBurstShots>18</ticksBetweenBurstShots>
@@ -283,7 +283,7 @@
 			<recoilAmount>1.78</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_CruciblePistol</defaultProjectile>
+			<defaultProjectile>Bullet_CruciblePistolAD</defaultProjectile>
 			<warmupTime>0.6</warmupTime>
 			<burstShotCount>5</burstShotCount>
 			<ticksBetweenBurstShots>20</ticksBetweenBurstShots>
@@ -403,7 +403,7 @@
 			<recoilAmount>1.06</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_CruciblePrecisionRifle</defaultProjectile>
+			<defaultProjectile>Bullet_CruciblePrecisionRifleAD</defaultProjectile>
 			<warmupTime>1.1</warmupTime>
 			<range>75</range>
 			<soundCast>RS_ShotCPR</soundCast>
@@ -441,6 +441,7 @@
 			<targetParams>
 				<canTargetLocations>true</canTargetLocations>
 			</targetParams>
+			<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
 		</Properties>
 		<FireModes/>
 	</Operation>
@@ -471,6 +472,7 @@
 			<targetParams>
 				<canTargetLocations>true</canTargetLocations>
 			</targetParams>
+			<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
 		</Properties>
 		<FireModes/>
 	</Operation>

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_RangedWeapons.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_RangedWeapons.xml
@@ -101,22 +101,29 @@
 			<SwayFactor>1.34</SwayFactor>
 			<Bulk>10.80</Bulk>
 			<Mass>5.60</Mass>
-			<RangedWeapon_Cooldown>0.75</RangedWeapon_Cooldown>
+			<RangedWeapon_Cooldown>0.45</RangedWeapon_Cooldown>
 		</statBases>
 		<Properties>
-			<recoilAmount>1.48</recoilAmount>
+			<recoilAmount>0.74</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_PlasmaRifle_Fed</defaultProjectile>
-			<warmupTime>1.1</warmupTime>
+			<warmupTime>1.35</warmupTime>
 			<range>55</range>
 			<soundCast>RS_ShotCR</soundCast>
 			<muzzleFlashScale>12</muzzleFlashScale>
 			<soundCastTail>GunTail_Heavy</soundCastTail>
+			<targetParams>
+				<canTargetLocations>true</canTargetLocations>
+			</targetParams>
 		</Properties>
 		<FireModes>
 			<aiUseBurstMode>FALSE</aiUseBurstMode>
 		</FireModes>
+		<AmmoUser>
+			<magazineSize>3</magazineSize>
+			<reloadTime>5</reloadTime>
+		</AmmoUser>
 	</Operation>
 
 	<!-- ==========  Aux Pistol  =========== -->
@@ -131,11 +138,11 @@
 			<RangedWeapon_Cooldown>1.50</RangedWeapon_Cooldown>
 		</statBases>
 		<Properties>
-			<recoilAmount>2</recoilAmount>
+			<recoilAmount>1</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_AuxiliaryPistol</defaultProjectile>
-			<warmupTime>0.55</warmupTime>
+			<warmupTime>0.8</warmupTime>
 			<burstShotCount>2</burstShotCount>
 			<ticksBetweenBurstShots>25</ticksBetweenBurstShots>
 			<range>18</range>
@@ -145,6 +152,10 @@
 		<FireModes>
 			<aiUseBurstMode>FALSE</aiUseBurstMode>
 		</FireModes>
+		<AmmoUser>
+			<magazineSize>6</magazineSize>
+			<reloadTime>3</reloadTime>
+		</AmmoUser>
 	</Operation>
 
 	<!-- ==========  Makeshift Crucible Rifle  =========== -->
@@ -160,17 +171,21 @@
 			<RangedWeapon_Cooldown>1.15</RangedWeapon_Cooldown>
 		</statBases>
 		<Properties>
-			<recoilAmount>1.56</recoilAmount>
+			<recoilAmount>0.78</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_MakeshiftCrucibleRifle</defaultProjectile>
-			<warmupTime>1.1</warmupTime>
+			<warmupTime>1.7</warmupTime>
 			<range>55</range>
 			<soundCast>RS_ShotCP</soundCast>
 			<soundCastTail>GunTail_Heavy</soundCastTail>
 			<muzzleFlashScale>9</muzzleFlashScale>
 		</Properties>
 		<FireModes/>
+		<AmmoUser>
+			<magazineSize>6</magazineSize>
+			<reloadTime>6</reloadTime>
+		</AmmoUser>
 	</Operation>
 
 	<!-- ==========  AD Crucible Rifle  =========== -->
@@ -184,15 +199,15 @@
 			<SwayFactor>1.44</SwayFactor>
 			<Bulk>9.50</Bulk>
 			<Mass>4.80</Mass>
-			<RangedWeapon_Cooldown>0.95</RangedWeapon_Cooldown>
+			<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
 		</statBases>
 		<Properties>
-			<recoilAmount>1.56</recoilAmount>
+			<recoilAmount>0.78</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_CrucibleRifle</defaultProjectile>
-			<warmupTime>1.1</warmupTime>
-			<burstShotCount>6</burstShotCount>
+			<warmupTime>1.6</warmupTime>
+			<burstShotCount>5</burstShotCount>
 			<ticksBetweenBurstShots>25</ticksBetweenBurstShots>
 			<range>55</range>
 			<soundCast>RS_ShotCR</soundCast>
@@ -203,6 +218,10 @@
 			<aiUseBurstMode>TRUE</aiUseBurstMode>
 			<aiAimMode>AimedShot</aiAimMode>
 		</FireModes>
+		<AmmoUser>
+			<magazineSize>15</magazineSize>
+			<reloadTime>4</reloadTime>
+		</AmmoUser>
 	</Operation>
 
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -214,15 +233,15 @@
 			<SwayFactor>1.44</SwayFactor>
 			<Bulk>9.50</Bulk>
 			<Mass>4.80</Mass>
-			<RangedWeapon_Cooldown>0.95</RangedWeapon_Cooldown>
+			<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
 		</statBases>
 		<Properties>
-			<recoilAmount>1.56</recoilAmount>
+			<recoilAmount>0.78</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_CrucibleRifleAD</defaultProjectile>
-			<warmupTime>1.1</warmupTime>
-			<burstShotCount>6</burstShotCount>
+			<warmupTime>1.6</warmupTime>
+			<burstShotCount>5</burstShotCount>
 			<ticksBetweenBurstShots>18</ticksBetweenBurstShots>
 			<range>55</range>
 			<soundCast>RS_ShotCR</soundCast>
@@ -233,6 +252,10 @@
 			<aiUseBurstMode>TRUE</aiUseBurstMode>
 			<aiAimMode>AimedShot</aiAimMode>
 		</FireModes>
+		<AmmoUser>
+			<magazineSize>15</magazineSize>
+			<reloadTime>4</reloadTime>
+		</AmmoUser>
 	</Operation>
 
 	<!-- ==========  AD Crucible Pistol  =========== -->
@@ -245,17 +268,17 @@
 			<SwayFactor>1.08</SwayFactor>
 			<Bulk>3.90</Bulk>
 			<Mass>2.40</Mass>
-			<RangedWeapon_Cooldown>0.75</RangedWeapon_Cooldown>
+			<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
 		</statBases>
 		<Properties>
-			<recoilAmount>1.78</recoilAmount>
+			<recoilAmount>0.89</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_CruciblePistol</defaultProjectile>
-			<warmupTime>0.6</warmupTime>
+			<warmupTime>0.7</warmupTime>
 			<burstShotCount>5</burstShotCount>
-			<ticksBetweenBurstShots>20</ticksBetweenBurstShots>
-			<range>12</range>
+			<ticksBetweenBurstShots>15</ticksBetweenBurstShots>
+			<range>21</range>
 			<soundCast>RS_ShotCP</soundCast>
 			<muzzleFlashScale>12</muzzleFlashScale>
 		</Properties>
@@ -266,6 +289,10 @@
 			<aimedBurstShotCount>3</aimedBurstShotCount>
 			<aiUseBurstMode>FALSE</aiUseBurstMode>
 		</FireModes>
+		<AmmoUser>
+			<magazineSize>15</magazineSize>
+			<reloadTime>3</reloadTime>
+		</AmmoUser>
 	</Operation>
 
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -277,17 +304,17 @@
 			<SwayFactor>1.08</SwayFactor>
 			<Bulk>3.90</Bulk>
 			<Mass>2.40</Mass>
-			<RangedWeapon_Cooldown>0.75</RangedWeapon_Cooldown>
+			<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
 		</statBases>
 		<Properties>
-			<recoilAmount>1.78</recoilAmount>
+			<recoilAmount>0.89</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_CruciblePistolAD</defaultProjectile>
-			<warmupTime>0.6</warmupTime>
+			<warmupTime>0.7</warmupTime>
 			<burstShotCount>5</burstShotCount>
-			<ticksBetweenBurstShots>20</ticksBetweenBurstShots>
-			<range>12</range>
+			<ticksBetweenBurstShots>15</ticksBetweenBurstShots>
+			<range>21</range>
 			<soundCast>RS_ShotCP</soundCast>
 			<muzzleFlashScale>12</muzzleFlashScale>
 		</Properties>
@@ -298,6 +325,10 @@
 			<aimedBurstShotCount>3</aimedBurstShotCount>
 			<aiUseBurstMode>FALSE</aiUseBurstMode>
 		</FireModes>
+		<AmmoUser>
+			<magazineSize>15</magazineSize>
+			<reloadTime>3</reloadTime>
+		</AmmoUser>
 	</Operation>
 
 	<!-- ==========  AD Heat Cannon  =========== -->
@@ -309,16 +340,16 @@
 			<SwayFactor>1.48</SwayFactor>
 			<Bulk>12.70</Bulk>
 			<Mass>7.50</Mass>
-			<RangedWeapon_Cooldown>0.90</RangedWeapon_Cooldown>
+			<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
 		</statBases>
 		<Properties>
-			<recoilAmount>1.58</recoilAmount>
+			<recoilAmount>0.79</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_HeatCannon</defaultProjectile>
-			<warmupTime>1.1</warmupTime>
+			<warmupTime>1.35</warmupTime>
 			<burstShotCount>5</burstShotCount>
-			<ticksBetweenBurstShots>50</ticksBetweenBurstShots>
+			<ticksBetweenBurstShots>40</ticksBetweenBurstShots>
 			<range>55</range>
 			<soundCast>RS_ShotHC</soundCast>
 			<muzzleFlashScale>12</muzzleFlashScale>
@@ -330,6 +361,10 @@
 			<aimedBurstShotCount>3</aimedBurstShotCount>
 			<aiUseBurstMode>FALSE</aiUseBurstMode>
 		</FireModes>
+		<AmmoUser>
+			<magazineSize>30</magazineSize>
+			<reloadTime>6</reloadTime>
+		</AmmoUser>
 	</Operation>
 
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -340,16 +375,16 @@
 			<SwayFactor>1.48</SwayFactor>
 			<Bulk>12.70</Bulk>
 			<Mass>7.50</Mass>
-			<RangedWeapon_Cooldown>0.90</RangedWeapon_Cooldown>
+			<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
 		</statBases>
 		<Properties>
-			<recoilAmount>1.58</recoilAmount>
+			<recoilAmount>0.79</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_HeatCannon</defaultProjectile>
-			<warmupTime>1.1</warmupTime>
+			<warmupTime>1.35</warmupTime>
 			<burstShotCount>5</burstShotCount>
-			<ticksBetweenBurstShots>50</ticksBetweenBurstShots>
+			<ticksBetweenBurstShots>40</ticksBetweenBurstShots>
 			<range>55</range>
 			<soundCast>RS_ShotHC</soundCast>
 			<muzzleFlashScale>12</muzzleFlashScale>
@@ -361,6 +396,10 @@
 			<aimedBurstShotCount>3</aimedBurstShotCount>
 			<aiUseBurstMode>FALSE</aiUseBurstMode>
 		</FireModes>
+		<AmmoUser>
+			<magazineSize>30</magazineSize>
+			<reloadTime>6</reloadTime>
+		</AmmoUser>
 	</Operation>
 
 	<!-- ==========  AD Crucible Precision Rifle  =========== -->
@@ -372,14 +411,14 @@
 			<SwayFactor>1.46</SwayFactor>
 			<Bulk>12.40</Bulk>
 			<Mass>5.20</Mass>
-			<RangedWeapon_Cooldown>0.95</RangedWeapon_Cooldown>
+			<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
 		</statBases>
 		<Properties>
-			<recoilAmount>1.06</recoilAmount>
+			<recoilAmount>0.53</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_CruciblePrecisionRifle</defaultProjectile>
-			<warmupTime>1.1</warmupTime>
+			<warmupTime>1.6</warmupTime>
 			<range>75</range>
 			<soundCast>RS_ShotCPR</soundCast>
 			<muzzleFlashScale>12</muzzleFlashScale>
@@ -387,6 +426,10 @@
 		<FireModes>
 			<aiAimMode>AimedShot</aiAimMode>
 		</FireModes>
+		<AmmoUser>
+			<magazineSize>6</magazineSize>
+			<reloadTime>4</reloadTime>
+		</AmmoUser>
 	</Operation>
 
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -397,14 +440,14 @@
 			<SwayFactor>1.46</SwayFactor>
 			<Bulk>12.40</Bulk>
 			<Mass>5.20</Mass>
-			<RangedWeapon_Cooldown>0.95</RangedWeapon_Cooldown>
+			<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
 		</statBases>
 		<Properties>
-			<recoilAmount>1.06</recoilAmount>
+			<recoilAmount>0.53</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_CruciblePrecisionRifleAD</defaultProjectile>
-			<warmupTime>1.1</warmupTime>
+			<warmupTime>1.6</warmupTime>
 			<range>75</range>
 			<soundCast>RS_ShotCPR</soundCast>
 			<muzzleFlashScale>12</muzzleFlashScale>
@@ -412,6 +455,10 @@
 		<FireModes>
 			<aiAimMode>AimedShot</aiAimMode>
 		</FireModes>
+		<AmmoUser>
+			<magazineSize>6</magazineSize>
+			<reloadTime>4</reloadTime>
+		</AmmoUser>
 	</Operation>
 
 	<!-- ==========  AD Plasma Caster  =========== -->
@@ -423,18 +470,16 @@
 			<SwayFactor>1.96</SwayFactor>
 			<Bulk>18.20</Bulk>
 			<Mass>10.00</Mass>
-			<RangedWeapon_Cooldown>1.75</RangedWeapon_Cooldown>
+			<RangedWeapon_Cooldown>1.2</RangedWeapon_Cooldown>
 		</statBases>
 		<Properties>
-			<recoilAmount>5</recoilAmount>
+			<recoilAmount>0.50</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_PlasmaCaster</defaultProjectile>
-			<warmupTime>3.25</warmupTime>
+			<warmupTime>1.9</warmupTime>
 			<minRange>3</minRange>
-			<burstShotCount>3</burstShotCount>
-			<ticksBetweenBurstShots>8</ticksBetweenBurstShots>
-			<range>40</range>
+			<range>35</range>
 			<soundCast>RS_ShotHarmonizer</soundCast>
 			<soundCastTail>GunTail_Heavy</soundCastTail>
 			<muzzleFlashScale>18</muzzleFlashScale>
@@ -444,6 +489,10 @@
 			<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
 		</Properties>
 		<FireModes/>
+		<AmmoUser>
+			<magazineSize>3</magazineSize>
+			<reloadTime>5</reloadTime>
+		</AmmoUser>
 	</Operation>
 
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -454,18 +503,16 @@
 			<SwayFactor>1.96</SwayFactor>
 			<Bulk>18.20</Bulk>
 			<Mass>10.00</Mass>
-			<RangedWeapon_Cooldown>1.75</RangedWeapon_Cooldown>
+			<RangedWeapon_Cooldown>1.2</RangedWeapon_Cooldown>
 		</statBases>
 		<Properties>
-			<recoilAmount>5</recoilAmount>
+			<recoilAmount>0.50</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_PlasmaCaster</defaultProjectile>
-			<warmupTime>4.25</warmupTime>
+			<defaultProjectile>Bullet_PlasmaCaster_Fed</defaultProjectile>
+			<warmupTime>1.9</warmupTime>
 			<minRange>3</minRange>
-			<burstShotCount>3</burstShotCount>
-			<ticksBetweenBurstShots>8</ticksBetweenBurstShots>
-			<range>40</range>
+			<range>35</range>
 			<soundCast>RS_ShotHarmonizer</soundCast>
 			<soundCastTail>GunTail_Heavy</soundCastTail>
 			<muzzleFlashScale>18</muzzleFlashScale>
@@ -475,6 +522,10 @@
 			<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
 		</Properties>
 		<FireModes/>
+		<AmmoUser>
+			<magazineSize>3</magazineSize>
+			<reloadTime>5</reloadTime>
+		</AmmoUser>
 	</Operation>
 
 	<!-- ==========  AD Crucible Carbine  =========== -->
@@ -487,14 +538,14 @@
 			<SwayFactor>1.11</SwayFactor>
 			<Bulk>8.20</Bulk>
 			<Mass>4.10</Mass>
-			<RangedWeapon_Cooldown>0.85</RangedWeapon_Cooldown>
+			<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
 		</statBases>
 		<Properties>
-			<recoilAmount>1.38</recoilAmount>
+			<recoilAmount>0.69</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_CrucibleCarbine</defaultProjectile>
-			<warmupTime>0.85</warmupTime>
+			<warmupTime>1.07</warmupTime>
 			<burstShotCount>5</burstShotCount>
 			<ticksBetweenBurstShots>22</ticksBetweenBurstShots>
 			<range>32</range>
@@ -505,5 +556,9 @@
 			<aimedBurstShotCount>3</aimedBurstShotCount>
 			<aiUseBurstMode>FALSE</aiUseBurstMode>
 		</FireModes>
+		<AmmoUser>
+			<magazineSize>15</magazineSize>
+			<reloadTime>4</reloadTime>
+		</AmmoUser>
 	</Operation>
 </Patch>

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_RangedWeapons.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_RangedWeapons.xml
@@ -544,7 +544,7 @@
 			<recoilAmount>0.69</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_CrucibleCarbine</defaultProjectile>
+			<defaultProjectile>Bullet_CrucibleCarbine_CE</defaultProjectile>
 			<warmupTime>1.07</warmupTime>
 			<burstShotCount>5</burstShotCount>
 			<ticksBetweenBurstShots>22</ticksBetweenBurstShots>

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_Security.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_Security.xml
@@ -4,9 +4,19 @@
 		<xpath>Defs/ThingDef[
 			@Name="FedHarvester" or
 			@Name="Harmonizer"
-			]/thingClass </xpath>
+			]/thingClass</xpath>
 		<value>
 			<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[
+			defName="Turret_FedHarvester" or
+			defName="Turret_PB"
+			]/building/turretBurstCooldownTime</xpath>
+		<value>
+			<turretBurstCooldownTime>0.4</turretBurstCooldownTime>
 		</value>
 	</Operation>
 
@@ -20,17 +30,17 @@
 			<SwayFactor>0.80</SwayFactor>
 			<Bulk>22.00</Bulk>
 			<Mass>18.50</Mass>
-			<RangedWeapon_Cooldown>1.55</RangedWeapon_Cooldown>
+			<RangedWeapon_Cooldown>0.4</RangedWeapon_Cooldown>
 		</statBases>
 		<Properties>
-			<recoilAmount>1.12</recoilAmount>
+			<recoilAmount>0.54</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_HarvesterCannon</defaultProjectile>
 			<warmupTime>1.55</warmupTime>
-			<ticksBetweenBurstShots>10</ticksBetweenBurstShots>
-			<burstShotCount>10</burstShotCount>
-			<range>55</range>
+			<ticksBetweenBurstShots>20</ticksBetweenBurstShots>
+			<burstShotCount>13</burstShotCount>
+			<range>75</range>
 			<soundCast>RS_ShotCR</soundCast>
 			<soundCastTail>GunTail_Medium</soundCastTail>
 			<muzzleFlashScale>12</muzzleFlashScale>
@@ -39,9 +49,13 @@
 			</targetParams>
 			<recoilPattern>Mounted</recoilPattern>
 		</Properties>
+		<AmmoUser>
+			<magazineSize>65</magazineSize>
+			<reloadTime>8</reloadTime>
+		</AmmoUser>
 		<FireModes>
 			<aimedBurstShotCount>5</aimedBurstShotCount>
-			<aiUseBurstMode>TRUE</aiUseBurstMode>
+			<aiAimMode>AimedShot</aiAimMode>
 		</FireModes>
 	</Operation>
 
@@ -53,13 +67,24 @@
 			<comps>
 				<li Class="CombatExtended.CompProperties_Charges">
 					<chargeSpeeds>
-						<li>30</li>
-						<li>50</li>
-						<li>70</li>
-						<li>90</li>
+						<li>15</li>
+						<li>25</li>
+						<li>35</li>
+						<li>45</li>
 					</chargeSpeeds>
 				</li>
+				<li Class="CombatExtended.CompProperties_AmmoUser">
+					<magazineSize>1</magazineSize>
+					<reloadTime>20</reloadTime>
+				</li>
 			</comps>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName = "Gun_PB"]/statBases</xpath>
+		<value>
+			<ShotSpread>0.4</ShotSpread>
 		</value>
 	</Operation>
 
@@ -73,9 +98,9 @@
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_PlasmaTurretBombard</defaultProjectile>
 					<warmupTime>3.55</warmupTime>
-					<range>500</range>
+					<range>900</range>
 					<minRange>25</minRange>
-					<burstShotCount>10</burstShotCount>
+					<burstShotCount>1</burstShotCount>
 					<soundCast>RS_ShotHarmonizer</soundCast>
 					<soundCastTail>GunTail_Heavy</soundCastTail>
 					<muzzleFlashScale>26</muzzleFlashScale>
@@ -95,6 +120,7 @@
 			<weaponTags>
 				<li>Artillery</li>
 				<li>TurretGun</li>
+				<li>Artillery_BaseDestroyer</li>
 			</weaponTags>
 		</value>
 	</Operation>

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Races/Race_Bion.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Races/Race_Bion.xml
@@ -9,41 +9,120 @@
 			</li>
 		</value>
 	</Operation>
+	
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[@Name="BaseBion"]</xpath>
+		<value>
+			<li Class="CombatExtended.PartialArmorExt">
+				<stats>
+					<li>
+						<useStatic>false</useStatic>
+						<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
+						<parts>
+							<li>Eye</li>
+						</parts>
+					</li>
+					<li>
+						<useStatic>false</useStatic>
+						<ArmorRating_Blunt>0.25</ArmorRating_Blunt>
+						<parts>
+							<li>Eye</li>
+						</parts>
+					</li>
+				</stats>
+			</li>
+		</value>
+	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Bion_Base"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
-			<ArmorRating_Blunt>12</ArmorRating_Blunt>
+			<ArmorRating_Blunt>30</ArmorRating_Blunt>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Bion_Base"]/statBases/ArmorRating_Heat</xpath>
 		<value>
-			<ArmorRating_Heat>0.70</ArmorRating_Heat>
+			<ArmorRating_Heat>1.40</ArmorRating_Heat>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Bion_Base"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
-			<ArmorRating_Sharp>22</ArmorRating_Sharp>
+			<ArmorRating_Sharp>44</ArmorRating_Sharp>
 			<NightVisionEfficiency>0.70</NightVisionEfficiency>
+			<PainShockThreshold>1</PainShockThreshold>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Bion_Stalker"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
-			<ArmorRating_Sharp>18</ArmorRating_Sharp>
+			<ArmorRating_Sharp>36</ArmorRating_Sharp>
+			<ArmorRating_Blunt>15</ArmorRating_Blunt>
 			<NightVisionEfficiency>0.90</NightVisionEfficiency>
+			<PainShockThreshold>1</PainShockThreshold>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Bion_Stalker"]/statBases/ArmorRating_Heat</xpath>
 		<value>
-			<ArmorRating_Heat>0.70</ArmorRating_Heat>
+			<ArmorRating_Heat>1.40</ArmorRating_Heat>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="Bion_Base"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Bion_Base"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Bion_Base"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>700</Durability>
+				<Regenerates>true</Regenerates>
+				<RegenInterval>600</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<MinArmorPct>0</MinArmorPct>
+				<MinArmorValueSharp>16.5</MinArmorValueSharp>
+				<MinArmorValueBlunt>6</MinArmorValueBlunt>
+				<MinArmorValueHeat>0.7</MinArmorValueHeat>
+			</li>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="Bion_Stalker"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Bion_Stalker"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Bion_Stalker"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>375</Durability>
+				<Regenerates>true</Regenerates>
+				<RegenInterval>600</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<MinArmorPct>0</MinArmorPct>
+				<MinArmorValueSharp>13.5</MinArmorValueSharp>
+				<MinArmorValueBlunt>3</MinArmorValueBlunt>
+				<MinArmorValueHeat>0.7</MinArmorValueHeat>
+			</li>
 		</value>
 	</Operation>
 
@@ -52,8 +131,8 @@
 		<value>
 			<CarryWeight>50</CarryWeight>
 			<CarryBulk>50</CarryBulk>
-			<AimingAccuracy>1.2</AimingAccuracy>
-			<ShootingAccuracyPawn>1.2</ShootingAccuracyPawn>
+			<AimingAccuracy>1.3</AimingAccuracy>
+			<ShootingAccuracyPawn>1.3</ShootingAccuracyPawn>
 			<MeleeDodgeChance>0.15</MeleeDodgeChance>
 			<MeleeCritChance>0.15</MeleeCritChance>
 			<MeleeParryChance>0.1</MeleeParryChance>
@@ -82,7 +161,7 @@
 					<capacities>
 						<li>Blunt</li>
 					</capacities>
-					<power>2</power>
+					<power>8</power>
 					<cooldownTime>1.5</cooldownTime>
 					<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
 					<surpriseAttack>
@@ -93,14 +172,14 @@
 							</li>
 						</extraMeleeDamages>
 					</surpriseAttack>
-					<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+					<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>right fist</label>
 					<capacities>
-						<li>Blunt</li>
+						<li>Stab</li>
 					</capacities>
-					<power>2</power>
+					<power>12</power>
 					<cooldownTime>1.5</cooldownTime>
 					<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
 					<surpriseAttack>
@@ -111,7 +190,8 @@
 							</li>
 						</extraMeleeDamages>
 					</surpriseAttack>
-					<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+					<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
+					<armorPenetrationSharp>5</armorPenetrationSharp>
 				</li>
 			</tools>
 		</value>

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Races/Race_Bion.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Races/Race_Bion.xml
@@ -53,7 +53,6 @@
 		<value>
 			<ArmorRating_Sharp>44</ArmorRating_Sharp>
 			<NightVisionEfficiency>0.70</NightVisionEfficiency>
-			<PainShockThreshold>1</PainShockThreshold>
 		</value>
 	</Operation>
 
@@ -63,7 +62,6 @@
 			<ArmorRating_Sharp>36</ArmorRating_Sharp>
 			<ArmorRating_Blunt>15</ArmorRating_Blunt>
 			<NightVisionEfficiency>0.90</NightVisionEfficiency>
-			<PainShockThreshold>1</PainShockThreshold>
 		</value>
 	</Operation>
 
@@ -127,13 +125,27 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Bion_Base" or defName="Bion_Stalker"]/statBases</xpath>
+		<xpath>Defs/ThingDef[defName="Bion_Base"]/statBases</xpath>
 		<value>
 			<CarryWeight>50</CarryWeight>
 			<CarryBulk>50</CarryBulk>
-			<AimingAccuracy>1.3</AimingAccuracy>
-			<ShootingAccuracyPawn>1.3</ShootingAccuracyPawn>
+			<AimingAccuracy>1.2</AimingAccuracy>
+			<ShootingAccuracyPawn>1.2</ShootingAccuracyPawn>
 			<MeleeDodgeChance>0.15</MeleeDodgeChance>
+			<MeleeCritChance>0.15</MeleeCritChance>
+			<MeleeParryChance>0.1</MeleeParryChance>
+			<SmokeSensitivity>0</SmokeSensitivity>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Bion_Stalker"]/statBases</xpath>
+		<value>
+			<CarryWeight>50</CarryWeight>
+			<CarryBulk>50</CarryBulk>
+			<AimingAccuracy>1.45</AimingAccuracy>
+			<ShootingAccuracyPawn>1.45</ShootingAccuracyPawn>
+			<MeleeDodgeChance>0.20</MeleeDodgeChance>
 			<MeleeCritChance>0.15</MeleeCritChance>
 			<MeleeParryChance>0.1</MeleeParryChance>
 			<SmokeSensitivity>0</SmokeSensitivity>
@@ -218,26 +230,12 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/ThingDef[@Name="BaseBion"]/damageMultipliers</xpath>
+		<xpath>Defs/PawnKindDef[@Name="BaseBionKind"]/ignoresPainShock</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[@Name="BaseBion"]</xpath>
+			<xpath>Defs/PawnKindDef[@Name="BaseBionKind"]</xpath>
 			<value>
-				<damageMultipliers/>
+				<ignoresPainShock>true</ignoresPainShock>
 			</value>
 		</nomatch>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[@Name="BaseBion"]/damageMultipliers</xpath>
-		<value>
-			<li>
-				<damageDef>Blunt</damageDef>
-				<multiplier>0.75</multiplier>
-			</li>
-			<li>
-				<damageDef>Bomb_Secondary</damageDef>
-				<multiplier>0.25</multiplier>
-			</li>
-		</value>
 	</Operation>
 </Patch>

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Races/Race_FederatorMech.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Races/Race_FederatorMech.xml
@@ -9,11 +9,18 @@
 			</li>
 		</value>
 	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Mech_Federator"]/race/baseHealthScale</xpath>
+		<value>
+			<baseHealthScale>7</baseHealthScale>
+		</value>
+	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mech_Federator"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
-			<ArmorRating_Blunt>200</ArmorRating_Blunt>
+			<ArmorRating_Blunt>400</ArmorRating_Blunt>
 		</value>
 	</Operation>
 
@@ -21,7 +28,6 @@
 		<xpath>Defs/ThingDef[defName="Mech_Federator"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>75</ArmorRating_Sharp>
-			<PainShockThreshold>1</PainShockThreshold>
 		</value>
 	</Operation>
 
@@ -44,6 +50,7 @@
 			<MeleeParryChance>0.3</MeleeParryChance>
 			<SmokeSensitivity>0</SmokeSensitivity>
 			<NightVisionEfficiency>0.80</NightVisionEfficiency>
+			<MeleeHitChance>1.5</MeleeHitChance>
 		</value>
 	</Operation>
 	
@@ -61,13 +68,13 @@
 		<xpath>Defs/ThingDef[defName="Mech_Federator"]/comps</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
-				<Durability>1875</Durability>
+				<Durability>3750</Durability>
 				<Regenerates>true</Regenerates>
 				<RegenInterval>600</RegenInterval>
 				<RegenValue>5</RegenValue>
 				<MinArmorPct>0</MinArmorPct>
 				<MinArmorValueSharp>26.25</MinArmorValueSharp>
-				<MinArmorValueBlunt>20</MinArmorValueBlunt>
+				<MinArmorValueBlunt>40</MinArmorValueBlunt>
 				<MinArmorValueHeat>0.7</MinArmorValueHeat>
 			</li>
 		</value>
@@ -79,15 +86,15 @@
 			<li Class="CombatExtended.PartialArmorExt">
 				<stats>
 					<li>
-						<useStatic>false</useStatic>
-						<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
+						<useStatic>true</useStatic>
+						<ArmorRating_Sharp>28</ArmorRating_Sharp>
 						<parts>
 							<li>SightSensor</li>
 						</parts>
 					</li>
 					<li>
-						<useStatic>false</useStatic>
-						<ArmorRating_Blunt>0.25</ArmorRating_Blunt>
+						<useStatic>true</useStatic>
+						<ArmorRating_Blunt>28</ArmorRating_Blunt>
 						<parts>
 							<li>SightSensor</li>
 						</parts>
@@ -118,7 +125,7 @@
 					<capacities>
 						<li>Blunt</li>
 					</capacities>
-					<power>35</power>
+					<power>40</power>
 					<cooldownTime>2.67</cooldownTime>
 					<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
 					<surpriseAttack>
@@ -129,14 +136,14 @@
 							</li>
 						</extraMeleeDamages>
 					</surpriseAttack>
-					<armorPenetrationBlunt>15</armorPenetrationBlunt>
+					<armorPenetrationBlunt>37.5</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>right fist</label>
 					<capacities>
 						<li>Stab</li>
 					</capacities>
-					<power>45</power>
+					<power>55</power>
 					<cooldownTime>2.67</cooldownTime>
 					<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
 					<surpriseAttack>
@@ -147,10 +154,20 @@
 							</li>
 						</extraMeleeDamages>
 					</surpriseAttack>
-					<armorPenetrationBlunt>15</armorPenetrationBlunt>
-					<armorPenetrationSharp>10</armorPenetrationSharp>
+					<armorPenetrationBlunt>37.5</armorPenetrationBlunt>
+					<armorPenetrationSharp>15</armorPenetrationSharp>
 				</li>
 			</tools>
 		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/PawnKindDef[@Name="BaseMechKind"]/ignoresPainShock</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/PawnKindDef[@Name="BaseMechKind"]</xpath>
+			<value>
+				<ignoresPainShock>true</ignoresPainShock>
+			</value>
+		</nomatch>
 	</Operation>
 </Patch>

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Races/Race_FederatorMech.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Races/Race_FederatorMech.xml
@@ -13,21 +13,22 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mech_Federator"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
-			<ArmorRating_Blunt>40</ArmorRating_Blunt>
+			<ArmorRating_Blunt>200</ArmorRating_Blunt>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mech_Federator"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
-			<ArmorRating_Sharp>35</ArmorRating_Sharp>
+			<ArmorRating_Sharp>75</ArmorRating_Sharp>
+			<PainShockThreshold>1</PainShockThreshold>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mech_Federator"]/statBases/ArmorRating_Heat</xpath>
 		<value>
-			<ArmorRating_Heat>0.95</ArmorRating_Heat>
+			<ArmorRating_Heat>1.90</ArmorRating_Heat>
 		</value>
 	</Operation>
 
@@ -36,13 +37,63 @@
 		<value>
 			<CarryWeight>60</CarryWeight>
 			<CarryBulk>60</CarryBulk>
-			<AimingAccuracy>1.1</AimingAccuracy>
-			<ShootingAccuracyPawn>1.1</ShootingAccuracyPawn>
+			<AimingAccuracy>1.4</AimingAccuracy>
+			<ShootingAccuracyPawn>1.4</ShootingAccuracyPawn>
 			<MeleeDodgeChance>0.05</MeleeDodgeChance>
 			<MeleeCritChance>0.4</MeleeCritChance>
 			<MeleeParryChance>0.3</MeleeParryChance>
 			<SmokeSensitivity>0</SmokeSensitivity>
 			<NightVisionEfficiency>0.80</NightVisionEfficiency>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="Mech_Federator"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Mech_Federator"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Mech_Federator"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>1875</Durability>
+				<Regenerates>true</Regenerates>
+				<RegenInterval>600</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<MinArmorPct>0</MinArmorPct>
+				<MinArmorValueSharp>26.25</MinArmorValueSharp>
+				<MinArmorValueBlunt>20</MinArmorValueBlunt>
+				<MinArmorValueHeat>0.7</MinArmorValueHeat>
+			</li>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="Mech_Federator"]</xpath>
+		<value>
+			<li Class="CombatExtended.PartialArmorExt">
+				<stats>
+					<li>
+						<useStatic>false</useStatic>
+						<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
+						<parts>
+							<li>SightSensor</li>
+						</parts>
+					</li>
+					<li>
+						<useStatic>false</useStatic>
+						<ArmorRating_Blunt>0.25</ArmorRating_Blunt>
+						<parts>
+							<li>SightSensor</li>
+						</parts>
+					</li>
+				</stats>
+			</li>
 		</value>
 	</Operation>
 
@@ -83,9 +134,9 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>right fist</label>
 					<capacities>
-						<li>Blunt</li>
+						<li>Stab</li>
 					</capacities>
-					<power>35</power>
+					<power>45</power>
 					<cooldownTime>2.67</cooldownTime>
 					<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
 					<surpriseAttack>
@@ -97,6 +148,7 @@
 						</extraMeleeDamages>
 					</surpriseAttack>
 					<armorPenetrationBlunt>15</armorPenetrationBlunt>
+					<armorPenetrationSharp>10</armorPenetrationSharp>
 				</li>
 			</tools>
 		</value>

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Races/Race_Hulk.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Races/Race_Hulk.xml
@@ -21,7 +21,6 @@
 		<xpath>Defs/ThingDef[defName="Bion_Hulk"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>50</ArmorRating_Sharp>
-			<PainShockThreshold>1</PainShockThreshold>
 		</value>
 	</Operation>
 
@@ -37,8 +36,8 @@
 		<value>
 			<CarryWeight>60</CarryWeight>
 			<CarryBulk>60</CarryBulk>
-			<AimingAccuracy>1.3</AimingAccuracy>
-			<ShootingAccuracyPawn>1.3</ShootingAccuracyPawn>
+			<AimingAccuracy>1.2</AimingAccuracy>
+			<ShootingAccuracyPawn>1.2</ShootingAccuracyPawn>
 			<MeleeDodgeChance>0.10</MeleeDodgeChance>
 			<MeleeCritChance>0.2</MeleeCritChance>
 			<MeleeParryChance>0.10</MeleeParryChance>

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Races/Race_Hulk.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Races/Race_Hulk.xml
@@ -13,21 +13,22 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Bion_Hulk"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
-			<ArmorRating_Blunt>20</ArmorRating_Blunt>
+			<ArmorRating_Blunt>50</ArmorRating_Blunt>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Bion_Hulk"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
-			<ArmorRating_Sharp>25</ArmorRating_Sharp>
+			<ArmorRating_Sharp>50</ArmorRating_Sharp>
+			<PainShockThreshold>1</PainShockThreshold>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Bion_Stalker"]/statBases/ArmorRating_Heat</xpath>
+		<xpath>Defs/ThingDef[defName="Bion_Hulk"]/statBases/ArmorRating_Heat</xpath>
 		<value>
-			<ArmorRating_Heat>0.85</ArmorRating_Heat>
+			<ArmorRating_Heat>1.7</ArmorRating_Heat>
 		</value>
 	</Operation>
 
@@ -36,13 +37,39 @@
 		<value>
 			<CarryWeight>60</CarryWeight>
 			<CarryBulk>60</CarryBulk>
-			<AimingAccuracy>1.2</AimingAccuracy>
-			<ShootingAccuracyPawn>1.2</ShootingAccuracyPawn>
+			<AimingAccuracy>1.3</AimingAccuracy>
+			<ShootingAccuracyPawn>1.3</ShootingAccuracyPawn>
 			<MeleeDodgeChance>0.10</MeleeDodgeChance>
 			<MeleeCritChance>0.2</MeleeCritChance>
 			<MeleeParryChance>0.10</MeleeParryChance>
 			<SmokeSensitivity>0</SmokeSensitivity>
 			<NightVisionEfficiency>0.80</NightVisionEfficiency>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="Bion_Hulk"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Bion_Hulk"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Bion_Hulk"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>1015</Durability>
+				<Regenerates>true</Regenerates>
+				<RegenInterval>600</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<MinArmorPct>0</MinArmorPct>
+				<MinArmorValueSharp>18.75</MinArmorValueSharp>
+				<MinArmorValueBlunt>10</MinArmorValueBlunt>
+				<MinArmorValueHeat>0.7</MinArmorValueHeat>
+			</li>
 		</value>
 	</Operation>
 
@@ -67,7 +94,7 @@
 					<capacities>
 						<li>Blunt</li>
 					</capacities>
-					<power>7</power>
+					<power>12</power>
 					<cooldownTime>2.24</cooldownTime>
 					<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
 					<surpriseAttack>
@@ -78,14 +105,14 @@
 							</li>
 						</extraMeleeDamages>
 					</surpriseAttack>
-					<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
+					<armorPenetrationBlunt>7.5</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>right fist</label>
 					<capacities>
-						<li>Blunt</li>
+						<li>Stab</li>
 					</capacities>
-					<power>5</power>
+					<power>20</power>
 					<cooldownTime>2.24</cooldownTime>
 					<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
 					<surpriseAttack>
@@ -96,7 +123,8 @@
 							</li>
 						</extraMeleeDamages>
 					</surpriseAttack>
-					<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
+					<armorPenetrationBlunt>7.5</armorPenetrationBlunt>
+					<armorPenetrationSharp>5</armorPenetrationSharp>
 				</li>
 			</tools>
 		</value>

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Races/Race_SeekerMech.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Races/Race_SeekerMech.xml
@@ -13,14 +13,15 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Mech_Seeker"]/statBases</xpath>
 		<value>
-			<ArmorRating_Blunt>5</ArmorRating_Blunt>
+			<ArmorRating_Blunt>8</ArmorRating_Blunt>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mech_Seeker"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
-			<ArmorRating_Sharp>6</ArmorRating_Sharp>
+			<ArmorRating_Sharp>4</ArmorRating_Sharp>
+			<PainShockThreshold>1</PainShockThreshold>
 		</value>
 	</Operation>
 
@@ -36,6 +37,31 @@
 			<MeleeParryChance>0.025</MeleeParryChance>
 			<SmokeSensitivity>0</SmokeSensitivity>
 			<NightVisionEfficiency>1</NightVisionEfficiency>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="Mech_Seeker"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Mech_Seeker"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Mech_Seeker"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>125</Durability>
+				<Regenerates>true</Regenerates>
+				<RegenInterval>600</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<MinArmorPct>0</MinArmorPct>
+				<MinArmorValueSharp>2</MinArmorValueSharp>
+				<MinArmorValueBlunt>0</MinArmorValueBlunt>
+			</li>
 		</value>
 	</Operation>
 

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Races/Race_SeekerMech.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Races/Race_SeekerMech.xml
@@ -21,7 +21,6 @@
 		<xpath>Defs/ThingDef[defName="Mech_Seeker"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>4</ArmorRating_Sharp>
-			<PainShockThreshold>1</PainShockThreshold>
 		</value>
 	</Operation>
 

--- a/ModPatches/Rimsenal Feral/Defs/Rimsenal Feral/ThingDefs_Misc/Ammo_Feral.xml
+++ b/ModPatches/Rimsenal Feral/Defs/Rimsenal Feral/ThingDefs_Misc/Ammo_Feral.xml
@@ -26,8 +26,7 @@
 			<Ammo_Feral_Scrap>Bullet_Feral_Scrap</Ammo_Feral_Scrap>
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
-	
-	
+
 	<CombatExtended.AmmoSetDef>
 		<defName>AmmoSet_Feral_Rivet</defName>
 		<label>nail</label>

--- a/ModPatches/Rimsenal Feral/Defs/Rimsenal Feral/ThingDefs_Misc/Ammo_Feral.xml
+++ b/ModPatches/Rimsenal Feral/Defs/Rimsenal Feral/ThingDefs_Misc/Ammo_Feral.xml
@@ -26,6 +26,15 @@
 			<Ammo_Feral_Scrap>Bullet_Feral_Scrap</Ammo_Feral_Scrap>
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
+	
+	
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_Feral_Rivet</defName>
+		<label>nail</label>
+		<ammoTypes>
+			<Ammo_Feral_Scrap>Bullet_Feral_Rivet</Ammo_Feral_Scrap>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->
 
@@ -74,22 +83,26 @@
 			<dropsCasings>false</dropsCasings>
 		</projectile>
 	</ThingDef>
+	
+
+	<ThingDef ParentName="Base556x45mmNATOBullet">
+		<defName>Bullet_Feral_Rivet</defName>
+		<label>rivet</label>
+		<graphicData>
+			<texPath>Projectile/Crucifier</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>73</speed>
+			<dropsCasings>false</dropsCasings>
+			<damageAmountBase>21</damageAmountBase>
+			<armorPenetrationBlunt>41</armorPenetrationBlunt>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
+		</projectile>
+	</ThingDef>
 
 	<!-- ==================== Nails ========================== -->
-
-	<ThingCategoryDef>
-		<defName>AmmoFeralNail</defName>
-		<label>nail</label>
-		<parent>AmmoRifles</parent>
-		<iconPath>Things/Ammo/Nail/Nail_c</iconPath>
-	</ThingCategoryDef>
-
-	<CombatExtended.AmmoCategoryDef>
-		<defName>FeralNail</defName>
-		<label>nail</label>
-		<labelShort>nail</labelShort>
-		<description>Rusty, pointy nails arranged in strips.</description>
-	</CombatExtended.AmmoCategoryDef>
 
 	<!-- ==================== AmmoSet ========================== -->
 
@@ -97,43 +110,13 @@
 		<defName>AmmoSet_Feral_Nail</defName>
 		<label>nail</label>
 		<ammoTypes>
-			<Ammo_Feral_Nail>Bullet_Feral_Nail</Ammo_Feral_Nail>
+			<Ammo_Nail>Bullet_Feral_Nail</Ammo_Nail>
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
 
-	<!-- ==================== Ammo ========================== -->
-
-	<ThingDef Class="CombatExtended.AmmoDef" Name="BaseFeralNail" ParentName="SmallAmmoBase" Abstract="True">
-		<description>A pointed, slightly rusty carpentry nail a few inches long. While an extremely inaccurate projectile at best, its shape means it tends to tumble when it strikes a target, leaving large wounds.</description>
-		<statBases>
-			<Mass>0.02</Mass>
-			<Bulk>0.02</Bulk>
-		</statBases>
-		<tradeTags>
-			<li>CE_AutoEnableTrade</li>
-			<li>CE_AutoEnableCrafting</li>
-		</tradeTags>
-		<thingCategories>
-			<li>AmmoFeralNail</li>
-		</thingCategories>
-	</ThingDef>
-
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseFeralNail">
-		<defName>Ammo_Feral_Nail</defName>
-		<label>nail</label>
-		<graphicData>
-			<texPath>Things/Ammo/Nail</texPath>
-			<graphicClass>Graphic_StackCount</graphicClass>
-		</graphicData>
-		<statBases>
-			<MarketValue>0.02</MarketValue>
-		</statBases>
-		<ammoClass>FeralNail</ammoClass>
-	</ThingDef>
-
 	<!-- ================== Projectiles ================== -->
-
-	<ThingDef ParentName="Base556x45mmNATOBullet">
+	
+	<ThingDef ParentName="NailShotBullet">
 		<defName>Bullet_Feral_Nail</defName>
 		<label>nail</label>
 		<graphicData>
@@ -141,41 +124,12 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>Bullet</damageDef>
-			<speed>73</speed>
-			<dropsCasings>false</dropsCasings>
-			<damageAmountBase>8</damageAmountBase>
-			<armorPenetrationBlunt>10</armorPenetrationBlunt>
-			<armorPenetrationSharp>2.5</armorPenetrationSharp>
+			<speed>32</speed>
+			<damageAmountBase>3</damageAmountBase>
+			<armorPenetrationBlunt>0.82</armorPenetrationBlunt>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
 		</projectile>
 	</ThingDef>
-
-	<!-- ==================== Recipes ========================== -->
-
-	<RecipeDef ParentName="AmmoRecipeBase">
-		<defName>MakeAmmo_Feral_Nail</defName>
-		<label>make nails x500</label>
-		<description>Craft 500 steel nails.</description>
-		<jobString>Making nails.</jobString>
-		<ingredients>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>Steel</li>
-					</thingDefs>
-				</filter>
-				<count>15</count>
-			</li>
-		</ingredients>
-		<fixedIngredientFilter>
-			<thingDefs>
-				<li>Steel</li>
-			</thingDefs>
-		</fixedIngredientFilter>
-		<products>
-			<Ammo_Feral_Nail>500</Ammo_Feral_Nail>
-		</products>
-	</RecipeDef>
 
 	<!-- ==================== Twin 9x19mm Para ========================== -->
 

--- a/ModPatches/Rimsenal Feral/Patches/Rimsenal Feral/ThingDefs_Misc/Feral_MutantWeapons.xml
+++ b/ModPatches/Rimsenal Feral/Patches/Rimsenal Feral/ThingDefs_Misc/Feral_MutantWeapons.xml
@@ -42,11 +42,11 @@
 			<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 			<SightsEfficiency>0.8</SightsEfficiency>
 			<ShotSpread>0.8</ShotSpread>
-			<SwayFactor>2.53</SwayFactor>
+			<SwayFactor>1.72</SwayFactor>
 			<Bulk>12</Bulk>
 		</statBases>
 		<Properties>
-			<recoilAmount>2.2</recoilAmount>
+			<recoilAmount>1.1</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_303British_FMJ</defaultProjectile>
@@ -89,24 +89,24 @@
 			<SightsEfficiency>0.8</SightsEfficiency>
 		</statBases>
 		<Properties>
+			<recoilAmount>1.74</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_Feral_Scrap</defaultProjectile>
 			<warmupTime>0.6</warmupTime>
-			<range>24</range>
+			<range>18</range>
 			<soundCast>ShotScatterStick</soundCast>
 			<soundCastTail>GunTail_Heavy</soundCastTail>
 			<muzzleFlashScale>12</muzzleFlashScale>
 			<ticksBetweenBurstShots>1</ticksBetweenBurstShots>
+			<ammoConsumedPerShotCount>5</ammoConsumedPerShotCount>
 		</Properties>
 		<AmmoUser>
 			<magazineSize>20</magazineSize>
-			<reloadTime>10</reloadTime>
+			<reloadTime>3.5</reloadTime>
 			<ammoSet>AmmoSet_Feral_Scrap</ammoSet>
 		</AmmoUser>
 		<FireModes>
-			<aimedBurstShotCount>4</aimedBurstShotCount>
-			<aiUseBurstMode>true</aiUseBurstMode>
 			<aiAimMode>SuppressFire</aiAimMode>
 		</FireModes>
 		<weaponTags>
@@ -118,15 +118,15 @@
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>Feral_RivetCannon</defName>
 		<statBases>
-			<Mass>5.3</Mass>
+			<Mass>8</Mass>
 			<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
 			<SightsEfficiency>0.89</SightsEfficiency>
 			<ShotSpread>0.17</ShotSpread>
-			<SwayFactor>1.7</SwayFactor>
+			<SwayFactor>1.26</SwayFactor>
 			<Bulk>11.03</Bulk>
 		</statBases>
 		<Properties>
-			<recoilAmount>1.83</recoilAmount>
+			<recoilAmount>0.92</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_Feral_Nail</defaultProjectile>
@@ -141,7 +141,7 @@
 		<AmmoUser>
 			<magazineSize>80</magazineSize>
 			<reloadTime>6.7</reloadTime>
-			<ammoSet>AmmoSet_Feral_Nail</ammoSet>
+			<ammoSet>AmmoSet_Feral_Rivet</ammoSet>
 		</AmmoUser>
 		<FireModes>
 			<aimedBurstShotCount>8</aimedBurstShotCount>

--- a/ModPatches/Rimsenal Feral/Patches/Rimsenal Feral/ThingDefs_Misc/Feral_MutantWeapons.xml
+++ b/ModPatches/Rimsenal Feral/Patches/Rimsenal Feral/ThingDefs_Misc/Feral_MutantWeapons.xml
@@ -129,7 +129,7 @@
 			<recoilAmount>0.92</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_Feral_Nail</defaultProjectile>
+			<defaultProjectile>Bullet_Feral_Rivet</defaultProjectile>
 			<warmupTime>1.1</warmupTime>
 			<range>48</range>
 			<burstShotCount>8</burstShotCount>

--- a/ModPatches/Rimsenal Feral/Patches/Rimsenal Feral/ThingDefs_Races/Race_Ogrons.xml
+++ b/ModPatches/Rimsenal Feral/Patches/Rimsenal Feral/ThingDefs_Races/Race_Ogrons.xml
@@ -67,7 +67,6 @@
 			<li Class="CombatExtended.PartialArmorExt">
 				<stats>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
 						<parts>
 							<li>Shoulder</li>
@@ -78,7 +77,6 @@
 						</parts>
 					</li>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Blunt>0.1</ArmorRating_Blunt>
 						<parts>
 							<li>Shoulder</li>
@@ -89,7 +87,6 @@
 						</parts>
 					</li>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Sharp>0.65</ArmorRating_Sharp>
 						<parts>
 							<li>Head</li>
@@ -97,7 +94,6 @@
 						</parts>
 					</li>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Blunt>0.65</ArmorRating_Blunt>
 						<parts>
 							<li>Head</li>
@@ -169,6 +165,5 @@
 			</tools>
 		</value>
 	</Operation>
-	
-	
+
 </Patch>

--- a/ModPatches/Rimsenal Feral/Patches/Rimsenal Feral/ThingDefs_Races/Race_Ogrons.xml
+++ b/ModPatches/Rimsenal Feral/Patches/Rimsenal Feral/ThingDefs_Races/Race_Ogrons.xml
@@ -34,7 +34,85 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mutant_Ogron"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
-			<ArmorRating_Blunt>2</ArmorRating_Blunt>
+			<ArmorRating_Blunt>12</ArmorRating_Blunt>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="Mutant_Ogron"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Mutant_Ogron"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Mutant_Ogron"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>1500</Durability>
+				<Regenerates>true</Regenerates>
+				<RegenInterval>600</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<MinArmorPct>0.25</MinArmorPct>
+			</li>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="Mutant_Ogron"]</xpath>
+		<value>
+			<li Class="CombatExtended.PartialArmorExt">
+				<stats>
+					<li>
+						<useStatic>false</useStatic>
+						<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
+						<parts>
+							<li>Shoulder</li>
+							<li>Arm</li>
+							<li>Hand</li>
+							<li>Leg</li>
+							<li>Foot</li>
+						</parts>
+					</li>
+					<li>
+						<useStatic>false</useStatic>
+						<ArmorRating_Blunt>0.1</ArmorRating_Blunt>
+						<parts>
+							<li>Shoulder</li>
+							<li>Arm</li>
+							<li>Hand</li>
+							<li>Leg</li>
+							<li>Foot</li>
+						</parts>
+					</li>
+					<li>
+						<useStatic>false</useStatic>
+						<ArmorRating_Sharp>0.65</ArmorRating_Sharp>
+						<parts>
+							<li>Head</li>
+							<li>Neck</li>
+						</parts>
+					</li>
+					<li>
+						<useStatic>false</useStatic>
+						<ArmorRating_Blunt>0.65</ArmorRating_Blunt>
+						<parts>
+							<li>Head</li>
+							<li>Neck</li>
+						</parts>
+					</li>
+				</stats>
+			</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Mutant_Ogron"]/statBases</xpath>
+		<value>
+			<PartialArmorBody>0</PartialArmorBody>
 		</value>
 	</Operation>
 
@@ -91,4 +169,6 @@
 			</tools>
 		</value>
 	</Operation>
+	
+	
 </Patch>

--- a/ModPatches/Rimsenal Feral/Patches/Rimsenal Feral/ThingDefs_Races/Race_Razortooth.xml
+++ b/ModPatches/Rimsenal Feral/Patches/Rimsenal Feral/ThingDefs_Races/Race_Razortooth.xml
@@ -15,11 +15,60 @@
 		<xpath>Defs/ThingDef[defName="Mutant_Razortooth"]/statBases</xpath>
 		<value>
 			<ArmorRating_Blunt>20</ArmorRating_Blunt>
-			<ArmorRating_Sharp>2</ArmorRating_Sharp>
-			<MeleeDodgeChance>1</MeleeDodgeChance>
+			<ArmorRating_Sharp>4</ArmorRating_Sharp>
+			<MeleeDodgeChance>0.25</MeleeDodgeChance>
 			<MeleeCritChance>0.18</MeleeCritChance>
 			<MeleeParryChance>0.05</MeleeParryChance>
 			<SmokeSensitivity>0.4</SmokeSensitivity>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="Mutant_Razortooth"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Mutant_Razortooth"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Mutant_Razortooth"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>800</Durability>
+				<Regenerates>true</Regenerates>
+				<RegenInterval>600</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<MinArmorPct>0.25</MinArmorPct>
+			</li>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="Mutant_Razortooth"]</xpath>
+		<value>
+			<li Class="CombatExtended.PartialArmorExt">
+				<stats>
+					<li>
+						<useStatic>false</useStatic>
+						<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
+						<parts>
+							<li>Leg</li>
+							<li>Paw</li>
+						</parts>
+					</li>
+					<li>
+						<useStatic>false</useStatic>
+						<ArmorRating_Blunt>0.25</ArmorRating_Blunt>
+						<parts>
+							<li>Leg</li>
+							<li>Paw</li>
+						</parts>
+					</li>
+				</stats>
+			</li>
 		</value>
 	</Operation>
 

--- a/ModPatches/Rimsenal Feral/Patches/Rimsenal Feral/ThingDefs_Races/Race_Shadark.xml
+++ b/ModPatches/Rimsenal Feral/Patches/Rimsenal Feral/ThingDefs_Races/Race_Shadark.xml
@@ -102,4 +102,5 @@
 			</tools>
 		</value>
 	</Operation>
+
 </Patch>

--- a/ModPatches/Rimsenal Feral/Patches/Rimsenal Feral/ThingDefs_Races/Race_Shadark.xml
+++ b/ModPatches/Rimsenal Feral/Patches/Rimsenal Feral/ThingDefs_Races/Race_Shadark.xml
@@ -13,10 +13,35 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Mutant_Shadark"]/statBases</xpath>
 		<value>
-			<MeleeDodgeChance>1</MeleeDodgeChance>
+			<ArmorRating_Blunt>4</ArmorRating_Blunt>
+			<ArmorRating_Sharp>0.35</ArmorRating_Sharp>
+			<MeleeDodgeChance>0.5</MeleeDodgeChance>
 			<MeleeCritChance>1</MeleeCritChance>
 			<MeleeParryChance>1</MeleeParryChance>
 			<SmokeSensitivity>0</SmokeSensitivity>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="Mutant_Shadark"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Mutant_Shadark"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Mutant_Shadark"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>650</Durability>
+				<Regenerates>true</Regenerates>
+				<RegenInterval>600</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<MinArmorPct>0.25</MinArmorPct>
+			</li>
 		</value>
 	</Operation>
 

--- a/ModPatches/Rimsenal Feral/Patches/Rimsenal Feral/ThingDefs_Races/Race_Twisted.xml
+++ b/ModPatches/Rimsenal Feral/Patches/Rimsenal Feral/ThingDefs_Races/Race_Twisted.xml
@@ -13,9 +13,34 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Mutant_Twisted"]/statBases</xpath>
 		<value>
+			<ArmorRating_Blunt>4</ArmorRating_Blunt>
+			<ArmorRating_Sharp>0.35</ArmorRating_Sharp>
 			<MeleeDodgeChance>0.5</MeleeDodgeChance>
 			<MeleeCritChance>1</MeleeCritChance>
 			<MeleeParryChance>0.5</MeleeParryChance>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="Mutant_Twisted"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Mutant_Twisted"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Mutant_Twisted"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>675</Durability>
+				<Regenerates>true</Regenerates>
+				<RegenInterval>600</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<MinArmorPct>0.25</MinArmorPct>
+			</li>
 		</value>
 	</Operation>
 


### PR DESCRIPTION
## Additions

Partial armor where suggested.
Natural Armor degradation.

Federation weapons now have a non-ammo consuming reload system.
Buffed armor that degrades for bions
Bions are now pain shock immune.
Federation custom bombardment response and shelling type. (Cluster and Heavy plasma bombs, prefer bombing to raiding and have slow world projectiles)

## Changes

Bions now have much higher base armor, but it now degrades to less, more signficantly for blunt armor which will reduce down to 20%, while the sharp will reduce down to around 50% of the new value (slightly lower than what they were prior to this change)

Mutants also have degrading armor. The hulk mutant now  has partial on the arms/legs roughly equivalent to flak, and steel helmet/vest equivalent on their head/torso.

Federation ammo has been tweaeked to now inherit from its own bases.
Plasma has been slowed to near vanilla speed now, suppression effect and damage raised.
Federation weapons now have a reload comp, but still do not use ammo.

## Testing

Check tests you have performed:
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
