### PR TITLE
Reduce ammo crafting skill gain

### DIFF
--- a/Defs/Ammo/AmmoBases.xml
+++ b/Defs/Ammo/AmmoBases.xml
@@ -114,6 +114,7 @@
 		<allowMixingIngredients>true</allowMixingIngredients>
 		<workAmount>10000</workAmount>
 		<workSkill>Crafting</workSkill>
+		<workSkillLearnFactor>0.5</workSkillLearnFactor>
 		<targetCountAdjustment>20</targetCountAdjustment>
 		<recipeUsers>
 			<!-- Need an empty list here or the ammo injector will throw a null ref exception -->

--- a/Defs/Ammo/AmmoBases.xml
+++ b/Defs/Ammo/AmmoBases.xml
@@ -165,6 +165,7 @@
 		<allowMixingIngredients>true</allowMixingIngredients>
 		<workAmount>2000</workAmount>
 		<workSkill>Crafting</workSkill>
+		<workSkillLearnFactor>0.5</workSkillLearnFactor>		
 		<targetCountAdjustment>20</targetCountAdjustment>
 		<unfinishedThingDef>UnfinishedArrows</unfinishedThingDef>
 	</RecipeDef>


### PR DESCRIPTION
## Changes

- Reduced ammo crafting skill gain by half.

## Reasoning

- Ammo crafting giving the same amount of exp as individual items makes it a bit too easy to level/maintain crafting.

## Testing

Check tests you have performed:
- [x] Game runs without errors