### PR TITLE
Fixed a name inconsistency in generic mech shells

### DIFF
--- a/Defs/Ammo/Generic/Mech.xml
+++ b/Defs/Ammo/Generic/Mech.xml
@@ -97,7 +97,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="MechShellAmmo">
 		<defName>Ammo_MechShell_Incendiary</defName>
-		<label>mechanoid shell (Incendiary)</label>
+		<label>mech shell (Incendiary)</label>
 		<graphicData>
 			<texPath>Things/Ammo/FuelCell/Large</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>


### PR DESCRIPTION
## Changes

Changed the name of the generic `mechanoid shell (Incendiary)` item to `mech shell (Incendiary)`

Yes, I know this is a very minor nitpick.

## Reasoning

The ammo sets and the recipes of incendiary mech shells refer to the item as mech shells. The item for the other mech shell type - demolition - is also called a mech shell. This seems to be an oversight.

## Alternatives

Rename all mech shells to mechanoid shells.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [X] Game runs without errors (Tested with changes thrown into compiled dev version)
- [X] Playtested a colony (2 minutes, spawned the items in)
