### PR TITLE
Misc. Patch Tweaks/Updates

### DIFF
--- a/Defs/ThingDefs_Misc/Apparel_Carrying.xml
+++ b/Defs/ThingDefs_Misc/Apparel_Carrying.xml
@@ -413,6 +413,7 @@
 			<WorkToMake>28500</WorkToMake>
 			<Mass>7</Mass>
 			<Bulk>8</Bulk>
+			<WornBulk>2.5</WornBulk>
 		</statBases>
 		<costList>
 			<Steel>120</Steel>

--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -242,6 +242,7 @@
 		<li IfModActive="Mlie.JinRohKerberosPanzerCopArmor">ModPatches/Jin-Roh Kerberos Panzer Cop Armor</li>
 		<li IfModActive="K4G.Core">ModPatches/K4G Empires of Old - Core</li>
 		<li IfModActive="K4G.Guild">ModPatches/K4G Empires of Old - Engineers Institute</li>
+		<li IfModActive="K4G.K4G.Fellowship">ModPatches/K4G Empires of Old - The Alekeepers</li>		
 		<li IfModActive="K4G.Sultanate">ModPatches/K4G Empires of Old - The Faceless Sultainate</li>
 		<li IfModActive="K4G.Legion">ModPatches/K4G Empires of Old - The Polluted Legion</li>
 		<li IfModActive="K4G.Dynasty">ModPatches/K4G Empires of Old - The Rising Sun</li>

--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -55,7 +55,7 @@
 		<li IfModActive="ALIEN.ArasakaCorporation">ModPatches/Arasaka Corporation [1.3]</li>
 		<li IfModActive="Teok25.ArchotechExpanded">ModPatches/Archotech Expanded</li>
 		<li IfModActive="Teok25.ArchotechExpanded.Prosthetics">ModPatches/Archotech Expanded Prosthetics</li>
-		<li IfModActive="JangoDsoul.Archotech.PowerArmor">ModPatches/Archotech PowerArmor</li>
+		<li IfModActive="New.ArchotechPowerArmor">ModPatches/Archotech PowerArmor</li>
 		<li IfModActive="Edern.ArchotechWeaponry">ModPatches/Archotech Weaponry</li>
 		<li IfModActive="Mlie.ArchotechPlus">ModPatches/Archotech+</li>
 		<li IfModActive="Mlie.ArgoniansofBlackmarsh">ModPatches/Argonians of Blackmarsh</li>

--- a/ModPatches/Archotech PowerArmor/Patches/Archotech PowerArmor/Apparel_JDS.xml
+++ b/ModPatches/Archotech PowerArmor/Patches/Archotech PowerArmor/Apparel_JDS.xml
@@ -27,6 +27,14 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="APA_Archotech_Palatine_Helmet"]/costList</xpath>
+		<value>
+			<Uranium>30</Uranium>
+			<Hyperweave>45</Hyperweave>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[@Name="APA_ArmorBase"]/costList</xpath>
 		<value>
 			<Uranium>45</Uranium>
@@ -34,29 +42,24 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="APA_Archotech_Palatine_Armor"]/costList</xpath>
+		<value>
+			<Uranium>70</Uranium>
+			<Hyperweave>135</Hyperweave>
+		</value>
+	</Operation>
+
 	<!-- ===== Stats Adjustment ===== -->
 
 	<!-- === Archotech Power Helmet === -->
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[@Name="APA_HelmetBase"]/statBases/WorkToMake</xpath>
-		<value>
-			<WorkToMake>26250</WorkToMake>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[@Name="APA_HelmetBase"]/statBases/MaxHitPoints</xpath>
-		<value>
-			<MaxHitPoints>360</MaxHitPoints>
-			<Bulk>5.5</Bulk>
-			<WornBulk>1.25</WornBulk>
-		</value>
-	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="APA_HelmetBase"]/statBases/Mass</xpath>
 		<value>
 			<Mass>5</Mass>
+			<Bulk>5.5</Bulk>
+			<WornBulk>1</WornBulk>
 		</value>
 	</Operation>
 
@@ -116,27 +119,81 @@
 		</value>
 	</Operation>
 
-	<!-- === Archotech Power Armor === -->
+	<!-- === Palatine Helmet === -->
+
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[@Name="APA_ArmorBase"]/statBases/WorkToMake</xpath>
+		<xpath>Defs/ThingDef[defName="APA_Archotech_Palatine_Helmet"]/statBases/Mass</xpath>
 		<value>
