### PR TITLE
Fix initially dormant mech ammo beacons

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoResupplyOnWakeup.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoResupplyOnWakeup.cs
@@ -45,7 +45,7 @@ namespace CombatExtended
                     return false;
                 }
 
-                if (parent.TryGetComp<CompCanBeDormant>()?.Awake ?? false)
+                if (!(parent.TryGetComp<CompCanBeDormant>()?.Awake ?? true))
                 {
                     return false;
                 }


### PR DESCRIPTION
## Changes

65ff9683efa00fa36d68ec6e11e523c44ff3d998 mistakenly turned off mech ammo beacons for clusters that start off dormant. Fix the logic so that beacons in such clusters correctly drop ammo once the cluster is awake and other conditions are met.


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony -- verified that the local mech cluster that started off dormant now receives ammo once its turrets have been exhausted
