### PR TITLE
CompPawnGizmo Duplicate Proof

### DIFF
--- a/ModPatches/Miho Race/Patches/Miho Race/ThingDefs_Races/AlienRace_Miho.xml
+++ b/ModPatches/Miho Race/Patches/Miho Race/ThingDefs_Races/AlienRace_Miho.xml
@@ -19,9 +19,6 @@
       <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]</xpath>
       <value>
         <comps>
-          <li>
-            <compClass>CombatExtended.CompPawnGizmo</compClass>
-          </li>
           <li Class="CombatExtended.CompProperties_Suppressable"/>
           <li Class="CombatExtended.CompProperties_ArmorDurability">
             <Durability>500</Durability>

--- a/ModPatches/Miho Race/Patches/Miho Race/ThingDefs_Races/AlienRace_Miho.xml
+++ b/ModPatches/Miho Race/Patches/Miho Race/ThingDefs_Races/AlienRace_Miho.xml
@@ -5,9 +5,6 @@
     <match Class="PatchOperationAdd">
       <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]/comps</xpath>
       <value>
-        <li>
-          <compClass>CombatExtended.CompPawnGizmo</compClass>
-        </li>
         <li Class="CombatExtended.CompProperties_Suppressable"/>
         <li Class="CombatExtended.CompProperties_ArmorDurability">
           <Durability>500</Durability>