-			<WorkToMake>80000</WorkToMake>
+			<Mass>5</Mass>
+			<Bulk>7.5</Bulk>
+			<WornBulk>1</WornBulk>			
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="APA_Archotech_Palatine_Helmet"]/apparel/immuneToToxGasExposure</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="APA_Archotech_Palatine_Helmet"]/apparel</xpath>
+			<value>
+				<immuneToToxGasExposure>true</immuneToToxGasExposure>
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="APA_Archotech_Palatine_Helmet"]/equippedStatOffsets</xpath>
+		<value>
+			<AimingAccuracy>0.20</AimingAccuracy>
+			<ToxicEnvironmentResistance>0.50</ToxicEnvironmentResistance>
+			<SmokeSensitivity>-1</SmokeSensitivity>
+			<NightVisionEfficiency_Apparel>1.0</NightVisionEfficiency_Apparel>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[@Name="APA_ArmorBase"]/statBases/MaxHitPoints</xpath>
+		<xpath>Defs/ThingDef[defName="APA_Archotech_Palatine_Helmet"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
-			<MaxHitPoints>650</MaxHitPoints>
-			<Bulk>100</Bulk>
-			<WornBulk>15</WornBulk>
+			<ArmorRating_Sharp>32</ArmorRating_Sharp>
 		</value>
 	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="APA_Archotech_Palatine_Helmet"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>64</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="APA_Archotech_Palatine_Helmet"]</xpath>
+		<value>
+			<li Class="CombatExtended.PartialArmorExt">
+				<stats>
+					<li>
+						<ArmorRating_Sharp>1.05</ArmorRating_Sharp>
+						<parts>
+							<li>Eye</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>1.05</ArmorRating_Blunt>
+						<parts>
+							<li>Eye</li>
+						</parts>
+					</li>
+				</stats>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- === Archotech Power Armor === -->
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="APA_ArmorBase"]/statBases/Mass</xpath>
 		<value>
 			<Mass>60</Mass>
+			<Bulk>100</Bulk>
+			<WornBulk>15</WornBulk>			
 		</value>
 	</Operation>
 
@@ -144,7 +201,7 @@
 		<xpath>Defs/ThingDef[@Name="APA_ArmorBase"]/equippedStatOffsets</xpath>
 		<value>
 			<CarryWeight>90</CarryWeight>
-			<CarryBulk>12.5</CarryBulk>
+			<CarryBulk>15</CarryBulk>
 			<ShootingAccuracyPawn>0.20</ShootingAccuracyPawn>
 		</value>
 	</Operation>
@@ -165,6 +222,62 @@
 
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[@Name="APA_ArmorBase"]</xpath>
+		<value>
+			<li Class="CombatExtended.PartialArmorExt">
+				<stats>
+					<li>
+						<ArmorRating_Sharp>0.95</ArmorRating_Sharp>
+						<parts>
+							<li>Hand</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.95</ArmorRating_Blunt>
+						<parts>
+							<li>Hand</li>
+						</parts>
+					</li>
+				</stats>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- === Palatine Power Armor === -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="APA_Archotech_Palatine_Armor"]/statBases/Mass</xpath>
+		<value>
+			<Mass>60</Mass>
+			<Bulk>110</Bulk>
+			<WornBulk>15</WornBulk>			
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="APA_Archotech_Palatine_Armor"]/equippedStatOffsets</xpath>
+		<value>
+			<CarryWeight>110</CarryWeight>
+			<CarryBulk>30</CarryBulk>
+			<ShootingAccuracyPawn>0.20</ShootingAccuracyPawn>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="APA_Archotech_Palatine_Armor"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>45</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="APA_Archotech_Palatine_Armor"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>94</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="APA_Archotech_Palatine_Armor"]</xpath>
 		<value>
 			<li Class="CombatExtended.PartialArmorExt">
 				<stats>

