### PR TITLE
Generic ammo fixes

### DIFF
--- a/Defs/Ammo/Generic/Generics_Misc.xml
+++ b/Defs/Ammo/Generic/Generics_Misc.xml
@@ -5,7 +5,7 @@
 	<!-- ==================== Taurus Judge ========================== -->
 	<CombatExtended.AmmoSetDef>
 		<defName>AmmoSet_RevolverShotgun</defName>
-		<label>revolver shotgun</label>
+		<label>pistol</label>
 		<ammoTypes>
 			<Ammo_PistolMagnum_FMJ>Bullet_45Colt_FMJ</Ammo_PistolMagnum_FMJ>
 			<Ammo_PistolMagnum_AP>Bullet_45Colt_AP</Ammo_PistolMagnum_AP>

--- a/Defs/Ammo/Generic/Generics_Misc.xml
+++ b/Defs/Ammo/Generic/Generics_Misc.xml
@@ -5,7 +5,7 @@
 	<!-- ==================== Taurus Judge ========================== -->
 	<CombatExtended.AmmoSetDef>
 		<defName>AmmoSet_RevolverShotgun</defName>
-		<label>pistol</label>
+		<label>revolver shotgun</label>
 		<ammoTypes>
 			<Ammo_PistolMagnum_FMJ>Bullet_45Colt_FMJ</Ammo_PistolMagnum_FMJ>
 			<Ammo_PistolMagnum_AP>Bullet_45Colt_AP</Ammo_PistolMagnum_AP>

--- a/Defs/Ammo/Generic/ShotgunShell.xml
+++ b/Defs/Ammo/Generic/ShotgunShell.xml
@@ -97,6 +97,7 @@
 			<MarketValue>0.87</MarketValue>
 		</statBases>
 		<ammoClass>ElectroSlug</ammoClass>
+    <generateAllowChance>0.5</generateAllowChance>
 		<cookOffProjectile>Bullet_12Gauge_ElectroSlug</cookOffProjectile>
 	</ThingDef>
 


### PR DESCRIPTION
## Additions

Adds <generateAllowChance>0.5</generateAllowChance> to generic shotgun ammo (emp) just like the non-generic versions

## Changes

Renamed the label of revolver shotgun ammoset to "pistol". This fixes an issue where all pistol caliber bullets are called "revolver shotgun bullet"


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (few years in-game)
