### PR TITLE
Add null-check to loadout updates

### DIFF
--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_UpdateLoadout.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_UpdateLoadout.cs
@@ -282,7 +282,7 @@ namespace CombatExtended
         {
             if (thing != null && thing.def.IsNutritionGivingIngestible)
             {
-                return pawn.foodRestriction.GetCurrentRespectedRestriction(pawn).Allows(thing);
+                return pawn.foodRestriction.GetCurrentRespectedRestriction(pawn)?.Allows(thing) ?? true; //better to ignore food restrictions than never pick up a meal
             }
             else
             {


### PR DESCRIPTION
## Changes

- Added a null check to food policy in loadout updates, with true as a fallback

## References

- Related bug report: https://discordapp.com/channels/278818534069501953/324222101550661663/1296770969045700669
- Conflict with Pawn Rules

## Reasoning

- If a pawn ends up with no food policy it's better to accept any meal than not pick up any

## Alternatives

- Set it to false
- Do a more extensive compat with Pawn Rules

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
