### PR TITLE
Ion weaponry patch

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -233,6 +233,7 @@
 		<li IfModActive="jemlpro.Infusion2Expansion">ModPatches/Infused 2 Expansion</li>
 		<li IfModActive="latta.infusion">ModPatches/Infusion 2</li>
 		<li IfModActive="SirMashedPotato.InsectsHaveChitin">ModPatches/Insects have chitin</li>
+		<li IfModActive="EL.IonWeaponry">ModPatches/Ion Weaponry</li>
 		<li IfModActive="JangoDsoul.CastleWalls,gideon.castlewalls">ModPatches/JDS Castle Walls</li>
 		<li IfModActive="JangoDsoul.EFT.Apparel">ModPatches/JDS EFT Apparel</li>
 		<li IfModActive="JangoDsoul.ExiledDawn">ModPatches/JDS Exiled Dawn</li>

--- a/ModPatches/Ion Weaponry/Defs/Ion Weaponry/Ammo.xml
+++ b/ModPatches/Ion Weaponry/Defs/Ion Weaponry/Ammo.xml
@@ -38,7 +38,7 @@
 		<defName>AmmoSet_8mmRailgunIon_Lance</defName>
 		<label>12mm Railgun Ion(lance)</label>
 		<ammoTypes>
-			<Ammo_12mmRailgun_Ion>Bullet_8mmRailgun_Ion_Lance</Ammo_12mmRailgun_Ion>
+			<Ammo_12mmRailgun_Ion>Bullet_12mmRailgun_Ion_Lance</Ammo_12mmRailgun_Ion>
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
 
@@ -46,7 +46,7 @@
 		<defName>AmmoSet_8mmRailgunIon_Blast</defName>
 		<label>Ion Blast</label>
 		<ammoTypes>
-			<Ammo_12mmRailgun_Ion>Bullet_8mmRailgun_Ion_Blast</Ammo_12mmRailgun_Ion>
+			<Ammo_12mmRailgun_Ion>Bullet_12mmRailgun_Ion_Blast</Ammo_12mmRailgun_Ion>
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
 

--- a/ModPatches/Ion Weaponry/Defs/Ion Weaponry/Ammo.xml
+++ b/ModPatches/Ion Weaponry/Defs/Ion Weaponry/Ammo.xml
@@ -35,15 +35,17 @@
 	</CombatExtended.AmmoSetDef>
 
 	<CombatExtended.AmmoSetDef>
-		<defName>AmmoSet_8mmRailgunIon_Lance</defName>
+		<defName>AmmoSet_12mmRailgunIon_Lance</defName>
 		<label>12mm Railgun Ion(lance)</label>
 		<ammoTypes>
 			<Ammo_12mmRailgun_Ion>Bullet_12mmRailgun_Ion_Lance</Ammo_12mmRailgun_Ion>
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
 
+	<!-- ==== incase the ability patch broke==== -->
+	
 	<CombatExtended.AmmoSetDef>
-		<defName>AmmoSet_8mmRailgunIon_Blast</defName>
+		<defName>AmmoSet_12mmRailgunIon_Blast</defName>
 		<label>Ion Blast</label>
 		<ammoTypes>
 			<Ammo_12mmRailgun_Ion>Bullet_12mmRailgun_Ion_Blast</Ammo_12mmRailgun_Ion>
@@ -227,6 +229,7 @@
 			<texPath>Projectile/IW_IonBulletHeavy</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 			<shaderType>TransparentPostLight</shaderType>
+			<drawSize>1.3</drawSize>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>