--- a/ModPatches/Miho Race/Patches/Miho Race/ThingDefs_Races/AlienRace_Miho.xml
+++ b/ModPatches/Miho Race/Patches/Miho Race/ThingDefs_Races/AlienRace_Miho.xml
@@ -1,132 +1,132 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
-	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]/comps</xpath>
-		<match Class="PatchOperationAdd">
-			<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]/comps</xpath>
-			<value>
-				<li>
-					<compClass>CombatExtended.CompPawnGizmo</compClass>
-				</li>
-				<li Class="CombatExtended.CompProperties_Suppressable"/>
-				<li Class="CombatExtended.CompProperties_ArmorDurability">
-					<Durability>500</Durability>
-					<Regenerates>true</Regenerates>
-					<RegenInterval>600</RegenInterval>
-					<RegenValue>5</RegenValue>
-					<MinArmorPct>0.75</MinArmorPct>
-				</li>
-			</value>
-		</match>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]</xpath>
-			<value>
-				<comps>
-					<li>
-						<compClass>CombatExtended.CompPawnGizmo</compClass>
-					</li>
-					<li Class="CombatExtended.CompProperties_Suppressable"/>
-					<li Class="CombatExtended.CompProperties_ArmorDurability">
-						<Durability>500</Durability>
-						<Regenerates>true</Regenerates>
-						<RegenInterval>600</RegenInterval>
-						<RegenValue>5</RegenValue>
-						<MinArmorPct>0.75</MinArmorPct>
-					</li>
-				</comps>
-			</value>
-		</nomatch>
-	</Operation>
+  <Operation Class="PatchOperationConditional">
+    <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]/comps</xpath>
+    <match Class="PatchOperationAdd">
+      <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]/comps</xpath>
+      <value>
+        <li>
+          <compClass>CombatExtended.CompPawnGizmo</compClass>
+        </li>
+        <li Class="CombatExtended.CompProperties_Suppressable"/>
+        <li Class="CombatExtended.CompProperties_ArmorDurability">
+          <Durability>500</Durability>
+          <Regenerates>true</Regenerates>
+          <RegenInterval>600</RegenInterval>
+          <RegenValue>5</RegenValue>
+          <MinArmorPct>0.75</MinArmorPct>
+        </li>
+      </value>
+    </match>
+    <nomatch Class="PatchOperationAdd">
+      <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]</xpath>
+      <value>
+        <comps>
+          <li>
+            <compClass>CombatExtended.CompPawnGizmo</compClass>
+          </li>
+          <li Class="CombatExtended.CompProperties_Suppressable"/>
+          <li Class="CombatExtended.CompProperties_ArmorDurability">
+            <Durability>500</Durability>
+            <Regenerates>true</Regenerates>
+            <RegenInterval>600</RegenInterval>
+            <RegenValue>5</RegenValue>
+            <MinArmorPct>0.75</MinArmorPct>
+          </li>
+        </comps>
+      </value>
+    </nomatch>
+  </Operation>
 
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]</xpath>
-		<value>
-			<li Class="CombatExtended.RacePropertiesExtensionCE">
-				<bodyShape>Humanoid</bodyShape>
-			</li>
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]</xpath>
+    <value>
+      <li Class="CombatExtended.RacePropertiesExtensionCE">
+        <bodyShape>Humanoid</bodyShape>
+      </li>
+    </value>
+  </Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]/statBases/MeleeDodgeChance</xpath>
-		<value>
-			<MeleeDodgeChance>0.5</MeleeDodgeChance>
-			<Suppressability>1</Suppressability>
-			<SmokeSensitivity>0.5</SmokeSensitivity>
-			<AimingAccuracy>0.75</AimingAccuracy>
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]/statBases/MeleeDodgeChance</xpath>
+    <value>
+      <MeleeDodgeChance>0.5</MeleeDodgeChance>
+      <Suppressability>1</Suppressability>
+      <SmokeSensitivity>0.5</SmokeSensitivity>
+      <AimingAccuracy>0.75</AimingAccuracy>
+    </value>
+  </Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]/tools</xpath>
-		<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-					<label>left fist</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>1</power>
-					<cooldownTime>1.26</cooldownTime>
-					<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
-					<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>right fist</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>1</power>
-					<cooldownTime>1.26</cooldownTime>
-					<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
-					<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>head</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>2</power>
-					<cooldownTime>4.49</cooldownTime>
-					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-					<chanceFactor>0.2</chanceFactor>
-					<armorPenetrationBlunt>0.625</armorPenetrationBlunt>
-				</li>
-			</tools>
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]/tools</xpath>
+    <value>
+      <tools>
+        <li Class="CombatExtended.ToolCE">
+          <label>left fist</label>
+          <capacities>
+            <li>Blunt</li>
+          </capacities>
+          <power>1</power>
+          <cooldownTime>1.26</cooldownTime>
+          <linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+          <armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+        </li>
+        <li Class="CombatExtended.ToolCE">
+          <label>right fist</label>
+          <capacities>
+            <li>Blunt</li>
+          </capacities>
+          <power>1</power>
+          <cooldownTime>1.26</cooldownTime>
+          <linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+          <armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+        </li>
+        <li Class="CombatExtended.ToolCE">
+          <label>head</label>
+          <capacities>
+            <li>Blunt</li>
+          </capacities>
+          <power>2</power>
+          <cooldownTime>4.49</cooldownTime>
+          <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+          <chanceFactor>0.2</chanceFactor>
+          <armorPenetrationBlunt>0.625</armorPenetrationBlunt>
+        </li>
+      </tools>
+    </value>
+  </Operation>
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]/damageMultipliers</xpath>
-		<value>
-			<li>
-				<damageDef>PrometheumFlame</damageDef>
-				<multiplier>0.25</multiplier>
-			</li>
-			<li>
-				<damageDef>Flame_Secondary</damageDef>
-				<multiplier>0.25</multiplier>
-			</li>
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]/damageMultipliers</xpath>
+    <value>
+      <li>
+        <damageDef>PrometheumFlame</damageDef>
+        <multiplier>0.25</multiplier>
+      </li>
+      <li>
+        <damageDef>Flame_Secondary</damageDef>
+        <multiplier>0.25</multiplier>
+      </li>
+    </value>
+  </Operation>
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]/alienRace/raceRestriction/whiteApparelList</xpath>
-		<value>
-			<li>CE_Apparel_TacVest</li>
-			<li>CE_Apparel_Backpack</li>
-			<li>CE_Apparel_TribalBackpack</li>
-			<li>CE_Apparel_BallisticShield</li>
-			<li>CE_Apparel_MeleeShield</li>
-			<li>CE_Apparel_GasMask</li>
-			<li>CE_Apparel_ImprovGasMask</li>
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]/alienRace/raceRestriction/whiteApparelList</xpath>
+    <value>
+      <li>CE_Apparel_TacVest</li>
+      <li>CE_Apparel_Backpack</li>
+      <li>CE_Apparel_TribalBackpack</li>
+      <li>CE_Apparel_BallisticShield</li>
+      <li>CE_Apparel_MeleeShield</li>
+      <li>CE_Apparel_GasMask</li>
+      <li>CE_Apparel_ImprovGasMask</li>
+    </value>
+  </Operation>
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/GeneDef[defName="Ears_Arctic_Miho"]/statOffsets</xpath>
-		<value>
-			<CarryWeight>10</CarryWeight>
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/GeneDef[defName="Ears_Arctic_Miho"]/statOffsets</xpath>
+    <value>
+      <CarryWeight>10</CarryWeight>
+    </value>
+  </Operation>
 </Patch>

