### PR TITLE
VAE patch fix

### DIFF
--- a/ModPatches/Vanilla Animals Expanded/Patches/Vanilla Animals Expanded/ExtremeDesert_Animals.xml
+++ b/ModPatches/Vanilla Animals Expanded/Patches/Vanilla Animals Expanded/ExtremeDesert_Animals.xml
@@ -78,7 +78,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AEXP_Megascorpion"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
-			<ArmorRating_Blunt>2.25</ArmorRating_Blunt>
+			<ArmorRating_Blunt>1.75</ArmorRating_Blunt>
 		</value>
 	</Operation>
 

--- a/ModPatches/Vanilla Animals Expanded/Patches/Vanilla Animals Expanded/ExtremeDesert_Animals.xml
+++ b/ModPatches/Vanilla Animals Expanded/Patches/Vanilla Animals Expanded/ExtremeDesert_Animals.xml
@@ -72,8 +72,20 @@
 			<MeleeDodgeChance>0.19</MeleeDodgeChance>
 			<MeleeCritChance>0.33</MeleeCritChance>
 			<MeleeParryChance>0.17</MeleeParryChance>
-			<ArmorRating_Blunt>1</ArmorRating_Blunt>
-			<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AEXP_Megascorpion"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>2.25</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AEXP_Megascorpion"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>0.7</ArmorRating_Sharp>
 		</value>
 	</Operation>
 


### PR DESCRIPTION
## Changes

- Fixed the armor patches for the megascorpion.

## References

- Closes #3445

## Reasoning

- The animal has the same amount of armor as a megascarab.
- Somehow this patch had not failed for me until the steam release even though I've been playing with the mod and #3349 at the same time so far...

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
