### PR TITLE
Modded large insectoid durability buffs

### DIFF
--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/AA_VFEI2/ThingDefs_Races/Races_BlackEmpress.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/AA_VFEI2/ThingDefs_Races/Races_BlackEmpress.xml
@@ -21,6 +21,8 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="VFEI2_BlackEmpress"]/statBases</xpath>
 					<value>
+						<IncomingDamageFactor>0.75</IncomingDamageFactor>
+						<PainShockThreshold>99</PainShockThreshold>
 						<MeleeDodgeChance>0.05</MeleeDodgeChance>
 						<MeleeCritChance>0.33</MeleeCritChance>
 						<MeleeParryChance>0.57</MeleeParryChance>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/AA_VFEI2/ThingDefs_Races/Races_BlackEmpress.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/AA_VFEI2/ThingDefs_Races/Races_BlackEmpress.xml
@@ -21,8 +21,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="VFEI2_BlackEmpress"]/statBases</xpath>
 					<value>
-						<IncomingDamageFactor>0.75</IncomingDamageFactor>
-						<PainShockThreshold>99</PainShockThreshold>
+						<PainShockThreshold>0.99</PainShockThreshold>
 						<MeleeDodgeChance>0.05</MeleeDodgeChance>
 						<MeleeCritChance>0.33</MeleeCritChance>
 						<MeleeParryChance>0.57</MeleeParryChance>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/AA_VFEI2/ThingDefs_Races/Races_BlackQueen.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/AA_VFEI2/ThingDefs_Races/Races_BlackQueen.xml
@@ -21,6 +21,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="VFEI2_BlackQueen"]/statBases</xpath>
 					<value>
+						<PainShockThreshold>99</PainShockThreshold>
 						<MeleeDodgeChance>0.03</MeleeDodgeChance>
 						<MeleeCritChance>0.30</MeleeCritChance>
 						<MeleeParryChance>0.57</MeleeParryChance>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/AA_VFEI2/ThingDefs_Races/Races_BlackQueen.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/AA_VFEI2/ThingDefs_Races/Races_BlackQueen.xml
@@ -21,7 +21,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="VFEI2_BlackQueen"]/statBases</xpath>
 					<value>
-						<PainShockThreshold>99</PainShockThreshold>
+						<PainShockThreshold>0.95</PainShockThreshold>
 						<MeleeDodgeChance>0.03</MeleeDodgeChance>
 						<MeleeCritChance>0.30</MeleeCritChance>
 						<MeleeParryChance>0.57</MeleeParryChance>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_BlackQueen.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_BlackQueen.xml
@@ -21,6 +21,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="AAVPE_BlackQueen"]/statBases</xpath>
 					<value>
+						<PainShockThreshold>99</PainShockThreshold>
 						<MeleeDodgeChance>0.03</MeleeDodgeChance>
 						<MeleeCritChance>0.30</MeleeCritChance>
 						<MeleeParryChance>0.57</MeleeParryChance>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_BlackQueen.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_BlackQueen.xml
@@ -21,7 +21,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="AAVPE_BlackQueen"]/statBases</xpath>
 					<value>
-						<PainShockThreshold>99</PainShockThreshold>
+						<PainShockThreshold>0.95</PainShockThreshold>
 						<MeleeDodgeChance>0.03</MeleeDodgeChance>
 						<MeleeCritChance>0.30</MeleeCritChance>
 						<MeleeParryChance>0.57</MeleeParryChance>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Ravager.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Ravager.xml
@@ -26,6 +26,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="AA_Ravager"]/statBases</xpath>
 		<value>
+			<PainShockThreshold>99</PainShockThreshold>
 			<MeleeDodgeChance>0.01</MeleeDodgeChance>
 			<MeleeCritChance>0.36</MeleeCritChance>
 			<MeleeParryChance>0.2</MeleeParryChance>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Ravager.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Ravager.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="AA_Ravager"]</xpath>
 		<value>
@@ -26,7 +27,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="AA_Ravager"]/statBases</xpath>
 		<value>
-			<PainShockThreshold>99</PainShockThreshold>
+			<PainShockThreshold>0.9</PainShockThreshold>
 			<MeleeDodgeChance>0.01</MeleeDodgeChance>
 			<MeleeCritChance>0.36</MeleeCritChance>
 			<MeleeParryChance>0.2</MeleeParryChance>
@@ -86,4 +87,5 @@
 			</li>
 		</value>
 	</Operation>
+
 </Patch>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Empress.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Empress.xml
