### PR TITLE
Fixed the appearance of unresearched buildings 

### DIFF
--- a/Source/CombatExtended/Harmony/Designator_Dropdown_Patch.cs
+++ b/Source/CombatExtended/Harmony/Designator_Dropdown_Patch.cs
@@ -1,0 +1,26 @@
+﻿using RimWorld;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Verse;
+
+namespace CombatExtended
+{
+    [HarmonyLib.HarmonyPatch(typeof(Designator_Dropdown), nameof(Designator.Visible), HarmonyLib.MethodType.Getter)]
+    internal static class Designator_Dropdown_Patch
+    {
+        static void Postfix(Designator_Dropdown __instance, bool __result)
+        {
+            if (__result && !__instance.activeDesignator.Visible)
+            {
+                var visibleElement = __instance.elements.FirstOrDefault(x => x.Visible);
+                if (visibleElement != null)
+                {
+                    __instance.SetActiveDesignator(visibleElement, false);
+                }
+            }
+        }
+    }
+}

--- a/Source/CombatExtended/Harmony/Harmony_Designator_Dropdown.cs
+++ b/Source/CombatExtended/Harmony/Harmony_Designator_Dropdown.cs
@@ -9,7 +9,7 @@ using Verse;
 namespace CombatExtended
 {
     [HarmonyLib.HarmonyPatch(typeof(Designator_Dropdown), nameof(Designator.Visible), HarmonyLib.MethodType.Getter)]
-    internal static class Designator_Dropdown_Patch
+    internal static class Harmony_Designator_Dropdown
     {
         static void Postfix(Designator_Dropdown __instance, bool __result)
         {


### PR DESCRIPTION
## How to reproduce

1. Research "Gas operation" or "Gun turret";
2. Check Security tab for KPV or Charge blaster turret.

## Changes

- Player won't be able to build KPV (and few other turrets) w/o research

## Reasoning

- Player able to build KPV w/o research

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tynan\Ludeon, fix it, please;
- Validate active designator when game loaded/project researched instead of validation while accessing Visibility (not sure how it affects performance now);
- Let players build Mid-late game turrets w/o researches;
- Suffer.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