--- a/ModPatches/Ion Weaponry/Defs/Ion Weaponry/Ammo.xml
+++ b/ModPatches/Ion Weaponry/Defs/Ion Weaponry/Ammo.xml
@@ -1,0 +1,451 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Defs>
+
+	<ThingCategoryDef>
+		<defName>AmmoRailgun_ION</defName>
+		<label>Railgun ammo (Ion)</label>
+		<parent>AmmoAdvanced</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberRailgunPistol</iconPath>
+	</ThingCategoryDef>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_4mmRailgunIon</defName>
+		<label>4mm Railgun Ion</label>
+		<ammoTypes>
+			<Ammo_4mmRailgun_Ion>Bullet_4mmRailgun_Ion</Ammo_4mmRailgun_Ion>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_6mmRailgunIon</defName>
+		<label>6mm Railgun</label>
+		<ammoTypes>
+			<Ammo_6mmRailgun_Ion>Bullet_6mmRailgun_Ion</Ammo_6mmRailgun_Ion>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_8mmRailgunIon</defName>
+		<label>8mm Railgun Ion</label>
+		<ammoTypes>
+			<Ammo_8mmRailgun_Ion>Bullet_8mmRailgun_Ion</Ammo_8mmRailgun_Ion>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_8mmRailgunIon_Lance</defName>
+		<label>12mm Railgun Ion(lance)</label>
+		<ammoTypes>
+			<Ammo_12mmRailgun_Ion>Bullet_8mmRailgun_Ion_Lance</Ammo_12mmRailgun_Ion>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_8mmRailgunIon_Blast</defName>
+		<label>Ion Blast</label>
+		<ammoTypes>
+			<Ammo_12mmRailgun_Ion>Bullet_8mmRailgun_Ion_Blast</Ammo_12mmRailgun_Ion>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="SpacerSmallAmmoBase">
+		<defName>Ammo_4mmRailgun_Ion</defName>
+		<label>4mm Railgun cartridge (Discharge)</label>
+		<description>Fin-stabilized tungsten carbide penetrator with discarding sabot, designed for railgun rifles. Features an ionized particle payload.</description>
+		<statBases>
+			<Mass>0.006</Mass>
+			<Bulk>0.008</Bulk>
+			<MarketValue>0.06</MarketValue>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting_FabricationBench</li>
+		</tradeTags>
+		<thingCategories>
+			<li>AmmoRailgun_ION</li>
+		</thingCategories>
+		<graphicData>
+			<texPath>ThirdParty/VanillaXCOM/Railgun/EMP/Pistol</texPath>
+			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+		</graphicData>
+		<ammoClass>Ionized</ammoClass>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="SpacerAmmoBase">
+		<defName>Ammo_6mmRailgun_Ion</defName>
+		<label>6mm Railgun cartridge (Discharge)</label>
+		<description>Fin-stabilized tungsten carbide penetrator with discarding sabot, designed for railgun rifles. Features an ionized particle payload.</description>
+		<statBases>
+			<Mass>0.008</Mass>
+			<Bulk>0.008</Bulk>
+			<MarketValue>0.08</MarketValue>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting_FabricationBench</li>
+		</tradeTags>
+		<thingCategories>
+			<li>AmmoRailgun_ION</li>
+		</thingCategories>
+		<graphicData>
+			<texPath>ThirdParty/VanillaXCOM/Railgun/EMP/Rifle</texPath>
+			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+		</graphicData>
+		<ammoClass>Ionized</ammoClass>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="SpacerAmmoBase">
+		<defName>Ammo_8mmRailgun_Ion</defName>
+		<label>8mm Railgun cartridge (Discharge)</label>
+		<description>Fin-stabilized tungsten carbide penetrator with discarding sabot, designed for railgun pistols. Features an ionized particle payload.</description>
+		<statBases>
+			<Mass>0.01</Mass>
+			<Bulk>0.01</Bulk>
+			<MarketValue>0.10</MarketValue>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting_FabricationBench</li>
+		</tradeTags>
+		<thingCategories>
+			<li>AmmoRailgun_ION</li>
+		</thingCategories>
+		<graphicData>
+			<texPath>ThirdParty/VanillaXCOM/Railgun/EMP/Rifle</texPath>
+			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+		</graphicData>
+		<ammoClass>Ionized</ammoClass>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="SpacerAmmoBase">
+		<defName>Ammo_12mmRailgun_Ion</defName>
+		<label>12mm Railgun cartridge (Discharge)</label>
+		<description>Fin-stabilized tungsten carbide penetrator with discarding sabot, designed for railgun pistols. Features an ionized particle payload.</description>
+		<statBases>
+			<Mass>0.012</Mass>
+			<Bulk>0.01</Bulk>
+			<MarketValue>0.12</MarketValue>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting_FabricationBench</li>
+		</tradeTags>
+		<thingCategories>
+			<li>AmmoRailgun_ION</li>
+		</thingCategories>
+		<graphicData>
+			<texPath>ThirdParty/VanillaXCOM/Railgun/EMP/HighCaliber</texPath>
+			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+		</graphicData>
+		<ammoClass>Ionized</ammoClass>
+	</ThingDef>
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef ParentName="BaseBulletCE">
+		<defName>Bullet_4mmRailgun_Ion</defName>
+		<label>4mm Railgun bullet (Discharge)</label>
+		<graphicData>
+			<texPath>Projectile/IW_IonBullet</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<shaderType>TransparentPostLight</shaderType>
+			<drawSize>0.6</drawSize>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<damageAmountBase>10</damageAmountBase>
+			<armorPenetrationSharp>8.4</armorPenetrationSharp>
+			<armorPenetrationBlunt>88.73</armorPenetrationBlunt>
+			<speed>250</speed>
+			<dropsCasings>false</dropsCasings>
+			<secondaryDamage>
+				<li>
+					<def>IW_IonBullet</def>
+					<amount>10</amount>
+				</li>
+			</secondaryDamage>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="BaseBulletCE">
+		<defName>Bullet_6mmRailgun_Ion</defName>
+		<label>6mm Railgun bullet (Discharge)</label>
+		<graphicData>
+			<texPath>Projectile/IW_IonBullet</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<shaderType>TransparentPostLight</shaderType>
+			<drawSize>1.1</drawSize>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<damageAmountBase>5.5</damageAmountBase>
+			<armorPenetrationSharp>22</armorPenetrationSharp>
+			<armorPenetrationBlunt>126.36</armorPenetrationBlunt>
+			<speed>300</speed>
+			<dropsCasings>false</dropsCasings>
+			<secondaryDamage>
+				<li>
+					<def>IW_IonBullet</def>
+					<amount>14</amount>
+				</li>
+			</secondaryDamage>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="BaseBulletCE">
+		<defName>Bullet_8mmRailgun_Ion</defName>
+		<label>8mm Railgun bullet (Discharge)</label>
+		<graphicData>
+			<texPath>Projectile/IW_IonBulletHeavy</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<shaderType>TransparentPostLight</shaderType>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<damageAmountBase>6</damageAmountBase>
+			<armorPenetrationSharp>37.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>145.4</armorPenetrationBlunt>
+			<speed>360</speed>
+			<dropsCasings>false</dropsCasings>
+			<secondaryDamage>
+				<li>
+					<def>IW_IonBullet</def>
+					<amount>20</amount>
+				</li>
+			</secondaryDamage>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="BaseBulletCE">
+		<defName>Bullet_12mmRailgun_Ion_Lance</defName>
+		<label>12mm Railgun bullet (Discharge)</label>
+		<graphicData>
+			<texPath>Projectile/IW_IonBulletHeavy</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<shaderType>TransparentPostLight</shaderType>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<damageAmountBase>10</damageAmountBase>
+			<armorPenetrationSharp>55</armorPenetrationSharp>
+			<armorPenetrationBlunt>252.720</armorPenetrationBlunt>
+			<speed>380</speed>
+			<dropsCasings>false</dropsCasings>
+			<secondaryDamage>
+				<li>
+					<def>IW_IonBullet</def>
+					<amount>20</amount>
+				</li>
+			</secondaryDamage>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="BaseExplosiveBullet">
+		<defName>Bullet_12mmRailgun_Ion_Blast</defName>
+		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+		<label>Ion Blast</label>
+		<graphicData>
+			<texPath>Projectile/IW_IonBlast</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<shaderType>TransparentPostLight</shaderType>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<flyOverhead>false</flyOverhead>
+			<dropsCasings>false</dropsCasings>
+			<damageDef>EMP</damageDef>
+			<damageAmountBase>40</damageAmountBase>
+			<explosionRadius>4.9</explosionRadius>
+			<speed>120</speed>
+			<secondaryDamage>
+				<li>
+					<def>IW_IonBullet</def>
+					<amount>20</amount>
+				</li>
+			</secondaryDamage>
+			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+		</projectile>
+	</ThingDef>
+
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_4mmRailgun_Ion</defName>
+		<label>make 4mm Railgun cartridge (Discharge) x500</label>
+		<description>Craft 500 4mm Railgun (Discharge) cartridges.</description>
+		<jobString>Making 4mm Railgun (Discharge) cartridges.</jobString>
+		<workAmount>3000</workAmount>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>1</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Uranium</li>
+					</thingDefs>
+				</filter>
+				<count>2</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>2</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Uranium</li>
+				<li>ComponentIndustrial</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_4mmRailgun_Ion>500</Ammo_4mmRailgun_Ion>
+		</products>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_6mmRailgun_Ion</defName>
+		<label>make 6mm Railgun cartridge (Discharge) x500</label>
+		<description>Craft 500 6mm Railgun (IDischarge) cartridges.</description>
+		<jobString>Making 6mm Railgun (Discharge) cartridges.</jobString>
+		<workAmount>3000</workAmount>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>2</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Uranium</li>
+					</thingDefs>
+				</filter>
+				<count>4</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>4</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>ComponentIndustrial</li>
+				<li>Steel</li>
+				<li>Uranium</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_6mmRailgun_Ion>500</Ammo_6mmRailgun_Ion>
+		</products>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_8mmRailgun_Ion</defName>
+		<label>make 8mm Railgun cartridge (Discharge) x500</label>
+		<description>Craft 500 8mm Railgun (Discharge) cartridges.</description>
+		<jobString>Making 8mm Railgun (Discharge) cartridges.</jobString>
+		<workAmount>3000</workAmount>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>2</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Uranium</li>
+					</thingDefs>
+				</filter>
+				<count>4</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>4</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>ComponentIndustrial</li>
+				<li>Steel</li>
+				<li>Uranium</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_8mmRailgun_Ion>500</Ammo_8mmRailgun_Ion>
+		</products>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_12mmRailgun_Ion</defName>
+		<label>make 12mm Railgun cartridge (Discharge) x200</label>
+		<description>Craft 200 12mm Railgun (Discharge) cartridges.</description>
+		<jobString>Making 12mm Railgun (Discharge) cartridges.</jobString>
+		<workAmount>3500</workAmount>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>2</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Uranium</li>
+					</thingDefs>
+				</filter>
+				<count>10</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>5</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>ComponentIndustrial</li>
+				<li>Steel</li>
+				<li>Uranium</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_12mmRailgun_Ion>200</Ammo_12mmRailgun_Ion>
+		</products>
+	</RecipeDef>
+
+</Defs>

