### PR TITLE
Add verb translation keys

### DIFF
--- a/Languages/English/Keyed/Keys.xml
+++ b/Languages/English/Keyed/Keys.xml
@@ -74,6 +74,15 @@
 	<CE_ReloadDesc>Reloads this gun.</CE_ReloadDesc>
 	<CE_TurretReloading>Reloading</CE_TurretReloading>
 
+	<!-- Ranged Attack -->
+	<CE_OutOfBounds>Out of bounds</CE_OutOfBounds>
+	<CE_NoSelfTarget>Can't target self</CE_NoSelfTarget>
+	<CE_NoLoS>No line of sight</CE_NoLoS>	
+	<CE_BlockedRoof>Blocked by roof</CE_BlockedRoof>
+	<CE_BlockedShield>Shooting disallowed by </CE_BlockedShield>
+	<CE_BlockedMaxRange>Outside of range</CE_BlockedMaxRange>
+	<CE_BlockedMinRange>Within minimum range</CE_BlockedMinRange>
+
 	<!-- Inventory -->
 	<CE_TakeFromOther_Equipping>Equipping</CE_TakeFromOther_Equipping>
 	<CE_TakeFromOther_Taking>Taking</CE_TakeFromOther_Taking>
@@ -122,10 +131,10 @@
 	<CE_degrees>&#176;</CE_degrees>
 	<CE_meters>m</CE_meters>
 	<CE_WeaponPenetrationFactor>Weapon penetration factor</CE_WeaponPenetrationFactor>
-  <CE_WeaponPenetrationSkillFactor>Skill factor</CE_WeaponPenetrationSkillFactor>
-  <CE_WeaponPenetrationOtherFactors>Other factors</CE_WeaponPenetrationOtherFactors>
+	<CE_WeaponPenetrationSkillFactor>Skill factor</CE_WeaponPenetrationSkillFactor>
+	<CE_WeaponPenetrationOtherFactors>Other factors</CE_WeaponPenetrationOtherFactors>
 	<CE_AdjustedForWeapon>Adjusted for weapon</CE_AdjustedForWeapon>
-  <CE_RangedQualityMultiplier>Penetration quality factor</CE_RangedQualityMultiplier>
+	<CE_RangedQualityMultiplier>Penetration quality factor</CE_RangedQualityMultiplier>
 	<CE_DPS>Damage per second</CE_DPS>
 	<CE_DamageVariation>Damage variation</CE_DamageVariation>
 	<CE_FinalAverageDamage>Final average damage</CE_FinalAverageDamage>
@@ -153,6 +162,7 @@
 
 	<!-- Assign menu -->
 	<CE_UpdateLoadoutNow>Rearm</CE_UpdateLoadoutNow>
+
 
 	<!-- Uncompiled dev build popup -->
 	<CE_UncompiledDevBuild>Uncompiled CE dev build\n\nYou're running a development build of Combat Extended that is not intended for gameplay purposes, this will create a large amount of errors if you attempt to play a colony.\n\nEither download an official CE release from GitHub's Releases section, or if you need the latest development snapshot for testing purposes, get it from the link below.</CE_UncompiledDevBuild>

--- a/Languages/English/Keyed/Keys.xml
+++ b/Languages/English/Keyed/Keys.xml
@@ -46,6 +46,15 @@
 
 	<CE_EstimatedHitChance>Estimated hit chance</CE_EstimatedHitChance>
 
+	<!-- Ranged Attack -->
+	<CE_OutOfBounds>Out of bounds</CE_OutOfBounds>
+	<CE_NoSelfTarget>Can't target self</CE_NoSelfTarget>
+	<CE_NoLoS>No line of sight</CE_NoLoS>	
+	<CE_BlockedRoof>Blocked by roof</CE_BlockedRoof>
+	<CE_BlockedShield>Shooting disallowed by </CE_BlockedShield>
+	<CE_BlockedMaxRange>Outside of range</CE_BlockedMaxRange>
+	<CE_BlockedMinRange>Within minimum range</CE_BlockedMinRange>
+
 	<!-- Artillery -->
 	<CE_ArtilleryTarget_Distance>Distance: {0}/{1} Tiles</CE_ArtilleryTarget_Distance>
 	<CE_ArtilleryTarget_Distance_Selections>Distance: {0} Tiles\nselections in range: {1}/{2}</CE_ArtilleryTarget_Distance_Selections>