--- a/ModPatches/Miho Race/Patches/Miho Race/ThingDefs_Races/AlienRace_Miho.xml
+++ b/ModPatches/Miho Race/Patches/Miho Race/ThingDefs_Races/AlienRace_Miho.xml
@@ -1,126 +1,126 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
-  <Operation Class="PatchOperationConditional">
-    <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]/comps</xpath>
-    <match Class="PatchOperationAdd">
-      <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]/comps</xpath>
-      <value>
-        <li Class="CombatExtended.CompProperties_Suppressable"/>
-        <li Class="CombatExtended.CompProperties_ArmorDurability">
-          <Durability>500</Durability>
-          <Regenerates>true</Regenerates>
-          <RegenInterval>600</RegenInterval>
-          <RegenValue>5</RegenValue>
-          <MinArmorPct>0.75</MinArmorPct>
-        </li>
-      </value>
-    </match>
-    <nomatch Class="PatchOperationAdd">
-      <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]</xpath>
-      <value>
-        <comps>
-          <li Class="CombatExtended.CompProperties_Suppressable"/>
-          <li Class="CombatExtended.CompProperties_ArmorDurability">
-            <Durability>500</Durability>
-            <Regenerates>true</Regenerates>
-            <RegenInterval>600</RegenInterval>
-            <RegenValue>5</RegenValue>
-            <MinArmorPct>0.75</MinArmorPct>
-          </li>
-        </comps>
-      </value>
-    </nomatch>
-  </Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]/comps</xpath>
+		<match Class="PatchOperationAdd">
+			<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]/comps</xpath>
+			<value>
+				<li Class="CombatExtended.CompProperties_Suppressable"/>
+				<li Class="CombatExtended.CompProperties_ArmorDurability">
+					<Durability>500</Durability>
+					<Regenerates>true</Regenerates>
+					<RegenInterval>600</RegenInterval>
+					<RegenValue>5</RegenValue>
+					<MinArmorPct>0.75</MinArmorPct>
+				</li>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]</xpath>
+			<value>
+				<comps>
+					<li Class="CombatExtended.CompProperties_Suppressable"/>
+					<li Class="CombatExtended.CompProperties_ArmorDurability">
+					<Durability>500</Durability>
+						<Regenerates>true</Regenerates>
+						<RegenInterval>600</RegenInterval>
+						<RegenValue>5</RegenValue>
+						<MinArmorPct>0.75</MinArmorPct>
+					</li>
+				</comps>
+			</value>
+		</nomatch>
+	</Operation>
 
-  <Operation Class="PatchOperationAddModExtension">
-    <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]</xpath>
-    <value>
-      <li Class="CombatExtended.RacePropertiesExtensionCE">
-        <bodyShape>Humanoid</bodyShape>
-      </li>
-    </value>
-  </Operation>
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]</xpath>
+		<value>
+			<li Class="CombatExtended.RacePropertiesExtensionCE">
+				<bodyShape>Humanoid</bodyShape>
+			</li>
+		</value>
+	</Operation>
 
-  <Operation Class="PatchOperationReplace">
-    <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]/statBases/MeleeDodgeChance</xpath>
-    <value>
-      <MeleeDodgeChance>0.5</MeleeDodgeChance>
-      <Suppressability>1</Suppressability>
-      <SmokeSensitivity>0.5</SmokeSensitivity>
-      <AimingAccuracy>0.75</AimingAccuracy>
-    </value>
-  </Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]/statBases/MeleeDodgeChance</xpath>
+		<value>
+			<MeleeDodgeChance>0.5</MeleeDodgeChance>
+			<Suppressability>1</Suppressability>
+			<SmokeSensitivity>0.5</SmokeSensitivity>
+			<AimingAccuracy>0.75</AimingAccuracy>
+		</value>
+	</Operation>
 
