### PR TITLE
Enable faster subsequent shots by default

### DIFF
--- a/Source/CombatExtended/CombatExtended/Settings.cs
+++ b/Source/CombatExtended/CombatExtended/Settings.cs
@@ -37,7 +37,7 @@ namespace CombatExtended
 
         private bool fragmentsFromWalls = false;
 
-        private bool fasterRepeatShots = false;
+        private bool fasterRepeatShots = true;
 
         public bool ShowCasings => showCasings;
 


### PR DESCRIPTION
## Changes

- Subsequent shots are now enabled by default for new configs.

## Reasoning

- Feels stable enough in testing.
- Larger number of people using it would help iron out the edge cases faster.