### PR TITLE
Generic texture variants + filepath cleanup.

### DIFF
--- a/Defs/Ammo/Generic/AntiMateriel.xml
+++ b/Defs/Ammo/Generic/AntiMateriel.xml
@@ -46,8 +46,8 @@
 		<defName>Ammo_AntiMateriel_FMJ</defName>
 		<label>anti-materiel cartridge (FMJ)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/HighCaliber/FMJ</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/HighCaliber/FMJ</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>0.5</MarketValue>
@@ -60,8 +60,8 @@
 		<defName>Ammo_AntiMateriel_AP</defName>
 		<label>anti-materiel cartridge (AP)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/HighCaliber/AP</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/HighCaliber/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>0.5</MarketValue>
@@ -74,8 +74,8 @@
 		<defName>Ammo_AntiMateriel_Incendiary</defName>
 		<label>anti-materiel cartridge (AP-I)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/HighCaliber/Incendiary</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>0.82</MarketValue>
@@ -88,8 +88,8 @@
 		<defName>Ammo_AntiMateriel_HE</defName>
 		<label>anti-materiel cartridge (AP-HE)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/HighCaliber/HE</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/HighCaliber/HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>1.36</MarketValue>
@@ -102,8 +102,8 @@
 		<defName>Ammo_AntiMateriel_Sabot</defName>
 		<label>anti-materiel cartridge (Sabot)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/HighCaliber/Sabot</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>0.57</MarketValue>

--- a/Defs/Ammo/Generic/Autocannon.xml
+++ b/Defs/Ammo/Generic/Autocannon.xml
@@ -45,8 +45,8 @@
 		<defName>Ammo_Autocannon_AP</defName>
 		<label>autocannon shell (AP)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/HighCaliber/AP</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/HighCaliber/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>1.04</MarketValue>
@@ -59,8 +59,8 @@
 		<defName>Ammo_Autocannon_Incendiary</defName>
 		<label>autocannon shell (AP-I)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/HighCaliber/Incendiary</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>1.67</MarketValue>
@@ -73,8 +73,8 @@
 		<defName>Ammo_Autocannon_HE</defName>
 		<label>autocannon shell (AP-HE)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/HighCaliber/HE</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/HighCaliber/HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>2.84</MarketValue>
@@ -87,8 +87,8 @@
 		<defName>Ammo_Autocannon_Sabot</defName>
 		<label>autocannon shell (Sabot)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/HighCaliber/Sabot</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<Mass>0.213</Mass>

--- a/Defs/Ammo/Generic/LauncherGrenade.xml
+++ b/Defs/Ammo/Generic/LauncherGrenade.xml
@@ -47,8 +47,8 @@
 		<defName>Ammo_LauncherGrenade_HE</defName>
 		<label>launcher grenade (HE)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/GrenadeLauncher/HE</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/GrenadeLauncher/HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>2.27</MarketValue>
@@ -61,7 +61,7 @@
 		<defName>Ammo_LauncherGrenade_HE_TFuzed</defName>
 		<label>launcher grenade (HE Time-Fuzed)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/GrenadeLauncher/AIR</texPath>
+			<texPath>Things/Ammo/GrenadeLauncher/AIR</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
@@ -75,7 +75,7 @@
 		<defName>Ammo_LauncherGrenade_HEDP</defName>
 		<label>launcher grenade (HEDP)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/GrenadeLauncher/DP</texPath>
+			<texPath>Things/Ammo/GrenadeLauncher/DP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
@@ -89,8 +89,8 @@
 		<defName>Ammo_LauncherGrenade_EMP</defName>
 		<label>launcher grenade (EMP)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/GrenadeLauncher/EMP</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/GrenadeLauncher/EMP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>4.57</MarketValue>
@@ -103,8 +103,8 @@
 		<defName>Ammo_LauncherGrenade_Smoke</defName>
 		<label>launcher grenade (Smoke)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/GrenadeLauncher/SMK</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/GrenadeLauncher/SMK</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>1.84</MarketValue>

