### PR TITLE
Prevent tribal penitent from being weaponless

### DIFF
--- a/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -555,7 +555,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[defName="Tribal_Penitent"]/weaponMoney</xpath>
 		<value>
-			<weaponMoney>50~150</weaponMoney>
+			<weaponMoney>52~150</weaponMoney>
 		</value>
 	</Operation>
 


### PR DESCRIPTION
## Changes

- Changed tribal pentinent's weaponMoney value from 50\~150 to 52\~150,

## Reasoning

- An unidentified weapon has a mininum cost of 51.024, which might cause tribal pentinent to be weaponless.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