--- a/ModPatches/Ion Weaponry/Patches/Ion Weaponry/Damages.xml
+++ b/ModPatches/Ion Weaponry/Patches/Ion Weaponry/Damages.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/DamageDef[defName="IW_IonBullet"]</xpath>
+		<value>
+			<li Class="CombatExtended.DamageDefExtensionCE">
+				<isAmbientDamage>true</isAmbientDamage>
+			</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/DamageDef[defName="IW_IonBullet"]</xpath>
+		<value>
+			<armorCategory>Electric</armorCategory>
+			<defaultArmorPenetration>0.50</defaultArmorPenetration>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/HediffDef[defName="IW_Ionization"]/comps/li[@Class="AthenaFramework.HediffCompProperties_Bomb"]/damageAmount</xpath>
+		<value>
+			<damageAmount>30</damageAmount>
+		</value>
+	</Operation>
+</Patch>

--- a/ModPatches/Ion Weaponry/Patches/Ion Weaponry/Damages.xml
+++ b/ModPatches/Ion Weaponry/Patches/Ion Weaponry/Damages.xml
@@ -12,8 +12,10 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/DamageDef[defName="IW_IonBullet"]</xpath>
 		<value>
+			<label>Ion Discharge</label>
 			<armorCategory>Electric</armorCategory>
 			<defaultArmorPenetration>0.50</defaultArmorPenetration>
