### PR TITLE
VFE Insectoids 2 and Alpha Animals patch update

### DIFF
--- a/ModPatches/Alpha Animals/Defs/Alpha Animals/Defs_DamageDef.xml
+++ b/ModPatches/Alpha Animals/Defs/Alpha Animals/Defs_DamageDef.xml
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+	<DamageDef>
+		<defName>AA_BlackHiveExplosion</defName>
+		<label>vile spit</label>
+		<workerClass>AlphaBehavioursAndEvents.DamageWorker_ExtraDamageMechanoidsAcid</workerClass>
+		<externalViolence>true</externalViolence>
+		<deathMessage>{0} has been poisoned to death.</deathMessage>
+		<hediff>Stab</hediff>
+		<hediffSolid>Crack</hediffSolid>
+		<additionalHediffs>
+			<li>
+				<hediff>AA_ToxicBuildup</hediff>
+				<severityPerDamageDealt>0.01</severityPerDamageDealt>
+				<victimSeverityScaling>ToxicResistance</victimSeverityScaling>
+				<inverseStatScaling>true</inverseStatScaling>
+			</li>
+		</additionalHediffs>
+		<isRanged>true</isRanged>
+		<harmAllLayersUntilOutside>true</harmAllLayersUntilOutside>
+		<impactSoundType>Blunt</impactSoundType>
+		<armorCategory>Heat</armorCategory>
+	</DamageDef>
+
+</Defs>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/AA_VFEI2/ThingDefs_Buildings/Buildings_Insectoid_AlphaAnimals.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/AA_VFEI2/ThingDefs_Buildings/Buildings_Insectoid_AlphaAnimals.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Factions Expanded - Insectoids 2</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<!-- Black Defiler -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="AA_BlackDefiler"]</xpath>
+					<value>
+						<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="AA_BlackDefiler"]/statBases</xpath>
+					<value>
+						<statBases>
+							<MaxHitPoints>500</MaxHitPoints>
+							<ShootingAccuracyTurret>1.0</ShootingAccuracyTurret>
+							<AimingAccuracy>0.5</AimingAccuracy>
+						</statBases>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="AA_BlackDefiler"]/building/turretBurstCooldownTime</xpath>
+					<value>
+						<turretBurstCooldownTime>4</turretBurstCooldownTime>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="AA_BlackDefiler_Gun"]/statBases/RangedWeapon_Cooldown</xpath>
+					<value>
+						<RangedWeapon_Cooldown>4</RangedWeapon_Cooldown>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="AA_BlackDefiler_Gun"]/verbs</xpath>
+					<value>
+						<verbs>
+							<li Class="CombatExtended.VerbPropertiesCE">
+								<recoilAmount>0.5</recoilAmount>
+								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+								<hasStandardCommand>true</hasStandardCommand>
+								<defaultProjectile>AA_BlackDefiler_Projectile</defaultProjectile>
+								<warmupTime>3.5</warmupTime>
+								<minRange>4.9</minRange>
+								<range>44</range>
+								<soundCast>VFEI2_AcidSpray_Resolve</soundCast>
+								<muzzleFlashScale>9</muzzleFlashScale>
+							</li>
+						</verbs>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="AA_BlackDefiler_Projectile"]</xpath>
+					<value>
+						<ThingDef ParentName="BaseBulletCE">
+							<defName>AA_BlackDefiler_Projectile</defName>
+							<label>black defiler projectile</label>
+							<graphicData>
+								<texPath>Things/Projectiles/AA_PoisonBolt</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+								<drawSize>2</drawSize>
+							</graphicData>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<speed>50</speed>
+								<damageDef>AA_BlackHiveBolt</damageDef>
+								<damageAmountBase>10</damageAmountBase>
+								<armorPenetrationSharp>9</armorPenetrationSharp>
+								<armorPenetrationBlunt>6</armorPenetrationBlunt>
+							</projectile>
+							<comps>
+								<li Class="CombatExtended.CompProperties_ExplosiveCE">
+									<damageAmountBase>20</damageAmountBase>
+									<explosiveDamageType>AA_BlackHiveExplosion</explosiveDamageType>
+									<explosiveRadius>3.9</explosiveRadius>
+									<preExplosionSpawnChance>0.4</preExplosionSpawnChance>
+									<preExplosionSpawnThingDef>AA_FilthSlimyPuke</preExplosionSpawnThingDef>
+									<explosionSound>VFEI2_AcidSpray_Resolve</explosionSound>
+								</li>
+							</comps>
+						</ThingDef>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_BlackQueen.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_BlackQueen.xml
@@ -3,7 +3,7 @@
 
 	<Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>Vanilla Factions Expanded - Insectoids 2</li>
