### PR TITLE
Fix true pos lerp

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -208,7 +208,7 @@ namespace CombatExtended
                 var sh = Mathf.Max(0f, (ExactPosition.y) * 0.84f);
                 if (FlightTicks < ticksToTruePosition)
                 {
-                    sh *= FlightTicks / ticksToTruePosition;
+                    sh *= (float)FlightTicks / ticksToTruePosition;
                 }
                 return new Vector3(ExactPosition.x, def.Altitude, ExactPosition.z + sh);
             }


### PR DESCRIPTION
## Changes

Fixed projectile true position lerp broken by a int/int mistake

## Alternatives

![VV78 ZPH0Y)HZ698}{DECF0_tmb](https://github.com/user-attachments/assets/5b80bf93-d58f-4098-84e6-933f4de67797)


## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
