### PR TITLE
Update Exotic Arsenal LoadFolder

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -164,7 +164,7 @@
 		<li IfModActive="Erin.Viera">ModPatches/Erin's Viera</li>
 		<li IfModActive="Erin.Wildlife">ModPatches/Erin's Wildlife</li>
 		<li IfModActive="StatistNo1.EvolvedOrgansRedux">ModPatches/EvolvedOrgansRedux</li>
-		<li IfModActive="xedos.arsenalexotic">ModPatches/Exotic Arsenal</li>
+		<li IfModActive="zal.arsenalexotic">ModPatches/Exotic Arsenal</li>
 		<li IfModActive="Argon.ExpandedMaterials.Metals">ModPatches/Expanded Materials - Metals</li>
 		<li IfModActive="Argon.VMEuP">ModPatches/Expanded Materials - Plastics</li>
 		<li IfModActive="Adventurer.ExpandWoodwork">ModPatches/Expanded Woodworking</li>


### PR DESCRIPTION
## Changes
- Update the Exotic Arsenal LoadFolder entry to the "Continued" version that works for 1.5.

## References
Close #3540 

## Reasoning
- The original version hasn't been updated since 1.2 and that doesn't seem likely to change anytime soon.

## Alternatives
- Leave it broken.
- Could overhaul the patch. A couple of weapons like the Celsius have dual fire modes that could take advantage of CE's new(ish) underbarrel mechanic.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x]Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
