### PR TITLE
Prosthetic Moving stat penalty replaced with movement speed and dodge chance

### DIFF
--- a/Patches/Core/HediffDefs/Hediffs_Local_AddedParts.xml
+++ b/Patches/Core/HediffDefs/Hediffs_Local_AddedParts.xml
@@ -57,6 +57,16 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/HediffDef[defName="PowerClaw"]/stages/li/capMods</xpath>
+		<value>
+			<statOffsets>
+				<MoveSpeed>-0.35</MoveSpeed>
+				<MeleeDodgeChance>-0.03</MeleeDodgeChance>
+			</statOffsets>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="PowerClaw"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
 		<value>
 			<tools>

--- a/Patches/Core/HediffDefs/Hediffs_Local_AddedParts.xml
+++ b/Patches/Core/HediffDefs/Hediffs_Local_AddedParts.xml
@@ -60,7 +60,7 @@
 		<xpath>Defs/HediffDef[defName="PowerClaw"]/stages/li/capMods</xpath>
 		<value>
 			<statOffsets>
-				<MoveSpeed>-0.35</MoveSpeed>
+				<MoveSpeed>-0.37</MoveSpeed>
 				<MeleeDodgeChance>-0.03</MeleeDodgeChance>
 			</statOffsets>
 		</value>

--- a/Royalty/Patches/HeDiffDefs/Hediffs_Implants.xml
+++ b/Royalty/Patches/HeDiffDefs/Hediffs_Implants.xml
@@ -3,6 +3,18 @@
 
 	<!-- Prosthetics -->
 
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/HediffDef[defName="DrillArm"]/stages/li/statOffsets</xpath>
+		<value>
+			<MoveSpeed>-0.35</MoveSpeed>
+			<MeleeDodgeChance>-0.03</MeleeDodgeChance>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/HediffDef[defName="DrillArm"]/stages/li/capMods</xpath>
+	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="DrillArm"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
 		<value>
@@ -22,6 +34,18 @@
 				</li>
 			</tools>
 		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/HediffDef[defName="FieldHand"]/stages/li/statOffsets</xpath>
+		<value>
+			<MoveSpeed>-0.35</MoveSpeed>
+			<MeleeDodgeChance>-0.03</MeleeDodgeChance>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/HediffDef[defName="FieldHand"]/stages/li/capMods</xpath>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">

--- a/Royalty/Patches/HeDiffDefs/Hediffs_Implants.xml
+++ b/Royalty/Patches/HeDiffDefs/Hediffs_Implants.xml
@@ -6,7 +6,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/HediffDef[defName="DrillArm"]/stages/li/statOffsets</xpath>
 		<value>
-			<MoveSpeed>-0.35</MoveSpeed>
+			<MoveSpeed>-0.37</MoveSpeed>
 			<MeleeDodgeChance>-0.03</MeleeDodgeChance>
 		</value>
 	</Operation>
@@ -39,7 +39,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/HediffDef[defName="FieldHand"]/stages/li/statOffsets</xpath>
 		<value>
-			<MoveSpeed>-0.35</MoveSpeed>
+			<MoveSpeed>-0.37</MoveSpeed>
 			<MeleeDodgeChance>-0.03</MeleeDodgeChance>
 		</value>
 	</Operation>


### PR DESCRIPTION
## Changes

- What it says on the tin.

## Reasoning

- Same exact treatment that armor glands received, the Moving stat is responsible in inventory capacities in CE which a hand/arm prosthetic impacting it doesn't make sense, a movement speed coupled with dodge chance penalty instead makes the most sense.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
