### PR TITLE
Defer gear-tab armor calcs to CE_Utility

### DIFF
--- a/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
@@ -520,7 +520,7 @@ namespace CombatExtended
             var shield = wornApparel.FirstOrDefault(x => x is Apparel_Shield);
             foreach (BodyPartRecord part in SelPawnForGear.RaceProps.body.AllParts)
             {
-                if (part.depth == BodyPartDepth.Outside && (part.coverage >= 0.1 || (part.def == CE_BodyPartDefOf.Neck || part.def == BodyPartDefOf.Eye)))
+                if (part.depth == BodyPartDepth.Outside && (part.coverage >= 0.1 || (part.def.tags.Contains(BodyPartTagDefOf.BreathingPathway) || part.def.tags.Contains(BodyPartTagDefOf.SightSource))))
                 {
                     var armorValue = SelPawnForGear.PartialStat(stat, part);
                     if (shield != null)

--- a/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
@@ -520,7 +520,7 @@ namespace CombatExtended
             var shield = wornApparel.FirstOrDefault(x => x is Apparel_Shield);
             foreach (BodyPartRecord part in SelPawnForGear.RaceProps.body.AllParts)
             {
-                if (part.depth == BodyPartDepth.Outside && (part.coverage >= 0.1 || (part.def == CE_BodyPartDefOf.Neck || BodyPartDefOf.Eye)))
+                if (part.depth == BodyPartDepth.Outside && (part.coverage >= 0.1 || (part.def == CE_BodyPartDefOf.Neck || part.def == BodyPartDefOf.Eye)))
                 {
                     var armorValue = SelPawnForGear.PartialStat(stat, part);
                     if (shield != null)

--- a/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
@@ -531,8 +531,8 @@ namespace CombatExtended
                             armorValue += shield.GetStatValue(stat);
                         }
                     }
+                    armorCache[part] = armorValue;
                 }
-                armorCache[part] = armorValue;
             }
         }
 

--- a/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
@@ -516,35 +516,20 @@ namespace CombatExtended
         private void RebuildArmorCache(Dictionary<BodyPartRecord, float> armorCache, StatDef stat)
         {
             armorCache.Clear();
-            float naturalArmor = SelPawnForGear.GetStatValue(stat);
             List<Apparel> wornApparel = SelPawnForGear.apparel?.WornApparel;
             var shield = wornApparel.FirstOrDefault(x => x is Apparel_Shield);
             foreach (BodyPartRecord part in SelPawnForGear.RaceProps.body.AllParts)
             {
-                //TODO: 1.5 should be Neck
-                if (part.depth == BodyPartDepth.Outside && (part.coverage >= 0.1 || (part.def == CE_BodyPartDefOf.Neck || part.def == CE_BodyPartDefOf.Neck)))
+                var armorValue = SelPawnForGear.PartialStat(stat, part);
+                if (shield != null)
                 {
-                    float armorValue = part.IsInGroup(CE_BodyPartGroupDefOf.CoveredByNaturalArmor) ? naturalArmor : 0f;
-                    if (wornApparel != null)
+                    var shieldCoverage = shield.def?.GetModExtension<ShieldDefExtension>()?.PartIsCoveredByShield(part, SelPawnForGear);
+                    if (shieldCoverage == true)
                     {
-                        foreach (var apparel in wornApparel)
-                        {
-                            if (apparel.def.apparel.CoversBodyPart(part))
-                            {
-                                armorValue += apparel.PartialStat(stat, part);
-                            }
-                        }
+                        armorValue += shield.GetStatValue(stat);
                     }
-                    if (shield != null)
-                    {
-                        var shieldCoverage = shield.def?.GetModExtension<ShieldDefExtension>()?.PartIsCoveredByShield(part, SelPawnForGear);
-                        if (shieldCoverage == true)
-                        {
-                            armorValue += shield.GetStatValue(stat);
-                        }
-                    }
-                    armorCache[part] = armorValue;
                 }
+                armorCache[part] = armorValue;
             }
         }
 

--- a/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
@@ -520,13 +520,16 @@ namespace CombatExtended
             var shield = wornApparel.FirstOrDefault(x => x is Apparel_Shield);
             foreach (BodyPartRecord part in SelPawnForGear.RaceProps.body.AllParts)
             {
-                var armorValue = SelPawnForGear.PartialStat(stat, part);
-                if (shield != null)
+                if (part.depth == BodyPartDepth.Outside && (part.coverage >= 0.1 || (part.def == CE_BodyPartDefOf.Neck || BodyPartDefOf.Eye)))
                 {
-                    var shieldCoverage = shield.def?.GetModExtension<ShieldDefExtension>()?.PartIsCoveredByShield(part, SelPawnForGear);
-                    if (shieldCoverage == true)
+                    var armorValue = SelPawnForGear.PartialStat(stat, part);
+                    if (shield != null)
                     {
-                        armorValue += shield.GetStatValue(stat);
+                        var shieldCoverage = shield.def?.GetModExtension<ShieldDefExtension>()?.PartIsCoveredByShield(part, SelPawnForGear);
+                        if (shieldCoverage == true)
+                        {
+                            armorValue += shield.GetStatValue(stat);
+                        }
                     }
                 }
                 armorCache[part] = armorValue;


### PR DESCRIPTION
## Changes

Instead of trying to duplicate the functionality in CE_Utility inline in the gear tab, we just use the same function to calculate location specific armor values.

## Reasoning

Changes to location based armor calculations (like the natural armor, and later location-specific partial armor) lead to the two versions of the code getting out of sync.  Always using the same calculation means the reported value should match the value the damage system actually uses.

## Alternatives

Fix the de-sync one issue at a time, forever.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
