### PR TITLE
Non lerp projectile fixes

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/BulletCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/BulletCE.cs
@@ -27,7 +27,10 @@ namespace CombatExtended
             {
                 var projectilePropsCE = (ProjectilePropertiesCE)def.projectile;
                 var isSharpDmg = def.projectile.damageDef.armorCategory == DamageArmorCategoryDefOf.Sharp;
-                return (equipment?.GetStatValue(StatDefOf.RangedWeapon_DamageMultiplier) ?? 1f) * (isSharpDmg ? projectilePropsCE.armorPenetrationSharp : projectilePropsCE.armorPenetrationBlunt);
+
+                float penetrationAmount = (equipment?.GetStatValue(StatDefOf.RangedWeapon_DamageMultiplier) ?? 1f) * (isSharpDmg ? projectilePropsCE.armorPenetrationSharp : projectilePropsCE.armorPenetrationBlunt);
+
+                return lerpPosition ? penetrationAmount : penetrationAmount * RemainingKineticEnergyPct;
             }
         }
 

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -239,12 +239,6 @@ namespace CombatExtended
         {
             get
             {
-                if (!lerpPosition)
-                {
-                    return Quaternion.AngleAxis(
-                           Mathf.Rad2Deg * Mathf.Atan2(-velocity.y, velocity.x) + 90f
-                           , Vector3.up);
-                }
                 Vector2 w = (Destination - origin);
 
                 var vx = w.x / startingTicksToImpact;

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -239,6 +239,12 @@ namespace CombatExtended
         {
             get
             {
+                if (!lerpPosition)
+                {
+                    return Quaternion.AngleAxis(
+                           Mathf.Rad2Deg * Mathf.Atan2(-velocity.y, velocity.x) + 90f
+                           , Vector3.up);
+                }
                 Vector2 w = (Destination - origin);
 
                 var vx = w.x / startingTicksToImpact;
@@ -894,7 +900,6 @@ namespace CombatExtended
             {
                 MoteMakerCE.ThrowText(cell.ToVector3Shifted(), Map, "x", Color.red);
             }
-
             Impact(null);
             return true;
         }
@@ -974,7 +979,6 @@ namespace CombatExtended
             {
                 MoteMakerCE.ThrowText(thing.Position.ToVector3Shifted(), thing.Map, "x", Color.red);
             }
-
             Impact(thing);
             return true;
         }
@@ -1078,8 +1082,8 @@ namespace CombatExtended
                 velocity = new Vector3(Mathf.Cos(sr) * Mathf.Cos(shotAngle) * sspt, Mathf.Sin(shotAngle) * sspt, Mathf.Sin(sr) * Mathf.Cos(shotAngle) * sspt);
                 initialSpeed = sspt;
             }
-            Vector3 newPosition = curPosition + velocity;
             Accelerate();
+            Vector3 newPosition = curPosition + velocity;
             shotSpeed = velocity.magnitude;
             return newPosition;
         }
@@ -1177,7 +1181,7 @@ namespace CombatExtended
                 def.projectile.soundImpactAnticipate.PlayOneShot(this);
             }
             //TODO : It appears that the final steps in the arc (past ticksToImpact == 0) don't CheckForCollisionBetween.
-            if (ticksToImpact <= 0 || nextPosition.y <= 0f)
+            if ((lerpPosition && ticksToImpact <= 0) || nextPosition.y <= 0f)
             {
                 ImpactSomething();
                 return;

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -1078,11 +1078,23 @@ namespace CombatExtended
             }
             Vector3 newPosition = curPosition + velocity;
             Accelerate();
+            shotSpeed = velocity.magnitude;
             return newPosition;
         }
 
-        // This can also be made virtual, and would be the ideal entry point for guided ammunition and rockets.
-        protected void Accelerate()
+        // This is the ideal entry point for guided ammunition and rockets.
+        protected virtual void Accelerate()
+        {
+            AffectedByDrag();
+            AffectedByGravity();
+        }
+
+        protected void AffectedByGravity()
+        {
+            velocity.y -= gravity / GenTicks.TicksPerRealSecond;
+        }
+
+        protected void AffectedByDrag()
         {
             float crossSectionalArea = radius;
             crossSectionalArea *= crossSectionalArea * 3.14159f;
@@ -1091,12 +1103,11 @@ namespace CombatExtended
             var dragForce = q * crossSectionalArea / ballisticCoefficient;
             // F = mA
             // A = F / m
-            var a = (float)((-dragForce / (float)mass));
+            var a = (float)-dragForce / mass;
             var normalized = velocity.normalized;
             velocity.x += a * normalized.x;
-            velocity.y += a * normalized.y - (float)(1 / ballisticCoefficient) * (float)gravity / GenTicks.TicksPerRealSecond;
+            velocity.y += a * normalized.y;
             velocity.z += a * normalized.z;
-            shotSpeed = velocity.magnitude;
         }
 
         #region Tick/Draw

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -90,9 +90,11 @@ namespace CombatExtended
                 {
                     return (float)this.damageAmount;
                 }
-                return ((float)this.damageAmount) * (shotSpeed * shotSpeed) / (initialSpeed * initialSpeed);
+                return ((float)this.damageAmount) * RemainingKineticEnergyPct;
             }
         }
+
+        public float RemainingKineticEnergyPct => (shotSpeed * shotSpeed) / (initialSpeed * initialSpeed);
 
         /// <summary>
         /// Reference to the weapon that fired this projectile, may be null.


### PR DESCRIPTION
## Changes

Non lerp projectile's armor pen now scales with velocity.
Made non lerp projectile's acceleration function virtual.
Fixed various problems including non lerp projectile hitting nothing because of ticktoimpact
Moved acceleration function in front of actual move code.

## Reasoning

Having acceleration behind exactpos+=velocity means that I need to caculate the velocity needed next tick instead of current tick, which fucks with guided missile.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (playing with missiles rn)