@@ -14,6 +14,8 @@
 		<xpath>Defs/ThingDef[defName="VFEI2_Empress"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>2.2</MoveSpeed>
+			<IncomingDamageFactor>0.75</IncomingDamageFactor>
+			<PainShockThreshold>99</PainShockThreshold>
 			<MeleeDodgeChance>0.03</MeleeDodgeChance>
 			<MeleeCritChance>0.30</MeleeCritChance>
 			<MeleeParryChance>0.57</MeleeParryChance>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Empress.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Empress.xml
@@ -14,8 +14,7 @@
 		<xpath>Defs/ThingDef[defName="VFEI2_Empress"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>2.2</MoveSpeed>
-			<IncomingDamageFactor>0.75</IncomingDamageFactor>
-			<PainShockThreshold>99</PainShockThreshold>
+			<PainShockThreshold>0.99</PainShockThreshold>
 			<MeleeDodgeChance>0.03</MeleeDodgeChance>
 			<MeleeCritChance>0.30</MeleeCritChance>
 			<MeleeParryChance>0.57</MeleeParryChance>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Gigalocust.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Gigalocust.xml
@@ -5,6 +5,7 @@
 		<xpath>Defs/ThingDef[defName="VFEI2_Gigalocust"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>4.0</MoveSpeed>
+			<PainShockThreshold>99</PainShockThreshold>
 			<MeleeDodgeChance>0.07</MeleeDodgeChance>
 			<MeleeCritChance>0.41</MeleeCritChance>
 			<MeleeParryChance>0.19</MeleeParryChance>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Gigalocust.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Gigalocust.xml
@@ -5,7 +5,7 @@
 		<xpath>Defs/ThingDef[defName="VFEI2_Gigalocust"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>4.0</MoveSpeed>
-			<PainShockThreshold>99</PainShockThreshold>
+			<PainShockThreshold>0.9</PainShockThreshold>
 			<MeleeDodgeChance>0.07</MeleeDodgeChance>
 			<MeleeCritChance>0.41</MeleeCritChance>
 			<MeleeParryChance>0.19</MeleeParryChance>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Gigamite.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Gigamite.xml
@@ -5,6 +5,8 @@
 		<xpath>Defs/ThingDef[defName="VFEI2_Gigamite"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>2.0</MoveSpeed>
+			<IncomingDamageFactor>0.75</IncomingDamageFactor>
+			<PainShockThreshold>99</PainShockThreshold>
 			<MeleeDodgeChance>0.03</MeleeDodgeChance>
 			<MeleeCritChance>0.29</MeleeCritChance>
 			<MeleeParryChance>0.38</MeleeParryChance>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Gigamite.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Gigamite.xml
@@ -5,8 +5,7 @@
 		<xpath>Defs/ThingDef[defName="VFEI2_Gigamite"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>2.0</MoveSpeed>
-			<IncomingDamageFactor>0.75</IncomingDamageFactor>
-			<PainShockThreshold>99</PainShockThreshold>
+			<PainShockThreshold>0.99</PainShockThreshold>
 			<MeleeDodgeChance>0.03</MeleeDodgeChance>
 			<MeleeCritChance>0.29</MeleeCritChance>
 			<MeleeParryChance>0.38</MeleeParryChance>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Gigamite.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Gigamite.xml
@@ -5,7 +5,7 @@
 		<xpath>Defs/ThingDef[defName="VFEI2_Gigamite"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>2.0</MoveSpeed>
-			<PainShockThreshold>0.99</PainShockThreshold>
+			<PainShockThreshold>0.85</PainShockThreshold>
 			<MeleeDodgeChance>0.03</MeleeDodgeChance>
 			<MeleeCritChance>0.29</MeleeCritChance>
 			<MeleeParryChance>0.38</MeleeParryChance>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Ironclad.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Ironclad.xml
@@ -5,6 +5,7 @@
 		<xpath>Defs/ThingDef[defName="VFEI2_Ironclad"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>2.0</MoveSpeed>
+			<PainShockThreshold>99</PainShockThreshold>
 			<MeleeDodgeChance>0.03</MeleeDodgeChance>
 			<MeleeCritChance>0.26</MeleeCritChance>
 			<MeleeParryChance>0.38</MeleeParryChance>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Ironclad.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Ironclad.xml
@@ -5,7 +5,7 @@
 		<xpath>Defs/ThingDef[defName="VFEI2_Ironclad"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>2.0</MoveSpeed>
-			<PainShockThreshold>99</PainShockThreshold>
+			<PainShockThreshold>0.95</PainShockThreshold>
 			<MeleeDodgeChance>0.03</MeleeDodgeChance>
 			<MeleeCritChance>0.26</MeleeCritChance>
 			<MeleeParryChance>0.38</MeleeParryChance>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Megapede.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Megapede.xml
@@ -5,6 +5,7 @@
 		<xpath>Defs/ThingDef[defName="VFEI2_Megapede"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>3.3</MoveSpeed>
+			<PainShockThreshold>99</PainShockThreshold>
 			<MeleeDodgeChance>0.03</MeleeDodgeChance>
 			<MeleeCritChance>0.36</MeleeCritChance>
 			<MeleeParryChance>0.38</MeleeParryChance>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Megapede.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Megapede.xml
@@ -5,7 +5,7 @@
 		<xpath>Defs/ThingDef[defName="VFEI2_Megapede"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>3.3</MoveSpeed>
-			<PainShockThreshold>99</PainShockThreshold>
+			<PainShockThreshold>0.95</PainShockThreshold>
 			<MeleeDodgeChance>0.03</MeleeDodgeChance>
 			<MeleeCritChance>0.36</MeleeCritChance>
 			<MeleeParryChance>0.38</MeleeParryChance>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Patriarch.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Patriarch.xml
@@ -14,6 +14,8 @@
 		<xpath>Defs/ThingDef[defName="VFEI2_Patriarch"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>2.2</MoveSpeed>
+			<IncomingDamageFactor>0.66</IncomingDamageFactor>
+			<PainShockThreshold>99</PainShockThreshold>
 			<MeleeDodgeChance>0.04</MeleeDodgeChance>
 			<MeleeCritChance>0.21</MeleeCritChance>
 			<MeleeParryChance>0.48</MeleeParryChance>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Patriarch.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Patriarch.xml
@@ -14,7 +14,7 @@
 		<xpath>Defs/ThingDef[defName="VFEI2_Patriarch"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>2.2</MoveSpeed>
-			<PainShockThreshold>99</PainShockThreshold>
+			<PainShockThreshold>0.99</PainShockThreshold>
 			<MeleeDodgeChance>0.04</MeleeDodgeChance>
 			<MeleeCritChance>0.21</MeleeCritChance>
 			<MeleeParryChance>0.48</MeleeParryChance>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Patriarch.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Patriarch.xml
@@ -14,7 +14,6 @@
 		<xpath>Defs/ThingDef[defName="VFEI2_Patriarch"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>2.2</MoveSpeed>
-			<IncomingDamageFactor>0.66</IncomingDamageFactor>
 			<PainShockThreshold>99</PainShockThreshold>
 			<MeleeDodgeChance>0.04</MeleeDodgeChance>
 			<MeleeCritChance>0.21</MeleeCritChance>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Queen.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Queen.xml
@@ -14,6 +14,7 @@
 		<xpath>Defs/ThingDef[defName="VFEI2_Queen"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>2.6</MoveSpeed>
+			<PainShockThreshold>99</PainShockThreshold>
 			<MeleeDodgeChance>0.03</MeleeDodgeChance>
 			<MeleeCritChance>0.30</MeleeCritChance>
 			<MeleeParryChance>0.57</MeleeParryChance>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Queen.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Queen.xml
@@ -14,7 +14,7 @@
 		<xpath>Defs/ThingDef[defName="VFEI2_Queen"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>2.6</MoveSpeed>
-			<PainShockThreshold>99</PainShockThreshold>
+			<PainShockThreshold>0.95</PainShockThreshold>
 			<MeleeDodgeChance>0.03</MeleeDodgeChance>
 			<MeleeCritChance>0.30</MeleeCritChance>
 			<MeleeParryChance>0.57</MeleeParryChance>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_RoyalMegaspider.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_RoyalMegaspider.xml
@@ -5,6 +5,7 @@
 		<xpath>Defs/ThingDef[defName="VFEI2_RoyalMegaspider"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>3.3</MoveSpeed>
+			<PainShockThreshold>99</PainShockThreshold>
 			<MeleeDodgeChance>0.03</MeleeDodgeChance>
 			<MeleeCritChance>0.36</MeleeCritChance>
 			<MeleeParryChance>0.38</MeleeParryChance>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_RoyalMegaspider.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_RoyalMegaspider.xml
@@ -5,7 +5,7 @@
 		<xpath>Defs/ThingDef[defName="VFEI2_RoyalMegaspider"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>3.3</MoveSpeed>
-			<PainShockThreshold>99</PainShockThreshold>
+			<PainShockThreshold>0.9</PainShockThreshold>
 			<MeleeDodgeChance>0.03</MeleeDodgeChance>
 			<MeleeCritChance>0.36</MeleeCritChance>
 			<MeleeParryChance>0.38</MeleeParryChance>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Silverfish.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Silverfish.xml
@@ -5,6 +5,8 @@
 		<xpath>Defs/ThingDef[defName="VFEI2_Silverfish"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>2.1</MoveSpeed>
+			<IncomingDamageFactor>0.75</IncomingDamageFactor>
+			<PainShockThreshold>99</PainShockThreshold>
 			<MeleeDodgeChance>0.03</MeleeDodgeChance>
 			<MeleeCritChance>0.26</MeleeCritChance>
 			<MeleeParryChance>0.38</MeleeParryChance>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Silverfish.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Silverfish.xml
@@ -5,8 +5,7 @@
 		<xpath>Defs/ThingDef[defName="VFEI2_Silverfish"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>2.1</MoveSpeed>
-			<IncomingDamageFactor>0.75</IncomingDamageFactor>
-			<PainShockThreshold>99</PainShockThreshold>
+			<PainShockThreshold>0.99</PainShockThreshold>
 			<MeleeDodgeChance>0.03</MeleeDodgeChance>
 			<MeleeCritChance>0.26</MeleeCritChance>
 			<MeleeParryChance>0.38</MeleeParryChance>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Silverfish.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Silverfish.xml
@@ -5,7 +5,7 @@
 		<xpath>Defs/ThingDef[defName="VFEI2_Silverfish"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>2.1</MoveSpeed>
-			<PainShockThreshold>0.99</PainShockThreshold>
+			<PainShockThreshold>0.9</PainShockThreshold>
 			<MeleeDodgeChance>0.03</MeleeDodgeChance>
 			<MeleeCritChance>0.26</MeleeCritChance>
 			<MeleeParryChance>0.38</MeleeParryChance>
@@ -98,7 +98,7 @@
 		<xpath>Defs/ThingDef[defName="VFEI2_Silverfish"]/comps</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
-				<Durability>3750</Durability>
+				<Durability>5625</Durability> <!-- +50% durability. -->
 				<Regenerates>true</Regenerates>
 				<RegenInterval>600</RegenInterval>
 				<RegenValue>5</RegenValue>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Teramantis.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Teramantis.xml
@@ -5,6 +5,8 @@
 		<xpath>Defs/ThingDef[defName="VFEI2_Teramantis"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>4.7</MoveSpeed>
+			<IncomingDamageFactor>0.75</IncomingDamageFactor>
+			<PainShockThreshold>99</PainShockThreshold>
 			<MeleeDodgeChance>0.07</MeleeDodgeChance>
 			<MeleeCritChance>0.55</MeleeCritChance>
 			<MeleeParryChance>0.44</MeleeParryChance>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Teramantis.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Teramantis.xml
@@ -5,8 +5,7 @@
 		<xpath>Defs/ThingDef[defName="VFEI2_Teramantis"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>4.7</MoveSpeed>
-			<IncomingDamageFactor>0.75</IncomingDamageFactor>
-			<PainShockThreshold>99</PainShockThreshold>
+			<PainShockThreshold>0.99</PainShockThreshold>
 			<MeleeDodgeChance>0.07</MeleeDodgeChance>
 			<MeleeCritChance>0.55</MeleeCritChance>
 			<MeleeParryChance>0.44</MeleeParryChance>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Titantick.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Titantick.xml
@@ -5,6 +5,8 @@
 		<xpath>Defs/ThingDef[defName="VFEI2_Titantick"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>2.5</MoveSpeed>
+			<IncomingDamageFactor>0.75</IncomingDamageFactor>
+			<PainShockThreshold>99</PainShockThreshold>
 			<MeleeDodgeChance>0.09</MeleeDodgeChance>
 			<MeleeCritChance>0.41</MeleeCritChance>
 			<MeleeParryChance>0.38</MeleeParryChance>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Titantick.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Titantick.xml
@@ -5,7 +5,7 @@
 		<xpath>Defs/ThingDef[defName="VFEI2_Titantick"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>2.5</MoveSpeed>
-			<PainShockThreshold>0.99</PainShockThreshold>
+			<PainShockThreshold>0.85</PainShockThreshold>
 			<MeleeDodgeChance>0.09</MeleeDodgeChance>
 			<MeleeCritChance>0.41</MeleeCritChance>
 			<MeleeParryChance>0.38</MeleeParryChance>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Titantick.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Titantick.xml
@@ -5,8 +5,7 @@
 		<xpath>Defs/ThingDef[defName="VFEI2_Titantick"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>2.5</MoveSpeed>
-			<IncomingDamageFactor>0.75</IncomingDamageFactor>
-			<PainShockThreshold>99</PainShockThreshold>
+			<PainShockThreshold>0.99</PainShockThreshold>
 			<MeleeDodgeChance>0.09</MeleeDodgeChance>
 			<MeleeCritChance>0.41</MeleeCritChance>
 			<MeleeParryChance>0.38</MeleeParryChance>


### PR DESCRIPTION
## Changes

- Added high pain shock threshold, damage reduction and in some cases both to VFE Insectoid 2 and Alpha Animals boss insects and very large bugs.

## Reasoning

- Large bugs are falling way too quickly due to pain, damage reduction and higher pain shock threshold is going to help with that since armor can only be so high.

## Alternatives

- Even higher DR% for the boss insects?

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Been playing with the changes for a couple days, the durability buff is nice.)
