### PR TITLE
Mossberg 500 parity checks and 12ga SB ammoset

### DIFF
--- a/Defs/Ammo/Shotgun/12Gauge.xml
+++ b/Defs/Ammo/Shotgun/12Gauge.xml
@@ -22,6 +22,18 @@
 		<similarTo>AmmoSet_Shotgun</similarTo>
 	</CombatExtended.AmmoSetDef>
 
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_12Gauge_SB</defName>
+		<label>12 Gauge</label>
+		<ammoTypes>
+			<Ammo_12Gauge_Buck>Bullet_12Gauge_Buck_SB</Ammo_12Gauge_Buck>
+			<Ammo_12Gauge_Slug>Bullet_12Gauge_Slug_SB</Ammo_12Gauge_Slug>
+			<Ammo_12Gauge_Beanbag>Bullet_12Gauge_Beanbag_SB</Ammo_12Gauge_Beanbag>
+			<Ammo_12Gauge_ElectroSlug>Bullet_12Gauge_ElectroSlug_SB</Ammo_12Gauge_ElectroSlug>
+		</ammoTypes>
+		<similarTo>AmmoSet_Shotgun</similarTo>
+	</CombatExtended.AmmoSetDef>
+
 	<!-- ==================== Ammo ========================== -->
 
 	<ThingDef Class="CombatExtended.AmmoDef" Name="12GaugeBase" ParentName="AmmoBase" Abstract="True">
@@ -175,6 +187,81 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<speed>43</speed>
+			<damageDef>EMP</damageDef>
+			<damageAmountBase>12</damageAmountBase>
+			<armorPenetrationSharp>0</armorPenetrationSharp>
+			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<empShieldBreakChance>0.2</empShieldBreakChance>
+			<casingMoteDefname>Fleck_ShotgunShell_Black</casingMoteDefname>
+			<casingFilthDefname>Filth_ShotgunAmmoCasings_Black</casingFilthDefname>
+		</projectile>
+	</ThingDef>
+
+	<!-- Slow Projectiles -->
+
+	<ThingDef ParentName="Base12GaugeBullet">
+		<defName>Bullet_12Gauge_Buck_SB</defName>
+		<label>buckshot pellet</label>
+		<graphicData>
+			<texPath>Things/Projectile/Shotgun_Pellet</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<speed>75</speed>
+			<damageAmountBase>7</damageAmountBase>
+			<pelletCount>9</pelletCount>
+			<armorPenetrationSharp>3.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>3.46</armorPenetrationBlunt>
+			<spreadMult>11.0</spreadMult>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base12GaugeBullet">
+		<defName>Bullet_12Gauge_Slug_SB</defName>
+		<label>shotgun slug</label>
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_big</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<speed>106</speed>
+			<damageAmountBase>26</damageAmountBase>
+			<armorPenetrationSharp>5</armorPenetrationSharp>
+			<armorPenetrationBlunt>70.76</armorPenetrationBlunt>
+			<casingMoteDefname>Fleck_ShotgunShell_Green</casingMoteDefname>
+			<casingFilthDefname>Filth_ShotgunAmmoCasings_Green</casingFilthDefname>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base12GaugeBullet">
+		<defName>Bullet_12Gauge_Beanbag_SB</defName>
+		<label>beanbag</label>
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_big</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<speed>26</speed>
+			<damageDef>Beanbag</damageDef>
+			<damageAmountBase>8</damageAmountBase>
+			<armorPenetrationSharp>0</armorPenetrationSharp>
+			<armorPenetrationBlunt>2.26</armorPenetrationBlunt>
+			<spreadMult>2</spreadMult>
+			<casingMoteDefname>Fleck_ShotgunShell_White</casingMoteDefname>
+			<casingFilthDefname>Filth_ShotgunAmmoCasings_White</casingFilthDefname>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base12GaugeBullet">
+		<defName>Bullet_12Gauge_ElectroSlug_SB</defName>
+		<label>EMP slug</label>
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_big</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<color>(68,210,215)</color>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<speed>33</speed>
 			<damageDef>EMP</damageDef>
 			<damageAmountBase>12</damageAmountBase>
 			<armorPenetrationSharp>0</armorPenetrationSharp>

--- a/Defs/Ammo/Shotgun/410Bore.xml
+++ b/Defs/Ammo/Shotgun/410Bore.xml
@@ -197,6 +197,8 @@
 		</projectile>
 	</ThingDef>
 
+	<!-- Slow Projectiles -->
+
 	<ThingDef ParentName="Base410BoreBullet">
 		<defName>Bullet_410Bore_Buck_SB</defName>
 		<label>buckshot pellet</label>

