### PR TITLE
Fix verb lighting tracker cache

### DIFF
--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -243,7 +243,7 @@ namespace CombatExtended
         {
             get
             {
-                if (_lightingTracker == null || _lightingTracker.map == null || _lightingTracker.map.Index < 0)
+                if (_lightingTracker == null || _lightingTracker.map == null || _lightingTracker.map.Index < 0 || _lightingTracker.map != caster.Map)
                 {
                     _lightingTracker = caster.Map.GetLightingTracker();
                 }


### PR DESCRIPTION
## Changes

Check if lightingtracker.map!=caster.map for recache

## Reasoning

I received bug report about pawns moving from one map to another can't fire their weapon. this is the fix

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (30min)
