### PR TITLE
Update roslyn

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,17 +12,19 @@ jobs:
     - uses: actions/checkout@v3
     - name: prebuild
       run: |
-        rm -rf AssemblyPublicizer
+        rm -rf AssemblyPublicizer csc.zip csc
         git clone https://github.com/CombatExtended-Continued/AssemblyPublicizer
         mkdir -p Assemblies
         mkdir -p ${{ runner.temp }}/downloads
+        wget https://github.com/CombatExtended-Continued/roslyn/releases/download/CSC-13/csc.zip
+        unzip csc.zip
     - name: remove loader
       run: |
         rm Assemblies/CombatExtendedLoader.dll
         
     - name: build core
       run: |
-        TEMP=${{ runner.temp }}/ python Make.py --csproj Source/CombatExtended/CombatExtended.csproj --output Assemblies/CombatExtended.dll --download-libs --all-libs --publicizer $PWD/AssemblyPublicizer
+        TEMP=${{ runner.temp }}/ python Make.py --csproj Source/CombatExtended/CombatExtended.csproj --output Assemblies/CombatExtended.dll --download-libs --all-libs --publicizer $PWD/AssemblyPublicizer --csc $PWD/csc
         
     - name: build compat
       run: |

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -22,6 +22,7 @@ jobs:
         git config --global user.name "GitHub Actions"
         git pull --no-ff --no-commit --allow-unrelated-histories -X theirs origin pull/${{ github.event.pull_request.number }}${{ github.event.inputs.PR }}/head:
         git status
+        rm *.py *.so ./*/*.py ./*/*.so
         wget https://raw.githubusercontent.com/CombatExtended-Continued/CombatExtended/Development/Make.py -O Make.py
         wget https://raw.githubusercontent.com/CombatExtended-Continued/CombatExtended/Development/BuildCompat.py -O BuildCompat.py
         mkdir -p Assemblies

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -26,8 +26,10 @@ jobs:
         wget https://raw.githubusercontent.com/CombatExtended-Continued/CombatExtended/Development/BuildCompat.py -O BuildCompat.py
         mkdir -p Assemblies
         mkdir -p ${{ runner.temp }}/downloads
-        rm -rf AssemblyPublicizer
+        rm -rf AssemblyPublicizer csc.zip csc
         git clone https://github.com/CombatExtended-Continued/AssemblyPublicizer
+        wget https://github.com/CombatExtended-Continued/roslyn/releases/download/CSC-13/csc.zip
+        unzip csc.zip
         
     - name: remove loader
       run: |
@@ -35,7 +37,7 @@ jobs:
         
     - name: build core
       run: |
-        TEMP=${{ runner.temp }}/ python Make.py --csproj Source/CombatExtended/CombatExtended.csproj --output Assemblies/CombatExtended.dll --download-libs --all-libs --publicizer $PWD/AssemblyPublicizer
+        TEMP=${{ runner.temp }}/ python Make.py --csproj Source/CombatExtended/CombatExtended.csproj --output Assemblies/CombatExtended.dll --download-libs --all-libs --publicizer $PWD/AssemblyPublicizer --csc $PWD/csc
 
     - name: build compat
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,17 +13,18 @@ jobs:
     - uses: actions/checkout@v2
     - name: prebuild
       run: |
-        rm -rf AssemblyPublicizer
+        rm -rf AssemblyPublicizer csc csc.zip
         git clone https://github.com/CombatExtended-Continued/AssemblyPublicizer
         mkdir -p Assemblies
         mkdir -p ${{ runner.temp }}/downloads
-        
+        wget https://github.com/CombatExtended-Continued/roslyn/releases/download/CSC-13/csc.zip
+        unzip csc.zip
     - name: remove loader
       run: |
         rm Assemblies/CombatExtendedLoader.dll
     - name: build core
       run: |
-        TEMP=${{ runner.temp }}/ python Make.py --csproj Source/CombatExtended/CombatExtended.csproj --output Assemblies/CombatExtended.dll --download-libs --all-libs --publicizer $PWD/AssemblyPublicizer
+        TEMP=${{ runner.temp }}/ python Make.py --csproj Source/CombatExtended/CombatExtended.csproj --output Assemblies/CombatExtended.dll --download-libs --all-libs --publicizer $PWD/AssemblyPublicizer --csc $PWD/csc
     - name: build compat
       run: |
         TEMP=${{ runner.temp }}/ python BuildCompat.py

--- a/Make.py
+++ b/Make.py
@@ -49,6 +49,7 @@ def parseArgs(argv):
     argParser.add_argument("--publicizer", type=str, metavar="PATH", help="Location of AssemblyPublicizer source code or parent directory of AssemblyPublicizer.exe")
     argParser.add_argument("--debug", action="store_true", default=False, help="Define `DEBUG` when calling csc")
     argParser.add_argument("--refout", metavar="PATH", default=None, help="Specify where to save a reference library")
+    argParser.add_argument("--csc", metavar="CSC", default=None, help="Specify directory containing updated csc.exe")
 
     options = argParser.parse_args(argv[1:])
     if not options.download_libs and options.reference is None:
@@ -61,6 +62,10 @@ def parseArgs(argv):
     if options.reference is None:
         options.reference = f"{tdir}/rwreference"
 
+    if options.csc is not None:
+        args[0] = options.csc + "/csc.exe"
+        args.insert(0, "mono")
+        
     return options
 
 


### PR DESCRIPTION
## Changes

Downloads the updated roslyn compiler from CombatExtended-Continued/roslyn and uses it to compile CE

## References

Links to the associated issues or other related pull requests, e.g.
- Required for #3428 

## Reasoning

The mono project is in flux, so the embedded version of the roslyn compiler is stuck on C# 9.  The external roslyn compiler supports C# 13.  This lets us use C# 13 syntax in CE when beneficial.

## Alternatives

Disable automatic building of PRs and use dotnet to compile.
Stick with C# 9 only.
Reimplement the csc frontend (it's actually fairly small, similar to the publicizer stuff)

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
