### PR TITLE
Update VWE - Frontier Patch

### DIFF
--- a/ModPatches/Vanilla Weapons Expanded - Frontier/Defs/Vanilla Weapons Expanded - Frontier/HighRoller_AddonAmmo.xml
+++ b/ModPatches/Vanilla Weapons Expanded - Frontier/Defs/Vanilla Weapons Expanded - Frontier/HighRoller_AddonAmmo.xml
@@ -96,7 +96,7 @@
 
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef Class="CombatExtended.Lasers.LaserBeamDefCE" ParentName="BaseLaserBullet">
+	<ThingDef Class="CombatExtended.Lasers.LaserBeamDefCE" ParentName="LaserBulletYellow">
 		<defName>Bullet_GaussRevolver_HR</defName>
 		<label>gauss revolver shot</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -116,7 +116,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.Lasers.LaserBeamDefCE" ParentName="BaseLaserBullet">
+	<ThingDef Class="CombatExtended.Lasers.LaserBeamDefCE" ParentName="LaserBulletYellow">
 		<defName>Bullet_GaussRepeater_HR</defName>
 		<label>gauss repeater shot</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">


### PR DESCRIPTION
## Additions

VWE - Gauss uses LaserBulletYellow as a parent for their gauss projectiles while the addon guns, present when both VWE - Gauss and VWE - Frontier are loaded, use BaseLaserBullet which causes errors when fired. The base gauss weapons do not have this issue.

## Changes

Changed the projectiles to use a parentname of LaserBulletYellow instead of BaseLaserBullet. Doing so fixes the errors that appear when the guns are fired.

## Reasoning

- I do not like errors.

## Alternatives

errors

## Testing

Check tests you have performed:
- [ ] Compiles without warnings - I did not test this as a recompile was not necessary
- [X] Game runs without errors - Changed patch in latest development version and tested with that 
- [X] Playtested a colony (specify how long) - 10 minutes, to make sure the guns fired correctly