### PR TITLE
Clean up useStatic tags on Partial Armor

### DIFF
--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Barb_Slinger.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Barb_Slinger.xml
@@ -90,7 +90,6 @@
 			<li Class="CombatExtended.PartialArmorExt">
 				<stats>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
 						<parts>
 							<li>AA_LeftPincer</li>
@@ -98,7 +97,6 @@
 						</parts>
 					</li>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Blunt>0.5</ArmorRating_Blunt>
 						<parts>
 							<li>AA_LeftPincer</li>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Base.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Base.xml
@@ -14,14 +14,12 @@
 			<li Class="CombatExtended.PartialArmorExt">
 				<stats>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
 						<parts>
 							<li>InsectLeg</li>
 						</parts>
 					</li>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Blunt>0.25</ArmorRating_Blunt>
 						<parts>
 							<li>InsectLeg</li>

--- a/ModPatches/Alpha Genes/Patches/Alpha Genes/ThingDefs_Races/Races_OcularSlinger.xml
+++ b/ModPatches/Alpha Genes/Patches/Alpha Genes/ThingDefs_Races/Races_OcularSlinger.xml
@@ -15,14 +15,12 @@
 						<li Class="CombatExtended.PartialArmorExt">
 							<stats>
 								<li>
-									<useStatic>false</useStatic>
 									<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
 									<parts>
 										<li>InsectLeg</li>
 									</parts>
 								</li>
 								<li>
-									<useStatic>false</useStatic>
 									<ArmorRating_Blunt>0.25</ArmorRating_Blunt>
 									<parts>
 										<li>InsectLeg</li>
@@ -39,7 +37,6 @@
 						<li Class="CombatExtended.PartialArmorExt">
 							<stats>
 								<li>
-									<useStatic>false</useStatic>
 									<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
 									<parts>
 										<li>AG_LeftPincer</li>
@@ -47,7 +44,6 @@
 									</parts>
 								</li>
 								<li>
-									<useStatic>false</useStatic>
 									<ArmorRating_Blunt>0.5</ArmorRating_Blunt>
 									<parts>
 										<li>AG_LeftPincer</li>

--- a/ModPatches/Metal Gear Rimworld-Gekko/Patches/Metal Gear Rimworld-Gekko/ThingDefs_Races/Races_Mechanoid.xml
+++ b/ModPatches/Metal Gear Rimworld-Gekko/Patches/Metal Gear Rimworld-Gekko/ThingDefs_Races/Races_Mechanoid.xml
@@ -99,21 +99,18 @@
 			<li Class="CombatExtended.PartialArmorExt">
 				<stats>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
 						<parts>
 							<li>SightSensor</li>
 						</parts>
 					</li>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Blunt>0.25</ArmorRating_Blunt>
 						<parts>
 							<li>SightSensor</li>
 						</parts>
 					</li>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Sharp>0.625</ArmorRating_Sharp>
 						<parts>
 							<li>MGR_SyntheticalLeg</li>
@@ -127,28 +124,24 @@
 						</parts>
 					</li>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Sharp>0.625</ArmorRating_Sharp>
 						<parts>
 							<li>MechanicalFoot</li>
 						</parts>
 					</li>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Blunt>0.625</ArmorRating_Blunt>
 						<parts>
 							<li>MechanicalFoot</li>
 						</parts>
 					</li>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Sharp>0.625</ArmorRating_Sharp>
 						<parts>
 							<li>PowerClaw</li>
 						</parts>
 					</li>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Blunt>0.625</ArmorRating_Blunt>
 						<parts>
 							<li>PowerClaw</li>

--- a/ModPatches/RimWorld - Witcher Monster Hunt/Patches/RimWorld - Witcher Monster Hunt/Races_KikimoreCE.xml
+++ b/ModPatches/RimWorld - Witcher Monster Hunt/Patches/RimWorld - Witcher Monster Hunt/Races_KikimoreCE.xml
@@ -7,14 +7,12 @@
 			<li Class="CombatExtended.PartialArmorExt">
 				<stats>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
 						<parts>
 							<li>InsectLeg</li>
 						</parts>
 					</li>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Blunt>0.25</ArmorRating_Blunt>
 						<parts>
 							<li>InsectLeg</li>

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Races/Race_Bion.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Races/Race_Bion.xml
@@ -16,14 +16,12 @@
 			<li Class="CombatExtended.PartialArmorExt">
 				<stats>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
 						<parts>
 							<li>Eye</li>
 						</parts>
 					</li>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Blunt>0.25</ArmorRating_Blunt>
 						<parts>
 							<li>Eye</li>