--- a/Defs/Ammo/Generic/Pistol.xml
+++ b/Defs/Ammo/Generic/Pistol.xml
@@ -43,8 +43,8 @@
 		<defName>Ammo_Pistol_FMJ</defName>
 		<label>pistol cartridge (FMJ)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/Pistol/FMJ</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/Pistol/FMJ</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>0.09</MarketValue>
@@ -57,8 +57,8 @@
 		<defName>Ammo_Pistol_AP</defName>
 		<label>pistol cartridge (AP)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/Pistol/AP</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/Pistol/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>0.09</MarketValue>
@@ -71,8 +71,8 @@
 		<defName>Ammo_Pistol_HP</defName>
 		<label>pistol cartridge (HP)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/Pistol/HP</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/Pistol/HP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>0.09</MarketValue>

--- a/Defs/Ammo/Generic/PistolMagnum.xml
+++ b/Defs/Ammo/Generic/PistolMagnum.xml
@@ -43,8 +43,8 @@
 		<defName>Ammo_PistolMagnum_FMJ</defName>
 		<label>magnum pistol cartridge (FMJ)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/Pistol/FMJ</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/Revolver/FMJ</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>0.1</MarketValue>
@@ -57,8 +57,8 @@
 		<defName>Ammo_PistolMagnum_AP</defName>
 		<label>magnum pistol cartridge (AP)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/Pistol/AP</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/Revolver/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>0.1</MarketValue>
@@ -71,8 +71,8 @@
 		<defName>Ammo_PistolMagnum_HP</defName>
 		<label>magnum pistol cartridge (HP)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/Pistol/HP</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/Revolver/HP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>0.1</MarketValue>

--- a/Defs/Ammo/Generic/Rifle.xml
+++ b/Defs/Ammo/Generic/Rifle.xml
@@ -46,8 +46,8 @@
 		<defName>Ammo_Rifle_FMJ</defName>
 		<label>rifle cartridge (FMJ)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/Rifle/FMJ</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/Rifle/Battlerifle/FMJ</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>0.11</MarketValue>
@@ -60,8 +60,8 @@
 		<defName>Ammo_Rifle_AP</defName>
 		<label>rifle cartridge (AP)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/Rifle/AP</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/Rifle/Battlerifle/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>0.11</MarketValue>
@@ -74,8 +74,8 @@
 		<defName>Ammo_Rifle_HP</defName>
 		<label>rifle cartridge (HP)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/Rifle/HP</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/Rifle/Battlerifle/HP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>0.11</MarketValue>
@@ -88,8 +88,8 @@
 		<defName>Ammo_Rifle_Incendiary</defName>
 		<label>rifle cartridge (AP-I)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/Rifle/Incendiary</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/Rifle/Battlerifle/Incendiary</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>0.17</MarketValue>
@@ -102,8 +102,8 @@
 		<defName>Ammo_Rifle_HE</defName>
 		<label>rifle cartridge (AP-HE)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/Rifle/HE</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/Rifle/Battlerifle/HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>0.31</MarketValue>
@@ -116,8 +116,8 @@
 		<defName>Ammo_Rifle_Sabot</defName>
 		<label>rifle cartridge (Sabot)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/Rifle/Sabot</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/Rifle/Battlerifle/Sabot</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>0.12</MarketValue>

--- a/Defs/Ammo/Generic/RifleIntermediate.xml
+++ b/Defs/Ammo/Generic/RifleIntermediate.xml
@@ -46,8 +46,8 @@
 		<defName>Ammo_RifleIntermediate_FMJ</defName>
 		<label>intermediate rifle cartridge (FMJ)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/Rifle/FMJ</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/Rifle/FMJ</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>0.06</MarketValue>
@@ -60,8 +60,8 @@
 		<defName>Ammo_RifleIntermediate_AP</defName>
 		<label>intermediate rifle cartridge (AP)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/Rifle/AP</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/Rifle/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>0.06</MarketValue>
