### PR TITLE
Generic Grenade Recipes & Quadruped Tail Fixes

### DIFF
--- a/Biotech/Patches/ThingDefs_Misc/Weapons/RangedIndustrial_Biotech.xml
+++ b/Biotech/Patches/ThingDefs_Misc/Weapons/RangedIndustrial_Biotech.xml
@@ -16,6 +16,13 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/CombatExtended.AmmoSetDef[defName="AmmoSet_LauncherGrenade"]/ammoTypes</xpath>
+		<value>
+			<Ammo_LauncherGrenade_Tox>Bullet_40x46mmGrenade_Tox</Ammo_LauncherGrenade_Tox>
+		</value>
+	</Operation>
+
 	<!-- ========== Tox Grenades ========== -->
 
 	<!-- Kill recipe maker -->

--- a/Defs/Ammo/Generic/LauncherGrenade.xml
+++ b/Defs/Ammo/Generic/LauncherGrenade.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Defs>
 
-	<!-- Relabeled 40x46mm grenades -->
+	<!-- Relabeled launcher grenades -->
 
 	<ThingCategoryDef>
 		<defName>AmmoLauncherGrenade</defName>
@@ -16,11 +16,11 @@
 		<defName>AmmoSet_LauncherGrenade</defName>
 		<label>launcher grenade</label>
 		<ammoTypes>
-			<Ammo_LauncherGrenade_HE>Bullet_40x46mmGrenade_HE</Ammo_LauncherGrenade_HE>
-			<Ammo_LauncherGrenade_HE_TFuzed>Bullet_40x46mmGrenade_HE_TFuzed</Ammo_LauncherGrenade_HE_TFuzed>
-			<Ammo_LauncherGrenade_HEDP>Bullet_40x46mmGrenade_HEDP</Ammo_LauncherGrenade_HEDP>
-			<Ammo_LauncherGrenade_EMP>Bullet_40x46mmGrenade_EMP</Ammo_LauncherGrenade_EMP>
-			<Ammo_LauncherGrenade_Smoke>Bullet_40x46mmGrenade_Smoke</Ammo_LauncherGrenade_Smoke>
+			<Ammo_LauncherGrenade_HE>Bullet_launcherGrenade_HE</Ammo_LauncherGrenade_HE>
+			<Ammo_LauncherGrenade_HE_TFuzed>Bullet_launcherGrenade_HE_TFuzed</Ammo_LauncherGrenade_HE_TFuzed>
+			<Ammo_LauncherGrenade_HEDP>Bullet_launcherGrenade_HEDP</Ammo_LauncherGrenade_HEDP>
+			<Ammo_LauncherGrenade_EMP>Bullet_launcherGrenade_EMP</Ammo_LauncherGrenade_EMP>
+			<Ammo_LauncherGrenade_Smoke>Bullet_launcherGrenade_Smoke</Ammo_LauncherGrenade_Smoke>
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
 
@@ -54,7 +54,7 @@
 			<MarketValue>2.27</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHE</ammoClass>
-		<detonateProjectile>Bullet_40x46mmGrenade_HE</detonateProjectile>
+		<detonateProjectile>Bullet_launcherGrenade_HE</detonateProjectile>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoLauncherGrenadeBase">
@@ -68,7 +68,7 @@
 			<MarketValue>3.25</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHETF</ammoClass>
-		<detonateProjectile>Bullet_40x46mmGrenade_HE</detonateProjectile>
+		<detonateProjectile>Bullet_launcherGrenade_HE</detonateProjectile>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoLauncherGrenadeBase">
@@ -82,7 +82,7 @@
 			<MarketValue>2.12</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHEDP</ammoClass>
-		<detonateProjectile>Bullet_40x46mmGrenade_HE</detonateProjectile>
+		<detonateProjectile>Bullet_launcherGrenade_HE</detonateProjectile>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoLauncherGrenadeBase">
@@ -96,7 +96,7 @@
 			<MarketValue>4.57</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeEMP</ammoClass>
-		<detonateProjectile>Bullet_40x46mmGrenade_EMP</detonateProjectile>
+		<detonateProjectile>Bullet_launcherGrenade_EMP</detonateProjectile>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoLauncherGrenadeBase">
@@ -111,7 +111,7 @@
 		</statBases>
 		<ammoClass>Smoke</ammoClass>
 		<generateAllowChance>0</generateAllowChance>
-		<detonateProjectile>Bullet_40x46mmGrenade_Smoke</detonateProjectile>
+		<detonateProjectile>Bullet_launcherGrenade_Smoke</detonateProjectile>
 	</ThingDef>
 
 	<!-- ==================== Recipes ========================== -->
@@ -158,6 +158,51 @@
 			<Ammo_LauncherGrenade_HE>100</Ammo_LauncherGrenade_HE>
 		</products>
 		<workAmount>9000</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="LauncherAmmoRecipeBase">
+		<defName>MakeAmmo_LauncherGrenade_HE_TFuzed</defName>
+		<label>make launcher HE Time-Fuzed grenades x100</label>
+		<description>Craft 100 launcher HE Time-Fuzed grenades.</description>
+		<jobString>Making launcher HE Time-Fuzed grenades.</jobString>
+		<researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>50</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>FSX</li>
+					</thingDefs>
+				</filter>
+				<count>8</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>5</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>FSX</li>
+				<li>ComponentIndustrial</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_LauncherGrenade_HE_TFuzed>100</Ammo_LauncherGrenade_HE_TFuzed>
+		</products>
+		<workAmount>11200</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="LauncherAmmoRecipeBase">
@@ -283,6 +328,54 @@
 		</fixedIngredientFilter>
 		<products>
 			<Ammo_LauncherGrenade_Smoke>100</Ammo_LauncherGrenade_Smoke>
+		</products>
+		<workAmount>7400</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="LauncherAmmoRecipeBase" MayRequire="Ludeon.RimWorld.Biotech">
+		<defName>MakeAmmo_LauncherGrenade_Tox</defName>
+		<label>make launcher tox grenades x100</label>
+		<description>Craft 100 launcher tox grenades.</description>
+		<jobString>Making launcher tox grenades.</jobString>
+		<researchPrerequisites>
+			<li>CE_Launchers</li>
+			<li>ToxGas</li>
+		</researchPrerequisites>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>50</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Prometheum</li>
+					</thingDefs>
+				</filter>
+				<count>3</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>2</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Prometheum</li>
+				<li>ComponentIndustrial</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_LauncherGrenade_Tox>100</Ammo_LauncherGrenade_Tox>
 		</products>
 		<workAmount>7400</workAmount>
 	</RecipeDef>

--- a/Defs/Ammo/Generic/LauncherGrenade.xml
+++ b/Defs/Ammo/Generic/LauncherGrenade.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Defs>
 
-	<!-- Relabeled launcher grenades -->
+	<!-- Relabeled 40x46mm grenades -->
 
 	<ThingCategoryDef>
 		<defName>AmmoLauncherGrenade</defName>
@@ -16,11 +16,11 @@
 		<defName>AmmoSet_LauncherGrenade</defName>
 		<label>launcher grenade</label>
 		<ammoTypes>
-			<Ammo_LauncherGrenade_HE>Bullet_launcherGrenade_HE</Ammo_LauncherGrenade_HE>
-			<Ammo_LauncherGrenade_HE_TFuzed>Bullet_launcherGrenade_HE_TFuzed</Ammo_LauncherGrenade_HE_TFuzed>
-			<Ammo_LauncherGrenade_HEDP>Bullet_launcherGrenade_HEDP</Ammo_LauncherGrenade_HEDP>
-			<Ammo_LauncherGrenade_EMP>Bullet_launcherGrenade_EMP</Ammo_LauncherGrenade_EMP>
-			<Ammo_LauncherGrenade_Smoke>Bullet_launcherGrenade_Smoke</Ammo_LauncherGrenade_Smoke>
+			<Ammo_LauncherGrenade_HE>Bullet_40x46mmGrenade_HE</Ammo_LauncherGrenade_HE>
+			<Ammo_LauncherGrenade_HE_TFuzed>Bullet_40x46mmGrenade_HE_TFuzed</Ammo_LauncherGrenade_HE_TFuzed>
+			<Ammo_LauncherGrenade_HEDP>Bullet_40x46mmGrenade_HEDP</Ammo_LauncherGrenade_HEDP>
+			<Ammo_LauncherGrenade_EMP>Bullet_40x46mmGrenade_EMP</Ammo_LauncherGrenade_EMP>
+			<Ammo_LauncherGrenade_Smoke>Bullet_40x46mmGrenade_Smoke</Ammo_LauncherGrenade_Smoke>
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
 
