### PR TITLE
Add a hunting research dependency to throwspikes from VFE - Tribals

### DIFF
--- a/ModPatches/Vanilla Factions Expanded - Tribals/Defs/Vanilla Factions Expanded - Tribals/Recipes_Tribals.xml
+++ b/ModPatches/Vanilla Factions Expanded - Tribals/Defs/Vanilla Factions Expanded - Tribals/Recipes_Tribals.xml
@@ -23,6 +23,7 @@
 		<defName>MakeAmmo_VFET_Throwspikes</defName>
 		<label>make throwspikes x20</label>
 		<description>Craft 20 throwspikes.</description>
+    <researchPrerequisite>VFET_Hunting</researchPrerequisite>
 		<workSpeedStat>GeneralLaborSpeed</workSpeedStat>
 		<workSkill>Crafting</workSkill>
 		<recipeUsers>

--- a/ModPatches/Vanilla Factions Expanded - Tribals/Defs/Vanilla Factions Expanded - Tribals/Recipes_Tribals.xml
+++ b/ModPatches/Vanilla Factions Expanded - Tribals/Defs/Vanilla Factions Expanded - Tribals/Recipes_Tribals.xml
@@ -23,7 +23,7 @@
 		<defName>MakeAmmo_VFET_Throwspikes</defName>
 		<label>make throwspikes x20</label>
 		<description>Craft 20 throwspikes.</description>
-    <researchPrerequisite>VFET_Hunting</researchPrerequisite>
+    	<researchPrerequisite>VFET_Hunting</researchPrerequisite>
 		<workSpeedStat>GeneralLaborSpeed</workSpeedStat>
 		<workSkill>Crafting</workSkill>
 		<recipeUsers>

--- a/ModPatches/Vanilla Factions Expanded - Tribals/Defs/Vanilla Factions Expanded - Tribals/Recipes_Tribals.xml
+++ b/ModPatches/Vanilla Factions Expanded - Tribals/Defs/Vanilla Factions Expanded - Tribals/Recipes_Tribals.xml
@@ -23,7 +23,7 @@
 		<defName>MakeAmmo_VFET_Throwspikes</defName>
 		<label>make throwspikes x20</label>
 		<description>Craft 20 throwspikes.</description>
-    	<researchPrerequisite>VFET_Hunting</researchPrerequisite>
+		<researchPrerequisite>VFET_Hunting</researchPrerequisite>
 		<workSpeedStat>GeneralLaborSpeed</workSpeedStat>
 		<workSkill>Crafting</workSkill>
 		<recipeUsers>


### PR DESCRIPTION
## Changes

Throwspikes from VFE - Tribals regularly requires the hunting research to be crafted and the research even mentions this.

![image](https://github.com/user-attachments/assets/daae183f-e539-4534-8e50-bad9e912b4d0)

The combat extended patch removes the multi-use throwable and adds a new recipe to make single-use throwspikes as usual, however this recipe does not have the appropriate research requirements.

## Reasoning

Why did you choose to implement things this way, e.g.
- Consistency with the original intent of the mod.

## Alternatives

Remove the mention of throwspikes from the research project.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings (This change to the patch does not require a recompile.)
- [X] Game runs without errors
- [X] Playtested a colony (specify how long) - 10ish minutes, made sure throwspikes were craftable with the hunting research.