### PR TITLE
Minor TE Adjustments

### DIFF
--- a/ModPatches/Rimsenal Core/Defs/Rimsenal Core/Ammo_TE.xml
+++ b/ModPatches/Rimsenal Core/Defs/Rimsenal Core/Ammo_TE.xml
@@ -120,12 +120,11 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>KineticImpact</damageDef>
 			<dropsCasings>false</dropsCasings>
-			<damageAmountBase>16</damageAmountBase>
-			<armorPenetrationBlunt>2000</armorPenetrationBlunt>
+			<damageAmountBase>20</damageAmountBase>
+			<armorPenetrationBlunt>4000</armorPenetrationBlunt>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>1</damageAmountBase>
 				<explosiveDamageType>KineticImpact</explosiveDamageType>
 				<explosiveRadius>0.5</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>false</applyDamageToExplosionCellsNeighbors>
@@ -206,7 +205,7 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
 				<explosiveDamageType>KineticImpact</explosiveDamageType>
-				<explosiveRadius>1.5</explosiveRadius>
+				<explosiveRadius>2.5</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>false</applyDamageToExplosionCellsNeighbors>
 			</li>
 		</comps>

--- a/ModPatches/Rimsenal Core/Patches/Rimsenal Core/Apparel_RS_CE.xml
+++ b/ModPatches/Rimsenal Core/Patches/Rimsenal Core/Apparel_RS_CE.xml
@@ -1842,7 +1842,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_HazardCarapace"]/statBases/ArmorRating_Heat</xpath>
 		<value>
-			<ArmorRating_Heat>1</ArmorRating_Heat>
+			<ArmorRating_Heat>1.5</ArmorRating_Heat>
 			<ArmorRating_Electric>1</ArmorRating_Electric>
 		</value>
 	</Operation>
@@ -1942,6 +1942,7 @@
 		<xpath>Defs/ThingDef[defName="Apparel_HazardCarapaceH"]/statBases/ArmorRating_Heat</xpath>
 		<value>
 			<ArmorRating_Heat>1.5</ArmorRating_Heat>
+			<ArmorRating_Electric>1</ArmorRating_Electric>
 		</value>
 	</Operation>
 


### PR DESCRIPTION
## Changes

Hazard armor heat and electric resistance changed for torso/head respectively. Kinetic lance ammo type now has higher secondary damage to assist with armor stripping of natural armor targets (like federators). Canister shots now have larger radius to account for damage falloff in CE.

## Reasoning

Buffed the federator a bit which is pretty much the specific prey of the kinetic lance. Buffs to the penetration/damage should assist with making them a bit better of an option against them without realistically making much difference against most ohter targets due to the weapon already mulching most targets anyway.
Hazard helmet is  supposed to share protection levels with the armor, boosted the heat armor a bit to help combat the federation pentration changes.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