--- a/ModPatches/Morgante Mafia Weapons Pack/Patches/Morgante Mafia Weapons Pack/Weapons_Guns.xml
+++ b/ModPatches/Morgante Mafia Weapons Pack/Patches/Morgante Mafia Weapons Pack/Weapons_Guns.xml
@@ -166,7 +166,7 @@
 		<Properties>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
+			<defaultProjectile>Bullet_12Gauge_Buck_SB</defaultProjectile>
 			<warmupTime>0.6</warmupTime>
 			<range>13</range>
 			<soundCast>Shot_Shotgun</soundCast>
@@ -177,7 +177,7 @@
 			<magazineSize>2</magazineSize>
 			<reloadOneAtATime>true</reloadOneAtATime>
 			<reloadTime>1.7</reloadTime>
-			<ammoSet>AmmoSet_12Gauge</ammoSet>
+			<ammoSet>AmmoSet_12Gauge_SB</ammoSet>
 		</AmmoUser>
 		<FireModes>
 			<aiAimMode>Snapshot</aiAimMode>

--- a/ModPatches/Pratt WWII Weapons Pack/Patches/Pratt WWII Weapons Pack/PWW2_CE_Patch_Weapons_Ranged_FR.xml
+++ b/ModPatches/Pratt WWII Weapons Pack/Patches/Pratt WWII Weapons Pack/PWW2_CE_Patch_Weapons_Ranged_FR.xml
@@ -267,7 +267,7 @@
 		<Properties>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
+			<defaultProjectile>Bullet_12Gauge_Buck_SB</defaultProjectile>
 			<warmupTime>0.6</warmupTime>
 			<range>11</range>
 			<soundCast>Shot_Shotgun</soundCast>
@@ -278,7 +278,7 @@
 		<AmmoUser>
 			<magazineSize>2</magazineSize>
 			<reloadTime>1.7</reloadTime>
-			<ammoSet>AmmoSet_12Gauge</ammoSet>
+			<ammoSet>AmmoSet_12Gauge_SB</ammoSet>
 		</AmmoUser>
 
 		<FireModes>

--- a/ModPatches/Rambo Weapons Pack/Patches/Rambo Weapons Pack/RamboWeaponsPack_shotguns.xml
+++ b/ModPatches/Rambo Weapons Pack/Patches/Rambo Weapons Pack/RamboWeaponsPack_shotguns.xml
@@ -616,7 +616,7 @@
 		<Properties>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>True</hasStandardCommand>
-			<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
+			<defaultProjectile>Bullet_12Gauge_Buck_SB</defaultProjectile>
 			<recoilAmount>0.75</recoilAmount>
 			<burstShotCount>2</burstShotCount>
 			<ticksBetweenBurstShots>0</ticksBetweenBurstShots>
@@ -629,7 +629,7 @@
 		<AmmoUser>
 			<magazineSize>2</magazineSize>
 			<reloadTime>1.7</reloadTime>
-			<ammoSet>AmmoSet_12Gauge</ammoSet>
+			<ammoSet>AmmoSet_12Gauge_SB</ammoSet>
 		</AmmoUser>
 		<FireModes>
 			<aiAimMode>Snapshot</aiAimMode>
@@ -703,7 +703,7 @@
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>True</hasStandardCommand>
 			<recoilAmount>0.75</recoilAmount>
-			<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
+			<defaultProjectile>Bullet_12Gauge_Buck_SB</defaultProjectile>
 			<burstShotCount>2</burstShotCount>
 			<ticksBetweenBurstShots>0</ticksBetweenBurstShots>
 			<warmupTime>0.6</warmupTime>
@@ -715,7 +715,7 @@
 		<AmmoUser>
 			<magazineSize>2</magazineSize>
 			<reloadTime>1.7</reloadTime>
-			<ammoSet>AmmoSet_12Gauge</ammoSet>
+			<ammoSet>AmmoSet_12Gauge_SB</ammoSet>
 		</AmmoUser>
 		<FireModes>
 			<aiAimMode>Snapshot</aiAimMode>

--- a/ModPatches/Rimmu-Nation - Weapons/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_Shotguns.xml
+++ b/ModPatches/Rimmu-Nation - Weapons/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_Shotguns.xml
@@ -564,7 +564,7 @@
 		<Properties>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
+			<defaultProjectile>Bullet_12Gauge_Buck_SB</defaultProjectile>
 			<warmupTime>0.6</warmupTime>
 			<range>11</range>
 			<soundCast>RNShotSawnOff</soundCast>
@@ -575,7 +575,7 @@
 		<AmmoUser>
 			<magazineSize>2</magazineSize>
 			<reloadTime>1.7</reloadTime>