--- a/ModPatches/K4G Empires of Old - The Alekeepers/Patches/K4G Empires of Old - The Alekeepers/Pawnkinds_Alekeepers.xml
+++ b/ModPatches/K4G Empires of Old - The Alekeepers/Patches/K4G Empires of Old - The Alekeepers/Pawnkinds_Alekeepers.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- Warrior Monks -->
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/PawnKindDef[defName="K4G_Fellowship_WarriorMonk"]</xpath>
+		<value>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>4</min>
+					<max>6</max>
+				</primaryMagazineCount>
+			</li>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/K4G Empires of Old - The Faceless Sultainate/Patches/K4G Empires of Old - The Faceless Sultainate/PawnKinds_Sultanate.xml
+++ b/ModPatches/K4G Empires of Old - The Faceless Sultainate/Patches/K4G Empires of Old - The Faceless Sultainate/PawnKinds_Sultanate.xml
@@ -2,56 +2,57 @@
 <Patch>
 	<!-- === Civilians / Royals === -->
 
-<Operation Class="PatchOperationAddModExtension">
-	<xpath>Defs/PawnKindDef[defName="K4G_Sultanate_Common_Trader" or defName="K4G_Sultanate_Common_Worker"]</xpath>
-	<value>
-		<li Class="CombatExtended.LoadoutPropertiesExtension">
-			<primaryMagazineCount>
-				<min>3</min>
-				<max>4</max>
-			</primaryMagazineCount>
-		</li>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/PawnKindDef[defName="K4G_Sultanate_Common_Trader" or defName="K4G_Sultanate_Common_Worker"]</xpath>
+		<value>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>3</min>
+					<max>4</max>
+				</primaryMagazineCount>
+			</li>
+		</value>
+	</Operation>
 
-<!-- === Fighters === -->
+	<!-- === Fighters === -->
 
-<Operation Class="PatchOperationAddModExtension">
-	<xpath>Defs/PawnKindDef[@Name="K4GSultanateGuerrillaBase" or @Name="K4GSultanateJanissaryBase"]</xpath>
-	<value>
-		<li Class="CombatExtended.LoadoutPropertiesExtension">
-			<primaryMagazineCount>
-				<min>4</min>
-				<max>6</max>
-			</primaryMagazineCount>
-		</li>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/PawnKindDef[@Name="K4GSultanateGuerrillaBase" or @Name="K4GSultanateJanissaryBase"]</xpath>
+		<value>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>4</min>
+					<max>6</max>
+				</primaryMagazineCount>
+			</li>
+		</value>
+	</Operation>
 
-<Operation Class="PatchOperationAddModExtension">
-	<xpath>Defs/PawnKindDef[
-	defName="K4G_Sultanate_Fighter_Cataphract" or
-	defName="K4G_Sultanate_Fighter_KhanGuardRanged" or
-	defName="K4G_Sultanate_Fighter_BlackMarketMercenary"]</xpath>
-	<value>
-		<li Class="CombatExtended.LoadoutPropertiesExtension">
-			<primaryMagazineCount>
-				<min>5</min>
-				<max>7</max>
-			</primaryMagazineCount>
-		</li>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/PawnKindDef[
+		defName="K4G_Sultanate_Fighter_Cataphract" or
+		defName="K4G_Sultanate_Fighter_KhanGuardRanged" or
+		defName="K4G_Sultanate_Fighter_BlackMarketMercenary"]</xpath>
+		<value>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>5</min>
+					<max>7</max>
+				</primaryMagazineCount>
+			</li>
+		</value>
+	</Operation>
 
-<Operation Class="PatchOperationAddModExtension">
-	<xpath>Defs/PawnKindDef[defName="K4G_Sultanate_Fighter_Bomber"]</xpath>
-	<value>
-		<li Class="CombatExtended.LoadoutPropertiesExtension">
-			<primaryMagazineCount>
-				<min>8</min>
-				<max>12</max>
-			</primaryMagazineCount>
-		</li>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/PawnKindDef[defName="K4G_Sultanate_Fighter_Bomber"]</xpath>
+		<value>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>8</min>
+					<max>12</max>
+				</primaryMagazineCount>
+			</li>
+		</value>
+	</Operation>
+
 </Patch>

--- a/ModPatches/K4G Empires of Old - The Faceless Sultainate/Patches/K4G Empires of Old - The Faceless Sultainate/TraderKinds_Sultanate.xml
+++ b/ModPatches/K4G Empires of Old - The Faceless Sultainate/Patches/K4G Empires of Old - The Faceless Sultainate/TraderKinds_Sultanate.xml
@@ -2,160 +2,160 @@
 <Patch>
 	<!-- ======= Trader Base =======-->
 
