### PR TITLE
Projectile secondary damage decoupling

### DIFF
--- a/Defs/Ammo/Grenade/20x42mmGrenade.xml
+++ b/Defs/Ammo/Grenade/20x42mmGrenade.xml
@@ -195,7 +195,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>12</amount>
+					<amount>24</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -211,7 +211,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>19</amount>
+					<amount>33</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/HighCaliber/12.7x108mmSoviet.xml
+++ b/Defs/Ammo/HighCaliber/12.7x108mmSoviet.xml
@@ -158,7 +158,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>16</amount>
+					<amount>15</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -174,7 +174,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>23</amount>
+					<amount>20</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/HighCaliber/13.2x92mmSRTuF.xml
+++ b/Defs/Ammo/HighCaliber/13.2x92mmSRTuF.xml
@@ -157,7 +157,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>16</amount>
+					<amount>15</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -173,7 +173,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>24</amount>
+					<amount>21</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/HighCaliber/14.5x114mmSoviet.xml
+++ b/Defs/Ammo/HighCaliber/14.5x114mmSoviet.xml
@@ -158,7 +158,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>21</amount>
+					<amount>17</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -174,7 +174,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>32</amount>
+					<amount>24</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/HighCaliber/2-Bore.xml
+++ b/Defs/Ammo/HighCaliber/2-Bore.xml
@@ -158,7 +158,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>22</amount>
+					<amount>37</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -174,7 +174,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>34</amount>
+					<amount>51</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/HighCaliber/20x102mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/20x102mmNATO.xml
@@ -133,7 +133,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>27</amount>
+					<amount>22</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -149,7 +149,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>42</amount>
+					<amount>31</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/HighCaliber/20x110mmHispano.xml
+++ b/Defs/Ammo/HighCaliber/20x110mmHispano.xml
@@ -149,7 +149,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>39</amount>
+					<amount>35</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/HighCaliber/20x128mmOerlikon.xml
+++ b/Defs/Ammo/HighCaliber/20x128mmOerlikon.xml
@@ -133,7 +133,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>30</amount>
+					<amount>25</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -149,7 +149,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>45</amount>
+					<amount>35</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/HighCaliber/20x138mmB.xml
+++ b/Defs/Ammo/HighCaliber/20x138mmB.xml
@@ -133,7 +133,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>27</amount>
+					<amount>26</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -149,7 +149,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>41</amount>
+					<amount>35</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/HighCaliber/20x139mm.xml
+++ b/Defs/Ammo/HighCaliber/20x139mm.xml
@@ -133,7 +133,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>30</amount>
+					<amount>26</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -149,7 +149,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>46</amount>
+					<amount>35</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/HighCaliber/20x82mmMauser.xml
+++ b/Defs/Ammo/HighCaliber/20x82mmMauser.xml
@@ -133,7 +133,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>22</amount>
+					<amount>24</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -149,7 +149,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>34</amount>
+					<amount>33</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/HighCaliber/20x99mmShVAK.xml
+++ b/Defs/Ammo/HighCaliber/20x99mmShVAK.xml
@@ -149,7 +149,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>33</amount>
+					<amount>31</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/HighCaliber/23x152mmB.xml
+++ b/Defs/Ammo/HighCaliber/23x152mmB.xml
@@ -133,7 +133,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>35</amount>
+					<amount>34</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -149,7 +149,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>53</amount>
+					<amount>46</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/HighCaliber/25x137mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/25x137mmNATO.xml
@@ -133,7 +133,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>39</amount>
+					<amount>33</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -149,7 +149,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>59</amount>
+					<amount>45</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/HighCaliber/300WinchesterMagnum.xml
+++ b/Defs/Ammo/HighCaliber/300WinchesterMagnum.xml
@@ -157,7 +157,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>9</amount>
+					<amount>6</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -173,7 +173,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>14</amount>
+					<amount>8</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/HighCaliber/30x113mmB.xml
+++ b/Defs/Ammo/HighCaliber/30x113mmB.xml
@@ -133,7 +133,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>37</amount>
+					<amount>42</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -149,7 +149,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>57</amount>
+					<amount>58</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/HighCaliber/30x165mm.xml
+++ b/Defs/Ammo/HighCaliber/30x165mm.xml
@@ -133,7 +133,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>46</amount>
+					<amount>52</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/HighCaliber/30x173mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/30x173mmNATO.xml
@@ -149,7 +149,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>76</amount>
+					<amount>69</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/HighCaliber/338LapuaMagnum.xml
+++ b/Defs/Ammo/HighCaliber/338LapuaMagnum.xml
@@ -157,7 +157,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>10</amount>
+					<amount>8</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -173,7 +173,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>15</amount>
+					<amount>11</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/HighCaliber/338NormaMagnum.xml
+++ b/Defs/Ammo/HighCaliber/338NormaMagnum.xml
@@ -157,7 +157,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>10</amount>
+					<amount>9</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -173,7 +173,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>15</amount>
+					<amount>12</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/HighCaliber/408CheyenneTactical.xml
+++ b/Defs/Ammo/HighCaliber/408CheyenneTactical.xml
@@ -157,7 +157,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>13</amount>
+					<amount>9</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -173,7 +173,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>14</amount>
+					<amount>12</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/HighCaliber/40x311mmR.xml
+++ b/Defs/Ammo/HighCaliber/40x311mmR.xml
@@ -133,7 +133,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>66</amount>
+					<amount>86</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -149,7 +149,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>101</amount>
+					<amount>117</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/HighCaliber/470NitroExpress.xml
+++ b/Defs/Ammo/HighCaliber/470NitroExpress.xml
@@ -173,7 +173,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>18</amount>
+					<amount>16</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/HighCaliber/50BMG.xml
+++ b/Defs/Ammo/HighCaliber/50BMG.xml
@@ -158,7 +158,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>16</amount>
+					<amount>14</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -174,7 +174,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>24</amount>
+					<amount>20</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/HighCaliber/55Boys.xml
+++ b/Defs/Ammo/HighCaliber/55Boys.xml
@@ -157,7 +157,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>19</amount>
+					<amount>17</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -173,7 +173,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>29</amount>
+					<amount>23</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/HighCaliber/600NitroExpress.xml
+++ b/Defs/Ammo/HighCaliber/600NitroExpress.xml
@@ -157,7 +157,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>15</amount>
+					<amount>17</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/HighCaliber/7.92x94mm Patronen.xml
+++ b/Defs/Ammo/HighCaliber/7.92x94mm Patronen.xml
@@ -158,7 +158,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>12</amount>
+					<amount>7</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -174,7 +174,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>18</amount>
+					<amount>10</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/HighCaliber/950JDJ.xml
+++ b/Defs/Ammo/HighCaliber/950JDJ.xml
@@ -157,7 +157,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>29</amount>
+					<amount>38</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -173,7 +173,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>45</amount>
+					<amount>52</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/Rifle/127x55mm.xml
+++ b/Defs/Ammo/Rifle/127x55mm.xml
@@ -181,7 +181,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>8</amount>
+					<amount>17</amount>
 				</li>
 			</secondaryDamage>
 			<armorPenetrationSharp>14</armorPenetrationSharp>
