### PR TITLE
Default pikeman combatPower reversion

### DIFF
--- a/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/PawnKindDefs/Pawnkinds_Mech.xml
+++ b/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/PawnKindDefs/Pawnkinds_Mech.xml
@@ -8,13 +8,6 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/PawnKindDef[defName="VFE_Mech_Pikeman" or defName="VFE_Mech_AdvancedPikeman"]/combatPower</xpath>
-		<value>
-			<combatPower>180</combatPower>
-		</value>
-	</Operation>
-
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[
 			defName="VFE_Mech_Knight" or
@@ -105,13 +98,6 @@
 					<xpath>Defs/PawnKindDef[defName="VFE_Mech_AdvancedCentipede_PlayerControlled"]/combatPower</xpath>
 					<value>
 						<combatPower>580</combatPower>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/PawnKindDef[defName="VFE_Mech_AdvancedPikeman_PlayerControlled"]/combatPower</xpath>
-					<value>
-						<combatPower>180</combatPower>
 					</value>
 				</li>
 

--- a/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
@@ -17,13 +17,6 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/PawnKindDef[defName="Mech_Pikeman"]/combatPower</xpath>
-		<value>
-			<combatPower>180</combatPower>
-		</value>
-	</Operation>
-
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[
 			defName="Mech_Lancer" or


### PR DESCRIPTION
## Changes

- Removed the combatPower patches from pikeman mech variants.

## Reasoning

- The patch was there to balance out the mortar pikemen, it's not necessary anymore.
- I've been planning on adding a hostile-only mortar pikeman variant, it will have the same combatPower level.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