+			<li>Vanilla Psycasts Expanded</li>
 		</mods>
 
 		<match Class="PatchOperationSequence">

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/AbilityDefs/Abilities.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/AbilityDefs/Abilities.xml
@@ -2,6 +2,62 @@
 <Patch>
 
 	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AbilityDef[defName="VFEI2_FlameSpew"]/verbProperties/range</xpath>
+		<value>
+			<range>14.9</range>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AbilityDef[defName="VFEI2_InsectAcidSpit"]/verbProperties/range</xpath>
+		<value>
+			<range>17.9</range>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AbilityDef[defName="VFEI2_InsectAcidSpew"]/verbProperties/range</xpath>
+		<value>
+			<range>23.9</range>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AbilityDef[defName="VFEI2_LargeAcidSpew"]/verbProperties/range</xpath>
+		<value>
+			<range>24.9</range>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AbilityDef[defName="VFEI2_LargeAcidSpew"]/comps/li[@Class="VFEInsectoids.CompProperties_AbilityAcidSpew"]/range</xpath>
+		<value>
+			<range>24.9</range>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AbilityDef[defName="VFEI2_ChemfuelSpew"]/verbProperties/range</xpath>
+		<value>
+			<range>17.9</range>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AbilityDef[defName="VFEI2_ChemfuelSpew"]/comps/li[@Class="VFEInsectoids.CompProperties_AbilityFuelSpew"]/range</xpath>
+		<value>
+			<range>15.9</range>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="VFEI2_ChemfuelSpit"]/projectile</xpath>
+		<value>
+			<damageAmountBase>15</damageAmountBase>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/AbilityDef[defName="VFEI2_InsectGlide_Short"]/verbProperties/range</xpath>
 		<value>
 			<range>11.9</range>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Buildings/Buildings_Insectoid.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Buildings/Buildings_Insectoid.xml
@@ -113,4 +113,76 @@
 		</value>
 	</Operation>
 
+	<!-- Thornspitter -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="VFEI2_Thornspitter"]</xpath>
+		<value>
+			<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VFEI2_Thornspitter"]/statBases</xpath>
+		<value>
+			<statBases>
+				<ShootingAccuracyTurret>1.0</ShootingAccuracyTurret>
+				<AimingAccuracy>0.5</AimingAccuracy>
+			</statBases>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VFEI2_Thornspitter"]/building/turretBurstCooldownTime</xpath>
+		<value>
+			<turretBurstCooldownTime>3</turretBurstCooldownTime>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VFEI2_Thornspitter_Gun"]/statBases/RangedWeapon_Cooldown</xpath>
+		<value>
+			<RangedWeapon_Cooldown>3</RangedWeapon_Cooldown>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VFEI2_Thornspitter_Gun"]/verbs</xpath>
+		<value>
+			<verbs>
+				<li Class="CombatExtended.VerbPropertiesCE">
+					<recoilAmount>0.5</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>VFEI2_Thornspitter_Projectile</defaultProjectile>
+					<warmupTime>1</warmupTime>
+					<range>20</range>
+					<soundCast>VFEI2_InsectThornpod_Release</soundCast>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</li>
+			</verbs>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VFEI2_Thornspitter_Projectile"]</xpath>
+		<value>
+			<ThingDef ParentName="BaseBulletCE">
+				<defName>VFEI2_Thornspitter_Projectile</defName>
+				<label>thornspitter projectile</label>
+				<graphicData>
+					<texPath>Things/Projectile/Projectile_Thornworm_Spike</texPath>
+					<graphicClass>Graphic_Single</graphicClass>
+				</graphicData>
+				<projectile Class="CombatExtended.ProjectilePropertiesCE">
+					<damageDef>Stab</damageDef>
+					<speed>90</speed>
+					<damageAmountBase>10</damageAmountBase>
+					<armorPenetrationSharp>6</armorPenetrationSharp>
+					<armorPenetrationBlunt>9</armorPenetrationBlunt>
+				</projectile>
+			</ThingDef>
+		</value>
+	</Operation>
+
 </Patch>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Buildings/Buildings_Insectoid.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Buildings/Buildings_Insectoid.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- Vilelobber -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VFEI2_Vilelobber"]/building/turretBurstCooldownTime</xpath>
+		<value>
+			<turretBurstCooldownTime>20</turretBurstCooldownTime>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VFEI2_Vilelobber_Gun"]/statBases/RangedWeapon_Cooldown</xpath>
+		<value>
+			<RangedWeapon_Cooldown>20</RangedWeapon_Cooldown>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VFEI2_Vilelobber_Gun"]/verbs/li/forcedMissRadius</xpath>
+		<value>
+			<forcedMissRadius>3</forcedMissRadius>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VFEI2_Vilelobber_Gun"]/verbs/li/defaultCooldownTime</xpath>
+		<value>
+			<defaultCooldownTime>20</defaultCooldownTime>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VFEI2_Vilelobber_Projectile"]/projectile/damageAmountBase</xpath>
+		<value>
+			<damageAmountBase>15</damageAmountBase>
+		</value>
+	</Operation>
+
+	<!-- Thornworm -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="VFEI2_Thornworm"]</xpath>
+		<value>
+			<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VFEI2_Thornworm"]/statBases</xpath>
+		<value>
+			<statBases>
+				<ShootingAccuracyTurret>1.0</ShootingAccuracyTurret>
+				<AimingAccuracy>0.5</AimingAccuracy>
+			</statBases>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VFEI2_Thornworm"]/building/turretBurstCooldownTime</xpath>
+		<value>
+			<turretBurstCooldownTime>4</turretBurstCooldownTime>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VFEI2_Thornworm_Gun"]/statBases/RangedWeapon_Cooldown</xpath>
+		<value>
+			<RangedWeapon_Cooldown>4</RangedWeapon_Cooldown>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VFEI2_Thornworm_Gun"]/verbs</xpath>
+		<value>
+			<verbs>
+				<li Class="CombatExtended.VerbPropertiesCE">
+					<recoilAmount>0.5</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>VFEI2_Thornworm_Projectile</defaultProjectile>
+					<warmupTime>2</warmupTime>
+					<range>35</range>
+					<ticksBetweenBurstShots>15</ticksBetweenBurstShots>
+					<burstShotCount>3</burstShotCount>
+					<soundCast>VFEI2_InsectThornpod_Release</soundCast>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</li>
+			</verbs>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VFEI2_Thornworm_Projectile"]</xpath>
+		<value>
+			<ThingDef ParentName="BaseBulletCE">
+				<defName>VFEI2_Thornworm_Projectile</defName>
+				<label>thornworm projectile</label>
+				<graphicData>
+					<texPath>Things/Projectile/Projectile_Thornworm_Spike</texPath>
+					<graphicClass>Graphic_Single</graphicClass>
+				</graphicData>
+				<projectile Class="CombatExtended.ProjectilePropertiesCE">
+					<damageDef>Bullet</damageDef>
+					<speed>90</speed>
+					<damageAmountBase>8</damageAmountBase>
+					<armorPenetrationSharp>3.5</armorPenetrationSharp>
+					<armorPenetrationBlunt>5</armorPenetrationBlunt>
+				</projectile>
+			</ThingDef>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Buildings/Buildings_Insectoid.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Buildings/Buildings_Insectoid.xml
@@ -102,11 +102,11 @@
 					<graphicClass>Graphic_Single</graphicClass>
 				</graphicData>
 				<projectile Class="CombatExtended.ProjectilePropertiesCE">
