### PR TITLE
Made 164mm demo shells actually craftable

### DIFF
--- a/Defs/Ammo/Advanced/164x284mmDemoShell.xml
+++ b/Defs/Ammo/Advanced/164x284mmDemoShell.xml
@@ -33,6 +33,7 @@
 		<stackLimit>25</stackLimit>
 		<tradeTags>
 			<li>CE_AutoEnableTrade_Sellable</li>
+			<li MayRequire="Ludeon.RimWorld.Biotech">CE_AutoEnableCrafting_FabricationBench</li>
 		</tradeTags>
 	</ThingDef>
 


### PR DESCRIPTION
## Changes

- Added the missing tradeTag that makes the ammo craftable in the fabrication bench, the ammo had the required recipe but not the tradeTag to be injected properly.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
