### PR TITLE
Shield offset tweaks

### DIFF
--- a/Defs/ThingDefs_Misc/Apparel_Shield.xml
+++ b/Defs/ThingDefs_Misc/Apparel_Shield.xml
@@ -64,34 +64,34 @@
 			<MeleeParryChance>1.0</MeleeParryChance>
 		</equippedStatOffsets>
 		<apparel>
- 	     	<developmentalStageFilter>Child, Adult</developmentalStageFilter>
+			<developmentalStageFilter>Child, Adult</developmentalStageFilter>
 			<tags>
 				<li>TribalShield</li>
 			</tags>
 			<renderNodeProperties>
 				<li>
-				<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
-				<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
-				<texPath>Things/Apparel/Shield/CE_Shield</texPath>
-				<shaderTypeDef>CutoutComplex</shaderTypeDef>
-				<parentTagDef>ApparelBody</parentTagDef>
-				<drawData>
-					<scale>0.8</scale>
-					<defaultData>
-						<layer>80</layer>
-					</defaultData>
-					<dataEast>
-						<layer>-5</layer>
-						<offset>(0, 0, -0.1)</offset>						
-					</dataEast>
-					<dataNorth>
-						<layer>-5</layer>
-						<offset>(0.15, 0, -0.1)</offset>
-					</dataNorth>
-					<dataSouth>
-						<offset>(0.3, 0, -0.2)</offset>
-					</dataSouth>
-				</drawData>
+					<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
+					<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
+					<texPath>Things/Apparel/Shield/CE_Shield</texPath>
+					<shaderTypeDef>CutoutComplex</shaderTypeDef>
+					<parentTagDef>ApparelBody</parentTagDef>
+					<drawData>
+						<scale>0.8</scale>
+						<defaultData>
+							<layer>80</layer>
+						</defaultData>
+						<dataEast>
+							<layer>-5</layer>
+							<offset>(0, 0, -0.1)</offset>
+						</dataEast>
+						<dataNorth>
+							<layer>-5</layer>
+							<offset>(0.15, 0, -0.1)</offset>
+						</dataNorth>
+						<dataSouth>
+							<offset>(0.25, 0, -0.15)</offset>
+						</dataSouth>
+					</drawData>
 				</li>
 			</renderNodeProperties>
 		</apparel>
@@ -158,34 +158,34 @@
 			</tags>
 			<renderNodeProperties>
 				<li>
-				<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
-				<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
-				<texPath>Things/Apparel/BallisticShield/CE_BallisticShield</texPath>
-				<shaderTypeDef>CutoutComplex</shaderTypeDef>
-				<parentTagDef>ApparelBody</parentTagDef>
-				<drawData>
-					<scale>0.8</scale>
-					<defaultData>
-						<layer>80</layer>
-					</defaultData>
-					<dataEast>
-						<layer>-5</layer>
-						<offset>(0, 0, -0.1)</offset>
-						<rotationOffset>30</rotationOffset>
-					</dataEast>
-					<dataWest>
-						<rotationOffset>-30</rotationOffset>
-					</dataWest>						
-					<dataNorth>
-						<layer>-5</layer>
-						<offset>(0.15, 0, -0.1)</offset>
-					</dataNorth>
-					<dataSouth>
-						<offset>(0.15, 0, -0.1)</offset>
-					</dataSouth>
-				</drawData>
+					<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
+					<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
+					<texPath>Things/Apparel/BallisticShield/CE_BallisticShield</texPath>
+					<shaderTypeDef>CutoutComplex</shaderTypeDef>
+					<parentTagDef>ApparelBody</parentTagDef>
+					<drawData>
+						<scale>0.8</scale>
+						<defaultData>
+							<layer>80</layer>
+						</defaultData>
+						<dataEast>
+							<layer>-5</layer>
+							<offset>(0, 0, -0.1)</offset>
+							<rotationOffset>30</rotationOffset>
+						</dataEast>
+						<dataWest>
+							<rotationOffset>-30</rotationOffset>
+						</dataWest>
+						<dataNorth>
+							<layer>-5</layer>
+							<offset>(0.15, 0, -0.1)</offset>
+						</dataNorth>
+						<dataSouth>
+							<offset>(0.15, 0, -0.1)</offset>
+						</dataSouth>
+					</drawData>
 				</li>
