### PR TITLE
Cheat on Projectile and Weapon drawing positions to mask camera problems

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -37,6 +37,10 @@ namespace CombatExtended
         protected float initialSpeed;
         #endregion
 
+        #region Drawing
+        protected int ticksToTruePosition;
+        #endregion
+
         #region Origin destination
         public bool OffMapOrigin = false;
 
@@ -199,6 +203,10 @@ namespace CombatExtended
             get
             {
                 var sh = Mathf.Max(0f, (ExactPosition.y) * 0.84f);
+                if (FlightTicks < ticksToTruePosition)
+                {
+                    sh *= FlightTicks / ticksToTruePosition;
+                }
                 return new Vector3(ExactPosition.x, def.Altitude, ExactPosition.z + sh);
             }
         }
@@ -539,12 +547,14 @@ namespace CombatExtended
         /// <param name="shotSpeed">The shot speed (default: def.projectile.speed)</param>
         /// <param name="equipment">The equipment used to fire the projectile.</param>
         /// <param name="distance">The distance to the estimated intercept point</param>
-        public virtual void Launch(Thing launcher, Vector2 origin, float shotAngle, float shotRotation, float shotHeight = 0f, float shotSpeed = -1f, Thing equipment = null, float distance = -1)
+        /// <param name="ticksToTruePosition">The number of ticks before the bullet is drawn at its true height instead of the muzzle height</param>
+        public virtual void Launch(Thing launcher, Vector2 origin, float shotAngle, float shotRotation, float shotHeight = 0f, float shotSpeed = -1f, Thing equipment = null, float distance = -1, int ticksToTruePosition = 3)
         {
             this.shotAngle = shotAngle;
             this.shotHeight = shotHeight;
             this.shotRotation = shotRotation;
             this.shotSpeed = Math.Max(shotSpeed, def.projectile.speed);
+            this.ticksToTruePosition = ticksToTruePosition;
             if (def.projectile is ProjectilePropertiesCE props)
             {
                 this.castShadow = props.castShadow;

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_Bursting.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_Bursting.cs
@@ -23,7 +23,7 @@ namespace CombatExtended
             Scribe_Values.Look(ref this.ticksToBurst, "ticksToBurst", -1, false);
         }
 
-        public override void Launch(Thing launcher, Vector2 origin, float shotAngle, float shotRotation, float shotHeight = 0f, float shotSpeed = -1f, Thing equipment = null, float distance = -1)
+        public override void Launch(Thing launcher, Vector2 origin, float shotAngle, float shotRotation, float shotHeight = 0f, float shotSpeed = -1f, Thing equipment = null, float distance = -1, int ticksToTruePosition = 3)
         {
             int armingDelay = 0;
             if (def.projectile is ProjectilePropertiesCE props)

--- a/Source/CombatExtended/CombatExtended/Verbs/VerbPropertiesCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/VerbPropertiesCE.cs
@@ -16,6 +16,8 @@ namespace CombatExtended
         public float indirectFirePenalty = 0;
         public float circularError = 0;
         public float meleeArmorPenetration = 0;
+        public float firingOffset = 0.19f;
+        public int ticksToTruePosition = 5;
         public bool ejectsCasings = true;
         public bool ignorePartialLoSBlocker = false;
         public bool interruptibleBurst = true;

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -1064,6 +1064,7 @@ namespace CombatExtended
 
             float spreadDegrees = 0;
             float aperatureSize = 0;
+            int ticksToTruePosition = VerbPropsCE.ticksToTruePosition;
 
             if (Projectile.projectile is ProjectilePropertiesCE pprop)
             {
@@ -1118,7 +1119,8 @@ namespace CombatExtended
                         ShotHeight,
                         ShotSpeed,
                         EquipmentSource,
-                        distance);
+                        distance,
+                        ticksToTruePosition);
                 }
                 pelletMechanicsOnly = true;
             }

--- a/Source/CombatExtended/Harmony/Harmony_PawnRenderer.cs
+++ b/Source/CombatExtended/Harmony/Harmony_PawnRenderer.cs
@@ -49,10 +49,19 @@ namespace CombatExtended.HarmonyCE
 
         private static void DrawMesh(Mesh mesh, Matrix4x4 matrix, Material mat, int layer, Thing eq, Vector3 position, float aimAngle)
         {
+            CompEquippable compEquippable = eq.TryGetComp<CompEquippable>();
             GunDrawExtension drawData = eq.def.GetModExtension<GunDrawExtension>() ?? new GunDrawExtension() { DrawSize = eq.def.graphicData.drawSize };
             if (drawData.DrawSize == Vector2.one) { drawData.DrawSize = eq.def.graphicData.drawSize; }
             Vector3 scale = new Vector3(drawData.DrawSize.x, 1, drawData.DrawSize.y);
             Vector3 posVec = new Vector3(drawData.DrawOffset.x, 0, drawData.DrawOffset.y);
+            if (compEquippable != null && compEquippable.PrimaryVerb is Verb_LaunchProjectileCE verbLPCE)
+            {
+                VerbPropertiesCE vpce = verbLPCE.VerbPropsCE;
+                if (verbLPCE.ShooterPawn != null && verbLPCE.WarmingUp || muzzleJump != 0)
+                {
+                    posVec.z += verbLPCE.ShotHeight * vpce.firingOffset * Mathf.Abs(Mathf.Sin(aimAngle * 2 * 3.14f / 360f));
+                }
+            }
             Vector3 casingOffset = new Vector3(drawData.CasingOffset.x, 0, drawData.CasingOffset.y);
             if (aimAngle > 200 && aimAngle < 340)
             {
@@ -61,7 +70,6 @@ namespace CombatExtended.HarmonyCE
                 casingOffset.x *= -1;
             }
             matrix.SetTRS(position + posVec.RotatedBy(matrix.rotation.eulerAngles.y) + recoilOffset, Quaternion.AngleAxis(matrix.rotation.eulerAngles.y + muzzleJump, Vector3.up), scale);
-            CompEquippable compEquippable = eq.TryGetComp<CompEquippable>();
             if (compEquippable != null && compEquippable.PrimaryVerb is Verb_ShootCE verbCE)
             {
                 verbCE.drawPos = casingDrawPos + (casingOffset + posVec).RotatedBy(matrix.rotation.eulerAngles.y);


### PR DESCRIPTION
## Changes

- Weapons can have their vertical draw position tweaked while pawns are warming up or recoiling.
- Projectiles fudge their draw position for the first few ticks (default 5) to hide the latent camera perspective issues


## Alternatives

- Fully lie about projectile positions
- Draw projectile positions accurately, ignoring visual issues
- Change virtual camera perspective

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
