### PR TITLE
Rimsenal Federation - Thermal Pen

### DIFF
--- a/ModPatches/Rimsenal Federation/Defs/Rimsenal Federation/ThingDefs_Misc/Ammo_Fed.xml
+++ b/ModPatches/Rimsenal Federation/Defs/Rimsenal Federation/ThingDefs_Misc/Ammo_Fed.xml
@@ -262,7 +262,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>8</damageAmountBase>
+			<damageAmountBase>5</damageAmountBase>
 		</projectile>
 	</ThingDef>
 
@@ -279,7 +279,7 @@
 			<damageDef>Optic</damageDef>
 			<speed>90</speed>
 			<dropsCasings>false</dropsCasings>
-			<damageAmountBase>13</damageAmountBase>
+			<damageAmountBase>8</damageAmountBase>
 		</projectile>
 	</ThingDef>
 
@@ -299,7 +299,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>12</damageAmountBase>
+			<damageAmountBase>9</damageAmountBase>
 		</projectile>
 	</ThingDef>
 
@@ -319,7 +319,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>10</damageAmountBase>
+			<damageAmountBase>7</damageAmountBase>
 		</projectile>
 	</ThingDef>
 
@@ -359,7 +359,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>20</damageAmountBase>
+			<damageAmountBase>14</damageAmountBase>
 		</projectile>
 	</ThingDef>
 
@@ -438,7 +438,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>10</damageAmountBase>
+			<damageAmountBase>7</damageAmountBase>
 		</projectile>
 	</ThingDef>
 

--- a/ModPatches/Rimsenal Federation/Defs/Rimsenal Federation/ThingDefs_Misc/Ammo_Fed.xml
+++ b/ModPatches/Rimsenal Federation/Defs/Rimsenal Federation/ThingDefs_Misc/Ammo_Fed.xml
@@ -4,7 +4,7 @@
 	<!-- ==========  Bases =========== -->
 	
 	<ThingDef Name="BaseOpticBoltCE" ParentName="BaseBulletCE" Abstract="true">
-		<label>energy bolt</label>
+		<label>optical energy bolt</label>
 		<graphicData>
 			<texPath>Things/Projectile/Mlaser</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -17,7 +17,7 @@
 	</ThingDef>
 	
 	<ThingDef Name="BaseCrucibleBoltCE" ParentName="BaseBulletCE" Abstract="true">
-		<label>energy bolt</label>
+		<label>crucible energy bolt</label>
 		<graphicData>
 			<texPath>Things/Projectile/Cruciblebolt</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -51,7 +51,6 @@
 	<ThingDef ParentName="BaseOpticBoltCE">
 		<defName>Bullet_HarvesterCannon</defName>
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
-		<label>energy bolt</label>
 		<graphicData>
 			<texPath>Things/Projectile/Laser</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -67,7 +66,6 @@
 	<ThingDef ParentName="BaseExplosiveBullet">
 		<defName>Bullet_PlasmaTurretBombard</defName>
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
-		<label>energy bolt</label>
 		<graphicData>
 			<texPath>Things/Projectile/Plasma</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -93,7 +91,6 @@
 	<ThingDef ParentName="BaseExplosiveBullet">
 		<defName>Bullet_Federation_PlasmaBlast</defName>
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
-		<label>energy bolt</label>
 		<graphicData>
 			<texPath>Things/Projectile/MFlux</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -118,7 +115,6 @@
 	<ThingDef ParentName="BaseExplosiveBullet">
 		<defName>Bullet_Federation_PlasmaCluster</defName>
 		<thingClass>CombatExtended.ProjectileCE_HeightFuse</thingClass>
-		<label>energy bolt</label>
 		<graphicData>
 			<texPath>Things/Projectile/MFlux</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -154,7 +150,6 @@
 	<ThingDef ParentName="BaseExplosiveBullet">
 		<defName>Bullet_Federation_PlasmaSub</defName>
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
-		<label>energy bolt</label>
 		<graphicData>
 			<texPath>Things/Projectile/Plasma</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -176,7 +171,6 @@
 	<ThingDef ParentName="BaseCrucibleBoltCE">
 		<defName>Bullet_CrucibleCannon_CE</defName>
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
-		<label>energy bolt</label>
 		<graphicData>
 			<texPath>Things/Projectile/Mlaser</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -216,7 +210,6 @@
 	<ThingDef ParentName="BasePlasmaBombCE">
 		<defName>Bullet_PlasmaRifle_Fed</defName>
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
-		<label>plasma sphere</label>
 		<graphicData>
 			<texPath>Things/Projectile/Plasma</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -256,7 +249,6 @@
 
 	<ThingDef ParentName="BaseOpticBoltCE">
 		<defName>Bullet_AuxiliaryPistol</defName>
