### PR TITLE
Fix underbarrel aim mode bug

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompFireModes.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompFireModes.cs
@@ -16,10 +16,7 @@ namespace CombatExtended
         private Verb verbInt = null;
 
         private List<FireMode> availableFireModes = new List<FireMode>(Enum.GetNames(typeof(FireMode)).Length);
-        private List<AimMode> availableAimModes = new List<AimMode>(Enum.GetNames(typeof(AimMode)).Length)
-        {
-            AimMode.AimedShot
-        };
+        private List<AimMode> availableAimModes = new List<AimMode>(Enum.GetNames(typeof(AimMode)).Length);
         private FireMode currentFireModeInt;
         private AimMode currentAimModeInt;
         private bool newComp = true;
@@ -147,6 +144,7 @@ namespace CombatExtended
         public void InitAvailableFireModes()
         {
             availableFireModes.Clear();
+            availableAimModes.Add(AimMode.AimedShot);
             // Calculate available fire modes
             if (parent.GetStatValue(CE_StatDefOf.BurstShotCount) > 1 || Props.noSingleShot)
             {


### PR DESCRIPTION
## Changes
- Fixed the long-standing bug of underbarrel weapons removing the aimed shot mode from weapons permanently until reloading the save. All I did was move the line that added the aimed shot mode into the init function. It's really simple, but it works without issues in my testing so far.

## References
- Closes #3324

## Reasoning
- Underbarrels call the InitAvailableFireModes() function, which skipped adding the AimedShot mode as that gets added outside of the function.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (5 minute dev test)
