### PR TITLE
30x64 fuel cells buff

### DIFF
--- a/Defs/Ammo/Advanced/30x64mmFuelCell.xml
+++ b/Defs/Ammo/Advanced/30x64mmFuelCell.xml
@@ -46,7 +46,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>4.66</MarketValue>
+			<MarketValue>6.69</MarketValue>
 		</statBases>
 		<ammoClass>IncendiaryFuel</ammoClass>
 	</ThingDef>
@@ -59,7 +59,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>6.18</MarketValue>
+			<MarketValue>10.1</MarketValue>
 		</statBases>
 		<ammoClass>ThermobaricFuel</ammoClass>
 	</ThingDef>
@@ -72,7 +72,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>4.93</MarketValue>
+			<MarketValue>7.22</MarketValue>
 		</statBases>
 		<ammoClass>FoamFuel</ammoClass>
 		<generateAllowChance>0</generateAllowChance>
@@ -98,8 +98,8 @@
 		<label>incendiary bolt</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>PrometheumFlame</damageDef>
-			<damageAmountBase>6</damageAmountBase>
-			<explosionRadius>4.5</explosionRadius>
+			<damageAmountBase>10</damageAmountBase>
+			<explosionRadius>6</explosionRadius>
 			<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
 			<preExplosionSpawnChance>0.2</preExplosionSpawnChance>
 			<ai_IsIncendiary>true</ai_IsIncendiary>
@@ -111,9 +111,9 @@
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		<label>thermobaric bolt</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<explosionRadius>2.0</explosionRadius>
+			<explosionRadius>2.5</explosionRadius>
 			<damageDef>Thermobaric</damageDef>
-			<damageAmountBase>48</damageAmountBase>
+			<damageAmountBase>78</damageAmountBase>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 			<ai_IsIncendiary>true</ai_IsIncendiary>
@@ -128,7 +128,7 @@
 			<damageDef>Extinguish</damageDef>
 			<suppressionFactor>0.0</suppressionFactor>
 			<dangerFactor>0.0</dangerFactor>
-			<explosionRadius>3</explosionRadius>
+			<explosionRadius>4</explosionRadius>
 			<postExplosionSpawnThingDef>Filth_FireFoam</postExplosionSpawnThingDef>
 			<preExplosionSpawnChance>1</preExplosionSpawnChance>
 		</projectile>
@@ -157,7 +157,7 @@
 						<li>Prometheum</li>
 					</thingDefs>
 				</filter>
-				<count>14</count>
+				<count>30</count>
 			</li>
 			<li>
 				<filter>
@@ -178,7 +178,7 @@
 		<products>
 			<Ammo_30x64mmFuel_Incendiary>50</Ammo_30x64mmFuel_Incendiary>
 		</products>
-		<workAmount>10800</workAmount>
+		<workAmount>17200</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="LauncherAmmoRecipeBase">
@@ -202,7 +202,7 @@
 						<li>FSX</li>
 					</thingDefs>
 				</filter>
-				<count>21</count>
+				<count>46</count>
 			</li>
 			<li>
 				<filter>
@@ -222,7 +222,7 @@
 		<products>
 			<Ammo_30x64mmFuel_Thermobaric>50</Ammo_30x64mmFuel_Thermobaric>
 		</products>
-		<workAmount>13600</workAmount>
+		<workAmount>23600</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="LauncherAmmoRecipeBase">
@@ -250,7 +250,7 @@
 						<li>MeatRaw</li>
 					</categories>
 				</filter>
-				<count>47</count>
+				<count>100</count>
 			</li>
 			<li>
 				<filter>
@@ -273,7 +273,7 @@
 		<products>
 			<Ammo_30x64mmFuel_Foam>50</Ammo_30x64mmFuel_Foam>
 		</products>
-		<workAmount>14600</workAmount>
+		<workAmount>25200</workAmount>
 	</RecipeDef>
 
 </Defs>

--- a/ModPatches/Rimsenal Enhanced Vanilla/Defs/Rimsenal Enhanced Vanilla/Ammo_EnhancedVanilla.xml
+++ b/ModPatches/Rimsenal Enhanced Vanilla/Defs/Rimsenal Enhanced Vanilla/Ammo_EnhancedVanilla.xml
@@ -208,9 +208,9 @@ r = resource cost. -->
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		<label>concussion bolt</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<explosionRadius>2.0</explosionRadius>
+			<explosionRadius>2.5</explosionRadius>
 			<damageDef>Thump</damageDef>
-			<damageAmountBase>24</damageAmountBase>
+			<damageAmountBase>52</damageAmountBase>
 			<armorPenetrationSharp>0</armorPenetrationSharp>
 			<armorPenetrationBlunt>0</armorPenetrationBlunt>
 			<soundExplode>ThumpCannon_Impact</soundExplode>


### PR DESCRIPTION
## Changes

Improved capacity of fuel cells from 0.27 to 0.6.
Changed the rimsenal mini-thumper force from 1/2 power reduction to 1/3 reduction.

## Reasoning

Makes fuel cells better because who the heck actually uses thermobaric fuel cells. Prior to weight nerf at least they had the niche of being efficent for wallbusting, but now they're practically useless. You gain access to their production 
This change makes them slightly more weight to damage efficent as stick bombs.

Thumper force increased to make it more proficent in its role as a wall breacher given that regular thermal cells have a bit of actual anti-personel lethality now probably.


## Alternatives

Give fuel cells better ammo gated behind charge ammo.
Convince me how this is a bad thing that will utterly break game balance or something and that we should leave it as is.
Implement simmilar buff and also add plasteel to the recipe.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