-					<damageDef>Bullet</damageDef>
+					<damageDef>Stab</damageDef>
 					<speed>90</speed>
 					<damageAmountBase>8</damageAmountBase>
-					<armorPenetrationSharp>3.5</armorPenetrationSharp>
-					<armorPenetrationBlunt>5</armorPenetrationBlunt>
+					<armorPenetrationSharp>6</armorPenetrationSharp>
+					<armorPenetrationBlunt>9</armorPenetrationBlunt>
 				</projectile>
 			</ThingDef>
 		</value>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Buildings/Buildings_Insectoid.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Buildings/Buildings_Insectoid.xml
@@ -51,6 +51,7 @@
 		<xpath>Defs/ThingDef[defName="VFEI2_Thornworm"]/statBases</xpath>
 		<value>
 			<statBases>
+				<MaxHitPoints>500</MaxHitPoints>
 				<ShootingAccuracyTurret>1.0</ShootingAccuracyTurret>
 				<AimingAccuracy>0.5</AimingAccuracy>
 			</statBases>
@@ -104,7 +105,7 @@
 				<projectile Class="CombatExtended.ProjectilePropertiesCE">
 					<damageDef>Stab</damageDef>
 					<speed>90</speed>
-					<damageAmountBase>8</damageAmountBase>
+					<damageAmountBase>10</damageAmountBase>
 					<armorPenetrationSharp>6</armorPenetrationSharp>
 					<armorPenetrationBlunt>9</armorPenetrationBlunt>
 				</projectile>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Patriarch.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Patriarch.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="VFEI2_Patriarch"]</xpath>
