### PR TITLE
Duplicate natural armor durability fix

### DIFF
--- a/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Medium.xml
+++ b/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Medium.xml
@@ -105,28 +105,6 @@
 		</nomatch>
 	</Operation>
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Mech_Legionary" or defName="Mech_Tesseron"]/comps</xpath>
-		<value>
-			<li Class="CombatExtended.CompProperties_ArmorDurability">
-				<Durability>1000</Durability>
-				<Regenerates>true</Regenerates>
-				<RegenInterval>1250</RegenInterval>
-				<RegenValue>5</RegenValue>
-				<Repairable>true</Repairable>
-				<RepairIngredients>
-					<Steel>5</Steel>
-					<Plasteel>5</Plasteel>
-				</RepairIngredients>
-				<RepairTime>300</RepairTime>
-				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>100</MaxOverHeal>
-				<MinArmorPct>0.5</MinArmorPct>
-			</li>
-		</value>
-	</Operation>
-
 	<!-- ========== Scorcher ========== -->
 
 	<Operation Class="PatchOperationAddModExtension">


### PR DESCRIPTION
## Changes

- Removed the natural armor durability patch from the Tesseron and Legionary mechs.

## Reasoning

- Both have the Lancer mech as their parent def which has the armor durability already patched in, causing a duplicate natural armor comp.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