@@ -73,15 +82,6 @@
 	<CE_ReloadLabel>Reload</CE_ReloadLabel>
 	<CE_ReloadDesc>Reloads this gun.</CE_ReloadDesc>
 	<CE_TurretReloading>Reloading</CE_TurretReloading>
-
-	<!-- Ranged Attack -->
-	<CE_OutOfBounds>Out of bounds</CE_OutOfBounds>
-	<CE_NoSelfTarget>Can't target self</CE_NoSelfTarget>
-	<CE_NoLoS>No line of sight</CE_NoLoS>	
-	<CE_BlockedRoof>Blocked by roof</CE_BlockedRoof>
-	<CE_BlockedShield>Shooting disallowed by </CE_BlockedShield>
-	<CE_BlockedMaxRange>Outside of range</CE_BlockedMaxRange>
-	<CE_BlockedMinRange>Within minimum range</CE_BlockedMinRange>
 
 	<!-- Inventory -->
 	<CE_TakeFromOther_Equipping>Equipping</CE_TakeFromOther_Equipping>

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -847,7 +847,7 @@ namespace CombatExtended
             }
             if (caster?.Map == null || !targ.Cell.InBounds(caster.Map) || !root.InBounds(caster.Map))
             {
-                report = "Out of bounds";
+                report = "CE_OutofBounds".Translate();
                 return false;
             }
             // Check target self
@@ -855,7 +855,7 @@ namespace CombatExtended
             {
                 if (!verbProps.targetParams.canTargetSelf)
                 {
-                    report = "Can't target self";
+                    report = "CE_NoSelfTarget".Translate();
                     return false;
                 }
                 return true;
@@ -866,7 +866,7 @@ namespace CombatExtended
                 RoofDef roofDef = caster.Map.roofGrid.RoofAt(targ.Cell);
                 if (roofDef != null && roofDef.isThickRoof)
                 {
-                    report = "Blocked by roof";
+                    report = "CE_BlockedRoof".Translate();
                     return false;
                 }
             }
@@ -889,7 +889,7 @@ namespace CombatExtended
                         //pawns can use turrets while wearing shield belts, but the shield is disabled for the duration via Harmony patch (see Harmony-ShieldBelt.cs)
                         if (!current.AllowVerbCast(this) && !(current.TryGetComp<CompShield>() != null && isTurretOperator))
                         {
-                            report = "Shooting disallowed by " + current.LabelShort;
+                            report = "CE_BlockedShield".Translate() + current.LabelShort;
                             return false;
                         }
                     }
@@ -902,15 +902,15 @@ namespace CombatExtended
                 float lengthHorizontalSquared = (root - targ.Cell).LengthHorizontalSquared;
                 if (lengthHorizontalSquared > EffectiveRange * EffectiveRange)
                 {
-                    report = "Out of range";
+                    report = "CE_BlockedMaxRange".Translate();
                 }
                 else if (lengthHorizontalSquared < verbProps.minRange * verbProps.minRange)
                 {
-                    report = "Within minimum range";
+                    report = "CE_BlockedMinRange".Translate();
                 }
                 else
                 {
-                    report = "No line of sight";
+                    report = "CE_NoLoS".Translate();
                 }
                 return false;
             }


### PR DESCRIPTION
## Additions
- Keys for a few messages that can appear in the targeting/aiming info box.

## Changes
- Swap a few strings in English out for translation keys.

## References
- Closes #3305 

## Reasoning
- This text can appear to the player, so there's no reason not to key it.

## Alternatives
- Suffer (in languages other than English).

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
