### PR TITLE
Suppress multi for inhumanization

### DIFF
--- a/Anomaly/Patches/Hediffs/Hediffs_Misc.xml
+++ b/Anomaly/Patches/Hediffs/Hediffs_Misc.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Patch>
+
+	<!-- ========== Inhumanization ========== -->
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/HediffDef[defName="Inhumanized"]/stages/li/statFactors</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/HediffDef[defName="Inhumanized"]/stages/li</xpath>
+			<value>
+				<statFactors />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/HediffDef[defName="Inhumanized"]/stages/li/statFactors</xpath>
+		<value>
+			<Suppressability>0.5</Suppressability>
+		</value>
+	</Operation>
+
+</Patch>


### PR DESCRIPTION
## Additions

- Inhumanized hediff now also gives a 50% multiplier to suppressability.

## Reasoning

- People not caring about pain or other human concerns should probably care less about incoming fire

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