-		<label>energy bolt</label>
 		<graphicData>
 			<texPath>Things/Projectile/Laser</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -270,7 +262,6 @@
 
 	<ThingDef ParentName="BaseOpticBoltCE">
 		<defName>Bullet_MakeshiftCrucibleRifle</defName>
-		<label>energy bolt</label>
 		<graphicData>
 			<texPath>Things/Projectile/Laser</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -368,7 +359,6 @@
 	<ThingDef ParentName="BasePlasmaBombCE">
 		<defName>Bullet_PlasmaCaster</defName>
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
-		<label>plasma sphere</label>
 		<graphicData>
 			<texPath>Things/Projectile/Plasma</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -390,7 +380,6 @@
 	<ThingDef ParentName="BasePlasmaBombCE">
 		<defName>Bullet_PlasmaCaster_Fed</defName>
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
-		<label>plasma sphere</label>
 		<graphicData>
 			<texPath>Things/Projectile/Flux</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -432,7 +421,6 @@
 
 	<ThingDef ParentName="BaseOpticBoltCE">
 		<defName>Bullet_CrucibleCarbine_CE</defName>
-		<label>energy bolt</label>
 		<graphicData>
 			<texPath>Things/Projectile/Mlaser</texPath>
 			<graphicClass>Graphic_Single</graphicClass>

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_DamageDefs.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_DamageDefs.xml
@@ -12,4 +12,22 @@
 			</li>
 		</value>
 	</Operation>
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/DamageDef[defName="Optic"]</xpath>
+		<value>
+			<defaultArmorPenetration>0.8</defaultArmorPenetration>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/DamageDef[defName="Crucible"]</xpath>
+		<value>
+			<defaultArmorPenetration>0.4</defaultArmorPenetration>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/DamageDef[defName="Plasma"]</xpath>
+		<value>
+			<defaultArmorPenetration>0.30</defaultArmorPenetration>
+		</value>
+	</Operation>
 </Patch>

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_DamageDefs.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_DamageDefs.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
-
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/DamageDef[
 		defName="Optic" or
@@ -13,26 +12,22 @@
 			</li>
 		</value>
 	</Operation>
-
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/DamageDef[defName="Optic"]</xpath>
 		<value>
 			<defaultArmorPenetration>0.8</defaultArmorPenetration>
 		</value>
 	</Operation>
-
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/DamageDef[defName="Crucible"]</xpath>
 		<value>
 			<defaultArmorPenetration>0.4</defaultArmorPenetration>
 		</value>
 	</Operation>
-
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/DamageDef[defName="Plasma"]</xpath>
 		<value>
 			<defaultArmorPenetration>0.30</defaultArmorPenetration>
 		</value>
 	</Operation>
-
 </Patch>

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_DamageDefs.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_DamageDefs.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/DamageDef[
 		defName="Optic" or
@@ -12,22 +13,26 @@
 			</li>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/DamageDef[defName="Optic"]</xpath>
 		<value>
 			<defaultArmorPenetration>0.8</defaultArmorPenetration>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/DamageDef[defName="Crucible"]</xpath>
 		<value>
 			<defaultArmorPenetration>0.4</defaultArmorPenetration>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/DamageDef[defName="Plasma"]</xpath>
 		<value>
 			<defaultArmorPenetration>0.30</defaultArmorPenetration>
 		</value>
 	</Operation>
+
 </Patch>

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_RangedWeapons.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_RangedWeapons.xml
@@ -223,6 +223,49 @@
 			<reloadTime>4</reloadTime>
 		</AmmoUser>
 	</Operation>
+	
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="AD_CrucibleRifle"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="AD_CrucibleRifle"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="AD_CrucibleRifle"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_UnderBarrel">
+				<standardLabel>switch to crucible mode</standardLabel>
+				<underBarrelLabel>switch to optical mode</underBarrelLabel>
+				<oneAmmoHolder>True</oneAmmoHolder>
+				<propsUnderBarrel>
+					<magazineSize>15</magazineSize>
+					<reloadTime>4</reloadTime>
+				</propsUnderBarrel>
+				<verbPropsUnderBarrel>
+					<recoilAmount>0.78</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_CrucibleRifleAD</defaultProjectile>
+					<warmupTime>1.6</warmupTime>
+					<burstShotCount>5</burstShotCount>
+					<ticksBetweenBurstShots>25</ticksBetweenBurstShots>
+					<range>55</range>
+					<soundCast>RS_ShotCR</soundCast>
+					<muzzleFlashScale>12</muzzleFlashScale>
+				</verbPropsUnderBarrel>
+				<propsFireModesUnderBarrel>
+					<aiAimMode>AimedShot</aiAimMode>
+					<noSingleShot>false</noSingleShot>
+					<aimedBurstShotCount>5</aimedBurstShotCount>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+				</propsFireModesUnderBarrel>
+			</li>
+		</value>
+	</Operation>
 
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>AD_FedRifle</defName>
@@ -294,6 +337,49 @@
 			<reloadTime>3</reloadTime>
 		</AmmoUser>
 	</Operation>
+	
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="AD_CruciblePistol"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="AD_CruciblePistol"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="AD_CruciblePistol"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_UnderBarrel">
+				<standardLabel>switch to crucible mode</standardLabel>
+				<underBarrelLabel>switch to optical mode</underBarrelLabel>
+				<oneAmmoHolder>True</oneAmmoHolder>
+				<propsUnderBarrel>
+					<magazineSize>15</magazineSize>
+					<reloadTime>3</reloadTime>
+				</propsUnderBarrel>
+				<verbPropsUnderBarrel>
+					<recoilAmount>0.89</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_CruciblePistolAD</defaultProjectile>
+					<warmupTime>0.7</warmupTime>
+					<burstShotCount>5</burstShotCount>
+					<ticksBetweenBurstShots>15</ticksBetweenBurstShots>
+					<range>21</range>
+					<soundCast>RS_ShotCP</soundCast>
+					<muzzleFlashScale>12</muzzleFlashScale>
+				</verbPropsUnderBarrel>
+				<propsFireModesUnderBarrel>
+					<aiAimMode>AimedShot</aiAimMode>
+					<noSingleShot>false</noSingleShot>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+				</propsFireModesUnderBarrel>
+			</li>
+		</value>
+	</Operation>
 
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>AD_FedPistol</defName>
@@ -322,7 +408,7 @@
 			<li>CE_OneHandedWeapon</li>
 		</weaponTags>
 		<FireModes>
-			<aimedBurstShotCount>3</aimedBurstShotCount>
+			<aimedBurstShotCount>5</aimedBurstShotCount>
 			<aiUseBurstMode>FALSE</aiUseBurstMode>
 		</FireModes>
 		<AmmoUser>
@@ -431,6 +517,46 @@
 			<reloadTime>4</reloadTime>
 		</AmmoUser>
 	</Operation>
+	
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="AD_CruciblePresicionRifle"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="AD_CruciblePresicionRifle"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="AD_CruciblePresicionRifle"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_UnderBarrel">
+				<standardLabel>switch to crucible mode</standardLabel>
+				<underBarrelLabel>switch to optical mode</underBarrelLabel>
+				<oneAmmoHolder>True</oneAmmoHolder>
+				<propsUnderBarrel>
+					<magazineSize>15</magazineSize>
+					<reloadTime>4</reloadTime>
+				</propsUnderBarrel>
+				<verbPropsUnderBarrel>
+					<recoilAmount>0.53</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_CruciblePrecisionRifleAD</defaultProjectile>
+					<warmupTime>1.6</warmupTime>
+					<range>75</range>
+					<soundCast>RS_ShotCPR</soundCast>
+					<muzzleFlashScale>12</muzzleFlashScale>
+				</verbPropsUnderBarrel>
+				<propsFireModesUnderBarrel>
+					<aiAimMode>AimedShot</aiAimMode>
+					<noSingleShot>false</noSingleShot>
+					<aimedBurstShotCount>1</aimedBurstShotCount>
+				</propsFireModesUnderBarrel>
+			</li>
+		</value>
+	</Operation>
 
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>AD_FedSniperRifle</defName>
@@ -493,6 +619,50 @@
 			<magazineSize>3</magazineSize>
 			<reloadTime>5</reloadTime>
 		</AmmoUser>
+	</Operation>
+	
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="AD_PlasmaCaliver"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="AD_PlasmaCaliver"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="AD_PlasmaCaliver"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_UnderBarrel">
+				<standardLabel>switch to cluster mode</standardLabel>
+				<underBarrelLabel>switch to siege mode</underBarrelLabel>
+				<oneAmmoHolder>True</oneAmmoHolder>
+				<propsUnderBarrel>
+					<magazineSize>3</magazineSize>
+					<reloadTime>5</reloadTime>
+				</propsUnderBarrel>
+				<verbPropsUnderBarrel>
+					<recoilAmount>0.50</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_PlasmaCaster_Fed</defaultProjectile>
+					<warmupTime>1.9</warmupTime>
+					<minRange>3</minRange>
+					<range>35</range>
+					<soundCast>RS_ShotHarmonizer</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>18</muzzleFlashScale>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+					<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
+				</verbPropsUnderBarrel>
+				<propsFireModesUnderBarrel>
+					<aiAimMode>AimedShot</aiAimMode>
+				</propsFireModesUnderBarrel>
+			</li>
+		</value>
 	</Operation>
 
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_RangedWeapons.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_RangedWeapons.xml
@@ -11,7 +11,7 @@
 			defName="AD_CruciblePistol" or
 			defName="AD_FedPistol" or
 			defName="AD_AuxPistol"
-			]/tools </xpath>
+			]/tools</xpath>
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_RangedWeapons.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Misc/Fed_RangedWeapons.xml
@@ -11,7 +11,7 @@
 			defName="AD_CruciblePistol" or
 			defName="AD_FedPistol" or
 			defName="AD_AuxPistol"