+		<value>
+			<li Class="CombatExtended.RacePropertiesExtensionCE">
+				<bodyShape>Quadruped</bodyShape>
+			</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VFEI2_Patriarch"]/statBases/MoveSpeed</xpath>
+		<value>
+			<MoveSpeed>2.2</MoveSpeed>
+			<MeleeDodgeChance>0.04</MeleeDodgeChance>
+			<MeleeCritChance>0.21</MeleeCritChance>
+			<MeleeParryChance>0.48</MeleeParryChance>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VFEI2_Patriarch"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>34</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VFEI2_Patriarch"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>12.5</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VFEI2_Patriarch"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>head claw</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>24</power>
+					<cooldownTime>1.78</cooldownTime>
+					<linkedBodyPartsGroup>HeadClaw</linkedBodyPartsGroup>
+					<armorPenetrationSharp>1.0</armorPenetrationSharp>
+					<armorPenetrationBlunt>5.0</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>head claw</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>18</power>
+					<cooldownTime>1.78</cooldownTime>
+					<linkedBodyPartsGroup>HeadClaw</linkedBodyPartsGroup>
+					<armorPenetrationSharp>6</armorPenetrationSharp>
+					<armorPenetrationBlunt>3</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>front claw</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>30</power>
+					<cooldownTime>1.33</cooldownTime>
+					<linkedBodyPartsGroup>HeadClaw</linkedBodyPartsGroup>
+					<armorPenetrationSharp>40</armorPenetrationSharp>
+					<armorPenetrationBlunt>20</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>front claw</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>56</power>
+					<cooldownTime>1.9</cooldownTime>
+					<linkedBodyPartsGroup>HeadClaw</linkedBodyPartsGroup>
+					<armorPenetrationSharp>2</armorPenetrationSharp>
+					<armorPenetrationBlunt>10</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>17</power>
+					<cooldownTime>2.1</cooldownTime>
+					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+					<chanceFactor>0.2</chanceFactor>
+					<armorPenetrationBlunt>7.0</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="VFEI2_Patriarch"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="VFEI2_Patriarch"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="VFEI2_Patriarch"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>2700</Durability>
+				<Regenerates>true</Regenerates>
+				<RegenInterval>600</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<MinArmorPct>0.25</MinArmorPct>
+			</li>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_RoyalMegascarab.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_RoyalMegascarab.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VFEI2_RoyalMegascarab"]/statBases/MoveSpeed</xpath>
+		<value>
+			<MoveSpeed>4.5</MoveSpeed>
+			<MeleeDodgeChance>0.08</MeleeDodgeChance>
+			<MeleeCritChance>0.12</MeleeCritChance>
+			<MeleeParryChance>0.09</MeleeParryChance>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VFEI2_RoyalMegascarab"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>head claw</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>21</power>
+					<cooldownTime>1.78</cooldownTime>
+					<linkedBodyPartsGroup>HeadClaw</linkedBodyPartsGroup>
+					<armorPenetrationSharp>0.36</armorPenetrationSharp>
+					<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>head claw</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>15</power>
+					<cooldownTime>1.78</cooldownTime>
+					<linkedBodyPartsGroup>HeadClaw</linkedBodyPartsGroup>
+					<armorPenetrationSharp>4</armorPenetrationSharp>
+					<armorPenetrationBlunt>2</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>2</power>
+					<cooldownTime>1.5</cooldownTime>
+					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					<chanceFactor>0.2</chanceFactor>
+					<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VFEI2_RoyalMegascarab"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>9</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VFEI2_RoyalMegascarab"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>6</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="VFEI2_RoyalMegascarab"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="VFEI2_RoyalMegascarab"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="VFEI2_RoyalMegascarab"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>625</Durability>
+				<Regenerates>true</Regenerates>
+				<RegenInterval>600</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<MinArmorPct>0.25</MinArmorPct>
+			</li>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_RoyalMegaspider.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_RoyalMegaspider.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VFEI2_RoyalMegaspider"]/statBases/MoveSpeed</xpath>
+		<value>
+			<MoveSpeed>3.3</MoveSpeed>
+			<MeleeDodgeChance>0.03</MeleeDodgeChance>
+			<MeleeCritChance>0.36</MeleeCritChance>
+			<MeleeParryChance>0.38</MeleeParryChance>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VFEI2_RoyalMegaspider"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>25</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VFEI2_RoyalMegaspider"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>10</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VFEI2_RoyalMegaspider"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>head claw</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>63</power>
+					<cooldownTime>3.28</cooldownTime>
+					<linkedBodyPartsGroup>HeadClaw</linkedBodyPartsGroup>
+					<surpriseAttack>
+						<extraMeleeDamages>
+							<li>
+								<def>Stun</def>
+								<amount>14</amount>
+							</li>
+						</extraMeleeDamages>
+					</surpriseAttack>
+					<armorPenetrationSharp>2.43</armorPenetrationSharp>
+					<armorPenetrationBlunt>6</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>head claw</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>63</power>
+					<cooldownTime>3.28</cooldownTime>
+					<linkedBodyPartsGroup>HeadClaw</linkedBodyPartsGroup>
+					<surpriseAttack>
+						<extraMeleeDamages>
+							<li>
+								<def>Stun</def>
+								<amount>14</amount>
+							</li>
+						</extraMeleeDamages>
+					</surpriseAttack>
+					<armorPenetrationSharp>50</armorPenetrationSharp>
+					<armorPenetrationBlunt>25</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>mandibles</label>
+					<capacities>
+						<li>ToxicBite</li>
+					</capacities>
+					<power>32</power>
+					<cooldownTime>3.4</cooldownTime>
+					<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
+					<surpriseAttack>
+						<extraMeleeDamages>
+							<li>
+								<def>Stun</def>
+								<amount>14</amount>
+							</li>
+						</extraMeleeDamages>
+					</surpriseAttack>
+					<armorPenetrationSharp>10.56</armorPenetrationSharp>
+					<armorPenetrationBlunt>39.6</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>40</power>
+					<cooldownTime>3.65</cooldownTime>
+					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+					<chanceFactor>0.2</chanceFactor>
+					<armorPenetrationBlunt>17.5</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="VFEI2_RoyalMegaspider"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="VFEI2_RoyalMegaspider"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="VFEI2_RoyalMegaspider"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>1530</Durability>
+				<Regenerates>true</Regenerates>
+				<RegenInterval>600</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<MinArmorPct>0.25</MinArmorPct>
+			</li>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_RoyalSpelopede.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_RoyalSpelopede.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VFEI2_RoyalSpelopede"]/statBases/MoveSpeed</xpath>
+		<value>
+			<MoveSpeed>4.4</MoveSpeed>
+			<MeleeDodgeChance>0.07</MeleeDodgeChance>
+			<MeleeCritChance>0.31</MeleeCritChance>
+			<MeleeParryChance>0.17</MeleeParryChance>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VFEI2_RoyalSpelopede"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>head claw</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>24</power>
+					<cooldownTime>1.33</cooldownTime>
+					<linkedBodyPartsGroup>HeadClaw</linkedBodyPartsGroup>
+					<armorPenetrationSharp>40</armorPenetrationSharp>
+					<armorPenetrationBlunt>20</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>head claw</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>43</power>
+					<cooldownTime>2.48</cooldownTime>
+					<linkedBodyPartsGroup>HeadClaw</linkedBodyPartsGroup>
+					<armorPenetrationSharp>1.5</armorPenetrationSharp>
+					<armorPenetrationBlunt>7.5</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>24</power>
+					<cooldownTime>1.33</cooldownTime>
+					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					<chanceFactor>0.2</chanceFactor>
+					<armorPenetrationBlunt>6</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VFEI2_RoyalSpelopede"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>10</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VFEI2_RoyalSpelopede"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>4</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="VFEI2_RoyalSpelopede"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="VFEI2_RoyalSpelopede"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="VFEI2_RoyalSpelopede"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>925</Durability>
+				<Regenerates>true</Regenerates>
+				<RegenInterval>600</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<MinArmorPct>0.25</MinArmorPct>
+			</li>
+		</value>
+	</Operation>
+
+</Patch>


### PR DESCRIPTION
## Changes

- Patched and tweaked the turrets and pawn abilities.
- Fixed the temporary (psycast) Black Queen's patch.

## Reasoning

- Increased the insect ability ranges as done with abilities in CE.
- The Vilelobber is tweaked slightly to match CE's standards better and the Thronworm is given a proper CE projectile along with the necessary changes for it to work as a CE turret. The Thronworm projectile is intended to have this much AP, it has more than double the AP of the vanilla AR in vanilla and requires a core to be built so it has to perform (Could probably give it even more AP, up to 9mm). Same deal with the Black Defiler, it's intended to fire a sharp damage type in explosion form which doesn't vibe with CE so it's converted into a main sharp projectile that has an appropriate spit explosion attached to it. The Thornspitter is just a smaller Thronworm that shoots the same projectile in shorter ranges without the burst-fire.
- The Patriarch is a stronger Empress, the royal insects are one tier above the normal vanilla ones, royal megaspider being a copy of the megapede, royal spelopede being a vanilla megaspider and royal megascarab being a highly armored vanilla spelopede.
- The find mod op was changed to I-2 by mistake, should have remained as VPE.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Tested the changed things)
