### PR TITLE
Remove unused verb-related code

### DIFF
--- a/Source/CombatExtended/CombatExtended/Verbs/VerbPropertiesCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/VerbPropertiesCE.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using RimWorld;
 using Verse;
 using UnityEngine;
 
@@ -15,29 +14,9 @@ namespace CombatExtended
         public float recoilAmount = 0;
         public float indirectFirePenalty = 0;
         public float circularError = 0;
-        public float meleeArmorPenetration = 0;
-        public float firingOffset = 0.19f;
         public int ticksToTruePosition = 5;
         public bool ejectsCasings = true;
         public bool ignorePartialLoSBlocker = false;
         public bool interruptibleBurst = true;
-
-        public float AdjustedArmorPenetrationCE(Verb ownerVerb, Pawn attacker)
-        {
-            var toolCE = (ToolCE)ownerVerb.tool;
-            if (ownerVerb.verbProps != this)
-            {
-                Log.ErrorOnce("Tried to calculate armor penetration for a verb with different verb props. verb=" + ownerVerb, 9865767);
-                return 0f;
-            }
-            if (ownerVerb.EquipmentSource != null && ownerVerb.EquipmentSource.def.IsWeapon)
-            {
-                return toolCE.armorPenetration * ownerVerb.EquipmentSource.GetStatValue(CE_StatDefOf.MeleePenetrationFactor);
-            }
-            else
-            {
-                return toolCE.armorPenetration;
-            }
-        }
     }
 }

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -17,14 +17,6 @@ namespace CombatExtended
 {
     public class Verb_LaunchProjectileCE : Verb
     {
-        #region Constants
-
-        // Cover check constants
-        private const float distToCheckForCover = 3f;   // How many cells to raycast on the cover check
-        private const float segmentLength = 0.2f;       // How long a single raycast segment is
-        //private const float shotHeightFactor = 0.85f;   // The height at which pawns hold their guns
-
-        #endregion
 
         #region Fields
 
@@ -74,14 +66,6 @@ namespace CombatExtended
         // Returns either the pawn aiming the weapon or in case of turret guns the turret operator or null if neither exists        
         public Pawn ShooterPawn => CasterPawn ?? CE_Utility.TryGetTurretOperator(caster);
         public Thing Shooter => ShooterPawn ?? caster;
-
-        public override float EffectiveRange
-        {
-            get
-            {
-                return base.EffectiveRange;
-            }
-        }
 
         public override int ShotsPerBurst
         {
@@ -1276,46 +1260,13 @@ namespace CombatExtended
                 goodDest = IntVec3.Invalid;
                 return false;
             }
-            // DISABLED: reason is testing a better alternative..
-            //if (ShooterPawn != null && !Caster.Faction.IsPlayerSafe() && IntercepterBlockingTarget(shotSource, targ.CenterVector3))
-            //{
-            //    goodDest = IntVec3.Invalid;
-            //    return false;
-            //}
+
             if (CanHitCellFromCellIgnoringRange(shotSource, targ.Cell, targ.Thing))
             {
                 goodDest = targ.Cell;
                 return true;
             }
             goodDest = IntVec3.Invalid;
-            return false;
-        }
-
-        private bool IntercepterBlockingTarget(Vector3 source, Vector3 target)
-        {
-            List<Thing> list = Caster.Map.listerThings.ThingsInGroup(ThingRequestGroup.ProjectileInterceptor);
-            for (int i = 0; i < list.Count; i++)
-            {
-                Thing thing = list[i];
-                CompProjectileInterceptor interceptor = thing.TryGetComp<CompProjectileInterceptor>();
-                if (!interceptor.Active)
-                {
-                    continue;
-                }
-                float d1 = Vector3.Distance(source, thing.Position.ToVector3());
-                if (d1 < interceptor.Props.radius + 1)
-                {
-                    continue;
-                }
-                if (Vector3.Distance(target, thing.Position.ToVector3()) < interceptor.Props.radius)
-                {
-                    return true;
-                }
-                if (thing.Position.ToVector3().DistanceToSegment(source, target, out _) < interceptor.Props.radius)
-                {
-                    return true;
-                }
-            }
             return false;
         }
 

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -123,14 +123,6 @@ namespace CombatExtended
             }
         }
 
-        public float SpreadDegrees
-        {
-            get
-            {
-                return (EquipmentSource?.GetStatValue(CE_StatDefOf.ShotSpread) ?? 0) * (projectilePropsCE != null ? projectilePropsCE.spreadMult : 0f);
-            }
-        }
-
         // Whether our shooter is currently under suppressive fire
         private bool IsSuppressed => ShooterPawn?.TryGetComp<CompSuppressable>()?.isSuppressed ?? false;
 
@@ -266,33 +258,6 @@ namespace CombatExtended
             {
                 EquipmentSource.TryGetComp<BipodComp>().SetUpStart(CasterPawn);
             }
-        }
-
-        public virtual ShiftVecReport SimulateShiftVecReportFor(LocalTargetInfo target, AimMode aimMode)
-        {
-            IntVec3 targetCell = target.Cell;
-            ShiftVecReport report = new ShiftVecReport();
-
-            report.target = target;
-            report.aimingAccuracy = AimingAccuracy;
-            report.sightsEfficiency = SightsEfficiency;
-            if (ShooterPawn != null && !ShooterPawn.health.capacities.CapableOf(PawnCapacityDefOf.Sight))
-            {
-                report.sightsEfficiency = 0;
-            }
-            report.shotDist = (targetCell - caster.Position).LengthHorizontal;
-            report.maxRange = EffectiveRange;
-            report.lightingShift = CE_Utility.GetLightingShift(Shooter, LightingTracker.CombatGlowAtFor(caster.Position, targetCell));
-
-            if (!caster.Position.Roofed(caster.Map) || !targetCell.Roofed(caster.Map))  //Change to more accurate algorithm?
-            {
-                report.weatherShift = 1 - caster.Map.weatherManager.CurWeatherAccuracyMultiplier;
-            }
-            report.shotSpeed = ShotSpeed;
-            report.swayDegrees = SwayAmplitudeFor(aimMode);
-            float spreadmult = projectilePropsCE != null ? projectilePropsCE.spreadMult : 0f;
-            report.spreadDegrees = (EquipmentSource?.GetStatValue(CE_StatDefOf.ShotSpread) ?? 0) * spreadmult;
-            return report;
         }
 
         /// <summary>


### PR DESCRIPTION


## Changes
Verb classes contain a good deal of unused code, let's remove it.

## Reasoning

Reduces confusion and also lessens the potential maintenance burden going forward.


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony - smoke tested combat on a quicktest colony
