### PR TITLE
Make BuildCompat.py aware of new roslyn csc

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
         
     - name: build compat
       run: |
-        TEMP=${{ runner.temp }}/ python BuildCompat.py
+        TEMP=${{ runner.temp }}/ python BuildCompat.py --csc $PWD/csc
         
     - name: package
       run: |

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: build compat
       run: |
-        TEMP=${{ runner.temp }}/ python BuildCompat.py
+        TEMP=${{ runner.temp }}/ python BuildCompat.py --csc $PWD/csc
         
     - name: package
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         TEMP=${{ runner.temp }}/ python Make.py --csproj Source/CombatExtended/CombatExtended.csproj --output Assemblies/CombatExtended.dll --download-libs --all-libs --publicizer $PWD/AssemblyPublicizer --csc $PWD/csc
     - name: build compat
       run: |
-        TEMP=${{ runner.temp }}/ python BuildCompat.py
+        TEMP=${{ runner.temp }}/ python BuildCompat.py --csc $PWD/csc
     - name: package
       run: |
         mkdir CombatExtended

--- a/BuildCompat.py
+++ b/BuildCompat.py
@@ -10,6 +10,8 @@ tm = '-m' in sys.argv
 
 parallel = '-j' in sys.argv
 
+csc = sys.argv[sys.argv.index("--csc") + 1]
+
 PROJECT_PATTERN = re.compile(r'''Project.".[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}.". = '''
                              r'''"([0-9a-zA-Z]+Compat)", '''
                              r'''"([0-9A-zA-Z\/]+.csproj)", '''
@@ -52,7 +54,7 @@ with open("Source/CombatExtended.sln") as f:
                             output = od.child(name+".dll")
 
             print(f"Building {name}")
-            system("python3", "Make.py", "--csproj", csproj.path, "--output", output.path, DOWNLOAD_LIBS, "--all-libs", "--publicizer", PUBLICIZER, "--", "-r:Assemblies/CombatExtended.dll")
+            system("python3", "Make.py", "--csproj", csproj.path, "--output", output.path, DOWNLOAD_LIBS, "--all-libs", "--publicizer", PUBLICIZER, "--csc", csc, "--", "-r:Assemblies/CombatExtended.dll")
 
 for t in tasks:
     t.wait()


### PR DESCRIPTION

## Changes

The workflows now tell BuildCompat.py where to find csc, it passes that information on to Make.py

## References

- Needed to build #3428

## Reasoning

We should use the same compiler for all assemblies.
The new PsyBlaster compat assembly uses C#10 syntax.