-			</renderNodeProperties>			
+			</renderNodeProperties>
 		</apparel>
 		<modExtensions>
 			<li Class="CombatExtended.ShieldDefExtension">

--- a/ModPatches/Vanilla Factions Expanded - Classical/Defs/Vanilla Factions Expanded - Classical/ThingDefs_Shields.xml
+++ b/ModPatches/Vanilla Factions Expanded - Classical/Defs/Vanilla Factions Expanded - Classical/ThingDefs_Shields.xml
@@ -84,7 +84,7 @@
 							<offset>(0.15, 0, -0.1)</offset>
 						</dataNorth>
 						<dataSouth>
-							<offset>(0.25, 0, -0.15)</offset>
+							<offset>(0.25, 0, -0.2)</offset>
 						</dataSouth>
 					</drawData>
 				</li>

--- a/ModPatches/Vanilla Factions Expanded - Classical/Defs/Vanilla Factions Expanded - Classical/ThingDefs_Shields.xml
+++ b/ModPatches/Vanilla Factions Expanded - Classical/Defs/Vanilla Factions Expanded - Classical/ThingDefs_Shields.xml
@@ -56,40 +56,40 @@
 		</comps>
 		<apparel>
 			<developmentalStageFilter>Child, Adult</developmentalStageFilter>
-		  <tags>
-			  <li>TribalShield</li>
-		  </tags>
-		  <renderNodeProperties>
-			  <li>
-			  <nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
-			  <workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
-			  <texPath>Things/Item/Equipment/Shield/HeavyShield/HeavyShield</texPath>
-			  <shaderTypeDef>CutoutComplex</shaderTypeDef>
-			  <parentTagDef>ApparelBody</parentTagDef>
-			  <drawData>
-				  <scale>0.65</scale>
-				  <defaultData>
-					  <layer>80</layer>
-				  </defaultData>
-				  <dataEast>
-					  <layer>-5</layer>
-					  <offset>(0, 0, -0.1)</offset>
-					  <rotationOffset>30</rotationOffset>
-				  </dataEast>
-				  <dataWest>
-					<rotationOffset>-30</rotationOffset>
-				</dataWest>				  
-				  <dataNorth>
-					  <layer>-5</layer>
-					  <offset>(0.15, 0, -0.1)</offset>
-				  </dataNorth>
-				  <dataSouth>
-					  <offset>(0.3, 0, -0.2)</offset>
-				  </dataSouth>
-			  </drawData>
-			  </li>
-		  </renderNodeProperties>
-	  </apparel>		
+			<tags>
+				<li>TribalShield</li>
+			</tags>
+			<renderNodeProperties>
+				<li>
+					<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
+					<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
+					<texPath>Things/Item/Equipment/Shield/HeavyShield/HeavyShield</texPath>
+					<shaderTypeDef>CutoutComplex</shaderTypeDef>
+					<parentTagDef>ApparelBody</parentTagDef>
+					<drawData>
+						<scale>0.65</scale>
+						<defaultData>
+							<layer>80</layer>
+						</defaultData>
+						<dataEast>
+							<layer>-5</layer>
+							<offset>(0, 0, -0.1)</offset>
+							<rotationOffset>30</rotationOffset>
+						</dataEast>
+						<dataWest>
+							<rotationOffset>-30</rotationOffset>
+						</dataWest>
+						<dataNorth>
+							<layer>-5</layer>
+							<offset>(0.15, 0, -0.1)</offset>
+						</dataNorth>
+						<dataSouth>
+							<offset>(0.25, 0, -0.15)</offset>
+						</dataSouth>
+					</drawData>
+				</li>
+			</renderNodeProperties>
+		</apparel>
 		<modExtensions>
 			<li Class="CombatExtended.ShieldDefExtension">
 				<shieldCoverage>


### PR DESCRIPTION
## Changes

- What it says on the tin.

## Reasoning

- The base CE melee shield and the VFE one were too much to the left and low in the south perspective, similar to the ones in Armory fixed in: https://github.com/CombatExtended-Continued/CombatExtendedArmory/pull/94

## Alternatives

- Suffer from the jank offsets.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
