### PR TITLE
Incendiary and Thump ammo minor tweaks

### DIFF
--- a/Defs/Ammo/Advanced/164x284mmDemoShell.xml
+++ b/Defs/Ammo/Advanced/164x284mmDemoShell.xml
@@ -75,7 +75,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Thump</damageDef>
-			<damageAmountBase>20</damageAmountBase>
+			<damageAmountBase>40</damageAmountBase>
 			<armorPenetrationSharp>0</armorPenetrationSharp>
 			<armorPenetrationBlunt>0</armorPenetrationBlunt>
 			<speed>61</speed>
@@ -110,7 +110,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Thump</damageDef>
-			<damageAmountBase>10</damageAmountBase>
+			<damageAmountBase>20</damageAmountBase>
 			<armorPenetrationSharp>0</armorPenetrationSharp>
 			<armorPenetrationBlunt>0</armorPenetrationBlunt>
 			<speed>1</speed>
@@ -145,7 +145,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Thump</damageDef>
-			<damageAmountBase>10</damageAmountBase>
+			<damageAmountBase>20</damageAmountBase>
 			<armorPenetrationSharp>0</armorPenetrationSharp>
 			<armorPenetrationBlunt>0</armorPenetrationBlunt>
 			<speed>1</speed>

--- a/Defs/Ammo/Advanced/164x284mmDemoShell.xml
+++ b/Defs/Ammo/Advanced/164x284mmDemoShell.xml
@@ -80,7 +80,7 @@
 			<armorPenetrationBlunt>0</armorPenetrationBlunt>
 			<speed>61</speed>
 			<flyOverhead>false</flyOverhead>
-			<explosionRadius>2</explosionRadius>
+			<explosionRadius>3.9</explosionRadius>
 			<soundExplode>ThumpCannon_Impact</soundExplode>
 			<soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
 			<soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
@@ -116,7 +116,7 @@
 			<speed>1</speed>
 			<gravityFactor>50</gravityFactor>
 			<flyOverhead>false</flyOverhead>
-			<explosionRadius>2</explosionRadius>
+			<explosionRadius>2.9</explosionRadius>
 			<soundExplode>ThumpCannon_Impact</soundExplode>
 			<soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
 			<soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>

--- a/Defs/Ammo/Advanced/66mmThermalBolt.xml
+++ b/Defs/Ammo/Advanced/66mmThermalBolt.xml
@@ -98,7 +98,7 @@
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>50</damageAmountBase>
+				<damageAmountBase>48</damageAmountBase>
 				<explosiveDamageType>Thermobaric</explosiveDamageType>
 				<explosiveRadius>1.5</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/Defs/Ammo/Advanced/66mmThermalBolt.xml
+++ b/Defs/Ammo/Advanced/66mmThermalBolt.xml
@@ -98,7 +98,7 @@
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>75</damageAmountBase>
+				<damageAmountBase>50</damageAmountBase>
 				<explosiveDamageType>Thermobaric</explosiveDamageType>
 				<explosiveRadius>1.5</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/Defs/Ammo/Advanced/80x256mmFuelCell.xml
+++ b/Defs/Ammo/Advanced/80x256mmFuelCell.xml
@@ -95,7 +95,7 @@
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>100</damageAmountBase>
+				<damageAmountBase>83</damageAmountBase>
 				<explosiveDamageType>Thermobaric</explosiveDamageType>
 				<explosiveRadius>2.0</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/Defs/Ammo/Advanced/80x256mmFuelCell.xml
+++ b/Defs/Ammo/Advanced/80x256mmFuelCell.xml
@@ -95,7 +95,7 @@
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>150</damageAmountBase>
+				<damageAmountBase>100</damageAmountBase>
 				<explosiveDamageType>Thermobaric</explosiveDamageType>
 				<explosiveRadius>2.0</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/Defs/Ammo/Rocket/84x246mmR.xml