--- a/ModPatches/Rimsenal Feral/Patches/Rimsenal Feral/ThingDefs_Races/Race_Razortooth.xml
+++ b/ModPatches/Rimsenal Feral/Patches/Rimsenal Feral/ThingDefs_Races/Race_Razortooth.xml
@@ -52,7 +52,6 @@
 			<li Class="CombatExtended.PartialArmorExt">
 				<stats>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
 						<parts>
 							<li>Leg</li>
@@ -60,7 +59,6 @@
 						</parts>
 					</li>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Blunt>0.25</ArmorRating_Blunt>
 						<parts>
 							<li>Leg</li>

--- a/ModPatches/Vanilla Animals Expanded - Waste Animals/Patches/Vanilla Animals Expanded - Waste Animals/ThingDefs_Races/WasteAnimals_Base.xml
+++ b/ModPatches/Vanilla Animals Expanded - Waste Animals/Patches/Vanilla Animals Expanded - Waste Animals/ThingDefs_Races/WasteAnimals_Base.xml
@@ -7,14 +7,12 @@
 			<li Class="CombatExtended.PartialArmorExt">
 				<stats>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
 						<parts>
 							<li>InsectLeg</li>
 						</parts>
 					</li>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Blunt>0.25</ArmorRating_Blunt>
 						<parts>
 							<li>InsectLeg</li>

--- a/ModPatches/Vanilla Animals Expanded - Waste Animals/Patches/Vanilla Animals Expanded - Waste Animals/ThingDefs_Races/WasteAnimals_Toxscorpion.xml
+++ b/ModPatches/Vanilla Animals Expanded - Waste Animals/Patches/Vanilla Animals Expanded - Waste Animals/ThingDefs_Races/WasteAnimals_Toxscorpion.xml
@@ -91,7 +91,6 @@
 			<li Class="CombatExtended.PartialArmorExt">
 				<stats>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
 						<parts>
 							<li>VAEWaste_LeftPincer</li>
@@ -99,7 +98,6 @@
 						</parts>
 					</li>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Blunt>0.5</ArmorRating_Blunt>
 						<parts>
 							<li>VAEWaste_LeftPincer</li>

--- a/ModPatches/Vanilla Animals Expanded/Patches/Vanilla Animals Expanded/Desert_Animals.xml
+++ b/ModPatches/Vanilla Animals Expanded/Patches/Vanilla Animals Expanded/Desert_Animals.xml
@@ -9,14 +9,12 @@
 			<li Class="CombatExtended.PartialArmorExt">
 				<stats>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
 						<parts>
 							<li>Leg</li>
 						</parts>
 					</li>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Blunt>0.5</ArmorRating_Blunt>
 						<parts>
 							<li>Leg</li>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Bases.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Bases.xml
@@ -16,14 +16,12 @@
 			<li Class="CombatExtended.PartialArmorExt">
 				<stats>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
 						<parts>
 							<li>InsectLeg</li>
 						</parts>
 					</li>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Blunt>0.25</ArmorRating_Blunt>
 						<parts>
 							<li>InsectLeg</li>

--- a/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Machines.xml
+++ b/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Machines.xml
@@ -31,14 +31,12 @@
 			<li Class="CombatExtended.PartialArmorExt">
 				<stats>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
 						<parts>
 							<li>SightSensor</li>
 						</parts>
 					</li>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Blunt>0.25</ArmorRating_Blunt>
 						<parts>
 							<li>SightSensor</li>

--- a/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -33,14 +33,12 @@
 			<li Class="CombatExtended.PartialArmorExt">
 				<stats>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
 						<parts>
 							<li>SightSensor</li>
 						</parts>
 					</li>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Blunt>0.25</ArmorRating_Blunt>
 						<parts>
 							<li>SightSensor</li>