+			<combatLogRules>Damage_EMP</combatLogRules>
 		</value>
 	</Operation>
 

--- a/ModPatches/Ion Weaponry/Patches/Ion Weaponry/RangedSpacer.xml
+++ b/ModPatches/Ion Weaponry/Patches/Ion Weaponry/RangedSpacer.xml
@@ -76,7 +76,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="IW_Gun_IonLMG"]/tools</xpath>
+		<xpath>Defs/ThingDef[defName="IW_Gun_IonLMG" or defName="IW_Gun_HeavyIonLance"]/tools</xpath>
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
@@ -369,6 +369,20 @@
 			<li>SpacerGun</li>
 			<li>Bipod_DMR</li>
 		</weaponTags>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName = "IW_Gun_HeavyIonLance"]/comps/li[@Class="CompProperties_EquippableAbilityReloadable"]/ammoDef</xpath>
+		<value>
+			<ammoDef>Ammo_12mmRailgun_Ion</ammoDef>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName = "IW_Gun_HeavyIonLance"]/comps/li[@Class="CompProperties_EquippableAbilityReloadable"]/ammoCountPerCharge</xpath>
+		<value>
+			<ammoCountPerCharge>50</ammoCountPerCharge>
+		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">

--- a/ModPatches/Ion Weaponry/Patches/Ion Weaponry/RangedSpacer.xml
+++ b/ModPatches/Ion Weaponry/Patches/Ion Weaponry/RangedSpacer.xml
@@ -349,7 +349,7 @@
 			<recoilAmount>3</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>True</hasStandardCommand>
-			<defaultProjectile>Bullet_8mmRailgun_Ion_Lance</defaultProjectile>
+			<defaultProjectile>Bullet_12mmRailgun_Ion_Lance</defaultProjectile>
 			<warmupTime>1.8</warmupTime>
 			<range>70</range>
 			<soundCast>IW_Shot_HeavyIonLance</soundCast>