-			]/tools</xpath>
+			]/tools </xpath>
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
@@ -238,8 +238,8 @@
 		<xpath>Defs/ThingDef[defName="AD_CrucibleRifle"]/comps</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_UnderBarrel">
-				<standardLabel>switch to crucible mode</standardLabel>
-				<underBarrelLabel>switch to optical mode</underBarrelLabel>
+				<standardLabel>switch to high-output crucible mode</standardLabel>
+				<underBarrelLabel>switch to high-penetration optical mode</underBarrelLabel>
 				<oneAmmoHolder>True</oneAmmoHolder>
 				<propsUnderBarrel>
 					<magazineSize>15</magazineSize>
@@ -260,7 +260,7 @@
 				<propsFireModesUnderBarrel>
 					<aiAimMode>AimedShot</aiAimMode>
 					<noSingleShot>false</noSingleShot>
-					<aimedBurstShotCount>5</aimedBurstShotCount>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
 					<aiUseBurstMode>TRUE</aiUseBurstMode>
 				</propsFireModesUnderBarrel>
 			</li>
@@ -352,8 +352,8 @@
 		<xpath>Defs/ThingDef[defName="AD_CruciblePistol"]/comps</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_UnderBarrel">
-				<standardLabel>switch to crucible mode</standardLabel>
-				<underBarrelLabel>switch to optical mode</underBarrelLabel>
+				<standardLabel>switch to high-output crucible mode</standardLabel>
+				<underBarrelLabel>switch to high-penetration optical mode</underBarrelLabel>
 				<oneAmmoHolder>True</oneAmmoHolder>
 				<propsUnderBarrel>
 					<magazineSize>15</magazineSize>