-<Operation Class="PatchOperationAdd">
-	<xpath>Defs/TraderKindDef[defName="K4G_Base_Sultanate_Standard"]/stockGenerators</xpath>
-	<value>
-		<li Class="StockGenerator_SingleDef">
-			<thingDef>FSX</thingDef>
-			<countRange>
-				<min>15</min>
-				<max>40</max>
-			</countRange>
-		</li>
-		<li Class="StockGenerator_SingleDef">
-			<thingDef>Prometheum</thingDef>
-			<countRange>
-				<min>15</min>
-				<max>40</max>
-			</countRange>
-		</li>
-		<li Class="StockGenerator_Tag">
-			<tradeTag>CE_Ammo</tradeTag>
-			<countRange>
-				<min>400</min>
-				<max>1000</max>
-			</countRange>
-			<thingDefCountRange>
-				<min>3</min>
-				<max>8</max>
-			</thingDefCountRange>
-		</li>
-		<li Class="StockGenerator_Tag">
-			<tradeTag>CE_MediumAmmo</tradeTag>
-			<countRange>
-				<min>400</min>
-				<max>1000</max>
-			</countRange>
-			<thingDefCountRange>
-				<min>3</min>
-				<max>8</max>
-			</thingDefCountRange>
-		</li>
-		<li Class="StockGenerator_Tag">
-			<tradeTag>CE_HeavyAmmo</tradeTag>
-			<countRange>
-				<min>10</min>
-				<max>50</max>
-			</countRange>
-			<thingDefCountRange>
-				<min>2</min>
-				<max>5</max>
-			</thingDefCountRange>
-		</li>
-		<li Class="StockGenerator_Category">
-			<categoryDef>Ammo</categoryDef>
-			<thingDefCountRange>
-				<min>0</min>
-				<max>0</max>
-			</thingDefCountRange>
-		</li>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/TraderKindDef[defName="K4G_Base_Sultanate_Standard"]/stockGenerators</xpath>
+		<value>
+			<li Class="StockGenerator_SingleDef">
+				<thingDef>FSX</thingDef>
+				<countRange>
+					<min>15</min>
+					<max>40</max>
+				</countRange>
+			</li>
+			<li Class="StockGenerator_SingleDef">
+				<thingDef>Prometheum</thingDef>
+				<countRange>
+					<min>15</min>
+					<max>40</max>
+				</countRange>
+			</li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>CE_Ammo</tradeTag>
+				<countRange>
+					<min>400</min>
+					<max>1000</max>
+				</countRange>
+				<thingDefCountRange>
+					<min>3</min>
+					<max>8</max>
+				</thingDefCountRange>
+			</li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>CE_MediumAmmo</tradeTag>
+				<countRange>
+					<min>400</min>
+					<max>1000</max>
+				</countRange>
+				<thingDefCountRange>
+					<min>3</min>
+					<max>8</max>
+				</thingDefCountRange>
+			</li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>CE_HeavyAmmo</tradeTag>
+				<countRange>
+					<min>10</min>
+					<max>50</max>
+				</countRange>
+				<thingDefCountRange>
+					<min>2</min>
+					<max>5</max>
+				</thingDefCountRange>
+			</li>
+			<li Class="StockGenerator_Category">
+				<categoryDef>Ammo</categoryDef>
+				<thingDefCountRange>
+					<min>0</min>
+					<max>0</max>
+				</thingDefCountRange>
+			</li>
+		</value>
+	</Operation>
 
