### PR TITLE
Remove Industrial Stuff Patch

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -408,6 +408,7 @@
 		<li IfModActive="Mlie.RedArmy">ModPatches/Red Army</li>
 		<li IfModActive="vonschtirlitz.RCA">ModPatches/Redcoat Apparel</li>
 		<li IfModActive="tikubonn.RemoteDetonator">ModPatches/Remote Detonator</li>
+		<li IfModActive="mlie.removeindustrialstuff">ModPatches/Remove Industrial Stuff</li>
 		<li IfModActive="FS.ReviaRace">ModPatches/Revia Race</li>
 		<li IfModActive="FS.ReviaRaceBiotech">ModPatches/Revia Race — biotech</li>
 		<li IfModActive="zerophoenix.contractorsarsenalfaction">ModPatches/Rim Contractors Arsenal</li>

--- a/ModPatches/Remove Industrial Stuff/Patches/RemoveIndustrial_AmmoInjector.xml
+++ b/ModPatches/Remove Industrial Stuff/Patches/RemoveIndustrial_AmmoInjector.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- Removed to prevent errors for Ammo Injector -->
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef/tradeTags/li[.="CE_AutoEnableCrafting_ElectricSmithy"]
+		</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef/tradeTags/li[.="CE_AutoEnableCrafting_TableMachining"]</xpath>
+	</Operation>
+
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -407,6 +407,7 @@ ReGrowth: Core |
 ReGrowth: Extinct Animals |
 ReGrowth: Wastelands |
 Remote Detonator	|
+Remove Industrial Stuff |
 Revia Race |
 Revia Race - biotech |
 Rim Contractors Arsenal	|


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Removes tradeTags to prevent Ammo Injector errors with Remove Industrial Stuff

## Reasoning

Why did you choose to implement things this way, e.g.
- Mod leaves Cannonballs and Arrows that Ammo Injector attempts to add to respective Industrial workbenches that have since been removed.

## Alternatives

Describe alternative implementations you have considered, e.g.
- Rewrite the Ammo Injector

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (Used these patches for many playthroughs)
