### PR TITLE
20x82mm casing mass fix

### DIFF
--- a/Defs/Ammo/HighCaliber/20x82mmMauser.xml
+++ b/Defs/Ammo/HighCaliber/20x82mmMauser.xml
@@ -27,7 +27,7 @@
 	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo20x82mmMauserBase" ParentName="MediumAmmoBase" Abstract="True">
 		<description>Large caliber cartridge used by autocannons and a handful of anti-tank rifles.</description>
 		<statBases>
-			<Mass>0.175</Mass>
+			<Mass>0.205</Mass>
 			<Bulk>0.22</Bulk>
 		</statBases>
 		<tradeTags>
@@ -48,7 +48,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.7</MarketValue>
+			<MarketValue>0.82</MarketValue>
 		</statBases>
 		<ammoClass>ArmorPiercing</ammoClass>
 		<cookOffProjectile>Bullet_20x82mmMauser_AP</cookOffProjectile>
@@ -62,7 +62,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>1.05</MarketValue>
+			<MarketValue>1.17</MarketValue>
 		</statBases>
 		<ammoClass>IncendiaryAP</ammoClass>
 		<cookOffProjectile>Bullet_20x82mmMauser_Incendiary</cookOffProjectile>
@@ -76,7 +76,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>1.56</MarketValue>
+			<MarketValue>1.68</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_20x82mmMauser_HE</cookOffProjectile>
@@ -90,8 +90,8 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.83</MarketValue>
-			<Mass>0.128</Mass>
+			<MarketValue>0.95</MarketValue>
+			<Mass>0.158</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
 		<cookOffProjectile>Bullet_20x82mmMauser_Sabot</cookOffProjectile>
@@ -180,7 +180,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>70</count>
+				<count>82</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -191,7 +191,7 @@
 		<products>
 			<Ammo_20x82mmMauser_AP>200</Ammo_20x82mmMauser_AP>
 		</products>
-		<workAmount>8400</workAmount>
+		<workAmount>9840</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
@@ -206,7 +206,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>70</count>
+				<count>82</count>
 			</li>
 			<li>
 				<filter>
@@ -226,7 +226,7 @@
 		<products>
 			<Ammo_20x82mmMauser_Incendiary>200</Ammo_20x82mmMauser_Incendiary>
 		</products>
-		<workAmount>11400</workAmount>
+		<workAmount>12600</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
@@ -241,7 +241,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>70</count>
+				<count>82</count>
 			</li>
 			<li>
 				<filter>
@@ -261,7 +261,7 @@
 		<products>
 			<Ammo_20x82mmMauser_HE>200</Ammo_20x82mmMauser_HE>
 		</products>
-		<workAmount>15800</workAmount>
+		<workAmount>17000</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
@@ -276,7 +276,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>26</count>
+				<count>38</count>
 			</li>
 			<li>
 				<filter>
@@ -305,7 +305,7 @@
 		<products>
 			<Ammo_20x82mmMauser_Sabot>200</Ammo_20x82mmMauser_Sabot>
 		</products>
-		<workAmount>10400</workAmount>
+		<workAmount>11600</workAmount>
 	</RecipeDef>
 
 </Defs>


### PR DESCRIPTION
## Changes

- What it says on the tin, increased the casing mass from 65 to 95 grams.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit?gid=1393347070#gid=1393347070

## Reasoning

- As noted in my spreadsheet, the total cartridge mass of 20x82mm is 205 grams, which with a 110 grams projectile it makes the rest of the cartridge have 95 grams off mass. 65 grams might have been a silly typo.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
