### PR TITLE
Multi stack held weapon reloading

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
@@ -718,7 +718,7 @@ namespace CombatExtended
             return false;
         }
 
-        public void LoadAmmo(Thing ammo = null)
+        public void LoadAmmo(Thing ammo = null, bool emptyMag = false)
         {
             Building_AutoloaderCE AutoLoader = null;
             if (parent is Building_AutoloaderCE)
@@ -770,7 +770,7 @@ namespace CombatExtended
                 else
                 {
                     int newAmmoCount = ammoThing.stackCount;
-                    if (turret != null || AutoLoader != null)   //Turrets are reloaded without unloading the mag first (if using same ammo type), to support very high capacity magazines
+                    if (!emptyMag)   //Turrets are reloaded without unloading the mag first (if using same ammo type), to support very high capacity magazines
                     {
                         newAmmoCount += curMagCountInt;
                     }
@@ -789,7 +789,7 @@ namespace CombatExtended
             {
                 newMagCount = (Props.reloadOneAtATime) ? (curMagCountInt + 1) : MagSize;
             }
-            CurMagCount += newMagCount;
+            CurMagCount = newMagCount;
             if (turret != null)
             {
                 turret.SetReloading(false);

--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
@@ -789,7 +789,7 @@ namespace CombatExtended
             {
                 newMagCount = (Props.reloadOneAtATime) ? (curMagCountInt + 1) : MagSize;
             }
-            CurMagCount = newMagCount;
+            CurMagCount += newMagCount;
             if (turret != null)
             {
                 turret.SetReloading(false);

--- a/Source/CombatExtended/CombatExtended/Jobs/JobDriver_Reload.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobDriver_Reload.cs
@@ -199,7 +199,7 @@ namespace CombatExtended
 
             //Actual reloader
             Toil reloadToil = new Toil();
-            reloadToil.AddFinishAction(() => compReloader.LoadAmmo(initAmmo));
+            reloadToil.AddFinishAction(() => DoReload());
             yield return reloadToil;
 
             // If reloading one shot at a time and if possible to reload, jump back to do-nothing toil
@@ -216,6 +216,18 @@ namespace CombatExtended
                 defaultCompleteMode = ToilCompleteMode.Instant
             };
             yield return continueToil;
+        }
+
+        void DoReload()
+        {
+            compReloader.LoadAmmo(initAmmo);
+            if (!(compReloader.Props.reloadOneAtATime || compReloader.FullMagazine))
+            {
+                while (!compReloader.FullMagazine && compReloader.TryFindAmmoInInventory(out initAmmo))
+                {
+                    compReloader.LoadAmmo(initAmmo);
+                }
+            }
         }
 
         public override bool TryMakePreToilReservations(bool errorOnFailed)

--- a/Source/CombatExtended/CombatExtended/Jobs/JobDriver_Reload.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobDriver_Reload.cs
@@ -220,7 +220,7 @@ namespace CombatExtended
 
         void DoReload()
         {
-            compReloader.LoadAmmo(initAmmo);
+            compReloader.LoadAmmo(initAmmo, true);
             if (!(compReloader.Props.reloadOneAtATime || compReloader.FullMagazine))
             {
                 while (!compReloader.FullMagazine && compReloader.TryFindAmmoInInventory(out initAmmo))


### PR DESCRIPTION
## Changes

Reloading held weapon will try to use multiple stacks of ammo if needed.

## Reasoning

-some weapons have more magazine capacity than ammo item stack count.

## Alternatives

Tune every ammo's stack count higher, only to run across weapon with even higher stack count.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] Playtested a colony (specify how long)
