### PR TITLE
Remove Tox Grenade Min range

### DIFF
--- a/Biotech/Patches/ThingDefs_Misc/Weapons/RangedIndustrial_Biotech.xml
+++ b/Biotech/Patches/ThingDefs_Misc/Weapons/RangedIndustrial_Biotech.xml
@@ -169,7 +169,6 @@
 			<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<range>10</range>
-			<minRange>3</minRange>
 			<warmupTime>0.8</warmupTime>
 			<noiseRadius>4</noiseRadius>
 			<ai_IsBuildingDestroyer>false</ai_IsBuildingDestroyer>


### PR DESCRIPTION

## Changes

Removed the minimum range for tox grenades.

## Reasoning

They're the same as flashbangs/smoke grenades where technically the explosion is unpleasant, but in most use cases you're wanting to actually throw these pretty close or cover yourself to slow down a non-tox immune target.

## Alternatives

Complicated, but overall mechanism for changing minimum range based on threat to user. Not something I'd be able to implement though

## Testing

Check tests you have performed:
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
