### PR TITLE
Ghoul plating stat typo fix

### DIFF
--- a/Anomaly/Patches/Hediffs/Hediffs_BodyParts_Prosthetic.xml
+++ b/Anomaly/Patches/Hediffs/Hediffs_BodyParts_Prosthetic.xml
@@ -26,7 +26,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="GhoulPlating"]/stages/li/statFactors/IncomingDamageFactor</xpath>
 		<value>
-			<IncomingDamageFactor>0.25</IncomingDamageFactor>
+			<IncomingDamageFactor>0.75</IncomingDamageFactor>
 		</value>
 	</Operation>
 


### PR DESCRIPTION
## Changes

- Fixed the incoming damage multiplier stat on the ghoul plating.

## Reasoning

- The patch was meant to reduce the damage resistance by 25%, not the other way around.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
