### PR TITLE
Robotic Servitude armor patch fixes

### DIFF
--- a/ModPatches/Robotic Servitude/Patches/ThingDefs_Races/Races_Mechanoid.xml
+++ b/ModPatches/Robotic Servitude/Patches/ThingDefs_Races/Races_Mechanoid.xml
@@ -164,14 +164,14 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Gha_Combat_Laborer"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
-			<ArmorRating_Blunt>5.25</ArmorRating_Blunt>
+			<ArmorRating_Blunt>11</ArmorRating_Blunt>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Gha_Combat_Laborer"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
-			<ArmorRating_Sharp>3.5</ArmorRating_Sharp>
+			<ArmorRating_Sharp>5.5</ArmorRating_Sharp>
 		</value>
 	</Operation>
 
@@ -201,7 +201,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Gha_Assassin_Laborer"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
-			<ArmorRating_Sharp>6</ArmorRating_Sharp>
+			<ArmorRating_Sharp>4.5</ArmorRating_Sharp>
 		</value>
 	</Operation>
 


### PR DESCRIPTION
## Changes

- What it says on the tin.

## Reasoning

- The armor values were given based on a simple comparison with vanilla walker mechs that have 40% S and 20% B armor, the combat laborer has 55% and 35% and the assassin has 45% and 55% sharp and blunt armor respectively. Their armor values are reversed and broken right now.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
