### PR TITLE
Memoize Y-offset for pawn rendering

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_PawnRenderer.cs
+++ b/Source/CombatExtended/Harmony/Harmony_PawnRenderer.cs
@@ -60,11 +60,13 @@ namespace CombatExtended.HarmonyCE
                 muzzleJump = -muzzleJump;
                 casingOffset.x *= -1;
             }
-            matrix.SetTRS(position + posVec.RotatedBy(matrix.rotation.eulerAngles.y) + recoilOffset, Quaternion.AngleAxis(matrix.rotation.eulerAngles.y + muzzleJump, Vector3.up), scale);
+
+            float yAngle = matrix.rotation.eulerAngles.y;
+            matrix.SetTRS(position + posVec.RotatedBy(yAngle) + recoilOffset, Quaternion.AngleAxis(yAngle + muzzleJump, Vector3.up), scale);
             CompEquippable compEquippable = eq.TryGetComp<CompEquippable>();
             if (compEquippable != null && compEquippable.PrimaryVerb is Verb_ShootCE verbCE)
             {
-                verbCE.drawPos = casingDrawPos + (casingOffset + posVec).RotatedBy(matrix.rotation.eulerAngles.y);
+                verbCE.drawPos = casingDrawPos + (casingOffset + posVec).RotatedBy(yAngle);
             }
             if (eq is WeaponPlatform platform)
             {


### PR DESCRIPTION


## Changes

Matrix4x4.rotation and Quaternion.eulerAngles are, somewhat confusingly, not fields but relatively costly property accessors. When rendering many pawns, repeated calls to them can have a measurable impact, so store the result in a local variable and reuse it.


## Reasoning
This cuts the overhead of our pawn rendering patch by half. Impact on the overall game performance would depend on how many pawns are being rendered in the viewport, but when profiling a 10k point tribal raid, it went from ~2.22% to ~1.23%.

## Testing

- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony -- compared the rendering of a 10k point tribal raid.