+++ b/Defs/Ammo/Rocket/84x246mmR.xml
@@ -454,9 +454,9 @@
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>60</damageAmountBase>
+				<damageAmountBase>113</damageAmountBase>
 				<explosiveDamageType>Thermobaric</explosiveDamageType>
-				<explosiveRadius>1.9</explosiveRadius>
+				<explosiveRadius>2.5</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 			</li>
 		</comps>

--- a/Defs/Ammo/Rocket/84x246mmR.xml
+++ b/Defs/Ammo/Rocket/84x246mmR.xml
@@ -454,7 +454,7 @@
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>90</damageAmountBase>
+				<damageAmountBase>60</damageAmountBase>
 				<explosiveDamageType>Thermobaric</explosiveDamageType>
 				<explosiveRadius>1.9</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/Defs/Ammo/Shell/105mmHowitzer.xml
+++ b/Defs/Ammo/Shell/105mmHowitzer.xml
@@ -244,7 +244,7 @@
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>120</damageAmountBase>
+				<damageAmountBase>90</damageAmountBase>
 				<explosiveDamageType>Thermobaric</explosiveDamageType>
 				<explosiveRadius>2.5</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
@@ -383,7 +383,7 @@
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>120</damageAmountBase>
+				<damageAmountBase>90</damageAmountBase>
 				<explosiveDamageType>Thermobaric</explosiveDamageType>
 				<explosiveRadius>2.5</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/Defs/Ammo/Shell/105mmHowitzer.xml
+++ b/Defs/Ammo/Shell/105mmHowitzer.xml
@@ -244,7 +244,7 @@
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>90</damageAmountBase>
+				<damageAmountBase>116</damageAmountBase>
 				<explosiveDamageType>Thermobaric</explosiveDamageType>
 				<explosiveRadius>2.5</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/Defs/Ammo/Shell/105mmHowitzer.xml
+++ b/Defs/Ammo/Shell/105mmHowitzer.xml
@@ -383,7 +383,7 @@
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>90</damageAmountBase>
+				<damageAmountBase>116</damageAmountBase>
 				<explosiveDamageType>Thermobaric</explosiveDamageType>
 				<explosiveRadius>2.5</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/Defs/Ammo/Shell/155mmHowitzer.xml
+++ b/Defs/Ammo/Shell/155mmHowitzer.xml
@@ -230,7 +230,7 @@
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>100</damageAmountBase>
+				<damageAmountBase>253</damageAmountBase>
 				<explosiveDamageType>Thermobaric</explosiveDamageType>
 				<explosiveRadius>4</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/Defs/Ammo/Shell/155mmHowitzer.xml
+++ b/Defs/Ammo/Shell/155mmHowitzer.xml
@@ -230,7 +230,7 @@
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>150</damageAmountBase>
+				<damageAmountBase>100</damageAmountBase>
 				<explosiveDamageType>Thermobaric</explosiveDamageType>
 				<explosiveRadius>4</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
@@ -337,7 +337,7 @@
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>150</damageAmountBase>
+				<damageAmountBase>100</damageAmountBase>
 				<explosiveDamageType>Thermobaric</explosiveDamageType>
 				<explosiveRadius>4</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/Defs/Ammo/Shell/155mmHowitzer.xml
+++ b/Defs/Ammo/Shell/155mmHowitzer.xml
@@ -337,7 +337,7 @@
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>100</damageAmountBase>
+				<damageAmountBase>253</damageAmountBase>
 				<explosiveDamageType>Thermobaric</explosiveDamageType>
 				<explosiveRadius>4</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>


### PR DESCRIPTION
## Changes

- Made large incendiary ammo deal less thermobaric damage, by 33% to be exact.
- Increased the raw damage dealt by the thump cannon ammo.

## Reasoning

- Initial values were arbitrary according to Serina and kinda overtuned.
- The shells underperform in general, more raw damage is better than a lot of frags as it's easier to keep track of.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
