### PR TITLE
Fix prometheum burning on water

### DIFF
--- a/Source/CombatExtended/CombatExtended/Things/IncendiaryFuel.cs
+++ b/Source/CombatExtended/CombatExtended/Things/IncendiaryFuel.cs
@@ -41,7 +41,7 @@ namespace CombatExtended
 
         public override void Tick()
         {
-            if (Position.GetThingList(base.Map).Any(x => x.def == ThingDefOf.Filth_FireFoam))
+            if (Position.GetThingList(base.Map).Any(x => x.def == ThingDefOf.Filth_FireFoam) || Position.GetTerrain(base.Map).IsWater)
             {
                 if (!Destroyed)
                 {


### PR DESCRIPTION
## Changes

- Prometheum how self-destroys when placed on water.

## Reasoning

- Unreachable prometheum burning infinitely on deep water is janky.

## Alternatives

- Patch a new tag onto deep water and check for that. This would still let prometheum burn on passable water.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