@@ -197,7 +197,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>13</amount>
+					<amount>23</amount>
 				</li>
 			</secondaryDamage>
 			<armorPenetrationSharp>7</armorPenetrationSharp>

--- a/Defs/Ammo/Rifle/243Winchester.xml
+++ b/Defs/Ammo/Rifle/243Winchester.xml
@@ -180,7 +180,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>6</amount>
+					<amount>4</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -196,7 +196,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>10</amount>
+					<amount>6</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/Rifle/277Fury.xml
+++ b/Defs/Ammo/Rifle/277Fury.xml
@@ -180,7 +180,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>8</amount>
+					<amount>5</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -196,7 +196,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>12</amount>
+					<amount>7</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/Rifle/280British.xml
+++ b/Defs/Ammo/Rifle/280British.xml
@@ -180,7 +180,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>7</amount>
+					<amount>5</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -196,7 +196,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>12</amount>
+					<amount>7</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/Rifle/30-30Winchester.xml
+++ b/Defs/Ammo/Rifle/30-30Winchester.xml
@@ -180,7 +180,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>7</amount>
+					<amount>6</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -196,7 +196,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>11</amount>
+					<amount>8</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/Rifle/3006Springfield.xml
+++ b/Defs/Ammo/Rifle/3006Springfield.xml
@@ -180,7 +180,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>8</amount>
+					<amount>6</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -196,7 +196,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>12</amount>
+					<amount>8</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/Rifle/300AACBlackout.xml
+++ b/Defs/Ammo/Rifle/300AACBlackout.xml
@@ -180,7 +180,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>6</amount>
+					<amount>5</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -196,7 +196,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>10</amount>
+					<amount>7</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/Rifle/303British.xml
+++ b/Defs/Ammo/Rifle/303British.xml
@@ -180,7 +180,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>8</amount>
+					<amount>6</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -196,7 +196,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>12</amount>
+					<amount>8</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/Rifle/30Carbine.xml
+++ b/Defs/Ammo/Rifle/30Carbine.xml
@@ -196,7 +196,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>8</amount>
+					<amount>6</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/Rifle/38-55Winchester.xml
+++ b/Defs/Ammo/Rifle/38-55Winchester.xml
@@ -180,7 +180,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>5</amount>
+					<amount>8</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -196,7 +196,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>8</amount>
+					<amount>11</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/Rifle/38-55Winchester.xml
+++ b/Defs/Ammo/Rifle/38-55Winchester.xml
@@ -180,7 +180,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>8</amount>
+					<amount>5</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -196,7 +196,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>12</amount>
+					<amount>8</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/Rifle/44-40Winchester.xml
+++ b/Defs/Ammo/Rifle/44-40Winchester.xml
@@ -180,7 +180,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>6</amount>
+					<amount>7</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -196,7 +196,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>8</amount>
+					<amount>9</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/Rifle/4570Gov.xml
+++ b/Defs/Ammo/Rifle/4570Gov.xml
@@ -196,7 +196,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>14</amount>
+					<amount>12</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/Rifle/458SOCOM.xml
+++ b/Defs/Ammo/Rifle/458SOCOM.xml
@@ -196,7 +196,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>13</amount>
+					<amount>12</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/Rifle/473x33mmCaseless.xml
+++ b/Defs/Ammo/Rifle/473x33mmCaseless.xml
@@ -179,7 +179,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>5</amount>
+					<amount>3</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -195,7 +195,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>7</amount>
+					<amount>4</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/Rifle/485x49mm.xml
+++ b/Defs/Ammo/Rifle/485x49mm.xml
@@ -180,7 +180,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>5</amount>
+					<amount>3</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -196,7 +196,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>8</amount>
+					<amount>4</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/Rifle/50Beowulf.xml
+++ b/Defs/Ammo/Rifle/50Beowulf.xml
@@ -196,7 +196,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>14</amount>
+					<amount>13</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/Rifle/545x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/545x39mmSoviet.xml
@@ -196,7 +196,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>5</amount>
+					<amount>3</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -212,7 +212,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>8</amount>
+					<amount>4</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -274,7 +274,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>4</amount>
+					<amount>3</amount>
 				</li>
 			</secondaryDamage>
 			<speed>142</speed>
@@ -291,7 +291,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>7</amount>
+					<amount>4</amount>
 				</li>
 			</secondaryDamage>
 			<speed>142</speed>

--- a/Defs/Ammo/Rifle/556x45mmNATO.xml
+++ b/Defs/Ammo/Rifle/556x45mmNATO.xml
@@ -194,7 +194,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>5</amount>
+					<amount>3</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -210,7 +210,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>8</amount>
+					<amount>5</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -272,7 +272,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>5</amount>
+					<amount>3</amount>
 				</li>
 			</secondaryDamage>
 			<speed>142</speed>
@@ -289,7 +289,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>7</amount>
+					<amount>5</amount>
 				</li>
 			</secondaryDamage>
 			<speed>142</speed>

--- a/Defs/Ammo/Rifle/56-56Spencer.xml
+++ b/Defs/Ammo/Rifle/56-56Spencer.xml
@@ -180,7 +180,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>7</amount>
+					<amount>9</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -196,7 +196,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>11</amount>
+					<amount>13</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/Rifle/58x42mmDBP10.xml
+++ b/Defs/Ammo/Rifle/58x42mmDBP10.xml
@@ -182,7 +182,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>6</amount>
+					<amount>3</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -198,7 +198,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>9</amount>
+					<amount>5</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/Rifle/6.5Creedmoor.xml
+++ b/Defs/Ammo/Rifle/6.5Creedmoor.xml
@@ -180,7 +180,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>8</amount>
+					<amount>6</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -196,7 +196,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>12</amount>
+					<amount>8</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/Rifle/6.5x52mm Carcano.xml
+++ b/Defs/Ammo/Rifle/6.5x52mm Carcano.xml
@@ -180,7 +180,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>7</amount>
+					<amount>6</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -196,7 +196,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>10</amount>
+					<amount>8</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/Rifle/65x50mmSRArisaka.xml
+++ b/Defs/Ammo/Rifle/65x50mmSRArisaka.xml
@@ -180,7 +180,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>7</amount>
+					<amount>5</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -196,7 +196,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>10</amount>
+					<amount>7</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/Rifle/7.92x57mmMauser.xml
+++ b/Defs/Ammo/Rifle/7.92x57mmMauser.xml
@@ -180,7 +180,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>8</amount>
+					<amount>6</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -196,7 +196,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>13</amount>
+					<amount>9</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/Rifle/75x54mmFrench.xml
+++ b/Defs/Ammo/Rifle/75x54mmFrench.xml
@@ -180,7 +180,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>7</amount>
+					<amount>5</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -196,7 +196,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>11</amount>
+					<amount>7</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/Rifle/762x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/762x39mmSoviet.xml
@@ -196,7 +196,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>7</amount>
+					<amount>5</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -212,7 +212,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>10</amount>
+					<amount>7</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -275,7 +275,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>6</amount>
+					<amount>5</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -292,7 +292,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>9</amount>
+					<amount>7</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/Rifle/762x51mmNATO.xml
+++ b/Defs/Ammo/Rifle/762x51mmNATO.xml
@@ -180,7 +180,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>8</amount>
+					<amount>6</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -196,7 +196,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>12</amount>
+					<amount>8</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/Rifle/762x54mmR.xml
+++ b/Defs/Ammo/Rifle/762x54mmR.xml
@@ -182,7 +182,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>8</amount>
+					<amount>6</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -198,7 +198,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>12</amount>
+					<amount>8</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/Rifle/77x58mmArisaka.xml
+++ b/Defs/Ammo/Rifle/77x58mmArisaka.xml
@@ -180,7 +180,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>7</amount>
+					<amount>6</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -196,7 +196,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>11</amount>
+					<amount>8</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/Rifle/792x33mmKurz.xml
+++ b/Defs/Ammo/Rifle/792x33mmKurz.xml
@@ -180,7 +180,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>6</amount>
+					<amount>5</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -196,7 +196,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>10</amount>
+					<amount>7</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/Rifle/8.6mmBlackout.xml
+++ b/Defs/Ammo/Rifle/8.6mmBlackout.xml
@@ -180,7 +180,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>8</amount>
+					<amount>6</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -196,7 +196,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>12</amount>
+					<amount>8</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/Rifle/8x50mmRLebel.xml
+++ b/Defs/Ammo/Rifle/8x50mmRLebel.xml
@@ -180,7 +180,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>8</amount>
+					<amount>7</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -196,7 +196,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>12</amount>
+					<amount>9</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/Rifle/8x50mmRMannlicher.xml
+++ b/Defs/Ammo/Rifle/8x50mmRMannlicher.xml
@@ -180,7 +180,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>7</amount>
+					<amount>8</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -196,7 +196,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>11</amount>
+					<amount>10</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Defs/Ammo/Rifle/9x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/9x39mmSoviet.xml
@@ -181,7 +181,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>5</amount>
+					<amount>8</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -197,7 +197,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>8</amount>
+					<amount>10</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>


### PR DESCRIPTION
## Changes

- Decoupled AP-I and APHE's secondary damage from velocity, it's only based on projectile mass.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit?gid=1393347070#gid=1393347070

## Reasoning

- Logic.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
