### PR TITLE
Better Loading incompatibility update

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -24,6 +24,7 @@
 		<li>jelly.ProperShotguns</li>
 		<li>swedishmask.ProperShotgunsPatch</li>
 		<li>me.samboycoding.betterloading</li>
+		<li>me.samboycoding.betterloading.dev</li>
 		<li>majorhoff.rimthreaded</li>
 		<li>falconne.AFF</li>
 		<li>Sk.FlankingBonus</li>


### PR DESCRIPTION
## Changes

- Added the new packageId of the Better Loading mod to the incompatibility list.

## Reasoning

- The author has changed the mod's ID which leads to the mod not being listed as incompatible, kept the old ID in place for future-proofing.
