### PR TITLE
12 gauge charged adjustments

### DIFF
--- a/Defs/Ammo/Advanced/12GaugeCharged.xml
+++ b/Defs/Ammo/Advanced/12GaugeCharged.xml
@@ -27,7 +27,7 @@
 		<description>Multi-pellet charge shot cartridge designed for shotgun-type weapons.</description>
 		<statBases>
 			<Mass>0.047</Mass>
-			<Bulk>0.08</Bulk>
+			<Bulk>0.06</Bulk>
 		</statBases>
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
@@ -121,7 +121,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>12</amount>
+					<amount>15</amount>
 				</li>
 			</secondaryDamage>
 			<armorPenetrationSharp>18</armorPenetrationSharp>

--- a/Defs/Ammo/Advanced/12GaugeCharged.xml
+++ b/Defs/Ammo/Advanced/12GaugeCharged.xml
@@ -103,7 +103,7 @@
 					<amount>3</amount>
 				</li>
 			</secondaryDamage>
-			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationSharp>12</armorPenetrationSharp>
 			<armorPenetrationBlunt>14.4</armorPenetrationBlunt>
 			<pelletCount>6</pelletCount>
 			<spreadMult>8.9</spreadMult>
@@ -124,7 +124,7 @@
 					<amount>12</amount>
 				</li>
 			</secondaryDamage>
-			<armorPenetrationSharp>10</armorPenetrationSharp>
+			<armorPenetrationSharp>18</armorPenetrationSharp>
 			<armorPenetrationBlunt>90</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -140,7 +140,7 @@
 					<amount>5</amount>
 				</li>
 			</secondaryDamage>
-			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationSharp>15</armorPenetrationSharp>
 			<armorPenetrationBlunt>14.4</armorPenetrationBlunt>
 			<pelletCount>6</pelletCount>
 			<spreadMult>8.9</spreadMult>

--- a/Defs/Ammo/Advanced/12GaugeCharged.xml
+++ b/Defs/Ammo/Advanced/12GaugeCharged.xml
@@ -103,7 +103,7 @@
 					<amount>3</amount>
 				</li>
 			</secondaryDamage>
-			<armorPenetrationSharp>12</armorPenetrationSharp>
+			<armorPenetrationSharp>10</armorPenetrationSharp>
 			<armorPenetrationBlunt>14.4</armorPenetrationBlunt>
 			<pelletCount>6</pelletCount>
 			<spreadMult>8.9</spreadMult>
@@ -124,7 +124,7 @@
 					<amount>15</amount>
 				</li>
 			</secondaryDamage>
-			<armorPenetrationSharp>18</armorPenetrationSharp>
+			<armorPenetrationSharp>15</armorPenetrationSharp>
 			<armorPenetrationBlunt>90</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -140,7 +140,7 @@
 					<amount>5</amount>
 				</li>
 			</secondaryDamage>
-			<armorPenetrationSharp>15</armorPenetrationSharp>
+			<armorPenetrationSharp>12.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>14.4</armorPenetrationBlunt>
 			<pelletCount>6</pelletCount>
 			<spreadMult>8.9</spreadMult>


### PR DESCRIPTION
## Changes

- Increased the sharp AP of the 12ga charged ammo types to 10, 15and 12.5
- The slug ammo type had the incorrect amount of bomb damage (should have been 14), fixed that and increases the slug diameter by 1mm as there was just enough room for it.
- Reduced the total length of the cartridge as it was the same as a normal 12ga disregarding the fact that charged ammo is caseless and so on.

## Reasoning

- Going with the normal charged ammo standard of the AP ratios and also the fact that 12ga charged buckshot pellets have the same exact velocity and mass, only 1 mm thinner in diameter which should even make them better at penetrating armor. So it makes 12mm for the base projectile, 18mm for the slugs same as how conc. is relative to normal charged and 15 for Ion same as normal Ion ammo but reduced the base AP value from 12 to 10 and adjusted the rest accordingly for reasons outside this PR.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors