### PR TITLE
Revert projectile shadows

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -1258,7 +1258,7 @@ namespace CombatExtended
                     //TODO : EXPERIMENTAL Add edifice height
                     var shadowPos = new Vector3(ExactPosition.x,
                                                 def.Altitude - 0.001f,
-                                                ExactPosition.z - Mathf.Max(0f, ExactPosition.y));
+                                                ExactPosition.z);
                     //EXPERIMENTAL: + (new CollisionVertical(ExactPosition.ToIntVec3().GetEdifice(Map))).Max);
 
                     //TODO : Vary ShadowMat plane


### PR DESCRIPTION
## Changes

- Reverted the projectile shadows to showing their exact position.

## Reasoning

- The current 'realistic' shadows for projectiles make it significantly harder to see the trajectory and current position of indirect fire shells that often go off-screen due to their altitude and doesn't add anything significant to direct-fire projectiles.

## Alternatives

- Use exact position only for indirect projectiles

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors