### PR TITLE
Fix potential lag from natural armor repair menu

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompArmorDurability.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompArmorDurability.cs
@@ -176,57 +176,62 @@ namespace CombatExtended
 
         public override IEnumerable<FloatMenuOption> CompFloatMenuOptions(Pawn selPawn)
         {
-            if (durabilityProps.Repairable && !this.parent.HostileTo(selPawn))
+            if (!durabilityProps.Repairable || this.parent.HostileTo(selPawn))
             {
-                var firstIngredientProvidedOrNotNeeded = true;
-                var secondIngredientProvidedOrNotNeeded = true;
-
-                List<Thing> ingredientsA = null;
-                List<Thing> ingredientsB = null;
-
-                // Only check for ingredients if there's any required
-                if (!durabilityProps.RepairIngredients.NullOrEmpty())
-                {
-                    ingredientsA = Find.CurrentMap.listerThings.AllThings.FindAll(x => !x.IsForbidden(selPawn) && x.def == durabilityProps.RepairIngredients.First().thingDef && x.stackCount >= durabilityProps.RepairIngredients.First().count);
-                    firstIngredientProvidedOrNotNeeded = ingredientsA.Any();
-
-                    //The system supports only 2 ingredients at max
-                    if (firstIngredientProvidedOrNotNeeded && durabilityProps.RepairIngredients.Count > 1)
-                    {
-                        ingredientsB = Find.CurrentMap.listerThings.AllThings.FindAll(x => !x.IsForbidden(selPawn) && x.def == durabilityProps.RepairIngredients.Last().thingDef && x.stackCount >= durabilityProps.RepairIngredients.Last().count);
-                        secondIngredientProvidedOrNotNeeded = ingredientsB.Any();
-                    }
-                }
-
-                if (curDurability < maxDurability + durabilityProps.MaxOverHeal && firstIngredientProvidedOrNotNeeded && secondIngredientProvidedOrNotNeeded)
-                {
-                    yield return new FloatMenuOption("CE_RepairArmorDurability".Translate(), delegate
-                    {
-                        Thing firstIngredient = null;
-                        Thing secondIngredient = null;
-
-                        // If ingredients are required, pick them. Otherwise just leave the variables as null.
-                        if (!ingredientsA.NullOrEmpty())
-                        {
-                            firstIngredient = ingredientsA.MinBy(x => x.Position.DistanceTo(selPawn.Position));
-                        }
-                        if (!ingredientsB.NullOrEmpty())
-                        {
-                            secondIngredient = ingredientsB.MinBy(x => x.Position.DistanceTo(selPawn.Position));
-                        }
-
-                        StartJob(selPawn, firstIngredient, secondIngredient);
-                    });
-                }
-                else if (this.curDurability >= maxDurability + durabilityProps.MaxOverHeal)
-                {
-                    yield return new FloatMenuOption("CE_ArmorDurability_CannotRepairUndamaged".Translate(), null);
-                }
-                else
-                {
-                    yield return new FloatMenuOption("CE_ArmorDurability_CannonRepairNoResource".Translate(), null);
-                }
+                yield break;
             }
+
+            if (this.curDurability >= maxDurability + durabilityProps.MaxOverHeal)
+            {
+                yield return new FloatMenuOption("CE_ArmorDurability_CannotRepairUndamaged".Translate(), null);
+                yield break;
+            }
+
+            // Only check for ingredients if there's any required
+            if (durabilityProps.RepairIngredients.NullOrEmpty())
+            {
+                yield return new FloatMenuOption(
+                    "CE_RepairArmorDurability".Translate(),
+                    () => StartJob(selPawn)
+                );
+                yield break;
+            }
+
+            var needsSecondIngredient = durabilityProps.RepairIngredients.Count >= 1;
+            Thing firstIngredient = FindIngredient(selPawn, durabilityProps.RepairIngredients.First());
+            Thing secondIngredient = needsSecondIngredient ? FindIngredient(selPawn, durabilityProps.RepairIngredients.Last()) : null;
+
+            if (firstIngredient != null && !(needsSecondIngredient && secondIngredient == null))
+            {
+                yield return new FloatMenuOption(
+                    "CE_RepairArmorDurability".Translate(),
+                    () => StartJob(selPawn, firstIngredient, secondIngredient)
+                );
+            }
+            else
+            {
+                yield return new FloatMenuOption("CE_ArmorDurability_CannonRepairNoResource".Translate(), null);
+            }
+        }
+
+        /// <summary>
+        /// Find an ingredient to be used for repairing the given pawn's natural armor.
+        /// </summary>
+        /// <param name="selPawn">The pawn that will be performing the repairs.</param>
+        /// <param name="ingredientDefCount">The required ingredient type and count</param>
+        /// <returns>The best matching ingredient stack, or null if none were found.</returns>
+        private static Thing FindIngredient(Pawn selPawn, ThingDefCountClass ingredientDefCount)
+        {
+            bool IsValidIngredient(Thing ingredient) => ingredient.stackCount >= ingredientDefCount.count && !ingredient.IsForbidden(selPawn);
+
+            return GenClosest.ClosestThingReachable(
+                selPawn.Position,
+                selPawn.Map,
+                ThingRequest.ForDef(ingredientDefCount.thingDef),
+                PathEndMode.ClosestTouch,
+                TraverseParms.For(selPawn),
+                validator: IsValidIngredient
+            );
         }
 
         [Compatibility.Multiplayer.SyncMethod]


### PR DESCRIPTION


## Changes
The current implementation of the "repair armor" menu option eagerly scans every item on the map when the menu is displayed, which can cause lag. As a fix, use GenClosest for each ingredient def with a custom validator to ensure only the relevant items are scanned, and reorder the checks to avoid doing this at all if the armor of the pawn being inspected cannot be repaired any further.

## References

- Closes #3339



## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony -- spawned in some mechs and verified the behavior of the menu for relevant cases (no repair needed, no ingredients, can repair)
