### PR TITLE
Parry for non-humans

### DIFF
--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
@@ -616,7 +616,6 @@ namespace CombatExtended
         {
             if (pawn == null
                     || pawn.Dead
-                    || !pawn.RaceProps.Humanlike
                     || pawn.WorkTagIsDisabled(WorkTags.Violent)
                     || !pawn.health.capacities.CapableOf(PawnCapacityDefOf.Manipulation)
                     || IsTargetImmobile(pawn)


### PR DESCRIPTION
## Changes

- What it says on the tin, made it possible for pawns other than humans to be able to parry.

## Reasoning

- Makes sense for all melee fighters (a pawn that is capable of melee which is already smart enough) to be able to parry in some capacity.
- Every single patched race/pawn has a parry chance stat attached to it but they (non-humans) are all incapable of actually parrying, it's a big nerf to melee pawns that are not human.

## Alternatives

- Every other pawn but humans being only capable of dodging.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] Playtested a colony (specify how long)