@@ -74,8 +74,8 @@
 		<defName>Ammo_RifleIntermediate_HP</defName>
 		<label>intermediate rifle cartridge (HP)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/Rifle/HP</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/Rifle/HP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>0.06</MarketValue>
@@ -88,8 +88,8 @@
 		<defName>Ammo_RifleIntermediate_Incendiary</defName>
 		<label>intermediate rifle cartridge (AP-I)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/Rifle/Incendiary</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/Rifle/Incendiary</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>0.1</MarketValue>
@@ -102,8 +102,8 @@
 		<defName>Ammo_RifleIntermediate_HE</defName>
 		<label>intermediate rifle cartridge (AP-HE)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/Rifle/HE</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/Rifle/HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>0.17</MarketValue>
@@ -116,8 +116,8 @@
 		<defName>Ammo_RifleIntermediate_Sabot</defName>
 		<label>intermediate rifle cartridge (Sabot)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/Rifle/Sabot</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/Rifle/Sabot</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>0.07</MarketValue>

--- a/Defs/Ammo/Generic/RifleMagnum.xml
+++ b/Defs/Ammo/Generic/RifleMagnum.xml
@@ -46,8 +46,8 @@
 		<defName>Ammo_RifleMagnum_FMJ</defName>
 		<label>magnum rifle cartridge (FMJ)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/HighCaliber/FMJ</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/HighCaliber/FMJ</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>0.2</MarketValue>
@@ -60,8 +60,8 @@
 		<defName>Ammo_RifleMagnum_AP</defName>
 		<label>magnum rifle cartridge (AP)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/HighCaliber/AP</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/HighCaliber/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>0.2</MarketValue>
@@ -74,8 +74,8 @@
 		<defName>Ammo_RifleMagnum_Incendiary</defName>
 		<label>magnum rifle cartridge (AP-I)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/HighCaliber/Incendiary</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>0.33</MarketValue>
@@ -88,8 +88,8 @@
 		<defName>Ammo_RifleMagnum_HE</defName>
 		<label>magnum rifle cartridge (AP-HE)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/HighCaliber/HE</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/HighCaliber/HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>0.52</MarketValue>
@@ -102,8 +102,8 @@
 		<defName>Ammo_RifleMagnum_Sabot</defName>
 		<label>magnum rifle cartridge (Sabot)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/HighCaliber/Sabot</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>0.21</MarketValue>

--- a/Defs/Ammo/Generic/ShotgunShell.xml
+++ b/Defs/Ammo/Generic/ShotgunShell.xml
@@ -44,8 +44,8 @@
 		<defName>Ammo_Shotgun_Buck</defName>
 		<label>shotgun shell (Buck)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/Shotgun/Shot</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/Shotgun/Shot</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>0.22</MarketValue>
@@ -58,8 +58,8 @@
 		<defName>Ammo_Shotgun_Slug</defName>
 		<label>shotgun shell (Slug)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/Shotgun/Slug</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/Shotgun/Slug</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<Mass>0.048</Mass>
@@ -74,8 +74,8 @@
 		<label>shotgun shell (Bean)</label>
 		<generateAllowChance>0</generateAllowChance>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/Shotgun/Beanbag</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/Shotgun/Beanbag</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<Mass>0.059</Mass>
@@ -89,8 +89,8 @@
 		<defName>Ammo_Shotgun_ElectroSlug</defName>
 		<label>shotgun shell (EMP)</label>
 		<graphicData>
-			<texPath>Things/Ammo/STACK_RANGED/Shotgun/EMP</texPath>
-			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+			<texPath>Things/Ammo/Shotgun/EMP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<Mass>0.054</Mass>


### PR DESCRIPTION
## Changes

- Full power rifle and pistol magnum now use the texture variants from their 'parent' calibers.
- Swapped generic stack classes to the vanilla `Graphic_StackCount`

## Reasoning

- No point in having two different stack types across two different modes. If the explicit range stack is preferred then the classic ammo stacks should be converted as well.

## Alternatives

- Read above.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors