### PR TITLE
Fix CE Patch for Wall Armor

### DIFF
--- a/ModPatches/ReBuild - Doors and Corners/Patches/ReBuild - Doors and Corners/Buildings_Structure.xml
+++ b/ModPatches/ReBuild - Doors and Corners/Patches/ReBuild - Doors and Corners/Buildings_Structure.xml
@@ -3,30 +3,64 @@
 
 	<!-- === Wall Armor === -->
 	<!-- adjust damageMultipliers dealt by damage defs -->
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName = "RB_ReinforcedGlassWall" or defName = "RB_ReinforcedClerestoryWall"]/damageMultipliers/li[damageDef = "Bomb" or damageDef = "Thump"]/multiplier</xpath>
-		<value>
-			<multiplier>0.5</multiplier>
-		</value>
+	<Operation Class="PatchOperationConditional">
+	    <xpath>Defs/ThingDef[defName="RB_OverwallArmor"]/damageMultipliers</xpath>
+		<nomatch Class="PatchOperationAdd">
+		  <xpath>Defs/ThingDef[defName="RB_OverwallArmor"]/</xpath>
+		  <value>
+			<damageMultipliers>
+			  <li>
+				<damageDef>Bomb</damageDef>
+				<multiplier>0.5</multiplier>
+			  </li>
+			  <li>
+				<damageDef>Thump</damageDef>
+				<multiplier>0.5</multiplier>
+			  </li>
+			  <li>
+				<damageDef>Thermobaric</damageDef>
+				<multiplier>0.5</multiplier>
+			  </li>
+			  <li>
+				<damageDef>Bomb_Secondary</damageDef>
+				<multiplier>0.5</multiplier>
+			  </li>
+			  <li>
+				<damageDef>Demolish</damageDef>
+				<multiplier>0.5</multiplier>
+			  </li>
+			</damageMultipliers>
+			</value>
+		</nomatch>
+		<match Class = "PatchOperationSequence">
+			<operations>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName = "RB_OverwallArmor"]/damageMultipliers/li[damageDef = "Bomb" or damageDef = "Thump"]/multiplier</xpath>
+				<value>
+					<multiplier>0.5</multiplier>
+				</value>
+			</li>
+			<li Class = "PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName = "RB_OverwallArmor"]/damageMultipliers</xpath>
+				<value>
+				<li>
+					<damageDef>Thermobaric</damageDef>
+					<multiplier>0.5</multiplier>
+				  </li>
+				  <li>
+					<damageDef>Bomb_Secondary</damageDef>
+					<multiplier>0.5</multiplier>
+				  </li>
+				  <li>
+					<damageDef>Demolish</damageDef>
+					<multiplier>0.5</multiplier>
+				  </li>
+				</value>
+			</li>
+
+			</operations>
+		</match>
 	</Operation>
 
-  <!-- add more damage defs -->
-  <Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName = "RB_ReinforcedGlassWall" or defName = "RB_ReinforcedClerestoryWall"]/damageMultipliers</xpath>
-		<value>
-		<li>
-			<damageDef>Thermobaric</damageDef>
-			<multiplier>0.5</multiplier>
-		</li>
-		<li>
-			<damageDef>Bomb_Secondary</damageDef>
-			<multiplier>0.5</multiplier>
-		</li>
-		<li>
-			<damageDef>Demolish</damageDef>
-			<multiplier>0.5</multiplier>
-    	</li>
-		</value>
-	</Operation>
 
 </Patch>


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
 - Fixed a patch for ReBuild: Walls and Corners 's wall armor. CE was trying to patch the damageMultipliers of the Wall armor, a node that didn't exist for some reason.

## Changes

Patch now checks if damageMultipliers node exists before patching

## References

None

## Reasoning
I was clearing errors from my log

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
