### PR TITLE
generic projectile label override

### DIFF
--- a/Defs/Ammo/Pistols/45ACP.xml
+++ b/Defs/Ammo/Pistols/45ACP.xml
@@ -97,7 +97,7 @@
 
   <!-- ================== Projectiles ================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="Base45ACPBullet" ParentName="BaseBulletCE" Abstract="true">
+  <ThingDef Name="Base45ACPBullet" ParentName="BaseBulletCE" Abstract="true">
     <graphicData>
       <texPath>Things/Projectile/Bullet_Small</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -108,11 +108,11 @@
       <dropsCasings>true</dropsCasings>
       <casingMoteDefname>Fleck_PistolAmmoCasings</casingMoteDefname>
       <casingFilthDefname>Filth_PistolAmmoCasings</casingFilthDefname>
+      <genericLabelOverride>pistol</genericLabelOverride>
     </projectile>
-    <genericLabelOverride>pistol</genericLabelOverride>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base45ACPBullet">
+  <ThingDef ParentName="Base45ACPBullet">
     <defName>Bullet_45ACP_FMJ</defName>
     <label>.45 ACP bullet (FMJ)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -122,7 +122,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base45ACPBullet">
+  <ThingDef ParentName="Base45ACPBullet">
     <defName>Bullet_45ACP_AP</defName>
     <label>.45 ACP bullet (AP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -132,7 +132,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base45ACPBullet">
+  <ThingDef ParentName="Base45ACPBullet">
     <defName>Bullet_45ACP_HP</defName>
     <label>.45 ACP bullet (HP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/Pistols/45ACP.xml
+++ b/Defs/Ammo/Pistols/45ACP.xml
@@ -1,225 +1,225 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Defs>
 
-  <ThingCategoryDef>
-    <defName>Ammo45ACP</defName>
-    <label>.45 ACP</label>
-    <parent>AmmoPistols</parent>
-    <iconPath>UI/Icons/ThingCategories/CaliberPistol</iconPath>
-  </ThingCategoryDef>
+	<ThingCategoryDef>
+		<defName>Ammo45ACP</defName>
+		<label>.45 ACP</label>
+		<parent>AmmoPistols</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberPistol</iconPath>
+	</ThingCategoryDef>
 
-  <!-- ==================== AmmoSet ========================== -->
+	<!-- ==================== AmmoSet ========================== -->
 
-  <CombatExtended.AmmoSetDef>
-    <defName>AmmoSet_45ACP</defName>
-    <label>.45 ACP</label>
-    <ammoTypes>
-      <Ammo_45ACP_FMJ>Bullet_45ACP_FMJ</Ammo_45ACP_FMJ>
-      <Ammo_45ACP_AP>Bullet_45ACP_AP</Ammo_45ACP_AP>
-      <Ammo_45ACP_HP>Bullet_45ACP_HP</Ammo_45ACP_HP>
-    </ammoTypes>
-    <similarTo>AmmoSet_Pistol</similarTo>
-  </CombatExtended.AmmoSetDef>
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_45ACP</defName>
+		<label>.45 ACP</label>
+		<ammoTypes>
+			<Ammo_45ACP_FMJ>Bullet_45ACP_FMJ</Ammo_45ACP_FMJ>
+			<Ammo_45ACP_AP>Bullet_45ACP_AP</Ammo_45ACP_AP>
+			<Ammo_45ACP_HP>Bullet_45ACP_HP</Ammo_45ACP_HP>
+		</ammoTypes>
+		<similarTo>AmmoSet_Pistol</similarTo>
+	</CombatExtended.AmmoSetDef>
 
-  <CombatExtended.AmmoSetDef>
-    <defName>AmmoSet_45ACP410Bore_SB</defName>
-    <label>.45 ACP/.410 bore</label>
-    <ammoTypes>
-      <Ammo_45ACP_FMJ>Bullet_45ACP_FMJ</Ammo_45ACP_FMJ>
-      <Ammo_45ACP_AP>Bullet_45ACP_AP</Ammo_45ACP_AP>
-      <Ammo_45ACP_HP>Bullet_45ACP_HP</Ammo_45ACP_HP>
-      <Ammo_410Bore_Buck>Bullet_410Bore_Buck_SB</Ammo_410Bore_Buck>
-      <Ammo_410Bore_Slug>Bullet_410Bore_Slug_SB</Ammo_410Bore_Slug>
-      <Ammo_410Bore_Beanbag>Bullet_410Bore_Beanbag_SB</Ammo_410Bore_Beanbag>
-      <Ammo_410Bore_ElectroSlug>Bullet_410Bore_ElectroSlug_SB</Ammo_410Bore_ElectroSlug>
-    </ammoTypes>
-    <similarTo>AmmoSet_RevolverShotgun</similarTo>
-  </CombatExtended.AmmoSetDef>
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_45ACP410Bore_SB</defName>
+		<label>.45 ACP/.410 bore</label>
+		<ammoTypes>
+			<Ammo_45ACP_FMJ>Bullet_45ACP_FMJ</Ammo_45ACP_FMJ>
+			<Ammo_45ACP_AP>Bullet_45ACP_AP</Ammo_45ACP_AP>
+			<Ammo_45ACP_HP>Bullet_45ACP_HP</Ammo_45ACP_HP>
+			<Ammo_410Bore_Buck>Bullet_410Bore_Buck_SB</Ammo_410Bore_Buck>
+			<Ammo_410Bore_Slug>Bullet_410Bore_Slug_SB</Ammo_410Bore_Slug>
+			<Ammo_410Bore_Beanbag>Bullet_410Bore_Beanbag_SB</Ammo_410Bore_Beanbag>
+			<Ammo_410Bore_ElectroSlug>Bullet_410Bore_ElectroSlug_SB</Ammo_410Bore_ElectroSlug>
+		</ammoTypes>
+		<similarTo>AmmoSet_RevolverShotgun</similarTo>
+	</CombatExtended.AmmoSetDef>
 
-  <!-- ==================== Ammo ========================== -->
+	<!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="45ACPBase" ParentName="SmallAmmoBase" Abstract="True">
-    <description>Pistol cartridge favoured for its above average stopping power.</description>
-    <statBases>
-      <Mass>0.02</Mass>
-      <Bulk>0.02</Bulk>
-    </statBases>
-    <tradeTags>
-      <li>CE_AutoEnableTrade</li>
-      <li>CE_AutoEnableCrafting</li>
-    </tradeTags>
-    <thingCategories>
-      <li>Ammo45ACP</li>
-    </thingCategories>
-  </ThingDef>
+	<ThingDef Class="CombatExtended.AmmoDef" Name="45ACPBase" ParentName="SmallAmmoBase" Abstract="True">
+		<description>Pistol cartridge favoured for its above average stopping power.</description>
+		<statBases>
+			<Mass>0.02</Mass>
+			<Bulk>0.02</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
+		<thingCategories>
+			<li>Ammo45ACP</li>
+		</thingCategories>
+	</ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="45ACPBase">
-    <defName>Ammo_45ACP_FMJ</defName>
-    <label>.45 ACP (FMJ)</label>
-    <graphicData>
-      <texPath>Things/Ammo/Pistol/FMJ</texPath>
-      <graphicClass>Graphic_StackCount</graphicClass>
-    </graphicData>
-    <statBases>
-      <MarketValue>0.09</MarketValue>
-    </statBases>
-    <ammoClass>FullMetalJacket</ammoClass>
-    <cookOffProjectile>Bullet_45ACP_FMJ</cookOffProjectile>
-  </ThingDef>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="45ACPBase">
+		<defName>Ammo_45ACP_FMJ</defName>
+		<label>.45 ACP (FMJ)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Pistol/FMJ</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.09</MarketValue>
+		</statBases>
+		<ammoClass>FullMetalJacket</ammoClass>
+		<cookOffProjectile>Bullet_45ACP_FMJ</cookOffProjectile>
+	</ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="45ACPBase">
-    <defName>Ammo_45ACP_AP</defName>
-    <label>.45 ACP (AP)</label>
-    <graphicData>
-      <texPath>Things/Ammo/Pistol/AP</texPath>
-      <graphicClass>Graphic_StackCount</graphicClass>
-    </graphicData>
-    <statBases>
-      <MarketValue>0.09</MarketValue>
-    </statBases>
-    <ammoClass>ArmorPiercing</ammoClass>
-    <cookOffProjectile>Bullet_45ACP_AP</cookOffProjectile>
-  </ThingDef>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="45ACPBase">
+		<defName>Ammo_45ACP_AP</defName>
+		<label>.45 ACP (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Pistol/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.09</MarketValue>
+		</statBases>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_45ACP_AP</cookOffProjectile>
+	</ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="45ACPBase">
-    <defName>Ammo_45ACP_HP</defName>
-    <label>.45 ACP (HP)</label>
-    <graphicData>
-      <texPath>Things/Ammo/Pistol/HP</texPath>
-      <graphicClass>Graphic_StackCount</graphicClass>
-    </graphicData>
-    <statBases>
-      <MarketValue>0.09</MarketValue>
-    </statBases>
-    <ammoClass>HollowPoint</ammoClass>
-    <cookOffProjectile>Bullet_45ACP_HP</cookOffProjectile>
-  </ThingDef>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="45ACPBase">
+		<defName>Ammo_45ACP_HP</defName>
+		<label>.45 ACP (HP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Pistol/HP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.09</MarketValue>
+		</statBases>
+		<ammoClass>HollowPoint</ammoClass>
+		<cookOffProjectile>Bullet_45ACP_HP</cookOffProjectile>
+	</ThingDef>
 
-  <!-- ================== Projectiles ================== -->
+	<!-- ================== Projectiles ================== -->
 
-  <ThingDef Name="Base45ACPBullet" ParentName="BaseBulletCE" Abstract="true">
-    <graphicData>
-      <texPath>Things/Projectile/Bullet_Small</texPath>
-      <graphicClass>Graphic_Single</graphicClass>
-    </graphicData>
-    <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageDef>Bullet</damageDef>
-      <speed>67</speed>
-      <dropsCasings>true</dropsCasings>
-      <casingMoteDefname>Fleck_PistolAmmoCasings</casingMoteDefname>
-      <casingFilthDefname>Filth_PistolAmmoCasings</casingFilthDefname>
-      <genericLabelOverride>pistol</genericLabelOverride>
-    </projectile>
-  </ThingDef>
+	<ThingDef Name="Base45ACPBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_Small</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>67</speed>
+			<dropsCasings>true</dropsCasings>
+			<casingMoteDefname>Fleck_PistolAmmoCasings</casingMoteDefname>
+			<casingFilthDefname>Filth_PistolAmmoCasings</casingFilthDefname>
+			<genericLabelOverride>pistol</genericLabelOverride>
+		</projectile>
+	</ThingDef>
 
-  <ThingDef ParentName="Base45ACPBullet">
-    <defName>Bullet_45ACP_FMJ</defName>
-    <label>.45 ACP bullet (FMJ)</label>
-    <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>12</damageAmountBase>
-      <armorPenetrationSharp>3.5</armorPenetrationSharp>
-      <armorPenetrationBlunt>10.860</armorPenetrationBlunt>
-    </projectile>
-  </ThingDef>
+	<ThingDef ParentName="Base45ACPBullet">
+		<defName>Bullet_45ACP_FMJ</defName>
+		<label>.45 ACP bullet (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>12</damageAmountBase>
+			<armorPenetrationSharp>3.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>10.860</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
 
-  <ThingDef ParentName="Base45ACPBullet">
-    <defName>Bullet_45ACP_AP</defName>
-    <label>.45 ACP bullet (AP)</label>
-    <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>7</damageAmountBase>
-      <armorPenetrationSharp>7</armorPenetrationSharp>
-      <armorPenetrationBlunt>10.860</armorPenetrationBlunt>
-    </projectile>
-  </ThingDef>
+	<ThingDef ParentName="Base45ACPBullet">
+		<defName>Bullet_45ACP_AP</defName>
+		<label>.45 ACP bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>7</damageAmountBase>
+			<armorPenetrationSharp>7</armorPenetrationSharp>
+			<armorPenetrationBlunt>10.860</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
 
-  <ThingDef ParentName="Base45ACPBullet">
-    <defName>Bullet_45ACP_HP</defName>
-    <label>.45 ACP bullet (HP)</label>
-    <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>15</damageAmountBase>
-      <armorPenetrationSharp>2</armorPenetrationSharp>
-      <armorPenetrationBlunt>10.860</armorPenetrationBlunt>
-    </projectile>
-  </ThingDef>
+	<ThingDef ParentName="Base45ACPBullet">
+		<defName>Bullet_45ACP_HP</defName>
+		<label>.45 ACP bullet (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>15</damageAmountBase>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationBlunt>10.860</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
 
-  <!-- ==================== Recipes ========================== -->
+	<!-- ==================== Recipes ========================== -->
 
-  <RecipeDef ParentName="AmmoRecipeBase">
-    <defName>MakeAmmo_45ACP_FMJ</defName>
-    <label>make .45 ACP (FMJ) cartridge x500</label>
-    <description>Craft 500 .45 ACP (FMJ) cartridges.</description>
-    <jobString>Making .45 ACP (FMJ) cartridges.</jobString>
-    <ingredients>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Steel</li>
-          </thingDefs>
-        </filter>
-        <count>22</count>
-      </li>
-    </ingredients>
-    <fixedIngredientFilter>
-      <thingDefs>
-        <li>Steel</li>
-      </thingDefs>
-    </fixedIngredientFilter>
-    <products>
-      <Ammo_45ACP_FMJ>500</Ammo_45ACP_FMJ>
-    </products>
-    <workAmount>2200</workAmount>
-  </RecipeDef>
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_45ACP_FMJ</defName>
+		<label>make .45 ACP (FMJ) cartridge x500</label>
+		<description>Craft 500 .45 ACP (FMJ) cartridges.</description>
+		<jobString>Making .45 ACP (FMJ) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>22</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_45ACP_FMJ>500</Ammo_45ACP_FMJ>
+		</products>
+		<workAmount>2200</workAmount>
+	</RecipeDef>
 
-  <RecipeDef ParentName="AmmoRecipeBase">
-    <defName>MakeAmmo_45ACP_AP</defName>
-    <label>make .45 ACP (AP) cartridge x500</label>
-    <description>Craft 500 .45 ACP (AP) cartridges.</description>
-    <jobString>Making .45 ACP (AP) cartridges.</jobString>
-    <ingredients>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Steel</li>
-          </thingDefs>
-        </filter>
-        <count>22</count>
-      </li>
-    </ingredients>
-    <fixedIngredientFilter>
-      <thingDefs>
-        <li>Steel</li>
-      </thingDefs>
-    </fixedIngredientFilter>
-    <products>
-      <Ammo_45ACP_AP>500</Ammo_45ACP_AP>
-    </products>
-    <workAmount>2640</workAmount>
-  </RecipeDef>
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_45ACP_AP</defName>
+		<label>make .45 ACP (AP) cartridge x500</label>
+		<description>Craft 500 .45 ACP (AP) cartridges.</description>
+		<jobString>Making .45 ACP (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>22</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_45ACP_AP>500</Ammo_45ACP_AP>
+		</products>
+		<workAmount>2640</workAmount>
+	</RecipeDef>
 
-  <RecipeDef ParentName="AmmoRecipeBase">
-    <defName>MakeAmmo_45ACP_HP</defName>
-    <label>make .45 ACP (HP) cartridge x500</label>
-    <description>Craft 500 .45 ACP (HP) cartridges.</description>
-    <jobString>Making .45 ACP (HP) cartridges.</jobString>
-    <ingredients>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Steel</li>
-          </thingDefs>
-        </filter>
-        <count>22</count>
-      </li>
-    </ingredients>
-    <fixedIngredientFilter>
-      <thingDefs>
-        <li>Steel</li>
-      </thingDefs>
-    </fixedIngredientFilter>
-    <products>
-      <Ammo_45ACP_HP>500</Ammo_45ACP_HP>
-    </products>
-    <workAmount>2200</workAmount>
-  </RecipeDef>
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_45ACP_HP</defName>
+		<label>make .45 ACP (HP) cartridge x500</label>
+		<description>Craft 500 .45 ACP (HP) cartridges.</description>
+		<jobString>Making .45 ACP (HP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>22</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_45ACP_HP>500</Ammo_45ACP_HP>
+		</products>
+		<workAmount>2200</workAmount>
+	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Pistols/45ACP.xml
+++ b/Defs/Ammo/Pistols/45ACP.xml
@@ -1,224 +1,225 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Defs>
 
-	<ThingCategoryDef>
-		<defName>Ammo45ACP</defName>
-		<label>.45 ACP</label>
-		<parent>AmmoPistols</parent>
-		<iconPath>UI/Icons/ThingCategories/CaliberPistol</iconPath>
-	</ThingCategoryDef>
+  <ThingCategoryDef>
+    <defName>Ammo45ACP</defName>
+    <label>.45 ACP</label>
+    <parent>AmmoPistols</parent>
+    <iconPath>UI/Icons/ThingCategories/CaliberPistol</iconPath>
+  </ThingCategoryDef>
 
-	<!-- ==================== AmmoSet ========================== -->
+  <!-- ==================== AmmoSet ========================== -->
 
-	<CombatExtended.AmmoSetDef>
-		<defName>AmmoSet_45ACP</defName>
-		<label>.45 ACP</label>
-		<ammoTypes>
-			<Ammo_45ACP_FMJ>Bullet_45ACP_FMJ</Ammo_45ACP_FMJ>
-			<Ammo_45ACP_AP>Bullet_45ACP_AP</Ammo_45ACP_AP>
-			<Ammo_45ACP_HP>Bullet_45ACP_HP</Ammo_45ACP_HP>
-		</ammoTypes>
-		<similarTo>AmmoSet_Pistol</similarTo>
-	</CombatExtended.AmmoSetDef>
+  <CombatExtended.AmmoSetDef>
+    <defName>AmmoSet_45ACP</defName>
+    <label>.45 ACP</label>
+    <ammoTypes>
+      <Ammo_45ACP_FMJ>Bullet_45ACP_FMJ</Ammo_45ACP_FMJ>
+      <Ammo_45ACP_AP>Bullet_45ACP_AP</Ammo_45ACP_AP>
+      <Ammo_45ACP_HP>Bullet_45ACP_HP</Ammo_45ACP_HP>
+    </ammoTypes>
+    <similarTo>AmmoSet_Pistol</similarTo>
+  </CombatExtended.AmmoSetDef>
 
-	<CombatExtended.AmmoSetDef>
-		<defName>AmmoSet_45ACP410Bore_SB</defName>
-		<label>.45 ACP/.410 bore</label>
-		<ammoTypes>
-			<Ammo_45ACP_FMJ>Bullet_45ACP_FMJ</Ammo_45ACP_FMJ>
-			<Ammo_45ACP_AP>Bullet_45ACP_AP</Ammo_45ACP_AP>
-			<Ammo_45ACP_HP>Bullet_45ACP_HP</Ammo_45ACP_HP>
-			<Ammo_410Bore_Buck>Bullet_410Bore_Buck_SB</Ammo_410Bore_Buck>
-			<Ammo_410Bore_Slug>Bullet_410Bore_Slug_SB</Ammo_410Bore_Slug>
-			<Ammo_410Bore_Beanbag>Bullet_410Bore_Beanbag_SB</Ammo_410Bore_Beanbag>
-			<Ammo_410Bore_ElectroSlug>Bullet_410Bore_ElectroSlug_SB</Ammo_410Bore_ElectroSlug>
-		</ammoTypes>
-		<similarTo>AmmoSet_RevolverShotgun</similarTo>
-	</CombatExtended.AmmoSetDef>
+  <CombatExtended.AmmoSetDef>
+    <defName>AmmoSet_45ACP410Bore_SB</defName>
+    <label>.45 ACP/.410 bore</label>
+    <ammoTypes>
+      <Ammo_45ACP_FMJ>Bullet_45ACP_FMJ</Ammo_45ACP_FMJ>
+      <Ammo_45ACP_AP>Bullet_45ACP_AP</Ammo_45ACP_AP>
+      <Ammo_45ACP_HP>Bullet_45ACP_HP</Ammo_45ACP_HP>
+      <Ammo_410Bore_Buck>Bullet_410Bore_Buck_SB</Ammo_410Bore_Buck>
+      <Ammo_410Bore_Slug>Bullet_410Bore_Slug_SB</Ammo_410Bore_Slug>
+      <Ammo_410Bore_Beanbag>Bullet_410Bore_Beanbag_SB</Ammo_410Bore_Beanbag>
+      <Ammo_410Bore_ElectroSlug>Bullet_410Bore_ElectroSlug_SB</Ammo_410Bore_ElectroSlug>
+    </ammoTypes>
+    <similarTo>AmmoSet_RevolverShotgun</similarTo>
+  </CombatExtended.AmmoSetDef>
 
-	<!-- ==================== Ammo ========================== -->
+  <!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="45ACPBase" ParentName="SmallAmmoBase" Abstract="True">
-		<description>Pistol cartridge favoured for its above average stopping power.</description>
-		<statBases>
-			<Mass>0.02</Mass>
-			<Bulk>0.02</Bulk>
-		</statBases>
-		<tradeTags>
-			<li>CE_AutoEnableTrade</li>
-			<li>CE_AutoEnableCrafting</li>
-		</tradeTags>
-		<thingCategories>
-			<li>Ammo45ACP</li>
-		</thingCategories>
-	</ThingDef>
+  <ThingDef Class="CombatExtended.AmmoDef" Name="45ACPBase" ParentName="SmallAmmoBase" Abstract="True">
+    <description>Pistol cartridge favoured for its above average stopping power.</description>
+    <statBases>
+      <Mass>0.02</Mass>
+      <Bulk>0.02</Bulk>
+    </statBases>
+    <tradeTags>
+      <li>CE_AutoEnableTrade</li>
+      <li>CE_AutoEnableCrafting</li>
+    </tradeTags>
+    <thingCategories>
+      <li>Ammo45ACP</li>
+    </thingCategories>
+  </ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="45ACPBase">
-		<defName>Ammo_45ACP_FMJ</defName>
-		<label>.45 ACP (FMJ)</label>
-		<graphicData>
-			<texPath>Things/Ammo/Pistol/FMJ</texPath>
-			<graphicClass>Graphic_StackCount</graphicClass>
-		</graphicData>
-		<statBases>
-			<MarketValue>0.09</MarketValue>
-		</statBases>
-		<ammoClass>FullMetalJacket</ammoClass>
-		<cookOffProjectile>Bullet_45ACP_FMJ</cookOffProjectile>
-	</ThingDef>
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="45ACPBase">
+    <defName>Ammo_45ACP_FMJ</defName>
+    <label>.45 ACP (FMJ)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Pistol/FMJ</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.09</MarketValue>
+    </statBases>
+    <ammoClass>FullMetalJacket</ammoClass>
+    <cookOffProjectile>Bullet_45ACP_FMJ</cookOffProjectile>
+  </ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="45ACPBase">
-		<defName>Ammo_45ACP_AP</defName>
-		<label>.45 ACP (AP)</label>
-		<graphicData>
-			<texPath>Things/Ammo/Pistol/AP</texPath>
-			<graphicClass>Graphic_StackCount</graphicClass>
-		</graphicData>
-		<statBases>
-			<MarketValue>0.09</MarketValue>
-		</statBases>
-		<ammoClass>ArmorPiercing</ammoClass>
-		<cookOffProjectile>Bullet_45ACP_AP</cookOffProjectile>
-	</ThingDef>
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="45ACPBase">
+    <defName>Ammo_45ACP_AP</defName>
+    <label>.45 ACP (AP)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Pistol/AP</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.09</MarketValue>
+    </statBases>
+    <ammoClass>ArmorPiercing</ammoClass>
+    <cookOffProjectile>Bullet_45ACP_AP</cookOffProjectile>
+  </ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="45ACPBase">
-		<defName>Ammo_45ACP_HP</defName>
-		<label>.45 ACP (HP)</label>
-		<graphicData>
-			<texPath>Things/Ammo/Pistol/HP</texPath>
-			<graphicClass>Graphic_StackCount</graphicClass>
-		</graphicData>
-		<statBases>
-			<MarketValue>0.09</MarketValue>
-		</statBases>
-		<ammoClass>HollowPoint</ammoClass>
-		<cookOffProjectile>Bullet_45ACP_HP</cookOffProjectile>
-	</ThingDef>
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="45ACPBase">
+    <defName>Ammo_45ACP_HP</defName>
+    <label>.45 ACP (HP)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Pistol/HP</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.09</MarketValue>
+    </statBases>
+    <ammoClass>HollowPoint</ammoClass>
+    <cookOffProjectile>Bullet_45ACP_HP</cookOffProjectile>
+  </ThingDef>
 
-	<!-- ================== Projectiles ================== -->
+  <!-- ================== Projectiles ================== -->
 
-	<ThingDef Name="Base45ACPBullet" ParentName="BaseBulletCE" Abstract="true">
-		<graphicData>
-			<texPath>Things/Projectile/Bullet_Small</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>Bullet</damageDef>
-			<speed>67</speed>
-			<dropsCasings>true</dropsCasings>
-			<casingMoteDefname>Fleck_PistolAmmoCasings</casingMoteDefname>
-			<casingFilthDefname>Filth_PistolAmmoCasings</casingFilthDefname>
-		</projectile>
-	</ThingDef>
+  <ThingDef Class="CombatExtended.AmmoDef" Name="Base45ACPBullet" ParentName="BaseBulletCE" Abstract="true">
+    <graphicData>
+      <texPath>Things/Projectile/Bullet_Small</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageDef>Bullet</damageDef>
+      <speed>67</speed>
+      <dropsCasings>true</dropsCasings>
+      <casingMoteDefname>Fleck_PistolAmmoCasings</casingMoteDefname>
+      <casingFilthDefname>Filth_PistolAmmoCasings</casingFilthDefname>
+    </projectile>
+    <genericLabelOverride>pistol</genericLabelOverride>
+  </ThingDef>
 
-	<ThingDef ParentName="Base45ACPBullet">
-		<defName>Bullet_45ACP_FMJ</defName>
-		<label>.45 ACP bullet (FMJ)</label>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>12</damageAmountBase>
-			<armorPenetrationSharp>3.5</armorPenetrationSharp>
-			<armorPenetrationBlunt>10.860</armorPenetrationBlunt>
-		</projectile>
-	</ThingDef>
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base45ACPBullet">
+    <defName>Bullet_45ACP_FMJ</defName>
+    <label>.45 ACP bullet (FMJ)</label>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageAmountBase>12</damageAmountBase>
+      <armorPenetrationSharp>3.5</armorPenetrationSharp>
+      <armorPenetrationBlunt>10.860</armorPenetrationBlunt>
+    </projectile>
+  </ThingDef>
 
-	<ThingDef ParentName="Base45ACPBullet">
-		<defName>Bullet_45ACP_AP</defName>
-		<label>.45 ACP bullet (AP)</label>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>7</damageAmountBase>
-			<armorPenetrationSharp>7</armorPenetrationSharp>
-			<armorPenetrationBlunt>10.860</armorPenetrationBlunt>
-		</projectile>
-	</ThingDef>
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base45ACPBullet">
+    <defName>Bullet_45ACP_AP</defName>
+    <label>.45 ACP bullet (AP)</label>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageAmountBase>7</damageAmountBase>
+      <armorPenetrationSharp>7</armorPenetrationSharp>
+      <armorPenetrationBlunt>10.860</armorPenetrationBlunt>
+    </projectile>
+  </ThingDef>
 
-	<ThingDef ParentName="Base45ACPBullet">
-		<defName>Bullet_45ACP_HP</defName>
-		<label>.45 ACP bullet (HP)</label>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>15</damageAmountBase>
-			<armorPenetrationSharp>2</armorPenetrationSharp>
-			<armorPenetrationBlunt>10.860</armorPenetrationBlunt>
-		</projectile>
-	</ThingDef>
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base45ACPBullet">
+    <defName>Bullet_45ACP_HP</defName>
+    <label>.45 ACP bullet (HP)</label>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageAmountBase>15</damageAmountBase>
+      <armorPenetrationSharp>2</armorPenetrationSharp>
+      <armorPenetrationBlunt>10.860</armorPenetrationBlunt>
+    </projectile>
+  </ThingDef>
 
-	<!-- ==================== Recipes ========================== -->
+  <!-- ==================== Recipes ========================== -->
 
-	<RecipeDef ParentName="AmmoRecipeBase">
-		<defName>MakeAmmo_45ACP_FMJ</defName>
-		<label>make .45 ACP (FMJ) cartridge x500</label>
-		<description>Craft 500 .45 ACP (FMJ) cartridges.</description>
-		<jobString>Making .45 ACP (FMJ) cartridges.</jobString>
-		<ingredients>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>Steel</li>
-					</thingDefs>
-				</filter>
-				<count>22</count>
-			</li>
-		</ingredients>
-		<fixedIngredientFilter>
-			<thingDefs>
-				<li>Steel</li>
-			</thingDefs>
-		</fixedIngredientFilter>
-		<products>
-			<Ammo_45ACP_FMJ>500</Ammo_45ACP_FMJ>
-		</products>
-		<workAmount>2200</workAmount>
-	</RecipeDef>
+  <RecipeDef ParentName="AmmoRecipeBase">
+    <defName>MakeAmmo_45ACP_FMJ</defName>
+    <label>make .45 ACP (FMJ) cartridge x500</label>
+    <description>Craft 500 .45 ACP (FMJ) cartridges.</description>
+    <jobString>Making .45 ACP (FMJ) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>22</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_45ACP_FMJ>500</Ammo_45ACP_FMJ>
+    </products>
+    <workAmount>2200</workAmount>
+  </RecipeDef>
 
-	<RecipeDef ParentName="AmmoRecipeBase">
-		<defName>MakeAmmo_45ACP_AP</defName>
-		<label>make .45 ACP (AP) cartridge x500</label>
-		<description>Craft 500 .45 ACP (AP) cartridges.</description>
-		<jobString>Making .45 ACP (AP) cartridges.</jobString>
-		<ingredients>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>Steel</li>
-					</thingDefs>
-				</filter>
-				<count>22</count>
-			</li>
-		</ingredients>
-		<fixedIngredientFilter>
-			<thingDefs>
-				<li>Steel</li>
-			</thingDefs>
-		</fixedIngredientFilter>
-		<products>
-			<Ammo_45ACP_AP>500</Ammo_45ACP_AP>
-		</products>
-		<workAmount>2640</workAmount>
-	</RecipeDef>
+  <RecipeDef ParentName="AmmoRecipeBase">
+    <defName>MakeAmmo_45ACP_AP</defName>
+    <label>make .45 ACP (AP) cartridge x500</label>
+    <description>Craft 500 .45 ACP (AP) cartridges.</description>
+    <jobString>Making .45 ACP (AP) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>22</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_45ACP_AP>500</Ammo_45ACP_AP>
+    </products>
+    <workAmount>2640</workAmount>
+  </RecipeDef>
 
-	<RecipeDef ParentName="AmmoRecipeBase">
-		<defName>MakeAmmo_45ACP_HP</defName>
-		<label>make .45 ACP (HP) cartridge x500</label>
-		<description>Craft 500 .45 ACP (HP) cartridges.</description>
-		<jobString>Making .45 ACP (HP) cartridges.</jobString>
-		<ingredients>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>Steel</li>
-					</thingDefs>
-				</filter>
-				<count>22</count>
-			</li>
-		</ingredients>
-		<fixedIngredientFilter>
-			<thingDefs>
-				<li>Steel</li>
-			</thingDefs>
-		</fixedIngredientFilter>
-		<products>
-			<Ammo_45ACP_HP>500</Ammo_45ACP_HP>
-		</products>
-		<workAmount>2200</workAmount>
-	</RecipeDef>
+  <RecipeDef ParentName="AmmoRecipeBase">
+    <defName>MakeAmmo_45ACP_HP</defName>
+    <label>make .45 ACP (HP) cartridge x500</label>
+    <description>Craft 500 .45 ACP (HP) cartridges.</description>
+    <jobString>Making .45 ACP (HP) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>22</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_45ACP_HP>500</Ammo_45ACP_HP>
+    </products>
+    <workAmount>2200</workAmount>
+  </RecipeDef>
 
 </Defs>

--- a/Languages/English/Keyed/Keys.xml
+++ b/Languages/English/Keyed/Keys.xml
@@ -1,176 +1,176 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LanguageData>
 
-  <!-- Tabs -->
-  <TabAttachments>Attachm.</TabAttachments>
+	<!-- Tabs -->
+	<TabAttachments>Attachm.</TabAttachments>
 
-  <!-- Billing -->
-  <CE_MissinGunsmithingBench>Requires gunsmithing bench</CE_MissinGunsmithingBench>
+	<!-- Billing -->
+	<CE_MissinGunsmithingBench>Requires gunsmithing bench</CE_MissinGunsmithingBench>
 
-  <!-- Suppression -->
-  <CE_SuppressedMote>Suppressed!</CE_SuppressedMote>
-  <CE_HunkeringMote>Hunkering!</CE_HunkeringMote>
-  <CE_CrouchWalking>Suppressed (crouch-walking)</CE_CrouchWalking>
+	<!-- Suppression -->
+	<CE_SuppressedMote>Suppressed!</CE_SuppressedMote>
+	<CE_HunkeringMote>Hunkering!</CE_HunkeringMote>
+	<CE_CrouchWalking>Suppressed (crouch-walking)</CE_CrouchWalking>
 
-  <!-- Aim/Fire modes -->
-  <CE_AutoFireLabel>Auto</CE_AutoFireLabel>
-  <CE_BurstFireLabel>Burst</CE_BurstFireLabel>
-  <CE_SingleFireLabel>Single</CE_SingleFireLabel>
-  <CE_SnapshotLabel>Snapshot</CE_SnapshotLabel>
-  <CE_AimedShotLabel>Aimed shot</CE_AimedShotLabel>
-  <CE_SuppressFireLabel>Suppress</CE_SuppressFireLabel>
-  <CE_HoldFireLabel>Hold fire</CE_HoldFireLabel>
-  <CE_ToggleFireModeDesc>Toggle fire mode.</CE_ToggleFireModeDesc>
-  <CE_ToggleAimModeDesc>Toggle aim mode.</CE_ToggleAimModeDesc>
+	<!-- Aim/Fire modes -->
+	<CE_AutoFireLabel>Auto</CE_AutoFireLabel>
+	<CE_BurstFireLabel>Burst</CE_BurstFireLabel>
+	<CE_SingleFireLabel>Single</CE_SingleFireLabel>
+	<CE_SnapshotLabel>Snapshot</CE_SnapshotLabel>
+	<CE_AimedShotLabel>Aimed shot</CE_AimedShotLabel>
+	<CE_SuppressFireLabel>Suppress</CE_SuppressFireLabel>
+	<CE_HoldFireLabel>Hold fire</CE_HoldFireLabel>
+	<CE_ToggleFireModeDesc>Toggle fire mode.</CE_ToggleFireModeDesc>
+	<CE_ToggleAimModeDesc>Toggle aim mode.</CE_ToggleAimModeDesc>
 
-  <!-- Bipod system -->
-  <CE_Bipod_Set_Up>Bipod IS set up</CE_Bipod_Set_Up>
-  <CE_Bipod_Not_Set_Up>Bipod IS NOT set up</CE_Bipod_Not_Set_Up>
-  <CE_Deploy_Bipod>Deploy bipod</CE_Deploy_Bipod>
-  <CE_Close_Bipod>Close bipod</CE_Close_Bipod>
+	<!-- Bipod system -->
+	<CE_Bipod_Set_Up>Bipod IS set up</CE_Bipod_Set_Up>
+	<CE_Bipod_Not_Set_Up>Bipod IS NOT set up</CE_Bipod_Not_Set_Up>
+	<CE_Deploy_Bipod>Deploy bipod</CE_Deploy_Bipod>
+	<CE_Close_Bipod>Close bipod</CE_Close_Bipod>
 
-  <!-- Aiming system -->
-  <CE_MarkedForArtillery>Marked for artillery, expires in</CE_MarkedForArtillery>
+	<!-- Aiming system -->
+	<CE_MarkedForArtillery>Marked for artillery, expires in</CE_MarkedForArtillery>
 
-  <CE_VisibilityError>Visibility error</CE_VisibilityError>
-  <CE_SmokeDensity>Smoke</CE_SmokeDensity>
-  <CE_LeadError>Lead error</CE_LeadError>
-  <CE_RangeError>Range error</CE_RangeError>
-  <CE_Sway>Sway</CE_Sway>
-  <CE_Spread>Spread</CE_Spread>
-  <CE_MissRadius>Miss radius</CE_MissRadius>
-  <CE_IndirectFire>Indirect fire</CE_IndirectFire>
-  <CE_CoverHeight>Cover height</CE_CoverHeight>
-  <CE_TargetHeight>Target height</CE_TargetHeight>
-  <CE_TargetWidth>Target width</CE_TargetWidth>
+	<CE_VisibilityError>Visibility error</CE_VisibilityError>
+	<CE_SmokeDensity>Smoke</CE_SmokeDensity>
+	<CE_LeadError>Lead error</CE_LeadError>
+	<CE_RangeError>Range error</CE_RangeError>
+	<CE_Sway>Sway</CE_Sway>
+	<CE_Spread>Spread</CE_Spread>
+	<CE_MissRadius>Miss radius</CE_MissRadius>
+	<CE_IndirectFire>Indirect fire</CE_IndirectFire>
+	<CE_CoverHeight>Cover height</CE_CoverHeight>
+	<CE_TargetHeight>Target height</CE_TargetHeight>
+	<CE_TargetWidth>Target width</CE_TargetWidth>
 
-  <CE_EstimatedHitChance>Estimated hit chance</CE_EstimatedHitChance>
+	<CE_EstimatedHitChance>Estimated hit chance</CE_EstimatedHitChance>
 
-  <!-- Ranged Attack -->
-  <CE_OutOfBounds>Out of bounds</CE_OutOfBounds>
-  <CE_NoSelfTarget>Can't target self</CE_NoSelfTarget>
-  <CE_NoLoS>No line of sight</CE_NoLoS>
-  <CE_BlockedRoof>Blocked by roof</CE_BlockedRoof>
-  <CE_BlockedShield>Shooting disallowed by </CE_BlockedShield>
-  <CE_BlockedMaxRange>Outside of range</CE_BlockedMaxRange>
-  <CE_BlockedMinRange>Within minimum range</CE_BlockedMinRange>
-
-  <!-- Artillery -->
-  <CE_ArtilleryTarget_Distance>Distance: {0}/{1} Tiles</CE_ArtilleryTarget_Distance>
-  <CE_ArtilleryTarget_Distance_Selections>Distance: {0} Tiles\nselections in range: {1}/{2}</CE_ArtilleryTarget_Distance_Selections>
-  <CE_ArtilleryTarget_DestinationBeyondMaximumRange>Target is beyond maximum range</CE_ArtilleryTarget_DestinationBeyondMaximumRange>
-  <CE_ArtilleryTarget_ClickToOrderAttack>Target:</CE_ArtilleryTarget_ClickToOrderAttack>
-  <CE_ArtilleryTarget_InvalidTarget>Invalid target</CE_ArtilleryTarget_InvalidTarget>
-  <CE_ArtilleryTarget_AttackingAllies>Are you sure you want to attack {0} ({1})?\n\nThis will make {1} hostile to you, and they may retaliate with raids and artillery fire against your colony!</CE_ArtilleryTarget_AttackingAllies>
-  <CE_ArtilleryTargetLabel>Attack world tile</CE_ArtilleryTargetLabel>
-  <CE_ArtilleryTargetDesc>Attack a world tile. If the selected tile contains a map, you can select the attack target within that map.</CE_ArtilleryTargetDesc>
-  <CE_ArtilleryTarget_AlreadyDestroyed>Selected target already destroyed</CE_ArtilleryTarget_AlreadyDestroyed>
-  <CE_ArtilleryTarget_MustTargetMark>Can only target artillery mark</CE_ArtilleryTarget_MustTargetMark>
-
-  <!-- Marking -->
-  <CE_MarkingUnavailableReason>Pawn cannot mark targets for artillery because they are on a map with no local artillery and they need a radio pack to communicate with the artillery crew.\n\nMarking targets is disabled when no artillery is available in local map and the pawn doesn't have access to long range radios.</CE_MarkingUnavailableReason>
-
-  <!-- Reloading -->
-  <CE_ReloadingEquipment>equipped</CE_ReloadingEquipment>
-  <CE_ReloadingInventory>stored</CE_ReloadingInventory>
-  <CE_ReloadingGenericAmmo>ammo</CE_ReloadingGenericAmmo>
-  <CE_ReloadingMote>Reloading {0}!</CE_ReloadingMote>
-  <CE_ReloadingTurretMote>Reloading turret {0}.</CE_ReloadingTurretMote>
-  <CE_MannedTurret>manned turret</CE_MannedTurret>
-  <CE_AutoTurret>auto-turret</CE_AutoTurret>
-  <CE_UnloadLabel>Unload</CE_UnloadLabel>
-  <CE_ReloadLabel>Reload</CE_ReloadLabel>
-  <CE_ReloadDesc>Reloads this gun.</CE_ReloadDesc>
-  <CE_TurretReloading>Reloading</CE_TurretReloading>
-
-  <!-- Inventory -->
-  <CE_TakeFromOther_Equipping>Equipping</CE_TakeFromOther_Equipping>
-  <CE_TakeFromOther_Taking>Taking</CE_TakeFromOther_Taking>
-
-  <CE_CarriedWeight>Carried weight</CE_CarriedWeight>
-  <CE_CarriedBulk>Carried bulk</CE_CarriedBulk>
-  <CE_Encumbered>Encumbered</CE_Encumbered>
-  <CE_FinalModifier>Final modifier</CE_FinalModifier>
-  <CE_InventoryFull>Inventory is full</CE_InventoryFull>
-  <CE_PickUp>Pick up</CE_PickUp>
-  <CE_PickUpHalf>Pick up half</CE_PickUpHalf>
-  <CE_CannotPickUp>Cannot pick up</CE_CannotPickUp>
-  <CE_OutOfAmmo>Out of ammo</CE_OutOfAmmo>
-  <CE_PutAway>Put away {0}</CE_PutAway>
-  <CE_ReloadApparel>Reload {0} with {1}</CE_ReloadApparel>
-  <CE_TamerInventoryFull>can't do taming job because of a full inventory.</CE_TamerInventoryFull>
-  <CE_DropThingHaul>Drop and haul</CE_DropThingHaul>
-  <CE_CannotDropThing>Cannot drop</CE_CannotDropThing>
-  <CE_CannotDropThingHaul>Cannot drop and haul</CE_CannotDropThingHaul>
-  <CE_CannotPutAway>Cannot put away {0}</CE_CannotPutAway>
-  <CE_CannotChangeEquipment>This person refuses to change equipment.</CE_CannotChangeEquipment>
-  <CE_Eat>Consume</CE_Eat>
-  <CE_HoldTrackerForget>Stop Holding</CE_HoldTrackerForget>
-  <CE_ForcedHold>Forced Holding</CE_ForcedHold>
-
-  <!-- Medical -->
-  <CE_Stabilize>Stabilize {0}</CE_Stabilize>
-  <CE_CannotStabilize>Cannot stabilize</CE_CannotStabilize>
-  <CE_NoMedicine>{0} is not carrying any medicine in inventory</CE_NoMedicine>
-  <CE_StabilizeHediffDescription>Wound stabilized - bleeding rate multiplied by {0}. Stabilization effect will fully expire in {1} hours.</CE_StabilizeHediffDescription>
-
-  <!-- Info Box -->
-  <CE_MagazineSize>Magazine size</CE_MagazineSize>
-  <CE_ReloadTime>Reload time</CE_ReloadTime>
-  <CE_AmmoSet>Caliber</CE_AmmoSet>
-  <CE_FireModes>Fire modes</CE_FireModes>
-  <CE_AimedBurstCount>Burst shot count</CE_AimedBurstCount>
-  <CE_UsedBy>Used by</CE_UsedBy>
-  <CE_StatsReport_FlammabilityPrecipitation>Multiplier for precipitation</CE_StatsReport_FlammabilityPrecipitation>
-  <CE_StatsReport_FlammabilityApparelFactor>Apparel flammability</CE_StatsReport_FlammabilityApparelFactor>
-  <CE_StatsReport_FlammabilityApparelCoverage>Apparel coverage</CE_StatsReport_FlammabilityApparelCoverage>
-  <CE_StatsReport_BaseValue>Base value</CE_StatsReport_BaseValue>
-  <CE_mmRHA>mm RHA</CE_mmRHA>
-  <CE_MPa>MPa</CE_MPa>
-  <CE_cells>c</CE_cells>
-  <CE_degrees>&#176;</CE_degrees>
-  <CE_meters>m</CE_meters>
-  <CE_WeaponPenetrationFactor>Weapon penetration factor</CE_WeaponPenetrationFactor>
-  <CE_WeaponPenetrationSkillFactor>Skill factor</CE_WeaponPenetrationSkillFactor>
-  <CE_WeaponPenetrationOtherFactors>Other factors</CE_WeaponPenetrationOtherFactors>
-  <CE_AdjustedForWeapon>Adjusted for weapon</CE_AdjustedForWeapon>
-  <CE_RangedQualityMultiplier>Penetration quality factor</CE_RangedQualityMultiplier>
-  <CE_DPS>Damage per second</CE_DPS>
-  <CE_DamageVariation>Damage variation</CE_DamageVariation>
-  <CE_FinalAverageDamage>Final average damage</CE_FinalAverageDamage>
-  <CE_WielderSkillLevel>Wielder skill level</CE_WielderSkillLevel>
-  <CE_Chance>chance</CE_Chance>
-  <CE_ChanceFactor>Chance factor</CE_ChanceFactor>
-
-  <!-- Alerts -->
-  <CE_ColonistHasShieldAndTwoHandedWeapon>Colonist has shield and two-handed weapon</CE_ColonistHasShieldAndTwoHandedWeapon>
-  <CE_ColonistHasShieldAndTwoHandedWeaponDesc>One of your colonists is carrying a shield and has a two-handed weapon equipped. They won't be able to attack unless they remove the shield or switch to another weapon.</CE_ColonistHasShieldAndTwoHandedWeaponDesc>
-
-  <!-- Letters -->
-  <CE_CounterShellingLabel>Counter shelling</CE_CounterShellingLabel>
-  <CE_MechWarningLabel>Strange signals</CE_MechWarningLabel>
-  <CE_MechWarningText>You have intercepted several strange electronic signals nearby. While harmless on their own, such signals are often an indicator of Mechanoid activity in the area.\n\nSome of the larger Mechanoids have heavy armor that will easily deflect all rifle fire. {0} says you will need something that can defeat at least {1}mm RHA, molotov cocktails which can sink into openings and overheat internal components or EMP weapons which can destroy their circuitry.</CE_MechWarningText>
-  <CE_MechWarningText_UnnamedColonist>One of your colonists</CE_MechWarningText_UnnamedColonist>
-
-  <!-- Special display stats -->
-  <CE_CoverHeightExplanation>Collision height of this object. Will stop gunfire up to this height and humanlikes will generally crouch down this low to shoot over it.\n\nIf higher than a shooter's shot height it can't be fired over. If higher than body height it will obscure entirely. For baseline, grown humans this means 1.5m shot/1.75m body height respectively.</CE_CoverHeightExplanation>
-
-  <!-- Tutorial popup -->
-  <CE_EnableTutorText>CE adds several tutorial entries on subjects such as how the armor mechanics work and how not to die from Centipedes. It is recommended first time players enable the learning helper.</CE_EnableTutorText>
-  <CE_EnableTutorEnable>Enable learning helper</CE_EnableTutorEnable>
-  <CE_EnableTutorDisable>I know the risk</CE_EnableTutorDisable>
-
-  <!-- Assign menu -->
-  <CE_UpdateLoadoutNow>Rearm</CE_UpdateLoadoutNow>
-
-
-  <!-- Uncompiled dev build popup -->
-  <CE_UncompiledDevBuild>Uncompiled CE dev build\n\nYou're running a development build of Combat Extended that is not intended for gameplay purposes, this will create a large amount of errors if you attempt to play a colony.\n\nEither download an official CE release from GitHub's Releases section, or if you need the latest development snapshot for testing purposes, get it from the link below.</CE_UncompiledDevBuild>
-  <CE_GetCompiledDevBuild>Get development snapshot</CE_GetCompiledDevBuild>
-  <CE_ContinueAnyway>Continue anyway</CE_ContinueAnyway>
-
-  <CE_UnpatchedWeapon>This weapon is yet patched for CE, while it will behave in vanilla way as fallback, please contact a patcher for compatibility patches.</CE_UnpatchedWeapon>
-  <CE_UnpatchedWeaponShort>Not patched for CE</CE_UnpatchedWeaponShort>
-
+	<!-- Ranged Attack -->
+	<CE_OutOfBounds>Out of bounds</CE_OutOfBounds>
+	<CE_NoSelfTarget>Can't target self</CE_NoSelfTarget>
+	<CE_NoLoS>No line of sight</CE_NoLoS>
+	<CE_BlockedRoof>Blocked by roof</CE_BlockedRoof>
+	<CE_BlockedShield>Shooting disallowed by </CE_BlockedShield>
+	<CE_BlockedMaxRange>Outside of range</CE_BlockedMaxRange>
+	<CE_BlockedMinRange>Within minimum range</CE_BlockedMinRange>
   <CE_GenericBullet>bullet</CE_GenericBullet>
+
+	<!-- Artillery -->
+	<CE_ArtilleryTarget_Distance>Distance: {0}/{1} Tiles</CE_ArtilleryTarget_Distance>
+	<CE_ArtilleryTarget_Distance_Selections>Distance: {0} Tiles\nselections in range: {1}/{2}</CE_ArtilleryTarget_Distance_Selections>
+	<CE_ArtilleryTarget_DestinationBeyondMaximumRange>Target is beyond maximum range</CE_ArtilleryTarget_DestinationBeyondMaximumRange>
+	<CE_ArtilleryTarget_ClickToOrderAttack>Target:</CE_ArtilleryTarget_ClickToOrderAttack>
+	<CE_ArtilleryTarget_InvalidTarget>Invalid target</CE_ArtilleryTarget_InvalidTarget>
+	<CE_ArtilleryTarget_AttackingAllies>Are you sure you want to attack {0} ({1})?\n\nThis will make {1} hostile to you, and they may retaliate with raids and artillery fire against your colony!</CE_ArtilleryTarget_AttackingAllies>
+	<CE_ArtilleryTargetLabel>Attack world tile</CE_ArtilleryTargetLabel>
+	<CE_ArtilleryTargetDesc>Attack a world tile. If the selected tile contains a map, you can select the attack target within that map.</CE_ArtilleryTargetDesc>
+	<CE_ArtilleryTarget_AlreadyDestroyed>Selected target already destroyed</CE_ArtilleryTarget_AlreadyDestroyed>
+	<CE_ArtilleryTarget_MustTargetMark>Can only target artillery mark</CE_ArtilleryTarget_MustTargetMark>
+
+	<!-- Marking -->
+	<CE_MarkingUnavailableReason>Pawn cannot mark targets for artillery because they are on a map with no local artillery and they need a radio pack to communicate with the artillery crew.\n\nMarking targets is disabled when no artillery is available in local map and the pawn doesn't have access to long range radios.</CE_MarkingUnavailableReason>
+
+	<!-- Reloading -->
+	<CE_ReloadingEquipment>equipped</CE_ReloadingEquipment>
+	<CE_ReloadingInventory>stored</CE_ReloadingInventory>
+	<CE_ReloadingGenericAmmo>ammo</CE_ReloadingGenericAmmo>
+	<CE_ReloadingMote>Reloading {0}!</CE_ReloadingMote>
+	<CE_ReloadingTurretMote>Reloading turret {0}.</CE_ReloadingTurretMote>
+	<CE_MannedTurret>manned turret</CE_MannedTurret>
+	<CE_AutoTurret>auto-turret</CE_AutoTurret>
+	<CE_UnloadLabel>Unload</CE_UnloadLabel>
+	<CE_ReloadLabel>Reload</CE_ReloadLabel>
+	<CE_ReloadDesc>Reloads this gun.</CE_ReloadDesc>
+	<CE_TurretReloading>Reloading</CE_TurretReloading>
+
+	<!-- Inventory -->
+	<CE_TakeFromOther_Equipping>Equipping</CE_TakeFromOther_Equipping>
+	<CE_TakeFromOther_Taking>Taking</CE_TakeFromOther_Taking>
+
+	<CE_CarriedWeight>Carried weight</CE_CarriedWeight>
+	<CE_CarriedBulk>Carried bulk</CE_CarriedBulk>
+	<CE_Encumbered>Encumbered</CE_Encumbered>
+	<CE_FinalModifier>Final modifier</CE_FinalModifier>
+	<CE_InventoryFull>Inventory is full</CE_InventoryFull>
+	<CE_PickUp>Pick up</CE_PickUp>
+	<CE_PickUpHalf>Pick up half</CE_PickUpHalf>
+	<CE_CannotPickUp>Cannot pick up</CE_CannotPickUp>
+	<CE_OutOfAmmo>Out of ammo</CE_OutOfAmmo>
+	<CE_PutAway>Put away {0}</CE_PutAway>
+	<CE_ReloadApparel>Reload {0} with {1}</CE_ReloadApparel>
+	<CE_TamerInventoryFull>can't do taming job because of a full inventory.</CE_TamerInventoryFull>
+	<CE_DropThingHaul>Drop and haul</CE_DropThingHaul>
+	<CE_CannotDropThing>Cannot drop</CE_CannotDropThing>
+	<CE_CannotDropThingHaul>Cannot drop and haul</CE_CannotDropThingHaul>
+	<CE_CannotPutAway>Cannot put away {0}</CE_CannotPutAway>
+	<CE_CannotChangeEquipment>This person refuses to change equipment.</CE_CannotChangeEquipment>
+	<CE_Eat>Consume</CE_Eat>
+	<CE_HoldTrackerForget>Stop Holding</CE_HoldTrackerForget>
+	<CE_ForcedHold>Forced Holding</CE_ForcedHold>
+
+	<!-- Medical -->
+	<CE_Stabilize>Stabilize {0}</CE_Stabilize>
+	<CE_CannotStabilize>Cannot stabilize</CE_CannotStabilize>
+	<CE_NoMedicine>{0} is not carrying any medicine in inventory</CE_NoMedicine>
+	<CE_StabilizeHediffDescription>Wound stabilized - bleeding rate multiplied by {0}. Stabilization effect will fully expire in {1} hours.</CE_StabilizeHediffDescription>
+
+	<!-- Info Box -->
+	<CE_MagazineSize>Magazine size</CE_MagazineSize>
+	<CE_ReloadTime>Reload time</CE_ReloadTime>
+	<CE_AmmoSet>Caliber</CE_AmmoSet>
+	<CE_FireModes>Fire modes</CE_FireModes>
+	<CE_AimedBurstCount>Burst shot count</CE_AimedBurstCount>
+	<CE_UsedBy>Used by</CE_UsedBy>
+	<CE_StatsReport_FlammabilityPrecipitation>Multiplier for precipitation</CE_StatsReport_FlammabilityPrecipitation>
+	<CE_StatsReport_FlammabilityApparelFactor>Apparel flammability</CE_StatsReport_FlammabilityApparelFactor>
+	<CE_StatsReport_FlammabilityApparelCoverage>Apparel coverage</CE_StatsReport_FlammabilityApparelCoverage>
+	<CE_StatsReport_BaseValue>Base value</CE_StatsReport_BaseValue>
+	<CE_mmRHA>mm RHA</CE_mmRHA>
+	<CE_MPa>MPa</CE_MPa>
+	<CE_cells>c</CE_cells>
+	<CE_degrees>&#176;</CE_degrees>
+	<CE_meters>m</CE_meters>
+	<CE_WeaponPenetrationFactor>Weapon penetration factor</CE_WeaponPenetrationFactor>
+	<CE_WeaponPenetrationSkillFactor>Skill factor</CE_WeaponPenetrationSkillFactor>
+	<CE_WeaponPenetrationOtherFactors>Other factors</CE_WeaponPenetrationOtherFactors>
+	<CE_AdjustedForWeapon>Adjusted for weapon</CE_AdjustedForWeapon>
+	<CE_RangedQualityMultiplier>Penetration quality factor</CE_RangedQualityMultiplier>
+	<CE_DPS>Damage per second</CE_DPS>
+	<CE_DamageVariation>Damage variation</CE_DamageVariation>
+	<CE_FinalAverageDamage>Final average damage</CE_FinalAverageDamage>
+	<CE_WielderSkillLevel>Wielder skill level</CE_WielderSkillLevel>
+	<CE_Chance>chance</CE_Chance>
+	<CE_ChanceFactor>Chance factor</CE_ChanceFactor>
+
+	<!-- Alerts -->
+	<CE_ColonistHasShieldAndTwoHandedWeapon>Colonist has shield and two-handed weapon</CE_ColonistHasShieldAndTwoHandedWeapon>
+	<CE_ColonistHasShieldAndTwoHandedWeaponDesc>One of your colonists is carrying a shield and has a two-handed weapon equipped. They won't be able to attack unless they remove the shield or switch to another weapon.</CE_ColonistHasShieldAndTwoHandedWeaponDesc>
+
+	<!-- Letters -->
+	<CE_CounterShellingLabel>Counter shelling</CE_CounterShellingLabel>
+	<CE_MechWarningLabel>Strange signals</CE_MechWarningLabel>
+	<CE_MechWarningText>You have intercepted several strange electronic signals nearby. While harmless on their own, such signals are often an indicator of Mechanoid activity in the area.\n\nSome of the larger Mechanoids have heavy armor that will easily deflect all rifle fire. {0} says you will need something that can defeat at least {1}mm RHA, molotov cocktails which can sink into openings and overheat internal components or EMP weapons which can destroy their circuitry.</CE_MechWarningText>
+	<CE_MechWarningText_UnnamedColonist>One of your colonists</CE_MechWarningText_UnnamedColonist>
+
+	<!-- Special display stats -->
+	<CE_CoverHeightExplanation>Collision height of this object. Will stop gunfire up to this height and humanlikes will generally crouch down this low to shoot over it.\n\nIf higher than a shooter's shot height it can't be fired over. If higher than body height it will obscure entirely. For baseline, grown humans this means 1.5m shot/1.75m body height respectively.</CE_CoverHeightExplanation>
+
+	<!-- Tutorial popup -->
+	<CE_EnableTutorText>CE adds several tutorial entries on subjects such as how the armor mechanics work and how not to die from Centipedes. It is recommended first time players enable the learning helper.</CE_EnableTutorText>
+	<CE_EnableTutorEnable>Enable learning helper</CE_EnableTutorEnable>
+	<CE_EnableTutorDisable>I know the risk</CE_EnableTutorDisable>
+
+	<!-- Assign menu -->
+	<CE_UpdateLoadoutNow>Rearm</CE_UpdateLoadoutNow>
+
+
+	<!-- Uncompiled dev build popup -->
+	<CE_UncompiledDevBuild>Uncompiled CE dev build\n\nYou're running a development build of Combat Extended that is not intended for gameplay purposes, this will create a large amount of errors if you attempt to play a colony.\n\nEither download an official CE release from GitHub's Releases section, or if you need the latest development snapshot for testing purposes, get it from the link below.</CE_UncompiledDevBuild>
+	<CE_GetCompiledDevBuild>Get development snapshot</CE_GetCompiledDevBuild>
+	<CE_ContinueAnyway>Continue anyway</CE_ContinueAnyway>
+
+	<CE_UnpatchedWeapon>This weapon is yet patched for CE, while it will behave in vanilla way as fallback, please contact a patcher for compatibility patches.</CE_UnpatchedWeapon>
+	<CE_UnpatchedWeaponShort>Not patched for CE</CE_UnpatchedWeaponShort>
+
 </LanguageData>

--- a/Languages/English/Keyed/Keys.xml
+++ b/Languages/English/Keyed/Keys.xml
@@ -1,175 +1,176 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LanguageData>
 
-	<!-- Tabs -->
-	<TabAttachments>Attachm.</TabAttachments>
+  <!-- Tabs -->
+  <TabAttachments>Attachm.</TabAttachments>
 
-	<!-- Billing -->
-	<CE_MissinGunsmithingBench>Requires gunsmithing bench</CE_MissinGunsmithingBench>
+  <!-- Billing -->
+  <CE_MissinGunsmithingBench>Requires gunsmithing bench</CE_MissinGunsmithingBench>
 
-	<!-- Suppression -->
-	<CE_SuppressedMote>Suppressed!</CE_SuppressedMote>
-	<CE_HunkeringMote>Hunkering!</CE_HunkeringMote>
-	<CE_CrouchWalking>Suppressed (crouch-walking)</CE_CrouchWalking>
+  <!-- Suppression -->
+  <CE_SuppressedMote>Suppressed!</CE_SuppressedMote>
+  <CE_HunkeringMote>Hunkering!</CE_HunkeringMote>
+  <CE_CrouchWalking>Suppressed (crouch-walking)</CE_CrouchWalking>
 
-	<!-- Aim/Fire modes -->
-	<CE_AutoFireLabel>Auto</CE_AutoFireLabel>
-	<CE_BurstFireLabel>Burst</CE_BurstFireLabel>
-	<CE_SingleFireLabel>Single</CE_SingleFireLabel>
-	<CE_SnapshotLabel>Snapshot</CE_SnapshotLabel>
-	<CE_AimedShotLabel>Aimed shot</CE_AimedShotLabel>
-	<CE_SuppressFireLabel>Suppress</CE_SuppressFireLabel>
-	<CE_HoldFireLabel>Hold fire</CE_HoldFireLabel>
-	<CE_ToggleFireModeDesc>Toggle fire mode.</CE_ToggleFireModeDesc>
-	<CE_ToggleAimModeDesc>Toggle aim mode.</CE_ToggleAimModeDesc>
+  <!-- Aim/Fire modes -->
+  <CE_AutoFireLabel>Auto</CE_AutoFireLabel>
+  <CE_BurstFireLabel>Burst</CE_BurstFireLabel>
+  <CE_SingleFireLabel>Single</CE_SingleFireLabel>
+  <CE_SnapshotLabel>Snapshot</CE_SnapshotLabel>
+  <CE_AimedShotLabel>Aimed shot</CE_AimedShotLabel>
+  <CE_SuppressFireLabel>Suppress</CE_SuppressFireLabel>
+  <CE_HoldFireLabel>Hold fire</CE_HoldFireLabel>
+  <CE_ToggleFireModeDesc>Toggle fire mode.</CE_ToggleFireModeDesc>
+  <CE_ToggleAimModeDesc>Toggle aim mode.</CE_ToggleAimModeDesc>
 
-	<!-- Bipod system -->
-	<CE_Bipod_Set_Up>Bipod IS set up</CE_Bipod_Set_Up>
-	<CE_Bipod_Not_Set_Up>Bipod IS NOT set up</CE_Bipod_Not_Set_Up>
-	<CE_Deploy_Bipod>Deploy bipod</CE_Deploy_Bipod>
-	<CE_Close_Bipod>Close bipod</CE_Close_Bipod>
+  <!-- Bipod system -->
+  <CE_Bipod_Set_Up>Bipod IS set up</CE_Bipod_Set_Up>
+  <CE_Bipod_Not_Set_Up>Bipod IS NOT set up</CE_Bipod_Not_Set_Up>
+  <CE_Deploy_Bipod>Deploy bipod</CE_Deploy_Bipod>
+  <CE_Close_Bipod>Close bipod</CE_Close_Bipod>
 
-	<!-- Aiming system -->
-	<CE_MarkedForArtillery>Marked for artillery, expires in</CE_MarkedForArtillery>
+  <!-- Aiming system -->
+  <CE_MarkedForArtillery>Marked for artillery, expires in</CE_MarkedForArtillery>
 
-	<CE_VisibilityError>Visibility error</CE_VisibilityError>
-	<CE_SmokeDensity>Smoke</CE_SmokeDensity>
-	<CE_LeadError>Lead error</CE_LeadError>
-	<CE_RangeError>Range error</CE_RangeError>
-	<CE_Sway>Sway</CE_Sway>
-	<CE_Spread>Spread</CE_Spread>
-	<CE_MissRadius>Miss radius</CE_MissRadius>
-	<CE_IndirectFire>Indirect fire</CE_IndirectFire>
-	<CE_CoverHeight>Cover height</CE_CoverHeight>
-	<CE_TargetHeight>Target height</CE_TargetHeight>
-	<CE_TargetWidth>Target width</CE_TargetWidth>
+  <CE_VisibilityError>Visibility error</CE_VisibilityError>
+  <CE_SmokeDensity>Smoke</CE_SmokeDensity>
+  <CE_LeadError>Lead error</CE_LeadError>
+  <CE_RangeError>Range error</CE_RangeError>
+  <CE_Sway>Sway</CE_Sway>
+  <CE_Spread>Spread</CE_Spread>
+  <CE_MissRadius>Miss radius</CE_MissRadius>
+  <CE_IndirectFire>Indirect fire</CE_IndirectFire>
+  <CE_CoverHeight>Cover height</CE_CoverHeight>
+  <CE_TargetHeight>Target height</CE_TargetHeight>
+  <CE_TargetWidth>Target width</CE_TargetWidth>
 
-	<CE_EstimatedHitChance>Estimated hit chance</CE_EstimatedHitChance>
+  <CE_EstimatedHitChance>Estimated hit chance</CE_EstimatedHitChance>
 
-	<!-- Ranged Attack -->
-	<CE_OutOfBounds>Out of bounds</CE_OutOfBounds>
-	<CE_NoSelfTarget>Can't target self</CE_NoSelfTarget>
-	<CE_NoLoS>No line of sight</CE_NoLoS>	
-	<CE_BlockedRoof>Blocked by roof</CE_BlockedRoof>
-	<CE_BlockedShield>Shooting disallowed by </CE_BlockedShield>
-	<CE_BlockedMaxRange>Outside of range</CE_BlockedMaxRange>
-	<CE_BlockedMinRange>Within minimum range</CE_BlockedMinRange>
+  <!-- Ranged Attack -->
+  <CE_OutOfBounds>Out of bounds</CE_OutOfBounds>
+  <CE_NoSelfTarget>Can't target self</CE_NoSelfTarget>
+  <CE_NoLoS>No line of sight</CE_NoLoS>
+  <CE_BlockedRoof>Blocked by roof</CE_BlockedRoof>
+  <CE_BlockedShield>Shooting disallowed by </CE_BlockedShield>
+  <CE_BlockedMaxRange>Outside of range</CE_BlockedMaxRange>
+  <CE_BlockedMinRange>Within minimum range</CE_BlockedMinRange>
 
-	<!-- Artillery -->
-	<CE_ArtilleryTarget_Distance>Distance: {0}/{1} Tiles</CE_ArtilleryTarget_Distance>
-	<CE_ArtilleryTarget_Distance_Selections>Distance: {0} Tiles\nselections in range: {1}/{2}</CE_ArtilleryTarget_Distance_Selections>
-	<CE_ArtilleryTarget_DestinationBeyondMaximumRange>Target is beyond maximum range</CE_ArtilleryTarget_DestinationBeyondMaximumRange>
-	<CE_ArtilleryTarget_ClickToOrderAttack>Target:</CE_ArtilleryTarget_ClickToOrderAttack>
-	<CE_ArtilleryTarget_InvalidTarget>Invalid target</CE_ArtilleryTarget_InvalidTarget>
-	<CE_ArtilleryTarget_AttackingAllies>Are you sure you want to attack {0} ({1})?\n\nThis will make {1} hostile to you, and they may retaliate with raids and artillery fire against your colony!</CE_ArtilleryTarget_AttackingAllies>
-	<CE_ArtilleryTargetLabel>Attack world tile</CE_ArtilleryTargetLabel>
-	<CE_ArtilleryTargetDesc>Attack a world tile. If the selected tile contains a map, you can select the attack target within that map.</CE_ArtilleryTargetDesc>
-	<CE_ArtilleryTarget_AlreadyDestroyed>Selected target already destroyed</CE_ArtilleryTarget_AlreadyDestroyed>
-	<CE_ArtilleryTarget_MustTargetMark>Can only target artillery mark</CE_ArtilleryTarget_MustTargetMark>
+  <!-- Artillery -->
+  <CE_ArtilleryTarget_Distance>Distance: {0}/{1} Tiles</CE_ArtilleryTarget_Distance>
+  <CE_ArtilleryTarget_Distance_Selections>Distance: {0} Tiles\nselections in range: {1}/{2}</CE_ArtilleryTarget_Distance_Selections>
+  <CE_ArtilleryTarget_DestinationBeyondMaximumRange>Target is beyond maximum range</CE_ArtilleryTarget_DestinationBeyondMaximumRange>
+  <CE_ArtilleryTarget_ClickToOrderAttack>Target:</CE_ArtilleryTarget_ClickToOrderAttack>
+  <CE_ArtilleryTarget_InvalidTarget>Invalid target</CE_ArtilleryTarget_InvalidTarget>
+  <CE_ArtilleryTarget_AttackingAllies>Are you sure you want to attack {0} ({1})?\n\nThis will make {1} hostile to you, and they may retaliate with raids and artillery fire against your colony!</CE_ArtilleryTarget_AttackingAllies>
+  <CE_ArtilleryTargetLabel>Attack world tile</CE_ArtilleryTargetLabel>
+  <CE_ArtilleryTargetDesc>Attack a world tile. If the selected tile contains a map, you can select the attack target within that map.</CE_ArtilleryTargetDesc>
+  <CE_ArtilleryTarget_AlreadyDestroyed>Selected target already destroyed</CE_ArtilleryTarget_AlreadyDestroyed>
+  <CE_ArtilleryTarget_MustTargetMark>Can only target artillery mark</CE_ArtilleryTarget_MustTargetMark>
 
-	<!-- Marking -->
-	<CE_MarkingUnavailableReason>Pawn cannot mark targets for artillery because they are on a map with no local artillery and they need a radio pack to communicate with the artillery crew.\n\nMarking targets is disabled when no artillery is available in local map and the pawn doesn't have access to long range radios.</CE_MarkingUnavailableReason>
+  <!-- Marking -->
+  <CE_MarkingUnavailableReason>Pawn cannot mark targets for artillery because they are on a map with no local artillery and they need a radio pack to communicate with the artillery crew.\n\nMarking targets is disabled when no artillery is available in local map and the pawn doesn't have access to long range radios.</CE_MarkingUnavailableReason>
 
-	<!-- Reloading -->
-	<CE_ReloadingEquipment>equipped</CE_ReloadingEquipment>
-	<CE_ReloadingInventory>stored</CE_ReloadingInventory>
-	<CE_ReloadingGenericAmmo>ammo</CE_ReloadingGenericAmmo>
-	<CE_ReloadingMote>Reloading {0}!</CE_ReloadingMote>
-	<CE_ReloadingTurretMote>Reloading turret {0}.</CE_ReloadingTurretMote>
-	<CE_MannedTurret>manned turret</CE_MannedTurret>
-	<CE_AutoTurret>auto-turret</CE_AutoTurret>
-	<CE_UnloadLabel>Unload</CE_UnloadLabel>
-	<CE_ReloadLabel>Reload</CE_ReloadLabel>
-	<CE_ReloadDesc>Reloads this gun.</CE_ReloadDesc>
-	<CE_TurretReloading>Reloading</CE_TurretReloading>
+  <!-- Reloading -->
+  <CE_ReloadingEquipment>equipped</CE_ReloadingEquipment>
+  <CE_ReloadingInventory>stored</CE_ReloadingInventory>
+  <CE_ReloadingGenericAmmo>ammo</CE_ReloadingGenericAmmo>
+  <CE_ReloadingMote>Reloading {0}!</CE_ReloadingMote>
+  <CE_ReloadingTurretMote>Reloading turret {0}.</CE_ReloadingTurretMote>
+  <CE_MannedTurret>manned turret</CE_MannedTurret>
+  <CE_AutoTurret>auto-turret</CE_AutoTurret>
+  <CE_UnloadLabel>Unload</CE_UnloadLabel>
+  <CE_ReloadLabel>Reload</CE_ReloadLabel>
+  <CE_ReloadDesc>Reloads this gun.</CE_ReloadDesc>
+  <CE_TurretReloading>Reloading</CE_TurretReloading>
 
-	<!-- Inventory -->
-	<CE_TakeFromOther_Equipping>Equipping</CE_TakeFromOther_Equipping>
-	<CE_TakeFromOther_Taking>Taking</CE_TakeFromOther_Taking>
+  <!-- Inventory -->
+  <CE_TakeFromOther_Equipping>Equipping</CE_TakeFromOther_Equipping>
+  <CE_TakeFromOther_Taking>Taking</CE_TakeFromOther_Taking>
 
-	<CE_CarriedWeight>Carried weight</CE_CarriedWeight>
-	<CE_CarriedBulk>Carried bulk</CE_CarriedBulk>
-	<CE_Encumbered>Encumbered</CE_Encumbered>
-	<CE_FinalModifier>Final modifier</CE_FinalModifier>
-	<CE_InventoryFull>Inventory is full</CE_InventoryFull>
-	<CE_PickUp>Pick up</CE_PickUp>
-	<CE_PickUpHalf>Pick up half</CE_PickUpHalf>
-	<CE_CannotPickUp>Cannot pick up</CE_CannotPickUp>
-	<CE_OutOfAmmo>Out of ammo</CE_OutOfAmmo>
-	<CE_PutAway>Put away {0}</CE_PutAway>
-	<CE_ReloadApparel>Reload {0} with {1}</CE_ReloadApparel>
-	<CE_TamerInventoryFull>can't do taming job because of a full inventory.</CE_TamerInventoryFull>
-	<CE_DropThingHaul>Drop and haul</CE_DropThingHaul>
-	<CE_CannotDropThing>Cannot drop</CE_CannotDropThing>
-	<CE_CannotDropThingHaul>Cannot drop and haul</CE_CannotDropThingHaul>
-	<CE_CannotPutAway>Cannot put away {0}</CE_CannotPutAway>
-	<CE_CannotChangeEquipment>This person refuses to change equipment.</CE_CannotChangeEquipment>
-	<CE_Eat>Consume</CE_Eat>
-	<CE_HoldTrackerForget>Stop Holding</CE_HoldTrackerForget>
-	<CE_ForcedHold>Forced Holding</CE_ForcedHold>
+  <CE_CarriedWeight>Carried weight</CE_CarriedWeight>
+  <CE_CarriedBulk>Carried bulk</CE_CarriedBulk>
+  <CE_Encumbered>Encumbered</CE_Encumbered>
+  <CE_FinalModifier>Final modifier</CE_FinalModifier>
+  <CE_InventoryFull>Inventory is full</CE_InventoryFull>
+  <CE_PickUp>Pick up</CE_PickUp>
+  <CE_PickUpHalf>Pick up half</CE_PickUpHalf>
+  <CE_CannotPickUp>Cannot pick up</CE_CannotPickUp>
+  <CE_OutOfAmmo>Out of ammo</CE_OutOfAmmo>
+  <CE_PutAway>Put away {0}</CE_PutAway>
+  <CE_ReloadApparel>Reload {0} with {1}</CE_ReloadApparel>
+  <CE_TamerInventoryFull>can't do taming job because of a full inventory.</CE_TamerInventoryFull>
+  <CE_DropThingHaul>Drop and haul</CE_DropThingHaul>
+  <CE_CannotDropThing>Cannot drop</CE_CannotDropThing>
+  <CE_CannotDropThingHaul>Cannot drop and haul</CE_CannotDropThingHaul>
+  <CE_CannotPutAway>Cannot put away {0}</CE_CannotPutAway>
+  <CE_CannotChangeEquipment>This person refuses to change equipment.</CE_CannotChangeEquipment>
+  <CE_Eat>Consume</CE_Eat>
+  <CE_HoldTrackerForget>Stop Holding</CE_HoldTrackerForget>
+  <CE_ForcedHold>Forced Holding</CE_ForcedHold>
 
-	<!-- Medical -->
-	<CE_Stabilize>Stabilize {0}</CE_Stabilize>
-	<CE_CannotStabilize>Cannot stabilize</CE_CannotStabilize>
-	<CE_NoMedicine>{0} is not carrying any medicine in inventory</CE_NoMedicine>
-	<CE_StabilizeHediffDescription>Wound stabilized - bleeding rate multiplied by {0}. Stabilization effect will fully expire in {1} hours.</CE_StabilizeHediffDescription>
+  <!-- Medical -->
+  <CE_Stabilize>Stabilize {0}</CE_Stabilize>
+  <CE_CannotStabilize>Cannot stabilize</CE_CannotStabilize>
+  <CE_NoMedicine>{0} is not carrying any medicine in inventory</CE_NoMedicine>
+  <CE_StabilizeHediffDescription>Wound stabilized - bleeding rate multiplied by {0}. Stabilization effect will fully expire in {1} hours.</CE_StabilizeHediffDescription>
 
-	<!-- Info Box -->
-	<CE_MagazineSize>Magazine size</CE_MagazineSize>
-	<CE_ReloadTime>Reload time</CE_ReloadTime>
-	<CE_AmmoSet>Caliber</CE_AmmoSet>
-	<CE_FireModes>Fire modes</CE_FireModes>
-	<CE_AimedBurstCount>Burst shot count</CE_AimedBurstCount>
-	<CE_UsedBy>Used by</CE_UsedBy>
-	<CE_StatsReport_FlammabilityPrecipitation>Multiplier for precipitation</CE_StatsReport_FlammabilityPrecipitation>
-	<CE_StatsReport_FlammabilityApparelFactor>Apparel flammability</CE_StatsReport_FlammabilityApparelFactor>
-	<CE_StatsReport_FlammabilityApparelCoverage>Apparel coverage</CE_StatsReport_FlammabilityApparelCoverage>
-	<CE_StatsReport_BaseValue>Base value</CE_StatsReport_BaseValue>
-	<CE_mmRHA>mm RHA</CE_mmRHA>
-	<CE_MPa>MPa</CE_MPa>
-	<CE_cells>c</CE_cells>
-	<CE_degrees>&#176;</CE_degrees>
-	<CE_meters>m</CE_meters>
-	<CE_WeaponPenetrationFactor>Weapon penetration factor</CE_WeaponPenetrationFactor>
-	<CE_WeaponPenetrationSkillFactor>Skill factor</CE_WeaponPenetrationSkillFactor>
-	<CE_WeaponPenetrationOtherFactors>Other factors</CE_WeaponPenetrationOtherFactors>
-	<CE_AdjustedForWeapon>Adjusted for weapon</CE_AdjustedForWeapon>
-	<CE_RangedQualityMultiplier>Penetration quality factor</CE_RangedQualityMultiplier>
-	<CE_DPS>Damage per second</CE_DPS>
-	<CE_DamageVariation>Damage variation</CE_DamageVariation>
-	<CE_FinalAverageDamage>Final average damage</CE_FinalAverageDamage>
-	<CE_WielderSkillLevel>Wielder skill level</CE_WielderSkillLevel>
-	<CE_Chance>chance</CE_Chance>
-	<CE_ChanceFactor>Chance factor</CE_ChanceFactor>
+  <!-- Info Box -->
+  <CE_MagazineSize>Magazine size</CE_MagazineSize>
+  <CE_ReloadTime>Reload time</CE_ReloadTime>
+  <CE_AmmoSet>Caliber</CE_AmmoSet>
+  <CE_FireModes>Fire modes</CE_FireModes>
+  <CE_AimedBurstCount>Burst shot count</CE_AimedBurstCount>
+  <CE_UsedBy>Used by</CE_UsedBy>
+  <CE_StatsReport_FlammabilityPrecipitation>Multiplier for precipitation</CE_StatsReport_FlammabilityPrecipitation>
+  <CE_StatsReport_FlammabilityApparelFactor>Apparel flammability</CE_StatsReport_FlammabilityApparelFactor>
+  <CE_StatsReport_FlammabilityApparelCoverage>Apparel coverage</CE_StatsReport_FlammabilityApparelCoverage>
+  <CE_StatsReport_BaseValue>Base value</CE_StatsReport_BaseValue>
+  <CE_mmRHA>mm RHA</CE_mmRHA>
+  <CE_MPa>MPa</CE_MPa>
+  <CE_cells>c</CE_cells>
+  <CE_degrees>&#176;</CE_degrees>
+  <CE_meters>m</CE_meters>
+  <CE_WeaponPenetrationFactor>Weapon penetration factor</CE_WeaponPenetrationFactor>
+  <CE_WeaponPenetrationSkillFactor>Skill factor</CE_WeaponPenetrationSkillFactor>
+  <CE_WeaponPenetrationOtherFactors>Other factors</CE_WeaponPenetrationOtherFactors>
+  <CE_AdjustedForWeapon>Adjusted for weapon</CE_AdjustedForWeapon>
+  <CE_RangedQualityMultiplier>Penetration quality factor</CE_RangedQualityMultiplier>
+  <CE_DPS>Damage per second</CE_DPS>
+  <CE_DamageVariation>Damage variation</CE_DamageVariation>
+  <CE_FinalAverageDamage>Final average damage</CE_FinalAverageDamage>
+  <CE_WielderSkillLevel>Wielder skill level</CE_WielderSkillLevel>
+  <CE_Chance>chance</CE_Chance>
+  <CE_ChanceFactor>Chance factor</CE_ChanceFactor>
 
-	<!-- Alerts -->
-	<CE_ColonistHasShieldAndTwoHandedWeapon>Colonist has shield and two-handed weapon</CE_ColonistHasShieldAndTwoHandedWeapon>
-	<CE_ColonistHasShieldAndTwoHandedWeaponDesc>One of your colonists is carrying a shield and has a two-handed weapon equipped. They won't be able to attack unless they remove the shield or switch to another weapon.</CE_ColonistHasShieldAndTwoHandedWeaponDesc>
+  <!-- Alerts -->
+  <CE_ColonistHasShieldAndTwoHandedWeapon>Colonist has shield and two-handed weapon</CE_ColonistHasShieldAndTwoHandedWeapon>
+  <CE_ColonistHasShieldAndTwoHandedWeaponDesc>One of your colonists is carrying a shield and has a two-handed weapon equipped. They won't be able to attack unless they remove the shield or switch to another weapon.</CE_ColonistHasShieldAndTwoHandedWeaponDesc>
 
-	<!-- Letters -->
-	<CE_CounterShellingLabel>Counter shelling</CE_CounterShellingLabel>
-	<CE_MechWarningLabel>Strange signals</CE_MechWarningLabel>
-	<CE_MechWarningText>You have intercepted several strange electronic signals nearby. While harmless on their own, such signals are often an indicator of Mechanoid activity in the area.\n\nSome of the larger Mechanoids have heavy armor that will easily deflect all rifle fire. {0} says you will need something that can defeat at least {1}mm RHA, molotov cocktails which can sink into openings and overheat internal components or EMP weapons which can destroy their circuitry.</CE_MechWarningText>
-	<CE_MechWarningText_UnnamedColonist>One of your colonists</CE_MechWarningText_UnnamedColonist>
+  <!-- Letters -->
+  <CE_CounterShellingLabel>Counter shelling</CE_CounterShellingLabel>
+  <CE_MechWarningLabel>Strange signals</CE_MechWarningLabel>
+  <CE_MechWarningText>You have intercepted several strange electronic signals nearby. While harmless on their own, such signals are often an indicator of Mechanoid activity in the area.\n\nSome of the larger Mechanoids have heavy armor that will easily deflect all rifle fire. {0} says you will need something that can defeat at least {1}mm RHA, molotov cocktails which can sink into openings and overheat internal components or EMP weapons which can destroy their circuitry.</CE_MechWarningText>
+  <CE_MechWarningText_UnnamedColonist>One of your colonists</CE_MechWarningText_UnnamedColonist>
 
-	<!-- Special display stats -->
-	<CE_CoverHeightExplanation>Collision height of this object. Will stop gunfire up to this height and humanlikes will generally crouch down this low to shoot over it.\n\nIf higher than a shooter's shot height it can't be fired over. If higher than body height it will obscure entirely. For baseline, grown humans this means 1.5m shot/1.75m body height respectively.</CE_CoverHeightExplanation>
+  <!-- Special display stats -->
+  <CE_CoverHeightExplanation>Collision height of this object. Will stop gunfire up to this height and humanlikes will generally crouch down this low to shoot over it.\n\nIf higher than a shooter's shot height it can't be fired over. If higher than body height it will obscure entirely. For baseline, grown humans this means 1.5m shot/1.75m body height respectively.</CE_CoverHeightExplanation>
 
-	<!-- Tutorial popup -->
-	<CE_EnableTutorText>CE adds several tutorial entries on subjects such as how the armor mechanics work and how not to die from Centipedes. It is recommended first time players enable the learning helper.</CE_EnableTutorText>
-	<CE_EnableTutorEnable>Enable learning helper</CE_EnableTutorEnable>
-	<CE_EnableTutorDisable>I know the risk</CE_EnableTutorDisable>
+  <!-- Tutorial popup -->
+  <CE_EnableTutorText>CE adds several tutorial entries on subjects such as how the armor mechanics work and how not to die from Centipedes. It is recommended first time players enable the learning helper.</CE_EnableTutorText>
+  <CE_EnableTutorEnable>Enable learning helper</CE_EnableTutorEnable>
+  <CE_EnableTutorDisable>I know the risk</CE_EnableTutorDisable>
 
-	<!-- Assign menu -->
-	<CE_UpdateLoadoutNow>Rearm</CE_UpdateLoadoutNow>
+  <!-- Assign menu -->
+  <CE_UpdateLoadoutNow>Rearm</CE_UpdateLoadoutNow>
 
 
-	<!-- Uncompiled dev build popup -->
-	<CE_UncompiledDevBuild>Uncompiled CE dev build\n\nYou're running a development build of Combat Extended that is not intended for gameplay purposes, this will create a large amount of errors if you attempt to play a colony.\n\nEither download an official CE release from GitHub's Releases section, or if you need the latest development snapshot for testing purposes, get it from the link below.</CE_UncompiledDevBuild>
-	<CE_GetCompiledDevBuild>Get development snapshot</CE_GetCompiledDevBuild>
-	<CE_ContinueAnyway>Continue anyway</CE_ContinueAnyway>
+  <!-- Uncompiled dev build popup -->
+  <CE_UncompiledDevBuild>Uncompiled CE dev build\n\nYou're running a development build of Combat Extended that is not intended for gameplay purposes, this will create a large amount of errors if you attempt to play a colony.\n\nEither download an official CE release from GitHub's Releases section, or if you need the latest development snapshot for testing purposes, get it from the link below.</CE_UncompiledDevBuild>
+  <CE_GetCompiledDevBuild>Get development snapshot</CE_GetCompiledDevBuild>
+  <CE_ContinueAnyway>Continue anyway</CE_ContinueAnyway>
 
-	<CE_UnpatchedWeapon>This weapon is yet patched for CE, while it will behave in vanilla way as fallback, please contact a patcher for compatibility patches.</CE_UnpatchedWeapon>
-	<CE_UnpatchedWeaponShort>Not patched for CE</CE_UnpatchedWeaponShort>
+  <CE_UnpatchedWeapon>This weapon is yet patched for CE, while it will behave in vanilla way as fallback, please contact a patcher for compatibility patches.</CE_UnpatchedWeapon>
+  <CE_UnpatchedWeaponShort>Not patched for CE</CE_UnpatchedWeaponShort>
 
+  <CE_GenericBullet>bullet</CE_GenericBullet>
 </LanguageData>

--- a/Source/CombatExtended/CombatExtended/AmmoGeneralizer.cs
+++ b/Source/CombatExtended/CombatExtended/AmmoGeneralizer.cs
@@ -30,7 +30,7 @@ namespace CombatExtended
                         var sameClass = ammoSource.ammoTypes.Find(x => x.ammo.ammoClass == link.ammo.ammoClass);
                         if (sameClass != null)
                         {
-                            string labelNew = (link.projectile is AmmoDef ammodef && ammodef.genericLabelOverride != null) ? ammodef.genericLabelOverride : ammoSource.label;
+                            string labelNew = (link.projectile.projectile is ProjectilePropertiesCE projPropCE && projPropCE.genericLabelOverride != null) ? projPropCE.genericLabelOverride : ammoSource.label;
                             link.projectile.label = labelNew + " " + "CE_GenericBullet".Translate() + " (" + link.ammo.ammoClass.labelShort + ")";
                             newAmmos.Add(new AmmoLink { ammo = sameClass.ammo, projectile = link.projectile });
                         }

--- a/Source/CombatExtended/CombatExtended/AmmoGeneralizer.cs
+++ b/Source/CombatExtended/CombatExtended/AmmoGeneralizer.cs
@@ -30,7 +30,8 @@ namespace CombatExtended
                         var sameClass = ammoSource.ammoTypes.Find(x => x.ammo.ammoClass == link.ammo.ammoClass);
                         if (sameClass != null)
                         {
-                            link.projectile.label = ammoSource.label + " bullet " + "(" + link.ammo.ammoClass.labelShort + ")";
+                            string labelNew = (link.projectile is AmmoDef ammodef && ammodef.genericLabelOverride != null) ? ammodef.genericLabelOverride : ammoSource.label;
+                            link.projectile.label = labelNew + " " + "CE_GenericBullet".Translate() + " (" + link.ammo.ammoClass.labelShort + ")";
                             newAmmos.Add(new AmmoLink { ammo = sameClass.ammo, projectile = link.projectile });
                         }
 

--- a/Source/CombatExtended/CombatExtended/Defs/AmmoDef.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/AmmoDef.cs
@@ -20,8 +20,6 @@ namespace CombatExtended
         public SoundDef cookOffSound = null;
         public SoundDef cookOffTailSound = null;
         public ThingDef detonateProjectile = null;
-        [MustTranslate]
-        public string genericLabelOverride = null;
 
         // mortar ammo should still availabe when the ammo system is off        
         public bool isMortarAmmo = false;

--- a/Source/CombatExtended/CombatExtended/Defs/AmmoDef.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/AmmoDef.cs
@@ -20,6 +20,8 @@ namespace CombatExtended
         public SoundDef cookOffSound = null;
         public SoundDef cookOffTailSound = null;
         public ThingDef detonateProjectile = null;
+        [MustTranslate]
+        public string genericLabelOverride = null;
 
         // mortar ammo should still availabe when the ammo system is off        
         public bool isMortarAmmo = false;
@@ -111,6 +113,7 @@ namespace CombatExtended
             }
         }
 
+        [NoTranslate]
         private string oldDescription;
         public void AddDescriptionParts()
         {

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectilePropertiesCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectilePropertiesCE.cs
@@ -39,6 +39,8 @@ namespace CombatExtended
         public ThingDef detonateMoteDef;
         public FleckDef detonateFleckDef;
         public float detonateEffectsScaleOverride = -1;
+        [MustTranslate]
+        public string genericLabelOverride = null;
 
         #region Bunker Buster fields
         /// <summary>


### PR DESCRIPTION
## Additions

GenericLabelOverride field in CombatExtended.AmmoDef. Ammo generalizer will use it for projectile name if present.

## Changes

Translation key for " bullet " in Ammo generalizer, since I stumbled across it.
NoTranslate annotation in AmmoDef's oldDescription, it has been annoying me forever and I happened to come across it.

## Reasoning

Intended for edge cases.

## Alternatives

Revolver shotgun SMG.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (a full mag from a machine pistol)