@@ -54,7 +54,7 @@
 			<MarketValue>2.27</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHE</ammoClass>
-		<detonateProjectile>Bullet_launcherGrenade_HE</detonateProjectile>
+		<detonateProjectile>Bullet_40x46mmGrenade_HE</detonateProjectile>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoLauncherGrenadeBase">
@@ -68,7 +68,7 @@
 			<MarketValue>3.25</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHETF</ammoClass>
-		<detonateProjectile>Bullet_launcherGrenade_HE</detonateProjectile>
+		<detonateProjectile>Bullet_40x46mmGrenade_HE</detonateProjectile>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoLauncherGrenadeBase">
@@ -82,7 +82,7 @@
 			<MarketValue>2.12</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHEDP</ammoClass>
-		<detonateProjectile>Bullet_launcherGrenade_HE</detonateProjectile>
+		<detonateProjectile>Bullet_40x46mmGrenade_HE</detonateProjectile>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoLauncherGrenadeBase">
@@ -96,7 +96,7 @@
 			<MarketValue>4.57</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeEMP</ammoClass>
-		<detonateProjectile>Bullet_launcherGrenade_EMP</detonateProjectile>
+		<detonateProjectile>Bullet_40x46mmGrenade_EMP</detonateProjectile>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoLauncherGrenadeBase">
@@ -111,7 +111,22 @@
 		</statBases>
 		<ammoClass>Smoke</ammoClass>
 		<generateAllowChance>0</generateAllowChance>
-		<detonateProjectile>Bullet_launcherGrenade_Smoke</detonateProjectile>
+		<detonateProjectile>Bullet_40x46mmGrenade_Smoke</detonateProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoLauncherGrenadeBase" MayRequire="Ludeon.RimWorld.Biotech">
+		<defName>Ammo_LauncherGrenade_Tox</defName>
+		<label>launcher grenade (Tox)</label>
+		<graphicData>
+			<texPath>Things/Ammo/GrenadeLauncher/Tox</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>1.84</MarketValue>
+		</statBases>
+		<ammoClass>Toxic</ammoClass>
+		<generateAllowChance>0</generateAllowChance>
+		<detonateProjectile>Bullet_40x46mmGrenade_Tox</detonateProjectile>
 	</ThingDef>
 
 	<!-- ==================== Recipes ========================== -->

--- a/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithPawsAndTail.xml
+++ b/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithPawsAndTail.xml
@@ -26,6 +26,27 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Tail"]/groups</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Tail"]</xpath>
+			<value>
+				<groups />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/groups</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]</xpath>
+			<value>
+				<groups />
+			</value>
+		</nomatch>
+	</Operation>
+
+
+	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]</xpath>
@@ -103,6 +124,14 @@
 			<li>CoveredByNaturalArmor</li>
 		</value>
 	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Tail"]/groups</xpath>
+		<value>
+			<li>CoveredByNaturalArmor</li>
+		</value>
+	</Operation>
+
 
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/groups</xpath>

--- a/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithPawsAndTail.xml
+++ b/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithPawsAndTail.xml
@@ -132,7 +132,6 @@
 		</value>
 	</Operation>
 
-
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/groups</xpath>
 		<value>


### PR DESCRIPTION
## Additions
- Add recipes for Tox and Airburst to the generic grenade launcher ammo. Uses 40x46mm crafting stats.
- Add Tox grenade to the generic launcher ammo set.

## Changes
- Add armor coverage to the tail of `QuadrupedAnimalsWithPawsAndTail`.

## Reasoning
- These grenades need to be craftable in generic ammo mode, too.
- Entries within `ammoTypes` in an AmmoSetDef don't currently work with `MayRequire`, so we have to patch it. 
- Don't see a reason why the tail shouldn't be armored--probably just an oversight when the patch was made.

## Alternatives
- Suffer.
- Fido keeps losing his tail.


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