@@ -360,7 +360,7 @@
 		<AmmoUser>
 			<magazineSize>10</magazineSize>
 			<reloadTime>8</reloadTime>
-			<ammoSet>AmmoSet_8mmRailgunIon_Lance</ammoSet>
+			<ammoSet>AmmoSet_12mmRailgunIon_Lance</ammoSet>
 		</AmmoUser>
 		<FireModes>
 			<aiAimMode>AimedShot</aiAimMode>

--- a/ModPatches/Ion Weaponry/Patches/Ion Weaponry/RangedSpacer.xml
+++ b/ModPatches/Ion Weaponry/Patches/Ion Weaponry/RangedSpacer.xml
@@ -1,0 +1,398 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<!-- === Compared to conventional weapons, ion weapons have longer warmups, but higher rates of fire, large magazines and high EMP damage. === -->
+
+	<!-- === Tools === -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName ="IW_Gun_IonPistol" or defName ="IW_Gun_IonPDW"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>grip</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>2</power>
+					<cooldownTime>1.54</cooldownTime>
+					<chanceFactor>1.5</chanceFactor>
+					<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>muzzle</label>
+					<capacities>
+						<li>Poke</li>
+					</capacities>
+					<power>2</power>
+					<cooldownTime>1.54</cooldownTime>
+					<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[
+			defName = "IW_Gun_IonRifle" or
+			defName = "IW_Gun_IonSlugthrower" or
+			defName = "IW_Gun_IonDMR"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>stock</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>8</power>
+					<cooldownTime>1.55</cooldownTime>
+					<chanceFactor>1.5</chanceFactor>
+					<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>barrel</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>5</power>
+					<cooldownTime>2.02</cooldownTime>
+					<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>muzzle</label>
+					<capacities>
+						<li>Poke</li>
+					</capacities>
+					<power>8</power>
+					<cooldownTime>1.55</cooldownTime>
+					<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="IW_Gun_IonLMG"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>barrel</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>10</power>
+					<cooldownTime>2.44</cooldownTime>
+					<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<!-- === Ion Pistol === -->
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>IW_Gun_IonPistol</defName>
+		<statBases>
+			<Mass>1.20</Mass>
+			<Bulk>2.25</Bulk>
+			<SwayFactor>0.90</SwayFactor>
+			<ShotSpread>0.17</ShotSpread>
+			<SightsEfficiency>0.8</SightsEfficiency>
+			<RangedWeapon_Cooldown>0.51</RangedWeapon_Cooldown>
+		</statBases>
+		<Properties>
+			<recoilAmount>2</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>True</hasStandardCommand>
+			<defaultProjectile>Bullet_4mmRailgun_Ion</defaultProjectile>
+			<warmupTime>0.6</warmupTime>
+			<range>20</range>
+			<soundCast>IW_Shot_IonPistol</soundCast>
+			<soundCastTail>GunTail_Light</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>10</magazineSize>
+			<reloadTime>4</reloadTime>
+			<ammoSet>AmmoSet_4mmRailgunIon</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aiAimMode>AimedShot</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>SpacerGun</li>
+			<li>CE_OneHandedWeapon</li>
+		</weaponTags>
+	</Operation>
+
+	<!-- === Ion PDW === -->
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>IW_Gun_IonPDW</defName>
+		<statBases>
+			<Mass>3</Mass>
+			<Bulk>4</Bulk>
+			<SwayFactor>1.2</SwayFactor>
+			<ShotSpread>0.2</ShotSpread>
+			<SightsEfficiency>0.8</SightsEfficiency>
+			<RangedWeapon_Cooldown>0.51</RangedWeapon_Cooldown>
+		</statBases>
+		<Properties>
+			<recoilAmount>4.0</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>True</hasStandardCommand>
+			<defaultProjectile>Bullet_4mmRailgun_Ion</defaultProjectile>
+			<warmupTime>0.6</warmupTime>
+			<burstShotCount>5</burstShotCount>
+			<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+			<range>15</range>
+			<soundCast>IW_Shot_IonPDW</soundCast>
+			<soundCastTail>GunTail_Light</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>30</magazineSize>
+			<reloadTime>4</reloadTime>
+			<ammoSet>AmmoSet_4mmRailgunIon</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aimedBurstShotCount>3</aimedBurstShotCount>
+			<aiAimMode>Snapshot</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>SpacerGun</li>
+			<li>CE_OneHandedWeapon</li>
+		</weaponTags>
+	</Operation>
+
+
+	<!-- === Ion Rifle === -->
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>IW_Gun_IonRifle</defName>
+		<statBases>
+			<Mass>5</Mass>
+			<Bulk>8</Bulk>
+			<SwayFactor>1.25</SwayFactor>
+			<ShotSpread>0.07</ShotSpread>
+			<SightsEfficiency>1.10</SightsEfficiency>
+			<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
+		</statBases>
+		<Properties>
+			<recoilAmount>3</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>True</hasStandardCommand>
+			<defaultProjectile>Bullet_6mmRailgun_Ion</defaultProjectile>
+			<warmupTime>1.1</warmupTime>
+			<range>50</range>
+			<burstShotCount>5</burstShotCount>
+			<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+			<soundCast>IW_Shot_IonRifle</soundCast>
+			<soundCastTail>GunTail_Medium</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>40</magazineSize>
+			<reloadTime>4</reloadTime>
+			<ammoSet>AmmoSet_6mmRailgunIon</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aiAimMode>AimedShot</aiAimMode>
+			<aiUseBurstMode>True</aiUseBurstMode>
+			<aimedBurstShotCount>3</aimedBurstShotCount>
+		</FireModes>
+		<weaponTags>
+			<li>SpacerGun</li>
+			<li>CE_AI_Rifle</li>
+		</weaponTags>
+	</Operation>
+
+	<!-- === Ion DMR === -->
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>IW_Gun_IonDMR</defName>
+		<statBases>
+			<Mass>6</Mass>
+			<Bulk>9.15</Bulk>
+			<SwayFactor>1.20</SwayFactor>
+			<ShotSpread>0.03</ShotSpread>
+			<SightsEfficiency>2.0</SightsEfficiency>
+			<RangedWeapon_Cooldown>0.82</RangedWeapon_Cooldown>
+			<NightVisionEfficiency_Weapon>0.6</NightVisionEfficiency_Weapon>
+		</statBases>
+		<Properties>
+			<recoilAmount>4</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>True</hasStandardCommand>
+			<defaultProjectile>Bullet_8mmRailgun_Ion</defaultProjectile>
+			<warmupTime>1.8</warmupTime>
+			<range>86</range>
+			<soundCast>IW_Shot_IonRifle</soundCast>
+			<soundCastTail>GunTail_Medium</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>5</magazineSize>
+			<reloadTime>3</reloadTime>
+			<ammoSet>AmmoSet_8mmRailgunIon</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aiAimMode>AimedShot</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>SpacerGun</li>
+			<li>CE_AI_SR</li>
+			<li>Bipod_DMR</li>
+		</weaponTags>
+	</Operation>
+
+	<!-- === Ion Slugthrower === -->
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>IW_Gun_IonSlugthrower</defName>
+		<statBases>
+			<Mass>5</Mass>
+			<Bulk>12</Bulk>
+			<SwayFactor>1.30</SwayFactor>
+			<ShotSpread>0.07</ShotSpread>
+			<SightsEfficiency>1.0</SightsEfficiency>
+			<RangedWeapon_Cooldown>0.98</RangedWeapon_Cooldown>
+		</statBases>
+		<Properties>
+			<recoilAmount>3.01</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>True</hasStandardCommand>
+			<defaultProjectile>Bullet_8mmRailgun_Ion</defaultProjectile>
+			<warmupTime>0.6</warmupTime>
+			<range>40</range>
+			<soundCast>IW_Shot_IonRifle</soundCast>
+			<soundCastTail>GunTail_Medium</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>8</magazineSize>
+			<reloadTime>0.8</reloadTime>
+			<reloadOneAtATime>true</reloadOneAtATime>
+			<ammoSet>AmmoSet_8mmRailgunIon</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aiAimMode>AimedShot</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>SpacerGun</li>
+		</weaponTags>
+	</Operation>
+
+	<!-- === Ion LMG === -->
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>IW_Gun_IonLMG</defName>
+		<statBases>
+			<Mass>40</Mass>
+			<Bulk>25</Bulk>
+			<SwayFactor>2</SwayFactor>
+			<ShotSpread>0.1</ShotSpread>
+			<SightsEfficiency>1</SightsEfficiency>
+			<RangedWeapon_Cooldown>1.2</RangedWeapon_Cooldown>
+		</statBases>
+		<Properties>
+			<recoilAmount>3</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>True</hasStandardCommand>
+			<defaultProjectile>Bullet_8mmRailgun_Ion</defaultProjectile>
+			<warmupTime>2.8</warmupTime>
+			<range>60</range>
+			<soundCast>IW_Shot_IonLMG</soundCast>
+			<soundCastTail>GunTail_Heavy</soundCastTail>
+			<muzzleFlashScale>18</muzzleFlashScale>
+			<burstShotCount>20</burstShotCount>
+			<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+			<recoilPattern>Regular</recoilPattern>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>200</magazineSize>
+			<reloadTime>8</reloadTime>
+			<ammoSet>AmmoSet_8mmRailgunIon</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aiAimMode>AimedShot</aiAimMode>
+			<aimedBurstShotCount>10</aimedBurstShotCount>
+		</FireModes>
+		<weaponTags>
+			<li>SpacerGun</li>
+			<li>CE_AI_LMG</li>
+			<li>Bipod_LMG</li>
+		</weaponTags>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName = "IW_Gun_IonLMG"]</xpath>
+		<value>
+			<li Class="CombatExtended.GunDrawExtension">
+				<DrawSize>1.20,1.20</DrawSize>
+				<DrawOffset>0.2,-0.1</DrawOffset>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- === Ion Lance === -->
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>IW_Gun_HeavyIonLance</defName>
+		<statBases>
+			<Mass>40</Mass>
+			<Bulk>25</Bulk>
+			<SwayFactor>2</SwayFactor>
+			<ShotSpread>0.1</ShotSpread>
+			<SightsEfficiency>2</SightsEfficiency>
+			<RangedWeapon_Cooldown>1.2</RangedWeapon_Cooldown>
+		</statBases>
+		<Properties>
+			<recoilAmount>3</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>True</hasStandardCommand>
+			<defaultProjectile>Bullet_8mmRailgun_Ion_Lance</defaultProjectile>
+			<warmupTime>1.8</warmupTime>
+			<range>70</range>
+			<soundCast>IW_Shot_HeavyIonLance</soundCast>
+			<soundCastTail>GunTail_Heavy</soundCastTail>
+			<muzzleFlashScale>18</muzzleFlashScale>
+			<recoilPattern>Regular</recoilPattern>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>10</magazineSize>
+			<reloadTime>8</reloadTime>
+			<ammoSet>AmmoSet_8mmRailgunIon_Lance</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aiAimMode>AimedShot</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>SpacerGun</li>
+			<li>Bipod_DMR</li>
+		</weaponTags>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AbilityDef[defName="IW_IonBlast"]/verbProperties/range</xpath>
+		<value>
+			<range>70</range>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AbilityDef[defName="IW_IonBlast"]/comps/li[@Class="CompProperties_AbilityLaunchProjectile"]/projectileDef</xpath>
+		<value>
+			<projectileDef>Bullet_12mmRailgun_Ion_Blast</projectileDef>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName = "IW_Gun_HeavyIonLance"]</xpath>
+		<value>
+			<li Class="CombatExtended.GunDrawExtension">
+				<DrawSize>1.30,1.30</DrawSize>
+				<DrawOffset>0.1,-0.15</DrawOffset>
+			</li>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Ion Weaponry/Patches/Ion Weaponry/RangedSpacer.xml
+++ b/ModPatches/Ion Weaponry/Patches/Ion Weaponry/RangedSpacer.xml
@@ -253,7 +253,7 @@
 		<statBases>
 			<Mass>5</Mass>
 			<Bulk>12</Bulk>