-<!-- ======= Trader Caravan Base =======-->
-<Operation Class="PatchOperationAdd">
-	<xpath>Defs/TraderKindDef[defName="K4G_Base_Sultanate_Standard"]/stockGenerators</xpath>
-	<value>
-		<li Class="StockGenerator_SingleDef">
-			<thingDef>FSX</thingDef>
-			<countRange>
-				<min>15</min>
-				<max>40</max>
-			</countRange>
-		</li>
-		<li Class="StockGenerator_SingleDef">
-			<thingDef>Prometheum</thingDef>
-			<countRange>
-				<min>15</min>
-				<max>40</max>
-			</countRange>
-		</li>
-		<li Class="StockGenerator_Tag">
-			<tradeTag>CE_Ammo</tradeTag>
-			<countRange>
-				<min>400</min>
-				<max>1000</max>
-			</countRange>
-			<price>Cheap</price>
-			<thingDefCountRange>
-				<min>3</min>
-				<max>8</max>
-			</thingDefCountRange>
-		</li>
-		<li Class="StockGenerator_Tag">
-			<tradeTag>CE_MediumAmmo</tradeTag>
-			<countRange>
-				<min>10</min>
-				<max>50</max>
-			</countRange>
-			<thingDefCountRange>
-				<min>2</min>
-				<max>4</max>
-			</thingDefCountRange>
-		</li>
-		<li Class="StockGenerator_Tag">
-			<tradeTag>CE_HeavyAmmo</tradeTag>
-			<countRange>
-				<min>5</min>
-				<max>30</max>
-			</countRange>
-			<thingDefCountRange>
-				<min>2</min>
-				<max>6</max>
-			</thingDefCountRange>
-		</li>
-		<li Class="StockGenerator_Category">
-			<categoryDef>Ammo</categoryDef>
-			<thingDefCountRange>
-				<min>0</min>
-				<max>0</max>
-			</thingDefCountRange>
-		</li>
-		<li Class="StockGenerator_Tag">
-			<tradeTag>CE_Turret</tradeTag>
-			<thingDefCountRange>
-				<min>-4</min>
-				<max>2</max>
-			</thingDefCountRange>
-			<countRange>
-				<min>1</min>
-				<max>1</max>
-			</countRange>
-		</li>
-		<li Class="StockGenerator_Category">
-			<categoryDef>WeaponsTurrets</categoryDef>
-			<thingDefCountRange>
-				<min>0</min>
-				<max>0</max>
-			</thingDefCountRange>
-		</li>
-		<li Class="StockGenerator_Animals">
-			<tradeTagsSell>
-				<li>CE_AnimalBoom</li>
-			</tradeTagsSell>
-			<tradeTagsBuy>
-				<li>CE_AnimalBoom</li>
-			</tradeTagsBuy>
-			<kindCountRange>
-				<min>0</min>
-				<max>1</max>
-			</kindCountRange>
-			<countRange>
-				<min>-1</min>
-				<max>2</max>
-			</countRange>
-		</li>
-	</value>
-</Operation>
+	<!-- ======= Trader Caravan Base =======-->
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/TraderKindDef[defName="K4G_Base_Sultanate_Standard"]/stockGenerators</xpath>
+		<value>
+			<li Class="StockGenerator_SingleDef">
+				<thingDef>FSX</thingDef>
+				<countRange>
+					<min>15</min>
+					<max>40</max>
+				</countRange>
+			</li>
+			<li Class="StockGenerator_SingleDef">
+				<thingDef>Prometheum</thingDef>
+				<countRange>
+					<min>15</min>
+					<max>40</max>
+				</countRange>
+			</li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>CE_Ammo</tradeTag>
+				<countRange>
+					<min>400</min>
+					<max>1000</max>
+				</countRange>
+				<price>Cheap</price>
+				<thingDefCountRange>
+					<min>3</min>
+					<max>8</max>
+				</thingDefCountRange>
+			</li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>CE_MediumAmmo</tradeTag>
+				<countRange>
+					<min>10</min>
+					<max>50</max>
+				</countRange>
+				<thingDefCountRange>
+					<min>2</min>
+					<max>4</max>
+				</thingDefCountRange>
+			</li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>CE_HeavyAmmo</tradeTag>
+				<countRange>
+					<min>5</min>
+					<max>30</max>
+				</countRange>
+				<thingDefCountRange>
+					<min>2</min>
+					<max>6</max>
+				</thingDefCountRange>
+			</li>
+			<li Class="StockGenerator_Category">
+				<categoryDef>Ammo</categoryDef>
+				<thingDefCountRange>
+					<min>0</min>
+					<max>0</max>
+				</thingDefCountRange>
+			</li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>CE_Turret</tradeTag>
+				<thingDefCountRange>
+					<min>-4</min>
+					<max>2</max>
+				</thingDefCountRange>
+				<countRange>
+					<min>1</min>
+					<max>1</max>
+				</countRange>
+			</li>
+			<li Class="StockGenerator_Category">
+				<categoryDef>WeaponsTurrets</categoryDef>
+				<thingDefCountRange>
+					<min>0</min>
+					<max>0</max>
+				</thingDefCountRange>
+			</li>
+			<li Class="StockGenerator_Animals">
+				<tradeTagsSell>
+					<li>CE_AnimalBoom</li>
+				</tradeTagsSell>
+				<tradeTagsBuy>
+					<li>CE_AnimalBoom</li>
+				</tradeTagsBuy>
+				<kindCountRange>
+					<min>0</min>
+					<max>1</max>
+				</kindCountRange>
+				<countRange>
+					<min>-1</min>
+					<max>2</max>
+				</countRange>
+			</li>
+		</value>
+	</Operation>
 
 </Patch>

