### PR TITLE
Proj from tall shooter under roof ignore roof

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -553,7 +553,7 @@ namespace CombatExtended
                 this.lerpPosition = props.lerpPosition;
                 this.GravityFactor = props.Gravity;
             }
-            if (shotHeight >= CollisionVertical.WallCollisionHeight && Position.Roofed(launcher.Map) && !def.projectile.flyOverhead)
+            if (shotHeight >= CollisionVertical.WallCollisionHeight && Position.Roofed(launcher.Map))
             {
                 ignoreRoof = true;
             }
@@ -1199,6 +1199,11 @@ namespace CombatExtended
             if (dangerFactor > 0f && nextPosition.y < CollisionVertical.WallCollisionHeight && distToOrigin > 3)
             {
                 DangerTracker?.Notify_BulletAt(Position, def.projectile.damageAmountBase * dangerFactor);
+            }
+            //If a flyoverhead ignore roof projectile is descending, enable roof check.
+            if (ignoreRoof && def.projectile.flyOverhead && shotAngle < 0)
+            {
+                ignoreRoof = false;
             }
         }
 

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -106,6 +106,7 @@ namespace CombatExtended
         public bool canTargetSelf;
         public bool castShadow = true;
         public bool logMisses = true;
+        protected bool ignoreRoof;
 
         public GlobalTargetInfo globalTargetInfo = GlobalTargetInfo.Invalid;
         public GlobalTargetInfo globalSourceInfo = GlobalTargetInfo.Invalid;
@@ -348,6 +349,7 @@ namespace CombatExtended
             Scribe_Values.Look<bool>(ref logMisses, "logMisses", true);
             Scribe_Values.Look<bool>(ref castShadow, "castShadow", true);
             Scribe_Values.Look<bool>(ref lerpPosition, "lerpPosition", true);
+            Scribe_Values.Look(ref ignoreRoof, "ignoreRoof", true);
 
             //To fix landed grenades sl problem
             Scribe_Values.Look(ref exactPosition, "exactPosition");
@@ -550,6 +552,10 @@ namespace CombatExtended
                 this.castShadow = props.castShadow;
                 this.lerpPosition = props.lerpPosition;
                 this.GravityFactor = props.Gravity;
+            }
+            if (shotHeight >= CollisionVertical.WallCollisionHeight && launcher.Position.Roofed(launcher.Map))
+            {
+                ignoreRoof = true;
             }
             Launch(launcher, origin, equipment);
         }
@@ -867,7 +873,7 @@ namespace CombatExtended
 
         protected virtual bool TryCollideWithRoof(IntVec3 cell)
         {
-            if (!cell.Roofed(Map))
+            if (!cell.Roofed(Map) || ignoreRoof)
             {
                 return false;
             }

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -553,7 +553,7 @@ namespace CombatExtended
                 this.lerpPosition = props.lerpPosition;
                 this.GravityFactor = props.Gravity;
             }
-            if (shotHeight >= CollisionVertical.WallCollisionHeight && launcher.Position.Roofed(launcher.Map) && !def.projectile.flyOverhead)
+            if (shotHeight >= CollisionVertical.WallCollisionHeight && Position.Roofed(launcher.Map) && !def.projectile.flyOverhead)
             {
                 ignoreRoof = true;
             }

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -553,7 +553,7 @@ namespace CombatExtended
                 this.lerpPosition = props.lerpPosition;
                 this.GravityFactor = props.Gravity;
             }
-            if (shotHeight >= CollisionVertical.WallCollisionHeight && launcher.Position.Roofed(launcher.Map))
+            if (shotHeight >= CollisionVertical.WallCollisionHeight && launcher.Position.Roofed(launcher.Map) && !def.projectile.flyOverhead)
             {
                 ignoreRoof = true;
             }


### PR DESCRIPTION
## Changes

If a projectile was launched above roof height and under roof, this projectile will ignore roof.
Fly overhead projectiles that meets above criteria will ignore roof when ascending, and re-enable roof colision when descending.


## Reasoning

So that tall shooter under roof won't end up hitting roof.

## Alternatives

-Disallow tall shooters from going under roof
--Good luck with AI pathing.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (A few bursts from DMS super tall mechs under all sorts of roof)