-			<SwayFactor>1.30</SwayFactor>
+			<SwayFactor>1.50</SwayFactor>
 			<ShotSpread>0.07</ShotSpread>
 			<SightsEfficiency>1.0</SightsEfficiency>
 			<RangedWeapon_Cooldown>0.98</RangedWeapon_Cooldown>
@@ -288,14 +288,14 @@
 		<defName>IW_Gun_IonLMG</defName>
 		<statBases>
 			<Mass>40</Mass>
-			<Bulk>25</Bulk>
-			<SwayFactor>1.25</SwayFactor>
-			<ShotSpread>0.1</ShotSpread>
+			<Bulk>20</Bulk>
+			<SwayFactor>2.64</SwayFactor>
+			<ShotSpread>0.06</ShotSpread>
 			<SightsEfficiency>1</SightsEfficiency>
 			<RangedWeapon_Cooldown>1.2</RangedWeapon_Cooldown>
 		</statBases>
 		<Properties>
-			<recoilAmount>1.15</recoilAmount>
+			<recoilAmount>1.05</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>True</hasStandardCommand>
 			<defaultProjectile>Bullet_8mmRailgun_Ion</defaultProjectile>
@@ -339,7 +339,7 @@
 		<defName>IW_Gun_HeavyIonLance</defName>
 		<statBases>
 			<Mass>40</Mass>
