### PR TITLE
12-Pounder recipe label tweaks

### DIFF
--- a/Defs/Ammo/Medieval/CannonBall.xml
+++ b/Defs/Ammo/Medieval/CannonBall.xml
@@ -305,9 +305,9 @@
 
 	<RecipeDef ParentName="AmmoRecipeBase">
 		<defName>MakeAmmo_CannonBall_Bursting</defName>
-		<label>make bursting shells cannon balls x5</label>
-		<description>Craft 5 bursting shells cannon balls.</description>
-		<jobString>Making bursting shells cannon balls.</jobString>
+		<label>make bursting cannon shells x5</label>
+		<description>Craft 5 bursting cannon shells.</description>
+		<jobString>Making bursting cannon shells.</jobString>
 		<researchPrerequisite>CE_Gunpowder</researchPrerequisite>
 		<ingredients>
 			<li>
@@ -341,9 +341,9 @@
 
 	<RecipeDef ParentName="AmmoRecipeBase">
 		<defName>MakeAmmo_CannonBall_Incendiary</defName>
-		<label>make incendiary shells cannon balls x5</label>
-		<description>Craft 5 incendiary shells cannon balls.</description>
-		<jobString>Making incendiary shells cannon balls.</jobString>
+		<label>make incendiary cannon shells x5</label>
+		<description>Craft 5 incendiary cannon shells.</description>
+		<jobString>Making incendiary cannon shells.</jobString>
 		<researchPrerequisite>CE_Gunpowder</researchPrerequisite>
 		<ingredients>
 			<li>


### PR DESCRIPTION
## Changes

- Tweaked the bursting and incendiary ammo recipe descriptions for the 12-pounder cannon shells.

## Reasoning

- Odd descriptions.

## Alternatives

- Better wording?

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
