### PR TITLE
Consistently apply shot height adjustment

### DIFF
--- a/Source/CombatExtended/CombatExtended/ShiftVecReport.cs
+++ b/Source/CombatExtended/CombatExtended/ShiftVecReport.cs
@@ -135,6 +135,16 @@ namespace CombatExtended
         public bool blindFiring = false;
         public bool roofed = false;
 
+        /// <summary>
+        /// The height at which this shot is fired, adjusted for potential cover or other factors.
+        /// </summary>
+        public float AdjustedShotHeight = 0f;
+
+        /// <summary>
+        /// Adjustment in radians to be added to the angle of this shot, adjusted for potential cover or other factors.
+        /// </summary>
+        public float ShotAngleAdjustment = 0f;
+
         // Copy-constructor
         public ShiftVecReport(ShiftVecReport report)
         {
@@ -215,6 +225,8 @@ namespace CombatExtended
                 stringBuilder.AppendLine("   " + $"DEBUG: weathershift\t\t{weatherShift}");
                 stringBuilder.AppendLine("   " + $"DEBUG: accuracyFactor\t\t{accuracyFactor}");
                 stringBuilder.AppendLine("   " + $"DEBUG: lightingShift\t\t{lightingShift}");
+                stringBuilder.AppendLine("   " + $"DEBUG: AdjustedShotHeight\t\t{AdjustedShotHeight}");
+                stringBuilder.AppendLine("   " + $"DEBUG: ShotAngleAdjustment\t\t{ShotAngleAdjustment}");
             }
 
             if (lightingShift > 0)

--- a/Source/SOS2Compat/SOS2Compat/Verb_ShootShipCE.cs
+++ b/Source/SOS2Compat/SOS2Compat/Verb_ShootShipCE.cs
@@ -177,15 +177,13 @@ namespace CombatExtended.Compatibility.SOS2Compat
 
                     if (instant)
                     {
-                        var shotHeight = ShotHeight;
-                        float tsa = AdjustShotHeight(caster, currentTarget, ref shotHeight);
                         projectileCE.RayCast(
                             Shooter,
                             verbProps,
                             sourceLoc,
-                            shotAngle + tsa,
+                            shotAngle,
                             shotRotation,
-                            shotHeight,
+                            report.AdjustedShotHeight,
                             ShotSpeed,
                             spreadDegrees,
                             aperatureSize,
@@ -204,7 +202,7 @@ namespace CombatExtended.Compatibility.SOS2Compat
                             sourceLoc,
                             shotAngle,
                             shotRotation,
-                            ShotHeight,
+                            report.AdjustedShotHeight,
                             ShotSpeed,
                             EquipmentSource,
                             distance);
@@ -298,7 +296,8 @@ namespace CombatExtended.Compatibility.SOS2Compat
             if (targetThing != null)
             {
                 float shotHeight = shotSource.y;
-                AdjustShotHeight(caster, targetThing, ref shotHeight);
+                GetHighestCoverAndSmokeForTarget(targetThing, out Thing highestCover, out _, out _);
+                AdjustShotHeight(caster, targetThing, highestCover, ref shotHeight);
                 shotSource.y = shotHeight;
                 Vector3 targDrawPos = targetThing.DrawPos;
                 targetPos = new Vector3(targDrawPos.x, new CollisionVertical(targetThing).Max, targDrawPos.z);


### PR DESCRIPTION


## Changes

0f52a9fa8aedae8c969a399a75d91fde38d6d708 introduced a system to adjust the shot height dynamically to compensate for the case where the target is partially obscured by cover or is tall enough for its center of mass to be higher than the shot height. However, this is currently applied only inconsistently: while all projectiles take it into account for shot line checks, only instant (IE: laser) weapons actually apply it to the projectile being fired.

Fix it by making the height and angle adjustments part of ShiftVecReport and using them as needed.


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony -- tested firing at a target behind various layers of cover with a sniper.
