### PR TITLE
Texture offset fixes

### DIFF
--- a/Anomaly/Patches/ThingDefs_Misc/Weapons_Ranged.xml
+++ b/Anomaly/Patches/ThingDefs_Misc/Weapons_Ranged.xml
@@ -134,7 +134,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Gun_HellcatRifle"]/graphicData</xpath>
 		<value>
-			<drawSize>(1.25,1.25)</drawSize>
+			<drawSize>(1.16,1.16)</drawSize>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -609,18 +609,11 @@
 		<researchPrerequisite>BlowbackOperation</researchPrerequisite>
 	</Operation>
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Gun_MachinePistol"]/graphicData</xpath>
-		<value>
-			<drawSize>(0.84,0.84)</drawSize>
-		</value>
-	</Operation>
-
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="Gun_MachinePistol"]</xpath>
 		<value>
 			<li Class="CombatExtended.GunDrawExtension">
-				<DrawOffset>-0.1,-0.1</DrawOffset>
+				<DrawOffset>-0.08,0.0</DrawOffset>
 				<CasingOffset>0.1,0.1</CasingOffset>
 				<CasingAngleOffset>-30</CasingAngleOffset>
 			</li>
@@ -679,7 +672,7 @@
 		<xpath>Defs/ThingDef[defName="Gun_HeavySMG"]</xpath>
 		<value>
 			<li Class="CombatExtended.GunDrawExtension">
-				<DrawOffset>-0.03,0.05</DrawOffset>
+				<DrawOffset>-0.03,0.0</DrawOffset>
 				<CasingOffset>0.1,0</CasingOffset>
 			</li>
 		</value>
@@ -755,7 +748,7 @@
 		<xpath>Defs/ThingDef[defName="Gun_IncendiaryLauncher"]</xpath>
 		<value>
 			<li Class="CombatExtended.GunDrawExtension">
-				<DrawOffset>0.1,-0.05</DrawOffset>
+				<DrawOffset>0.1,0.0</DrawOffset>
 			</li>
 		</value>
 	</Operation>
@@ -825,7 +818,7 @@
 		<xpath>Defs/ThingDef[defName="Gun_LMG"]</xpath>
 		<value>
 			<li Class="CombatExtended.GunDrawExtension">
-				<DrawOffset>0.13,-0.03</DrawOffset>
+				<DrawOffset>0.18,-0.03</DrawOffset>
 			</li>
 		</value>
 	</Operation>
@@ -891,7 +884,7 @@
 		<xpath>Defs/ThingDef[defName="Gun_ChargeRifle"]</xpath>
 		<value>
 			<li Class="CombatExtended.GunDrawExtension">
-				<DrawOffset>0.06,0.01</DrawOffset>
+				<DrawOffset>0.06,0.0</DrawOffset>
 			</li>
 		</value>
 	</Operation>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -672,7 +672,7 @@
 		<xpath>Defs/ThingDef[defName="Gun_HeavySMG"]</xpath>
 		<value>
 			<li Class="CombatExtended.GunDrawExtension">
-				<DrawOffset>-0.03,0.0</DrawOffset>
+				<DrawOffset>-0.03,0.05</DrawOffset>
 				<CasingOffset>0.1,0</CasingOffset>
 			</li>
 		</value>


### PR DESCRIPTION
## Changes

- Reverting some of the changes made here: https://github.com/CombatExtended-Continued/CombatExtended/pull/3458/commits/b9396ae110d12871720df5bf972f2949ec09976c, the rest are addressed here: https://github.com/CombatExtended-Continued/CombatExtended/pull/3554

## Reasoning

- How things were before the last minute commit: 
![image](https://github.com/user-attachments/assets/ebd41bf3-ff65-4782-90d5-718110cbe47e)
How things are now in the dev branch which is getting reverted: 
![image](https://github.com/user-attachments/assets/0b5f5606-b3f2-48e6-b059-a66e2105d60e)

## Alternatives

- Suffer and cringe at the offsets.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
