### PR TITLE
Some patch fixes/tweaks

### DIFF
--- a/ModPatches/Big and Small Genes/Defs/Big and Small Genes/Weapons/ThingDef_Ammo.xml
+++ b/ModPatches/Big and Small Genes/Defs/Big and Small Genes/Weapons/ThingDef_Ammo.xml
@@ -37,7 +37,7 @@
 		<effectWorking>Smelt</effectWorking>
 		<unfinishedThingDef>UnfinishedAmmo</unfinishedThingDef>
 		<workAmount>18000</workAmount>
-		<jobString>Making pila.</jobString>
+		<jobString>Making a giant javelin.</jobString>
 		<ingredients>
 			<li>
 				<filter>

--- a/ModPatches/Big and Small Genes/Patches/Big and Small Genes/Weapons/ThingDef_RangedNeolithic.xml
+++ b/ModPatches/Big and Small Genes/Patches/Big and Small Genes/Weapons/ThingDef_RangedNeolithic.xml
@@ -24,6 +24,9 @@
 			<techLevel>Medieval</techLevel>
 			<tradeNeverStack>true</tradeNeverStack>
 			<burnableByRecipe>true</burnableByRecipe>
+			<thingCategories>
+				<li>WeaponsRanged</li>
+			</thingCategories>
 		</value>
 	</Operation>
 

--- a/ModPatches/Vanilla Factions Expanded - Classical/Patches/Vanilla Factions Expanded - Classical/ThingDefs_WeaponsRanged.xml
+++ b/ModPatches/Vanilla Factions Expanded - Classical/Patches/Vanilla Factions Expanded - Classical/ThingDefs_WeaponsRanged.xml
@@ -23,6 +23,9 @@
 		<xpath>Defs/ThingDef[defName="VFEC_Javelin"]</xpath>
 		<value>
 			<techLevel>Neolithic</techLevel>
+			<thingCategories>
+				<li>WeaponsRanged</li>
+			</thingCategories>			
 		</value>
 	</Operation>
 

--- a/ModPatches/Vanilla Factions Expanded - Tribals/Patches/Vanilla Factions Expanded - Tribals/ThingDefs_WeaponsRanged.xml
+++ b/ModPatches/Vanilla Factions Expanded - Tribals/Patches/Vanilla Factions Expanded - Tribals/ThingDefs_WeaponsRanged.xml
@@ -28,6 +28,9 @@
 		<xpath>Defs/ThingDef[defName="VFET_Throwspikes"]</xpath>
 		<value>
 			<techLevel>Neolithic</techLevel>
+			<thingCategories>
+				<li>WeaponsRanged</li>
+			</thingCategories>			
 		</value>
 	</Operation>
 

--- a/ModPatches/Vanilla Weapons Expanded - Frontier/Patches/Vanilla Weapons Expanded - Frontier/Weapons_Frontier.xml
+++ b/ModPatches/Vanilla Weapons Expanded - Frontier/Patches/Vanilla Weapons Expanded - Frontier/Weapons_Frontier.xml
@@ -215,19 +215,19 @@
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>VWEFT_Gun_RollingBlockRifle</defName>
 		<statBases>
-			<Mass>7.30</Mass>
-			<RangedWeapon_Cooldown>0.85</RangedWeapon_Cooldown>
+			<Mass>4.20</Mass>
+			<RangedWeapon_Cooldown>0.88</RangedWeapon_Cooldown>
 			<SightsEfficiency>2.15</SightsEfficiency>
 			<ShotSpread>0.01</ShotSpread>
 			<SwayFactor>1.73</SwayFactor>
 			<Bulk>12.80</Bulk>
 		</statBases>
 		<Properties>
-			<recoilAmount>2.0</recoilAmount>
+			<recoilAmount>2.3</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_4570GovHR_FMJ</defaultProjectile>
-			<warmupTime>1.3</warmupTime>
+			<warmupTime>1.1</warmupTime>
 			<range>64</range>
 			<soundCast>Shot_SniperRifle</soundCast>
 			<soundCastTail>GunTail_Heavy</soundCastTail>


### PR DESCRIPTION
## Changes
- Tweak the stats of the VWE: Frontier Rolling Block Rifle
  - Weight was too high, not sure where the old values came from.
  - https://docs.google.com/spreadsheets/d/1R0to_-kn7-7Xut9P9BAenOdSII4hOVKQpZH2Ce8cRgQ/edit?usp=sharing
- Big & Small Genes javelin.
  - Changed the recipe labels a bit to improve clarity.
- Fix thing category for some thrown weapons.
  - Big & Small Genes
  - VWE - Tribal & Classical

## References
- Closes #3533

## Reasoning
- Some rolling block's other stats were slightly off compared to what the sheet comes up with.
- Some thrown weapons don't have an assigned thing category for stockpiles because we changed the parent, but forgot to give them a thing category.

## Alternatives
- Suffer.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
