### PR TITLE
Minor assorted housekeeping

### DIFF
--- a/Defs/Ammo/Medieval/BlunderbussShot.xml
+++ b/Defs/Ammo/Medieval/BlunderbussShot.xml
@@ -72,7 +72,7 @@
 			<speed>73</speed>
 			<damageAmountBase>7</damageAmountBase>
 			<pelletCount>20</pelletCount>
-			<armorPenetrationSharp>3.5</armorPenetrationSharp>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
 			<armorPenetrationBlunt>3.14</armorPenetrationBlunt>
 			<spreadMult>17.8</spreadMult>
 		</projectile>

--- a/Defs/Ammo/Medieval/MiniCannonBall.xml
+++ b/Defs/Ammo/Medieval/MiniCannonBall.xml
@@ -127,7 +127,7 @@
 			<speed>73</speed>
 			<damageAmountBase>15</damageAmountBase>
 			<pelletCount>10</pelletCount>
-			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationSharp>3.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>20.7</armorPenetrationBlunt>
 			<spreadMult>17.8</spreadMult>
 		</projectile>

--- a/Royalty/Patches/ThingDefs_Misc/Weapons_RoyaltyMelee.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Weapons_RoyaltyMelee.xml
@@ -95,6 +95,13 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_Warhammer"]/costStuffCount</xpath>
+		<value>
+			<costStuffCount>125</costStuffCount>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="MeleeWeapon_Warhammer"]/statBases/Mass</xpath>
 		<value>
 			<Mass>2.5</Mass>

--- a/Royalty/Patches/ThingDefs_Misc/Weapons_RoyaltyMelee.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Weapons_RoyaltyMelee.xml
@@ -95,13 +95,6 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="MeleeWeapon_Warhammer"]/costStuffCount</xpath>
-		<value>
-			<costStuffCount>100</costStuffCount>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="MeleeWeapon_Warhammer"]/statBases/Mass</xpath>
 		<value>
 			<Mass>2.5</Mass>

--- a/Royalty/Patches/ThingDefs_Misc/Weapons_RoyaltyMelee.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Weapons_RoyaltyMelee.xml
@@ -95,6 +95,13 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_Warhammer"]/costStuffCount</xpath>
+		<value>
+			<costStuffCount>100</costStuffCount>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="MeleeWeapon_Warhammer"]/statBases/Mass</xpath>
 		<value>
 			<Mass>2.5</Mass>


### PR DESCRIPTION
## Changes

- Swapped the sharp AP of blunderbuss and mini cannon ball grape ammo.
- Decreased the material requirement in the Royalty warhammer's recipe.

## Reasoning

- Blunderbuss shot should have had 3mm and the other 3.5mm, not the other way around.
- The CE Melee maul is heavier and requires 120 materials which is the baseline, the warhammer being lighter and costing 150 doesn't make sense.

## Alternatives

- Make the CE Melee maul require more work and materials? It requires 4000 less work in comparison too.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors

