### PR TITLE
Artillery shells don't use casings

### DIFF
--- a/Defs/Ammo/Shell/105mmHowitzer.xml
+++ b/Defs/Ammo/Shell/105mmHowitzer.xml
@@ -161,9 +161,7 @@
 			<soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
 			<soundAmbient>MortarRound_Ambient</soundAmbient>
 			<flyOverhead>true</flyOverhead>
-			<dropsCasings>true</dropsCasings>
-			<casingMoteDefname>Fleck_BigShell</casingMoteDefname>
-			<casingFilthDefname>Filth_CannonAmmoCasings</casingFilthDefname>
+			<dropsCasings>false</dropsCasings>
 			<gravityFactor>5</gravityFactor>
 			<shellingProps>
 				<tilesPerTick>0.10</tilesPerTick>
@@ -303,9 +301,7 @@
 			<speed>147</speed>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<flyOverhead>false</flyOverhead>
-			<dropsCasings>true</dropsCasings>
-			<casingMoteDefname>Fleck_BigShell</casingMoteDefname>
-			<casingFilthDefname>Filth_CannonAmmoCasings</casingFilthDefname>
+			<dropsCasings>false</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Shell/155mmHowitzer.xml
+++ b/Defs/Ammo/Shell/155mmHowitzer.xml
@@ -141,9 +141,7 @@
 			<soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
 			<soundAmbient>MortarRound_Ambient</soundAmbient>
 			<flyOverhead>true</flyOverhead>
-			<dropsCasings>true</dropsCasings>
-			<casingMoteDefname>Fleck_BigShell</casingMoteDefname>
-			<casingFilthDefname>Filth_CannonAmmoCasings</casingFilthDefname>
+			<dropsCasings>false</dropsCasings>
 			<gravityFactor>5</gravityFactor>
 			<shellingProps>
 				<tilesPerTick>0.12</tilesPerTick>


### PR DESCRIPTION
## Changes
A very minor one. Makes the 155mm and 105mm howitzer shells no longer drop casings.

## Reasoning
Realism. 105mm and 155mm shells being fired from artillery guns don't use fixed-cased projectiles, instead using bag charges. There are fixed-case 105mm shells that I've found, but we currently don't have anything that would use those.

## Alternatives
- Leave it as-is.
- Create separate variants of the 105 and 155 projectiles that do spit out casings when fired, in case we end up needing them.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