-			<Bulk>25</Bulk>
+			<Bulk>20</Bulk>
 			<SwayFactor>2</SwayFactor>
 			<ShotSpread>0.1</ShotSpread>
 			<SightsEfficiency>2</SightsEfficiency>

--- a/ModPatches/Ion Weaponry/Patches/Ion Weaponry/RangedSpacer.xml
+++ b/ModPatches/Ion Weaponry/Patches/Ion Weaponry/RangedSpacer.xml
@@ -105,7 +105,7 @@
 			<RangedWeapon_Cooldown>0.51</RangedWeapon_Cooldown>
 		</statBases>
 		<Properties>
-			<recoilAmount>2</recoilAmount>
+			<recoilAmount>1.2</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>True</hasStandardCommand>
 			<defaultProjectile>Bullet_4mmRailgun_Ion</defaultProjectile>
@@ -141,7 +141,7 @@
 			<RangedWeapon_Cooldown>0.51</RangedWeapon_Cooldown>
 		</statBases>
 		<Properties>
-			<recoilAmount>4.0</recoilAmount>
+			<recoilAmount>1.40</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>True</hasStandardCommand>
 			<defaultProjectile>Bullet_4mmRailgun_Ion</defaultProjectile>
@@ -181,7 +181,7 @@
 			<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
 		</statBases>
 		<Properties>
