### PR TITLE
Star Crafters Armory fix

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -489,7 +489,7 @@
 		<li IfModActive="Mlie.SpaceWorms">ModPatches/Spaceworm</li>
 		<li IfModActive="HALO.RSF, Mlie.RimworldSpartanFoundry">ModPatches/Spartan Foundry</li>
 		<li IfModActive="Mlie.SpidercampsHorses">ModPatches/Spidercamp's Horses</li>
-		<li IfModActive="AKRI.StarcraftersArmory_copy">ModPatches/Star Crafter's Armory</li>
+		<li IfModActive="akri.starcraftersarmory">ModPatches/Star Crafter's Armory</li>
 		<li IfModActive="projectjedi.factions">ModPatches/Star Wars - Factions</li>
 		<li IfModActive="walkingproblem.arachnid">ModPatches/Starship Troopers Arachnids</li>
 		<li IfModActive="Koni.Misc.SteamworldUniforms">ModPatches/Steamworld Uniforms</li>

--- a/ModPatches/Star Crafter's Armory/Patches/Star Crafter's Armory/Apparel.xml
+++ b/ModPatches/Star Crafter's Armory/Patches/Star Crafter's Armory/Apparel.xml
@@ -38,27 +38,13 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/ThingDef[defName="PPSa"]/equippedStatOffsets/ToxicSensitivity</xpath>
-		<match Class="PatchOperationRemove">
-			<xpath>Defs/ThingDef[defName="PPSa"]/equippedStatOffsets/ToxicSensitivity</xpath>
-		</match>
-	</Operation>
-
-	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/ThingDef[defName="PPSa"]/equippedStatOffsets/ToxicEnvironmentResistance</xpath>
-		<match Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="PPSa"]/equippedStatOffsets/ToxicEnvironmentResistance</xpath>
-			<value>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="PPSa"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<equippedStatOffsets>
 				<ToxicEnvironmentResistance>0.5</ToxicEnvironmentResistance>
-			</value>
-		</match>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="PPSa"]/equippedStatOffsets</xpath>
-			<value>
-				<ToxicEnvironmentResistance>0.5</ToxicEnvironmentResistance>
-			</value>
-		</nomatch>
+			</equippedStatOffsets>	
+		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
@@ -158,35 +144,13 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="PPSH"]/equippedStatOffsets</xpath>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="PPSH"]/equippedStatOffsets/ToxicEnvironmentResistance</xpath>
 		<value>
+			<ToxicEnvironmentResistance>0.5</ToxicEnvironmentResistance>
 			<AimingAccuracy>0.15</AimingAccuracy>
 			<SmokeSensitivity>-1</SmokeSensitivity>
 		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/ThingDef[defName="PPSH"]/equippedStatOffsets/ToxicSensitivity</xpath>
-		<match Class="PatchOperationRemove">
-			<xpath>Defs/ThingDef[defName="PPSH"]/equippedStatOffsets/ToxicSensitivity</xpath>
-		</match>
-	</Operation>
-
-	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/ThingDef[defName="PPSH"]/equippedStatOffsets/ToxicEnvironmentResistance</xpath>
-		<match Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="PPSH"]/equippedStatOffsets/ToxicEnvironmentResistance</xpath>
-			<value>
-				<ToxicEnvironmentResistance>0.5</ToxicEnvironmentResistance>
-			</value>
-		</match>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="PPSH"]/equippedStatOffsets</xpath>
-			<value>
-				<ToxicEnvironmentResistance>0.5</ToxicEnvironmentResistance>
-			</value>
-		</nomatch>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
@@ -226,4 +190,5 @@
 			</li>
 		</value>
 	</Operation>
+
 </Patch>

--- a/ModPatches/Star Crafter's Armory/Patches/Star Crafter's Armory/Apparel.xml
+++ b/ModPatches/Star Crafter's Armory/Patches/Star Crafter's Armory/Apparel.xml
@@ -38,15 +38,6 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="PPSa"]</xpath>
-		<value>
-			<equippedStatOffsets>
-				<ToxicEnvironmentResistance>0.5</ToxicEnvironmentResistance>
-			</equippedStatOffsets>	
-		</value>
-	</Operation>
-
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="PPSa"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
@@ -83,11 +74,12 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="PPSa"]/equippedStatOffsets</xpath>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="PPSa"]/equippedStatOffsets/ToxicEnvironmentResistance</xpath>
 		<value>
 			<CarryWeight>225</CarryWeight>
 			<CarryBulk>50</CarryBulk>
+			<ToxicEnvironmentResistance>0.5</ToxicEnvironmentResistance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Star Crafter's Armory/Patches/Star Crafter's Armory/Apparel.xml
+++ b/ModPatches/Star Crafter's Armory/Patches/Star Crafter's Armory/Apparel.xml
@@ -38,8 +38,8 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="PPSa"]/statBases/ArmorRating_Sharp</xpath>
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="PPSa"]</xpath>
 		<value>
 			<equippedStatOffsets>
 				<ToxicEnvironmentResistance>0.5</ToxicEnvironmentResistance>

--- a/ModPatches/Star Crafter's Armory/Patches/Star Crafter's Armory/PPS.xml
+++ b/ModPatches/Star Crafter's Armory/Patches/Star Crafter's Armory/PPS.xml
@@ -166,13 +166,6 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="PPSH"]/equippedStatOffsets/ToxicSensitivity</xpath>
-		<value>
-			<ToxicEnvironmentResistance>-0.5</ToxicEnvironmentResistance>
-		</value>
-	</Operation>
-
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="PPSH"]/equippedStatOffsets/ToxicSensitivity</xpath>
 		<match Class="PatchOperationRemove">


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Changes Star Crafters Armory packageID to correct one making the patches load with the mod again
- Removed one Patch Operation line for PPSH since it fails on load and is Unnecessary (The one below it does what it's supposed to do)

## References

Links to the associated issues or other related pull requests, e.g.
- https://discord.com/channels/278818534069501953/668604879526428713/1285281816281878540

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