-  <Operation Class="PatchOperationReplace">
-    <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]/tools</xpath>
-    <value>
-      <tools>
-        <li Class="CombatExtended.ToolCE">
-          <label>left fist</label>
-          <capacities>
-            <li>Blunt</li>
-          </capacities>
-          <power>1</power>
-          <cooldownTime>1.26</cooldownTime>
-          <linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
-          <armorPenetrationBlunt>0.250</armorPenetrationBlunt>
-        </li>
-        <li Class="CombatExtended.ToolCE">
-          <label>right fist</label>
-          <capacities>
-            <li>Blunt</li>
-          </capacities>
-          <power>1</power>
-          <cooldownTime>1.26</cooldownTime>
-          <linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
-          <armorPenetrationBlunt>0.250</armorPenetrationBlunt>
-        </li>
-        <li Class="CombatExtended.ToolCE">
-          <label>head</label>
-          <capacities>
-            <li>Blunt</li>
-          </capacities>
-          <power>2</power>
-          <cooldownTime>4.49</cooldownTime>
-          <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-          <chanceFactor>0.2</chanceFactor>
-          <armorPenetrationBlunt>0.625</armorPenetrationBlunt>
-        </li>
-      </tools>
-    </value>
-  </Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>left fist</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>1</power>
+					<cooldownTime>1.26</cooldownTime>
+					<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+					<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>right fist</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>1</power>
+					<cooldownTime>1.26</cooldownTime>
+					<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+					<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>2</power>
+					<cooldownTime>4.49</cooldownTime>
+					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					<chanceFactor>0.2</chanceFactor>
+					<armorPenetrationBlunt>0.625</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</Operation>
 
-  <Operation Class="PatchOperationAdd">
-    <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]/damageMultipliers</xpath>
-    <value>
-      <li>
-        <damageDef>PrometheumFlame</damageDef>
-        <multiplier>0.25</multiplier>
-      </li>
-      <li>
-        <damageDef>Flame_Secondary</damageDef>
-        <multiplier>0.25</multiplier>
-      </li>
-    </value>
-  </Operation>
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]/damageMultipliers</xpath>
+		<value>
+			<li>
+				<damageDef>PrometheumFlame</damageDef>
+				<multiplier>0.25</multiplier>
+			</li>
+			<li>
+				<damageDef>Flame_Secondary</damageDef>
+				<multiplier>0.25</multiplier>
+			</li>
+		</value>
+	</Operation>
 
-  <Operation Class="PatchOperationAdd">
-    <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]/alienRace/raceRestriction/whiteApparelList</xpath>
-    <value>
-      <li>CE_Apparel_TacVest</li>
-      <li>CE_Apparel_Backpack</li>
-      <li>CE_Apparel_TribalBackpack</li>
-      <li>CE_Apparel_BallisticShield</li>
-      <li>CE_Apparel_MeleeShield</li>
-      <li>CE_Apparel_GasMask</li>
-      <li>CE_Apparel_ImprovGasMask</li>
-    </value>
-  </Operation>
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]/alienRace/raceRestriction/whiteApparelList</xpath>
+		<value>
+			<li>CE_Apparel_TacVest</li>
+			<li>CE_Apparel_Backpack</li>
+			<li>CE_Apparel_TribalBackpack</li>
+			<li>CE_Apparel_BallisticShield</li>
+			<li>CE_Apparel_MeleeShield</li>
+			<li>CE_Apparel_GasMask</li>
+			<li>CE_Apparel_ImprovGasMask</li>
+		</value>
+	</Operation>
 
-  <Operation Class="PatchOperationAdd">
-    <xpath>Defs/GeneDef[defName="Ears_Arctic_Miho"]/statOffsets</xpath>
-    <value>
-      <CarryWeight>10</CarryWeight>
-    </value>
-  </Operation>
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/GeneDef[defName="Ears_Arctic_Miho"]/statOffsets</xpath>
+		<value>
+			<CarryWeight>10</CarryWeight>
+		</value>
+	</Operation>
 </Patch>

--- a/ModPatches/Miho Race/Patches/Miho Race/ThingDefs_Races/AlienRace_Miho.xml
+++ b/ModPatches/Miho Race/Patches/Miho Race/ThingDefs_Races/AlienRace_Miho.xml
@@ -21,7 +21,7 @@
 				<comps>
 					<li Class="CombatExtended.CompProperties_Suppressable"/>
 					<li Class="CombatExtended.CompProperties_ArmorDurability">
