### PR TITLE
Disregard burning ammunition when reloading turrets

### DIFF
--- a/Source/CombatExtended/CombatExtended/Jobs/Utils/JobGiverUtils_Reload.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/Utils/JobGiverUtils_Reload.cs
@@ -217,6 +217,11 @@ namespace CombatExtended.CombatExtended.Jobs.Utils
                     return false;
                 }
 
+                if (potentialAmmo.IsBurning())
+                {
+                    return false;
+                }
+
                 if (potentialAmmo.IsForbidden(pawn) || !pawn.CanReserve(potentialAmmo))
                 {
                     return false;


### PR DESCRIPTION


## Changes
Ignore burning ammo in JobGiverUtils_Reload, to match the corresponding jobdriver.

## Reasoning
The reload jobgiver ignores ammo that is burning, but the jobgiver does not. Because of this, if the best available ammo for a turret is on fire, it'll cause pawns to spam jobs ("X started 10 jobs in one tick"). 


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (with a mech cluster that had burning mech ammo laying around it)
