### PR TITLE
Buff Flak cannon protection

### DIFF
--- a/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
@@ -400,7 +400,7 @@
 		<uiIconPath>UI/Icons/Turrets/FlakTurret_uiIcon</uiIconPath>
 		<fillPercent>1</fillPercent>
 		<statBases>
-			<MaxHitPoints>1000</MaxHitPoints>
+			<MaxHitPoints>500</MaxHitPoints>
 			<Flammability>0.4</Flammability>
 			<WorkToBuild>45000</WorkToBuild>
 			<Mass>1000</Mass>
@@ -438,6 +438,20 @@
 			<li>CE_TurretHeavyWeapons</li>
 		</researchPrerequisites>
 		<designationCategory>Security</designationCategory>
+		<damageMultipliers>
+			<li>
+				<damageDef>Bomb</damageDef>
+				<multiplier>0.66</multiplier>
+			</li>
+			<li>
+				<damageDef>Bomb_Secondary</damageDef>
+				<multiplier>0.66</multiplier>
+			</li>
+			<li>
+				<damageDef>Bullet</damageDef>
+				<multiplier>0.66</multiplier>
+			</li>
+		</damageMultipliers>		
 	</ThingDef>
 
 </Defs>

--- a/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
@@ -398,8 +398,9 @@
 			</shadowData>
 		</graphicData>
 		<uiIconPath>UI/Icons/Turrets/FlakTurret_uiIcon</uiIconPath>
+		<fillPercent>1</fillPercent>
 		<statBases>
-			<MaxHitPoints>500</MaxHitPoints>
+			<MaxHitPoints>1000</MaxHitPoints>
 			<Flammability>0.4</Flammability>
 			<WorkToBuild>45000</WorkToBuild>
 			<Mass>1000</Mass>


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased turret HP to 1000
- Increased cover height to 3.5m

## Reasoning

Why did you choose to implement things this way, e.g.
- 90mm flak is a really weak turret for the resource investment. The only advantage over handheld launchers it has is double the range, while having twice as long aiming time and twice as long reloading time. And you can't move it, so it gets shot up by a centipede pretty quick. And it has 5x the steel cost, compared to a Carl Gustav, while having only 500 HP (like a granite wall), so 30 rounds of 7.62 APHE is enough to completely destroy it. 
- These changes would give it an advantage over handheld AT launchers in form of being much less risky to use.
- [Discord discussion link](https://discord.com/channels/278818534069501953/700236703180259358/1299429501759131692)

## Alternatives

Describe alternative implementations you have considered, e.g.
- Replace it with a 120mm howitzer than can do both direct and indirect fire with the use of underbarrel system.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
