### PR TITLE
No skill melee hit chance buff

### DIFF
--- a/Patches/Core/Stats/Stats.xml
+++ b/Patches/Core/Stats/Stats.xml
@@ -145,7 +145,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/StatDef[defName="MeleeHitChance"]/noSkillOffset</xpath>
 		<value>
-			<noSkillOffset>6.7</noSkillOffset>
+			<noSkillOffset>9</noSkillOffset>
 		</value>
 	</Operation>
 


### PR DESCRIPTION
## Changes

- Changed the default melee skill / hit chance of non-human pawns from 6.7 to 9.

## Reasoning

- For pawns that are meant to only be melee fighters, they're currently missing way too often. Level 9 is 'Solid Professional' which fits the bill imo.

## Alternatives

- Level 8 or 10?

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] Playtested a colony (specify how long)