-					<Durability>500</Durability>
+						<Durability>500</Durability>
 						<Regenerates>true</Regenerates>
 						<RegenInterval>600</RegenInterval>
 						<RegenValue>5</RegenValue>

--- a/Source/CombatExtended/CombatExtended/Comps_CCL/CompPawnGizmo.cs
+++ b/Source/CombatExtended/CombatExtended/Comps_CCL/CompPawnGizmo.cs
@@ -5,35 +5,52 @@ namespace CombatExtended
 {
     public class CompPawnGizmo : ThingComp
     {
-        public override IEnumerable<Gizmo> CompGetGizmosExtra()
-        {
-            var pawn = parent as Pawn;
-            var equip = pawn != null
-                        ? pawn.equipment.Primary
-                        : null;
+        bool duplicate = false;
 
-            if (
-                (equip != null) &&
-                (!equip.AllComps.NullOrEmpty())
-            )
+        public override void Initialize(CompProperties props)
+        {
+            base.Initialize(props);
+            foreach (var comp in parent.comps)
             {
-                foreach (var comp in equip.AllComps)
+                if (comp is CompPawnGizmo && comp != this)
                 {
-                    var gizmoGiver = comp as CompRangedGizmoGiver;
-                    if (
-                        (gizmoGiver != null) &&
-                        (gizmoGiver.isRangedGiver)
-                    )
-                    {
-                        foreach (var gizmo in gizmoGiver.CompGetGizmosExtra())
-                        {
-                            yield return gizmo;
-                        }
-                    }
+                    duplicate = true;
+                    Log.ErrorOnce($"{parent.def.defName} has multiple CompPawnGizmo, duplicates has been deactivated. Please report this to the patch provider of ${parent.def.modContentPack.Name} or CE team if the patch is integrated in CE.", parent.def.GetHashCode());
                 }
             }
         }
 
-    }
 
+        public override IEnumerable<Gizmo> CompGetGizmosExtra()
+        {
+            if (!duplicate)
+            {
+                var pawn = parent as Pawn;
+                var equip = pawn != null
+                            ? pawn.equipment.Primary
+                            : null;
+
+                if (
+                    (equip != null) &&
+                    (!equip.AllComps.NullOrEmpty())
+                )
+                {
+                    foreach (var comp in equip.AllComps)
+                    {
+                        var gizmoGiver = comp as CompRangedGizmoGiver;
+                        if (
+                            (gizmoGiver != null) &&
+                            (gizmoGiver.isRangedGiver)
+                        )
+                        {
+                            foreach (var gizmo in gizmoGiver.CompGetGizmosExtra())
+                            {
+                                yield return gizmo;
+                            }
+                        }
+                    }
+                }
+            };
+        }
+    }
 }

--- a/Source/CombatExtended/CombatExtended/Comps_CCL/CompPawnGizmo.cs
+++ b/Source/CombatExtended/CombatExtended/Comps_CCL/CompPawnGizmo.cs
@@ -15,7 +15,7 @@ namespace CombatExtended
                 if (comp is CompPawnGizmo && comp != this)
                 {
                     duplicate = true;
-                    Log.ErrorOnce($"{parent.def.defName} has multiple CompPawnGizmo, duplicates has been deactivated. Please report this to the patch provider of ${parent.def.modContentPack.Name} or CE team if the patch is integrated in CE.", parent.def.GetHashCode());
+                    Log.ErrorOnce($"{parent.def.defName} has multiple CompPawnGizmo, duplicates has been deactivated. Please report this to the patch provider of {parent.def.modContentPack.Name} or CE team if the patch is integrated in CE.", parent.def.GetHashCode());
                 }
             }
         }


### PR DESCRIPTION
## Changes

CompPawnGizmo will now check if duplicate exists. If there does, an error message will be shown and extra compPawnGizmos will be deactivated.

## Reasoning

Dupe CPG has been haunting HAR races for ages, as HAR patchers may not realize there's one in baseHuman. And duplicated CPGs causing gizmo to trigger twice upon click, breaking functions like aim height selection and UBGL. AFAIK it happened on miho and revia, and there're probably something else that does but not as popular.

An error message is with defname and mod name is provided so that patchers can locate the problem and players can report the issue to patch provider.

Duplicated CPG will skip their getgizmo so that functions still operate normally.

## Alternatives

Strongly-worded letter to HAR patchers, check the god damned parent def!

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors (it does, but only when I wanted)
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
