### PR TITLE
Remove profaned loadAfter

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -87,7 +87,6 @@
 		<li>Argon.VMEu</li>
 		<li>Bonible.rimsenalfactions</li>
 		<li>kentington.saveourship2</li>
-		<li>botchjob.profaned</li>
 		<li>oskarpotocki.vfe.mechanoid</li>
 	</loadAfter>
 


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Removes Profaned mod from having a loadAfter in About.xml

## Reasoning

Why did you choose to implement things this way, e.g.
- No longer required and could cause unneeded cyclical load orders

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (Tested launching game with CE above Profaned)