@@ -408,7 +408,7 @@
 			<li>CE_OneHandedWeapon</li>
 		</weaponTags>
 		<FireModes>
-			<aimedBurstShotCount>5</aimedBurstShotCount>
+			<aimedBurstShotCount>3</aimedBurstShotCount>
 			<aiUseBurstMode>FALSE</aiUseBurstMode>
 		</FireModes>
 		<AmmoUser>
@@ -532,8 +532,8 @@
 		<xpath>Defs/ThingDef[defName="AD_CruciblePresicionRifle"]/comps</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_UnderBarrel">
-				<standardLabel>switch to crucible mode</standardLabel>
-				<underBarrelLabel>switch to optical mode</underBarrelLabel>
+				<standardLabel>switch to high-output crucible mode</standardLabel>
+				<underBarrelLabel>switch to high-penetration optical mode</underBarrelLabel>
 				<oneAmmoHolder>True</oneAmmoHolder>
 				<propsUnderBarrel>
 					<magazineSize>15</magazineSize>


### PR DESCRIPTION
## Additions

Thermal penetration on the three Fed damage types
Manufacturable crucible weapons (Which are specifically the modifed versions, not any original federation ones) have the ability to switch between their default crucible type damage and optical damage via underbarrel comp.
Player made plasma cavilier now can switch to the bion variant fire mode via underbarrel comp.

## Changes

Optical type weapons outside of the heavy weapons have had their damage output reduced by ~1/3 to compensate for their ability to ignore a very significant amount of thermal armor (80%).
Crucible damage remains the same but now has 40% penetration.
Plasma has also received a moderate amount of penetration (30%).

## Reasoning

Optical weapons have received a significant penetration buff to help them retain efficency against the player where it's common that the player can reach very high levels.
Crucible default mode is designed moreso for player use but alternate mode provides ability to switch it over to the more penetrating optical mode.

## Alternatives

No penetration, as is.
Some alternate form of setup, possibly some form of ammoless ammoset.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
