### PR TITLE
VRE Lycan wolfman pawnKind patch

### DIFF
--- a/ModPatches/Vanilla Races Expanded - Lycanthrope/Patches/Vanilla Races Expanded - Lycanthrope/Pawnkinds_Special.xml
+++ b/ModPatches/Vanilla Races Expanded - Lycanthrope/Patches/Vanilla Races Expanded - Lycanthrope/Pawnkinds_Special.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/PawnKindDef[defName="VRE_WolfmenPawnKindDef"]</xpath>
+		<value>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>3</min>
+					<max>5</max>
+				</primaryMagazineCount>
+				<shieldMoney>
+					<min>200</min>
+					<max>600</max>
+				</shieldMoney>
+				<shieldTags>
+					<li>OutlanderShield</li>
+				</shieldTags>
+				<shieldChance>0.8</shieldChance>
+				<sidearms>
+					<li>
+						<sidearmMoney>
+							<min>200</min>
+							<max>400</max>
+						</sidearmMoney>
+						<weaponTags>
+							<li>CE_Sidearm_Melee</li>
+						</weaponTags>
+					</li>
+				</sidearms>
+			</li>
+		</value>
+	</Operation>
+
+</Patch>


### PR DESCRIPTION
## Changes

- What it says on the tin.

## Reasoning

- The pawnKind wasn't patched, the loadout is similar to sanguophage thralls.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (works)
