### PR TITLE
Correct Pawn Painshock Threshold Values

### DIFF
--- a/Anomaly/Patches/ThingDefs_Races/Races_Entities_Misc.xml
+++ b/Anomaly/Patches/ThingDefs_Races/Races_Entities_Misc.xml
@@ -254,7 +254,7 @@
 		<value>
 			<ArmorRating_Sharp>0.2</ArmorRating_Sharp>
 			<ArmorRating_Blunt>1</ArmorRating_Blunt>
-			<PainShockThreshold>90</PainShockThreshold>
+			<PainShockThreshold>0.90</PainShockThreshold>
 			<MeleeDodgeChance>0.17</MeleeDodgeChance>
 			<MeleeCritChance>0.08</MeleeCritChance>
 			<MeleeParryChance>0.06</MeleeParryChance>
@@ -377,7 +377,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Noctol"]/statBases</xpath>
 		<value>
-			<PainShockThreshold>90</PainShockThreshold>
+			<PainShockThreshold>0.90</PainShockThreshold>
 			<MeleeDodgeChance>0.23</MeleeDodgeChance>
 			<MeleeCritChance>0.28</MeleeCritChance>
 			<MeleeParryChance>0.09</MeleeParryChance>
@@ -505,7 +505,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Gorehulk"]/statBases</xpath>
 		<value>
-			<PainShockThreshold>90</PainShockThreshold>
+			<PainShockThreshold>0.90</PainShockThreshold>
 			<MeleeDodgeChance>0.11</MeleeDodgeChance>
 			<MeleeCritChance>0.07</MeleeCritChance>
 			<MeleeParryChance>0.14</MeleeParryChance>
@@ -606,7 +606,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Devourer"]/statBases</xpath>
 		<value>
-			<PainShockThreshold>90</PainShockThreshold>
+			<PainShockThreshold>0.90</PainShockThreshold>
 			<MeleeDodgeChance>0.06</MeleeDodgeChance>
 			<MeleeCritChance>0.46</MeleeCritChance>
 			<MeleeParryChance>0.51</MeleeParryChance>
@@ -699,7 +699,7 @@
 			<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
 			<ArmorRating_Blunt>5</ArmorRating_Blunt>
 			<IncomingDamageFactor>0.7</IncomingDamageFactor>
-			<PainShockThreshold>90</PainShockThreshold>
+			<PainShockThreshold>0.90</PainShockThreshold>
 			<MeleeDodgeChance>0.06</MeleeDodgeChance>
 			<MeleeCritChance>0.11</MeleeCritChance>
 			<MeleeParryChance>0.23</MeleeParryChance>

--- a/Anomaly/Patches/ThingDefs_Races/Races_Fleshbeasts.xml
+++ b/Anomaly/Patches/ThingDefs_Races/Races_Fleshbeasts.xml
@@ -5,7 +5,7 @@
 		<xpath>Defs/ThingDef[@Name="BaseFleshbeast"]/statBases</xpath>
 		<value>
 			<SmokeSensitivity>0.5</SmokeSensitivity>
-			<PainShockThreshold>99</PainShockThreshold>
+			<PainShockThreshold>0.99</PainShockThreshold>
 		</value>
 	</Operation>
 

--- a/ModPatches/Starship Troopers Arachnids/Patches/Starship Troopers Arachnids/Races.xml
+++ b/ModPatches/Starship Troopers Arachnids/Patches/Starship Troopers Arachnids/Races.xml
@@ -13,7 +13,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[@Name="BugsThingBase"]/statBases</xpath>
 		<value>
-			<PainShockThreshold>5</PainShockThreshold>
+			<PainShockThreshold>0.99</PainShockThreshold>
 		</value>
 	</Operation>
 


### PR DESCRIPTION
## Changes
- Change pain shock threshold of various pawns.
   - Change values of 99 to 0.99, to be more clear.
   - Change values of 90 to 0.90 so that they're actually less than the max threshold. 

## Reasoning
While `PainShockThreshold` will accept any numerical value, it is clamped between 0.01 and 0.99 by the StatDef, so only values in that range have any discrete function. All values < 0.01 are functionally the same as 0.01, and all values > 0.99 are functionally the same as 0.99--see the min and max values below.

```
<StatDef>
    <defName>PainShockThreshold</defName>
    <label>pain shock threshold</label>
    <description>The pain level at which this creature is downed from pain.</description>
    <category>BasicsPawn</category>
    <minValue>0.01</minValue>
    <maxValue>0.99</maxValue>
    <defaultBaseValue>0.8</defaultBaseValue>
    <toStringStyle>PercentZero</toStringStyle>
    <showOnMechanoids>false</showOnMechanoids>
    <displayPriorityInCategory>2000</displayPriorityInCategory>
  </StatDef>
```
Since several Entities have been assigned a threshold value of `90`, there's the distinct impression they were intended to have a lower shock threshold than the Fleshbeasts, which have been set to `99`. However, since both these values end up clamped to 0.99, they are mechanically the same in game, making the xml values misleading.

## Alternatives
- Leave as-is.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (about 20 minutes shooting a sightstealer)