--- a/ModPatches/K4G Empires of Old - The Polluted Legion/Patches/K4G Empires of Old - The Polluted Legion/PawnKinds_Legion.xml
+++ b/ModPatches/K4G Empires of Old - The Polluted Legion/Patches/K4G Empires of Old - The Polluted Legion/PawnKinds_Legion.xml
@@ -2,53 +2,54 @@
 <Patch>
 	<!-- === Civilians === -->
 
-<Operation Class="PatchOperationAddModExtension">
-	<xpath>Defs/PawnKindDef[defName="K4G_Legion_Common_Trader" or defName="K4G_Legion_Common_Worker"]</xpath>
-	<value>
-		<li Class="CombatExtended.LoadoutPropertiesExtension">
-			<primaryMagazineCount>
-				<min>3</min>
-				<max>4</max>
-			</primaryMagazineCount>
-		</li>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/PawnKindDef[defName="K4G_Legion_Common_Trader" or defName="K4G_Legion_Common_Worker"]</xpath>
+		<value>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>3</min>
+					<max>4</max>
+				</primaryMagazineCount>
+			</li>
+		</value>
+	</Operation>
 
-<!-- === Fighters === -->
+	<!-- === Fighters === -->
 
-<Operation Class="PatchOperationAddModExtension">
-	<xpath>Defs/PawnKindDef[@Name="K4GLegionMilitesBase" or @Name="K4GLegionLegionaryBase"]</xpath>
-	<value>
-		<li Class="CombatExtended.LoadoutPropertiesExtension">
-			<primaryMagazineCount>
-				<min>4</min>
-				<max>6</max>
-			</primaryMagazineCount>
-		</li>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/PawnKindDef[@Name="K4GLegionMilitesBase" or @Name="K4GLegionLegionaryBase"]</xpath>
+		<value>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>4</min>
+					<max>6</max>
+				</primaryMagazineCount>
+			</li>
+		</value>
+	</Operation>
 
-<Operation Class="PatchOperationAddModExtension">
-	<xpath>Defs/PawnKindDef[defName="K4G_Legion_Fighter_HeavyLegionnaire" or defName="K4G_Legion_Fighter_PraetorianGuardRanged"]</xpath>
-	<value>
-		<li Class="CombatExtended.LoadoutPropertiesExtension">
-			<primaryMagazineCount>
-				<min>5</min>
-				<max>7</max>
-			</primaryMagazineCount>
-		</li>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/PawnKindDef[defName="K4G_Legion_Fighter_HeavyLegionnaire" or defName="K4G_Legion_Fighter_PraetorianGuardRanged"]</xpath>
+		<value>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>5</min>
+					<max>7</max>
+				</primaryMagazineCount>
+			</li>
+		</value>
+	</Operation>
 
-<Operation Class="PatchOperationAddModExtension">
-	<xpath>Defs/PawnKindDef[defName="K4G_Legion_Fighter_Grenadier"]</xpath>
-	<value>
-		<li Class="CombatExtended.LoadoutPropertiesExtension">
-			<primaryMagazineCount>
-				<min>8</min>
-				<max>12</max>
-			</primaryMagazineCount>
-		</li>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/PawnKindDef[defName="K4G_Legion_Fighter_Grenadier"]</xpath>
+		<value>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>8</min>
+					<max>12</max>
+				</primaryMagazineCount>
+			</li>
+		</value>
+	</Operation>
+
 </Patch>

--- a/ModPatches/K4G Empires of Old - The Rising Sun/Patches/K4G Empires of Old - The Rising Sun/PawnKinds_Dynasty.xml
+++ b/ModPatches/K4G Empires of Old - The Rising Sun/Patches/K4G Empires of Old - The Rising Sun/PawnKinds_Dynasty.xml
@@ -2,53 +2,54 @@
 <Patch>
 	<!-- === Civilians === -->
 
