### PR TITLE
Add Apparel Armor to Gear Tab

### DIFF
--- a/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
@@ -523,6 +523,10 @@ namespace CombatExtended
                 if (part.depth == BodyPartDepth.Outside && (part.coverage >= 0.1 || (part.def.tags.Contains(BodyPartTagDefOf.BreathingPathway) || part.def.tags.Contains(BodyPartTagDefOf.SightSource))))
                 {
                     var armorValue = SelPawnForGear.PartialStat(stat, part);
+                    foreach (Apparel apparel in wornApparel)
+                    {
+                        armorValue += apparel.PartialStat(stat, part);
+                    }
                     if (shield != null)
                     {
                         var shieldCoverage = shield.def?.GetModExtension<ShieldDefExtension>()?.PartIsCoveredByShield(part, SelPawnForGear);

--- a/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
@@ -529,10 +529,13 @@ namespace CombatExtended
                     }
                     if (shield != null)
                     {
-                        var shieldCoverage = shield.def?.GetModExtension<ShieldDefExtension>()?.PartIsCoveredByShield(part, SelPawnForGear);
-                        if (shieldCoverage == true)
+                        if (!shield.def.apparel.CoversBodyPart(part))
                         {
-                            armorValue += shield.GetStatValue(stat);
+                            var shieldCoverage = shield.def?.GetModExtension<ShieldDefExtension>()?.PartIsCoveredByShield(part, SelPawnForGear);
+                            if (shieldCoverage == true)
+                            {
+                                armorValue += shield.GetStatValue(stat);
+                            }
                         }
                     }
                     armorCache[part] = armorValue;


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Adds apparel check back to Gear Tab
- Adds check that prevents adding armor value under shieldCoverage part if the bodyPart shows up in in the bodyPartGroups for the apparel section of the shield. Prevents doubling up of the armor value, but not normally shown anyways.

## Alternatives

Describe alternative implementations you have considered, e.g.
- Suffer

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Checked gear tab with and without apparel)
