### PR TITLE
Fix SOS2 Load order

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -48,7 +48,6 @@
 		<li>miho.fortifiedoutremer</li>
 		<li>co.uk.epicguru.whatsthatmod</li>
 		<li>sarg.alphagenes</li>
-		<li>kentington.saveourship2</li>
 	</loadBefore>
 	<loadAfter>
 		<li>brrainz.harmony</li>
@@ -87,6 +86,7 @@
 		<li>K4G.Sultanate</li>
 		<li>Argon.VMEu</li>
 		<li>Bonible.rimsenalfactions</li>
+		<li>kentington.saveourship2</li>
 	</loadAfter>
 
 </ModMetaData>


### PR DESCRIPTION
## Changes

- Changed SOS2 from needing CE to load before to needing CE to load after

## References

- Fixes [this](https://discord.com/channels/278818534069501953/994681225262415902/1275838774332493824) issue caused by the SOS2 assembly not being loaded by the time CE tries loading the SOS2Compat assembly

## Reasoning

- To fix the above issue

## Alternatives

- N/A

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony - Loaded save with a SOS2 ship and ground defences and all worked