-<Operation Class="PatchOperationAddModExtension">
-	<xpath>Defs/PawnKindDef[defName="K4G_Dynasty_Common_Trader" or defName="K4G_Dynasty_Common_Worker"]</xpath>
-	<value>
-		<li Class="CombatExtended.LoadoutPropertiesExtension">
-			<primaryMagazineCount>
-				<min>3</min>
-				<max>4</max>
-			</primaryMagazineCount>
-		</li>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/PawnKindDef[defName="K4G_Dynasty_Common_Trader" or defName="K4G_Dynasty_Common_Worker"]</xpath>
+		<value>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>3</min>
+					<max>4</max>
+				</primaryMagazineCount>
+			</li>
+		</value>
+	</Operation>
 
-<!-- === Fighters === -->
+	<!-- === Fighters === -->
 
-<Operation Class="PatchOperationAddModExtension">
-	<xpath>Defs/PawnKindDef[@Name="K4GDynastyRoninBase" or @Name="K4GDynastyAshigaruBase"]</xpath>
-	<value>
-		<li Class="CombatExtended.LoadoutPropertiesExtension">
-			<primaryMagazineCount>
-				<min>4</min>
-				<max>6</max>
-			</primaryMagazineCount>
-		</li>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/PawnKindDef[@Name="K4GDynastyRoninBase" or @Name="K4GDynastyAshigaruBase"]</xpath>
+		<value>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>4</min>
+					<max>6</max>
+				</primaryMagazineCount>
+			</li>
+		</value>
+	</Operation>
 
-<Operation Class="PatchOperationAddModExtension">
-	<xpath>Defs/PawnKindDef[defName="K4G_Dynasty_Fighter_Cataphract" or defName="K4G_Dynasty_Fighter_WarriorMonkRanged"]</xpath>
-	<value>
-		<li Class="CombatExtended.LoadoutPropertiesExtension">
-			<primaryMagazineCount>
-				<min>5</min>
-				<max>7</max>
-			</primaryMagazineCount>
-		</li>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/PawnKindDef[defName="K4G_Dynasty_Fighter_Cataphract" or defName="K4G_Dynasty_Fighter_WarriorMonkRanged"]</xpath>
+		<value>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>5</min>
+					<max>7</max>
+				</primaryMagazineCount>
+			</li>
+		</value>
+	</Operation>
 
-<Operation Class="PatchOperationAddModExtension">
-	<xpath>Defs/PawnKindDef[defName="K4G_Dynasty_Fighter_Grenadier"]</xpath>
-	<value>
-		<li Class="CombatExtended.LoadoutPropertiesExtension">
-			<primaryMagazineCount>
-				<min>8</min>
-				<max>12</max>
-			</primaryMagazineCount>
-		</li>
-	</value>
-</Operation>
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/PawnKindDef[defName="K4G_Dynasty_Fighter_Grenadier"]</xpath>
+		<value>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>8</min>
+					<max>12</max>
+				</primaryMagazineCount>
+			</li>
+		</value>
+	</Operation>
+
 </Patch>


### PR DESCRIPTION
## Additions
- Patch for [K4G] Empires of Old - The Alekeepers
  - Adds a single pawnkind with a ranged weapon that needs ammo.
  - Note: Empires of Old - Core has a patch failing. It's since added some new content, and needs some attention. That'll be its own PR when I get around to it.

## Changes
- Give the radio pack some WornBulk.
- Update [JDS] Archotech Armor to the 1.5 version that's floating around the workshop.
  - Patch the new helmet and armor added.
  - Remove some of our patches that made the armor cost less work and reduced the HP.
  - Consolidate some patches.
- Misc. whitespace housekeeping inside Empires of Old (before I realized the patches were going to need more attention and would be better in their own PR).

## References
Closes #3430

## Reasoning
- Might as well patch the Alekeepers with some ammo. No reason not to.
- Usually for backpacks, we don't worry about the WornBulk because the pack gives CarryBulk anyway, so we just handwave it. However, since the radio pack doesn't add any CarryBulk, it's appropriate that a bulk long-range radio pack should have some heft to it.
- Update the mod to the version that works for 1.5.
  - It's archotech stuff, it's _supposed_ to be fairly OP, and this is in keeping with the base mod.
- Clean things up some.

## Alternatives
- Let the pawnkind autopatcher handle the ranged weapon pawnkinds in Alekeeper.
- Could make the radio pack more of a pack and give CarryBulk if we really wanted to.
- Something different for the archotech armor balance.
- Suffer?

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
