### PR TITLE
Fix stray closing tag in Deserters patch

### DIFF
--- a/ModPatches/Vanilla Factions Expanded - Deserters/Patches/Vanilla Factions Expanded - Deserters/Contraband.xml
+++ b/ModPatches/Vanilla Factions Expanded - Deserters/Patches/Vanilla Factions Expanded - Deserters/Contraband.xml
@@ -109,7 +109,7 @@
 			</value>
 		</standard>
 	</Operation>
->
+
 	<Operation Class="CombatExtended.PatchOperation_ConditionalGeneric">
 		<standard Class="PatchOperationAddModExtension">
 			<xpath>Defs/ThingDef[defName="Ammo_8x50mmCharged_AP"]</xpath>


### PR DESCRIPTION
Removed a stray > symbol in the Deserters patch file.

...don't ask me why it didn't error out in testing.