-			<ammoSet>AmmoSet_12Gauge</ammoSet>
+			<ammoSet>AmmoSet_12Gauge_SB</ammoSet>
 		</AmmoUser>
 
 		<FireModes>

--- a/ModPatches/Vanilla Weapons Expanded/Patches/Vanilla Weapons Expanded/Industrial_Ranged.xml
+++ b/ModPatches/Vanilla Weapons Expanded/Patches/Vanilla Weapons Expanded/Industrial_Ranged.xml
@@ -168,7 +168,7 @@
 		<AmmoUser>
 			<ammoSet>AmmoSet_StreamlinedArrow</ammoSet>
 		</AmmoUser>
-		<FireModes/>
+		<FireModes />
 		<weaponTags Inherit="False">
 			<li>CE_Bow</li>
 		</weaponTags>
@@ -373,7 +373,7 @@
 			<recoilAmount>3.5</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
+			<defaultProjectile>Bullet_12Gauge_Buck_SB</defaultProjectile>
 			<warmupTime>0.6</warmupTime>
 			<range>14</range>
 			<soundCast>Shot_Shotgun_NoRack</soundCast>
@@ -384,7 +384,7 @@
 			<magazineSize>2</magazineSize>
 			<reloadOneAtATime>true</reloadOneAtATime>
 			<reloadTime>1.7</reloadTime>
-			<ammoSet>AmmoSet_12Gauge</ammoSet>
+			<ammoSet>AmmoSet_12Gauge_SB</ammoSet>
 		</AmmoUser>
 		<FireModes>
 			<aiAimMode>Snapshot</aiAimMode>
@@ -799,7 +799,7 @@
 			<reloadTime>7.8</reloadTime>
 			<ammoSet>AmmoSet_VWE_Extinguisher</ammoSet>
 		</AmmoUser>
-		<FireModes/>
+		<FireModes />
 		<weaponTags Inherit="False">
 			<li>ToolDecent</li>
 		</weaponTags>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -241,21 +241,21 @@
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>Gun_PumpShotgun</defName>
 		<statBases>
-			<Mass>3.00</Mass>
-			<RangedWeapon_Cooldown>1.0</RangedWeapon_Cooldown>
+			<Mass>3.05</Mass>
+			<RangedWeapon_Cooldown>0.99</RangedWeapon_Cooldown>
 			<ShotSpread>0.14</ShotSpread>
-			<SwayFactor>1.20</SwayFactor>
-			<Bulk>9.0</Bulk>
+			<SwayFactor>1.31</SwayFactor>
+			<Bulk>10.0</Bulk>
 			<SightsEfficiency>1</SightsEfficiency>
-			<WorkToMake>9500</WorkToMake>
+			<WorkToMake>10000</WorkToMake>
 		</statBases>
 		<costList>
-			<Steel>45</Steel>
+			<Steel>50</Steel>
 			<WoodLog>10</WoodLog>
 			<ComponentIndustrial>1</ComponentIndustrial>
 		</costList>
 		<Properties>
-			<recoilAmount>2.75</recoilAmount>
+			<recoilAmount>2.72</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
@@ -266,7 +266,7 @@
 			<muzzleFlashScale>9</muzzleFlashScale>
 		</Properties>
 		<AmmoUser>
-			<magazineSize>5</magazineSize>
+			<magazineSize>6</magazineSize>
 			<reloadOneAtATime>true</reloadOneAtATime>
 			<reloadTime>0.85</reloadTime>
 			<ammoSet>AmmoSet_12Gauge</ammoSet>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -266,7 +266,7 @@
 			<muzzleFlashScale>9</muzzleFlashScale>
 		</Properties>
 		<AmmoUser>
-			<magazineSize>6</magazineSize>
+			<magazineSize>5</magazineSize>
 			<reloadOneAtATime>true</reloadOneAtATime>
 			<reloadTime>0.85</reloadTime>
 			<ammoSet>AmmoSet_12Gauge</ammoSet>


### PR DESCRIPTION
## Changes

- Adjusted the weapon's stats based on https://www.mossberg.com/500-retrograde-50429.html.
- Added a short barrel 12 gauge ammoset for use in sawed-off shotguns.

## References

- https://docs.google.com/spreadsheets/d/1lbT0zzagCRPDJG4GctkeeoTsFCt3lYfM4SRnWt8ql-k/edit?gid=1573763037#gid=1573763037
- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit?gid=1393347070#gid=1393347070

## Reasoning

- Stat inconsistencies.
- Tests (https://www.kommandoblog.com/2017/05/16/shotgun-barrel-length-velocity/) show that an 11 inch barrel vs a 18~19 inch shotgun barrel have around 150 fps / 45 m/s difference in velocity.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
