### PR TITLE
Armor durability apply damage fix for non-health damaging or non external violence damage

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompArmorDurability.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompArmorDurability.cs
@@ -164,7 +164,7 @@ namespace CombatExtended
         public override void PostPreApplyDamage(ref DamageInfo dinfo, out bool absorbed)
         {
             base.PostPreApplyDamage(ref dinfo, out absorbed);
-            if (curDurability > 0)
+            if (curDurability > 0 && dinfo.Def.harmsHealth && dinfo.Def.ExternalViolenceFor(parent))
             {
                 curDurability -= dinfo.Amount;
                 if (curDurability < 0)


### PR DESCRIPTION
## Changes

Natural armor durability will not be reduced from damage that def harmshealth = false (firefoams) or is external violence (frostbite and SOS2 vacuum damage something)

## Reasoning

-As we all know, firefoam shell is the best AT weapon in the universe, we should equip our armies with fire engines.

## Alternatives

-Suffer.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] Playtested a colony (a centipede vs 100 pirates, and a centipede vs firefoam shell)
