### PR TITLE
VFE Mechanoid Load After

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -87,6 +87,7 @@
 		<li>Argon.VMEu</li>
 		<li>Bonible.rimsenalfactions</li>
 		<li>kentington.saveourship2</li>
+		<li>oskarpotocki.vfe.mechanoid</li>
 	</loadAfter>
 
 </ModMetaData>


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Adds loadAfter for VFE - Mechanoid

## References

Links to the associated issues or other related pull requests, e.g.
- Fixes error of when VFE - Mechanoid and Alpha Biomes are both loaded. Auto-sorting may put VFE - Mechanoid before Combat Extended. https://discord.com/channels/278818534069501953/324222101550661663/1279139876423602349

## Reasoning

Why did you choose to implement things this way, e.g.
- Fixes issue with CE patch of when VFE - Mechanoid and Alpha Biomes are both loaded, depending on load order of mod list. VFE - Mechanoid uses PatchOperationAdd to add a Def instead of LoadFolders.

## Alternatives

Describe alternative implementations you have considered, e.g.
- Ignore
  - Less potential for cyclical load orders

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
