### PR TITLE
Moving ticktotruepos from launch to projectileProps

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -552,13 +552,13 @@ namespace CombatExtended
         /// <param name="equipment">The equipment used to fire the projectile.</param>
         /// <param name="distance">The distance to the estimated intercept point</param>
         /// <param name="ticksToTruePosition">The number of ticks before the bullet is drawn at its true height instead of the muzzle height</param>
-        public virtual void Launch(Thing launcher, Vector2 origin, float shotAngle, float shotRotation, float shotHeight = 0f, float shotSpeed = -1f, Thing equipment = null, float distance = -1, int ticksToTruePosition = 3)
+        public virtual void Launch(Thing launcher, Vector2 origin, float shotAngle, float shotRotation, float shotHeight = 0f, float shotSpeed = -1f, Thing equipment = null, float distance = -1)
         {
             this.shotAngle = shotAngle;
             this.shotHeight = shotHeight;
             this.shotRotation = shotRotation;
             this.shotSpeed = Math.Max(shotSpeed, def.projectile.speed);
-            this.ticksToTruePosition = ticksToTruePosition;
+            this.ticksToTruePosition = (def.projectile as ProjectilePropertiesCE).TickToTruePos;
             if (def.projectile is ProjectilePropertiesCE props)
             {
                 this.castShadow = props.castShadow;

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_Bursting.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_Bursting.cs
@@ -23,7 +23,7 @@ namespace CombatExtended
             Scribe_Values.Look(ref this.ticksToBurst, "ticksToBurst", -1, false);
         }
 
-        public override void Launch(Thing launcher, Vector2 origin, float shotAngle, float shotRotation, float shotHeight = 0f, float shotSpeed = -1f, Thing equipment = null, float distance = -1, int ticksToTruePosition = 3)
+        public override void Launch(Thing launcher, Vector2 origin, float shotAngle, float shotRotation, float shotHeight = 0f, float shotSpeed = -1f, Thing equipment = null, float distance = -1)
         {
             int armingDelay = 0;
             if (def.projectile is ProjectilePropertiesCE props)
@@ -55,6 +55,7 @@ namespace CombatExtended
             this.shotHeight = shotHeight;
             this.shotRotation = shotRotation;
             this.shotSpeed = Math.Max(shotSpeed, def.projectile.speed);
+            this.ticksToTruePosition = (def.projectile as ProjectilePropertiesCE).TickToTruePos;
             Launch(launcher, origin, equipment);
         }
 

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectilePropertiesCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectilePropertiesCE.cs
@@ -39,6 +39,9 @@ namespace CombatExtended
         public ThingDef detonateMoteDef;
         public FleckDef detonateFleckDef;
         public float detonateEffectsScaleOverride = -1;
+        public int? tickToTruePos;
+        //If undefined, use 3 or the tick it needed to cover 10 cells, whichever is larger.
+        public int TickToTruePos => tickToTruePos ?? Mathf.Max(3, Mathf.CeilToInt(600 / speed));
         [MustTranslate]
         public string genericLabelOverride = null;
 

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -1119,8 +1119,7 @@ namespace CombatExtended
                         ShotHeight,
                         ShotSpeed,
                         EquipmentSource,
-                        distance,
-                        ticksToTruePosition);
+                        distance);
                 }
                 pelletMechanicsOnly = true;
             }


### PR DESCRIPTION
## Changes

Moving the logic of ticktotruepos from setted via launch to via projectileprop. A new field tickToTruePos is added for it, and if not present, the tick it takes to travel 10 tiles or 3 ticks will be used, whichever is larger.

## Reasoning

-To restore backward-compat of custom projectiles and save our already ill-reputated compatibility.

## Alternatives

-Breaking mods with their own custom CE projectile and not actively maintained.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (a few bursts with all sorts of guns)
