### PR TITLE
change Rand.Chance to Rand.ChanceSeeded for Multiplayer

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -958,7 +958,7 @@ namespace CombatExtended
                 {
                     MoteMakerCE.ThrowText(thing.Position.ToVector3Shifted(), thing.Map, chance.ToString());
                 }
-                if (!Rand.Chance(chance))
+                if (!Rand.ChanceSeeded(chance,thing.HashOffsetTicks()))
                 {
                     return false;
                 }

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -958,7 +958,7 @@ namespace CombatExtended
                 {
                     MoteMakerCE.ThrowText(thing.Position.ToVector3Shifted(), thing.Map, chance.ToString());
                 }
-                if (!Rand.ChanceSeeded(chance,thing.HashOffsetTicks()))
+                if (!Rand.ChanceSeeded(chance, thing.HashOffsetTicks()))
                 {
                     return false;
                 }


### PR DESCRIPTION
I made a small change in projectile collision calculation to use seeded randomness in order to avoid desyncing when shooting through plants/trees.

Currently ChanceSeeded is using the thing.HashOffsetTicks() as seed, not sure if ideal but seems to work with no obvious issues

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Changed Rand.Chance() to use Rand.ChanceSeeded() within TryCollideWith() while calculating collisions for plants/trees.

## Reasoning

I did some searching within the Multiplayer RW discord server about similar randomness issues, to which I found advice from a development team member of the Multiplayer mod that recommended using ChanceSeeded over Chance, with the seed being thing.HashOffsetTicks.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
