### PR TITLE
Remove LINQ from suppression code

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -779,6 +779,11 @@ namespace CombatExtended
         }
 
         /// <summary>
+        /// Cache field holding things that a projectile might collide with.
+        /// </summary>
+        private static readonly List<Thing> potentialCollisionCandidates = new List<Thing>();
+
+        /// <summary>
         /// Checks whether a collision occurs along flight path within this cell.
         /// </summary>
         /// <param name="cell">Where to check for collisions in</param>
@@ -791,34 +796,48 @@ namespace CombatExtended
             }
             var roofChecked = false;
 
-            var mainThingList = new List<Thing>(Map.thingGrid.ThingsListAtFast(cell)).Where(t => t is Pawn || t.def.Fillage != FillCategory.None).ToList();
+            potentialCollisionCandidates.Clear();
+
+            foreach (var thing in Map.thingGrid.ThingsListAtFast(cell))
+            {
+                if (thing is Pawn || thing.def.Fillage != FillCategory.None)
+                {
+                    potentialCollisionCandidates.AddDistinct(thing);
+                }
+            }
 
             //Find pawns in adjacent cells and append them to main list
-            var adjList = new List<IntVec3>();
             var rot4 = Rot4.FromAngleFlat(shotRotation);
             if (rot4.rotInt > 1)
             {
                 //For some reason south and west returns incorrect adjacent cells collection
                 rot4 = rot4.Opposite;
             }
-            adjList.AddRange(GenAdj.CellsAdjacentCardinal(cell, rot4, new IntVec2(collisionCheckSize, 0)).ToList());
+
             if (Controller.settings.DebugDrawInterceptChecks)
             {
                 Map.debugDrawer.debugCells.Clear();
                 Map.debugDrawer.DebugDrawerUpdate();
             }
             //Iterate through adjacent cells and find all the pawns
-            foreach (var curCell in adjList)
+            foreach (var curCell in GenAdj.CellsAdjacentCardinal(cell, rot4, new IntVec2(collisionCheckSize, 0)))
             {
-                if (curCell != cell && curCell.InBounds(Map))
+                if (curCell == cell || !curCell.InBounds(Map))
                 {
-                    mainThingList.AddRange(Map.thingGrid.ThingsListAtFast(curCell)
-                                           .Where(x => x is Pawn));
+                    continue;
+                }
 
-                    if (Controller.settings.DebugDrawInterceptChecks)
+                foreach (var thing in Map.thingGrid.ThingsListAtFast(curCell))
+                {
+                    if (thing is Pawn)
                     {
-                        Map.debugDrawer.FlashCell(curCell, 0.7f);
+                        potentialCollisionCandidates.AddDistinct(thing);
                     }
+                }
+
+                if (Controller.settings.DebugDrawInterceptChecks)
+                {
+                    Map.debugDrawer.FlashCell(curCell, 0.7f);
                 }
             }
 
@@ -832,8 +851,15 @@ namespace CombatExtended
                 roofChecked = true;
             }
 
-            foreach (var thing in mainThingList.Distinct().Where(x => !(x is ProjectileCE)).OrderBy(x => (x.DrawPos - LastPos).sqrMagnitude))
+            potentialCollisionCandidates.SortBy(thing => (thing.DrawPos - LastPos).sqrMagnitude);
+
+            foreach (var thing in potentialCollisionCandidates)
             {
+                if (thing is ProjectileCE)
+                {
+                    continue;
+                }
+
                 if ((thing == launcher || thing == mount) && !canTargetSelf)
                 {
                     continue;

--- a/Source/CombatExtended/Compatibility/BlockerRegistry.cs
+++ b/Source/CombatExtended/Compatibility/BlockerRegistry.cs
@@ -155,9 +155,16 @@ namespace CombatExtended.Compatibility
         {
             if (!enabledSZ)
             {
-                return null;
+                yield break;
             }
-            return shieldZonesCallback.SelectMany(cb => cb(thing));
+
+            foreach (var callback in shieldZonesCallback)
+            {
+                foreach (var zone in callback(thing))
+                {
+                    yield return zone;
+                }
+            }
         }
         public static bool PawnUnsuppressableFromCallback(Pawn pawn, IntVec3 origin)
         {


### PR DESCRIPTION

## Changes

Suppression code can be fairly hot, e.g. when an explosion occurs within a large group of pawns that sends them looking for cover. Some of the relevant logic in SuppressionUtility is using LINQ heavily, which causes significant memory pressure in such scenarios. When profiling a save with a doomsday hitting a 10k point tribal raid, InterceptorZonesFor() was responsible for ~3.7% of total time despite there being no shields on the map at all.

So, replace LINQ in relevant methods with iterator functions, which are less memory intensive, eliminating about ~3.5% of the total time.



## Testing

- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony - tested the after-effects of a doomsday explosion in the middle of a tribal raid