--- a/ModPatches/pphhyy Expanded Scythers/Patches/pphhyy Expanded Scythers/MechKind_CE.xml
+++ b/ModPatches/pphhyy Expanded Scythers/Patches/pphhyy Expanded Scythers/MechKind_CE.xml
@@ -297,7 +297,6 @@
 							</parts>
 						</li>
 						<li>
-							
 							<ArmorRating_Blunt>0.625</ArmorRating_Blunt>
 							<parts>
 								<li>MechanicalLeg</li>

--- a/ModPatches/pphhyy Expanded Scythers/Patches/pphhyy Expanded Scythers/MechKind_CE.xml
+++ b/ModPatches/pphhyy Expanded Scythers/Patches/pphhyy Expanded Scythers/MechKind_CE.xml
@@ -267,42 +267,37 @@
 				<li Class="CombatExtended.PartialArmorExt">
 					<stats>
 						<li>
-							<useStatic>false</useStatic>
 							<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
 							<parts>
 								<li>SightSensor</li>
 							</parts>
 						</li>
 						<li>
-							<useStatic>false</useStatic>
 							<ArmorRating_Blunt>0.25</ArmorRating_Blunt>
 							<parts>
 								<li>SightSensor</li>
 							</parts>
 						</li>
 						<li>
-							<useStatic>false</useStatic>
 							<ArmorRating_Sharp>0.625</ArmorRating_Sharp>
 							<parts>
 								<li>MechanicalHead</li>
 							</parts>
 						</li>
 						<li>
-							<useStatic>false</useStatic>
 							<ArmorRating_Blunt>0.625</ArmorRating_Blunt>
 							<parts>
 								<li>MechanicalHead</li>
 							</parts>
 						</li>
 						<li>
-							<useStatic>false</useStatic>
 							<ArmorRating_Sharp>0.625</ArmorRating_Sharp>
 							<parts>
 								<li>MechanicalLeg</li>
 							</parts>
 						</li>
 						<li>
-							<useStatic>false</useStatic>
+							
 							<ArmorRating_Blunt>0.625</ArmorRating_Blunt>
 							<parts>
 								<li>MechanicalLeg</li>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Farm.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Farm.xml
@@ -180,7 +180,8 @@
 			<stats>
 				<li>
 					<useStatic>true</useStatic>
-					When useStatic is true, this becomes the value used and it is NOT influenced by durability, health and similar
+					When useStatic is 'true', this becomes the value used and it is NOT influenced by durability, health and similar,
+					The default value is 'false'.
 					<ArmorRating_Sharp>4</ArmorRating_Sharp>
 					<parts>
 						<li>Neck</li>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Insect.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Insect.xml
@@ -18,14 +18,12 @@
 			<li Class="CombatExtended.PartialArmorExt">
 				<stats>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
 						<parts>
 							<li>InsectLeg</li>
 						</parts>
 					</li>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Blunt>0.25</ArmorRating_Blunt>
 						<parts>
 							<li>InsectLeg</li>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Temperate.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Temperate.xml
@@ -494,14 +494,12 @@
 			<li Class="CombatExtended.PartialArmorExt">
 				<stats>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
 						<parts>
 							<li>Leg</li>
 						</parts>
 					</li>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Blunt>0.5</ArmorRating_Blunt>
 						<parts>
 							<li>Leg</li>

--- a/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
@@ -92,14 +92,12 @@
 			<li Class="CombatExtended.PartialArmorExt">
 				<stats>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
 						<parts>
 							<li>SightSensor</li>
 						</parts>
 					</li>
 					<li>
-						<useStatic>false</useStatic>
 						<ArmorRating_Blunt>0.25</ArmorRating_Blunt>
 						<parts>
 							<li>SightSensor</li>


### PR DESCRIPTION
## Changes
- Remove all instances of `<useStatic>false</useStatic>` and add a bit of additional info to the in-line notes.

## Reasoning
`useStatic` is false by default, and so this doesn't need to be specified in the mod extension except in cases where the pawn might be inheriting it from somewhere (there are no such cases in our integrated patches).

I suspect this is simply a case of a value being copy-pasted while patches were being made without people really knowing why. It's functionally harmless, but removing it slightly shortens some file lengths and may reduce confusion as to the field's actual functionality.

## Alternatives
- Leave it as-is.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