-			<recoilAmount>3</recoilAmount>
+			<recoilAmount>1.3</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>True</hasStandardCommand>
 			<defaultProjectile>Bullet_6mmRailgun_Ion</defaultProjectile>
@@ -222,11 +222,11 @@
 			<NightVisionEfficiency_Weapon>0.6</NightVisionEfficiency_Weapon>
 		</statBases>
 		<Properties>
-			<recoilAmount>4</recoilAmount>
+			<recoilAmount>1.4</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>True</hasStandardCommand>
 			<defaultProjectile>Bullet_8mmRailgun_Ion</defaultProjectile>
-			<warmupTime>1.8</warmupTime>
+			<warmupTime>1.5</warmupTime>
 			<range>86</range>
 			<soundCast>IW_Shot_IonRifle</soundCast>
 			<soundCastTail>GunTail_Medium</soundCastTail>
@@ -259,7 +259,7 @@
 			<RangedWeapon_Cooldown>0.98</RangedWeapon_Cooldown>
 		</statBases>
 		<Properties>
-			<recoilAmount>3.01</recoilAmount>
+			<recoilAmount>1.3</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>True</hasStandardCommand>
 			<defaultProjectile>Bullet_8mmRailgun_Ion</defaultProjectile>
@@ -289,17 +289,17 @@
 		<statBases>
 			<Mass>40</Mass>
 			<Bulk>25</Bulk>
-			<SwayFactor>2</SwayFactor>
+			<SwayFactor>1.25</SwayFactor>
 			<ShotSpread>0.1</ShotSpread>
 			<SightsEfficiency>1</SightsEfficiency>
 			<RangedWeapon_Cooldown>1.2</RangedWeapon_Cooldown>
 		</statBases>
 		<Properties>
-			<recoilAmount>3</recoilAmount>
+			<recoilAmount>1.15</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>True</hasStandardCommand>
 			<defaultProjectile>Bullet_8mmRailgun_Ion</defaultProjectile>
-			<warmupTime>2.8</warmupTime>
+			<warmupTime>1.8</warmupTime>
 			<range>60</range>
 			<soundCast>IW_Shot_IonLMG</soundCast>
 			<soundCastTail>GunTail_Heavy</soundCastTail>
@@ -346,7 +346,7 @@
 			<RangedWeapon_Cooldown>1.2</RangedWeapon_Cooldown>
 		</statBases>
 		<Properties>
-			<recoilAmount>3</recoilAmount>
+			<recoilAmount>1.5</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>True</hasStandardCommand>
 			<defaultProjectile>Bullet_12mmRailgun_Ion_Lance</defaultProjectile>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -271,6 +271,7 @@ High Tech Laboratory Facilities	|
 Hive Armory |
 Idhale Race	|
 Impact Weaponry	|
+Ion Weaponry	|
 Imperial Arsenal: Royal Warcasket 	|
 Individuality 	|
 Industrial Melee Weaponry	|


### PR DESCRIPTION
## Additions
a little touch up of the patch made by xexe, modified and upload with permission.
## Changes
made the modded damage type to act like EMP damage with out the emp stun, increased emp explosion damage changed the ion blast to use CE ammo instead of components to reload.
## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
