### PR TITLE
Only consume ammo for shots that were actually fired

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
@@ -337,19 +337,37 @@ namespace CombatExtended
             }
         }
 
-        public bool Notify_ShotFired()
+
+        /// <summary>
+        /// <para>Reduces ammo count and updates inventory if necessary, call this whenever ammo is consumed by the gun (e.g. firing a shot, clearing a jam). </para>
+        /// <para>Has an optional argument for the amount of ammo to consume per shot, which defaults to 1; this caters for special cases such as different sci-fi weapons using up different amounts of the same energy cell ammo type per shot, or a double-barrelled shotgun that fires both cartridges at the same time (projectile treated as a single, more powerful bullet)</para>
+        /// </summary>
+        public void Notify_ShotFired(int ammoConsumedPerShot = 1)
         {
-            if (ammoToBeDeleted != null)
+            ammoConsumedPerShot = (ammoConsumedPerShot > 0) ? ammoConsumedPerShot : 1;
+
+            if (!IsEquippedGun && turret == null)
             {
-                ammoToBeDeleted.Destroy();
-                ammoToBeDeleted = null;
-                CompInventory.UpdateInventory();
-                if (!HasAmmoOrMagazine)
+                Log.Error(parent.ToString() + " tried reducing its ammo count without a wielder");
+            }
+
+            // Mag-less weapons feed directly from inventory
+            if (!HasMagazine)
+            {
+                if (ammoToBeDeleted != null)
                 {
-                    return false;
+                    ammoToBeDeleted.Destroy();
+                    ammoToBeDeleted = null;
+                    CompInventory.UpdateInventory();
                 }
             }
-            return true;
+
+            if (curMagCountInt <= 0)
+            {
+                Log.Error($"{parent} tried reducing its ammo count when already empty");
+            }
+            // Reduce ammo count and update inventory
+            CurMagCount = (curMagCountInt - ammoConsumedPerShot < 0) ? 0 : curMagCountInt - ammoConsumedPerShot;
         }
 
         public bool Notify_PostShotFired()
@@ -363,63 +381,45 @@ namespace CombatExtended
         }
 
         /// <summary>
-        /// <para>Reduces ammo count and updates inventory if necessary, call this whenever ammo is consumed by the gun (e.g. firing a shot, clearing a jam). </para>
-        /// <para>Has an optional argument for the amount of ammo to consume per shot, which defaults to 1; this caters for special cases such as different sci-fi weapons using up different amounts of the same energy cell ammo type per shot, or a double-barrelled shotgun that fires both cartridges at the same time (projectile treated as a single, more powerful bullet)</para>
+        /// Check whether ammo is available for firing a shot.
         /// </summary>
-        public bool TryReduceAmmoCount(int ammoConsumedPerShot = 1)
+        /// <remarks>
+        /// For weapons without a magazine, this may update the currently selected ammo type
+        /// if we ran out of the currently selected ammo type but have different, compatible, types
+        /// available in the inventory.
+        /// </remarks>
+        /// <returns></returns>
+        public bool TryPrepareShot()
         {
-            ammoConsumedPerShot = (ammoConsumedPerShot > 0) ? ammoConsumedPerShot : 1;
-
-            if (!IsEquippedGun && turret == null)
+            if (HasMagazine)
             {
-                Log.Error(parent.ToString() + " tried reducing its ammo count without a wielder");
-            }
-
-            // Mag-less weapons feed directly from inventory
-            if (!HasMagazine)
-            {
-                if (UseAmmo)
+                // If magazine is empty, return false
+                if (curMagCountInt <= 0)
                 {
-                    if (!TryFindAmmoInInventory(out ammoToBeDeleted))
-                    {
-                        return false;
-                    }
-                    if (ammoToBeDeleted.def != CurrentAmmo)
-                    {
-                        currentAmmoInt = ammoToBeDeleted.def as AmmoDef;
-                    }
-
-                    if (ammoToBeDeleted.stackCount > 1)
-                    {
-                        ammoToBeDeleted = ammoToBeDeleted.SplitOff(1);
-                    }
+                    CurMagCount = 0;
+                    return false;
                 }
+
                 return true;
             }
-            // If magazine is empty, return false
-            if (curMagCountInt <= 0)
+
+            if (UseAmmo)
             {
-                CurMagCount = 0;
-                return false;
+                if (!TryFindAmmoInInventory(out ammoToBeDeleted))
+                {
+                    return false;
+                }
+                if (ammoToBeDeleted.def != CurrentAmmo)
+                {
+                    currentAmmoInt = ammoToBeDeleted.def as AmmoDef;
+                }
+
+                if (ammoToBeDeleted.stackCount > 1)
+                {
+                    ammoToBeDeleted = ammoToBeDeleted.SplitOff(1);
+                }
             }
-            // Reduce ammo count and update inventory
-            CurMagCount = (curMagCountInt - ammoConsumedPerShot < 0) ? 0 : curMagCountInt - ammoConsumedPerShot;
 
-
-            /*if (curMagCountInt - ammoConsumedPerShot < 0)
-            {
-                curMagCountInt = 0;
-            } else
-            {
-                curMagCountInt = curMagCountInt - ammoConsumedPerShot;
-            }*/
-
-
-            // Original: curMagCountInt--;
-            if (curMagCountInt < 0)
-            {
-                TryStartReload();
-            }
             return true;
         }
 

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -41,7 +41,7 @@ namespace CombatExtended
         protected float distance = 10f;
 
         public CompCharges compCharges = null;
-        public CompAmmoUser compAmmo = null;
+
         public CompFireModes compFireModes = null;
         public CompChangeableProjectile compChangeable = null;
         public CompApparelReloadable compReloadable = null;
@@ -155,26 +155,10 @@ namespace CombatExtended
         public float SightsEfficiency => EquipmentSource?.GetStatValue(CE_StatDefOf.SightsEfficiency) ?? 1f;
         public virtual float SwayAmplitude => Mathf.Max(0, (4.5f - ShootingAccuracy) * (EquipmentSource?.GetStatValue(CE_StatDefOf.SwayFactor) ?? 1f));
 
-        // Ammo variables
-        public virtual CompAmmoUser CompAmmo
-        {
-            get
-            {
-                if (compAmmo == null && EquipmentSource != null)
-                {
-                    compAmmo = EquipmentSource.TryGetComp<CompAmmoUser>();
-                }
-                return compAmmo;
-            }
-        }
         public virtual ThingDef Projectile
         {
             get
             {
-                if (CompAmmo != null && CompAmmo.CurrentAmmo != null)
-                {
-                    return CompAmmo.CurAmmoProjectile;
-                }
                 if (CompChangeable != null && CompChangeable.Loaded)
                 {
                     return CompChangeable.Projectile;
@@ -235,8 +219,6 @@ namespace CombatExtended
                 return recoil;
             }
         }
-
-        private bool IsAttacking => ShooterPawn?.CurJobDef == JobDefOf.AttackStatic || WarmingUp;
 
         private LightingTracker _lightingTracker = null;
         protected LightingTracker LightingTracker
@@ -302,14 +284,7 @@ namespace CombatExtended
                 }
             }
 
-            // Add check for reload
-            if (Projectile == null || (IsAttacking && CompAmmo != null && !CompAmmo.CanBeFiredNow))
-            {
-                CompAmmo?.TryStartReload();
-                resetRetarget();
-                return false;
-            }
-            return true;
+            return Projectile != null;
         }
 
         /// <summary>
@@ -487,19 +462,13 @@ namespace CombatExtended
                                         Apparel LegArmor = LegArmors.MaxByWithFallback(funcArmor);
                                         #endregion
 
-                                        #region get CompAmmo's Current ammo projectile
-
-                                        var ProjCE = (ProjectilePropertiesCE)compAmmo?.CurAmmoProjectile?.projectile ?? null;
-
-                                        #endregion
-
                                         #region checks for whether the pawn can penetrate armor, which armor is stronger, etc
 
                                         var TargetedBodyPartArmor = TorsoArmor;
 
                                         bool flagTorsoArmor = ((TorsoArmor?.GetStatValue(StatDefOf.ArmorRating_Sharp) ?? 0.1f) >= (Helmet?.GetStatValue(StatDefOf.ArmorRating_Sharp) ?? 0f));
 
-                                        bool flag2 = ((ProjCE?.armorPenetrationSharp ?? 0f) >= (TorsoArmor?.GetStatValue(StatDefOf.ArmorRating_Sharp) ?? 0.1f));
+                                        bool flag2 = (projectilePropsCE.armorPenetrationSharp >= (TorsoArmor?.GetStatValue(StatDefOf.ArmorRating_Sharp) ?? 0.1f));
                                         //Headshots do too little damage too often, so if the pawn can penetrate torso armor, they should aim at it
                                         if ((flagTorsoArmor && !flag2))
                                         {
@@ -509,7 +478,7 @@ namespace CombatExtended
                                         bool flag3 = (TargetedBodyPartArmor?.GetStatValue(StatDefOf.ArmorRating_Sharp) ?? 0f) >= ((LegArmor?.GetStatValue(StatDefOf.ArmorRating_Sharp) ?? 0f) + 4f);
 
                                         //bool for whether the pawn can penetrate helmet
-                                        bool flag4 = ((ProjCE?.armorPenetrationSharp ?? 0f) >= (Helmet?.GetStatValue(StatDefOf.ArmorRating_Sharp) ?? 0.1f));
+                                        bool flag4 = (projectilePropsCE.armorPenetrationSharp >= (Helmet?.GetStatValue(StatDefOf.ArmorRating_Sharp) ?? 0.1f));
 
                                         //if the pawn can penetrate the helmet or torso armor there's no need to aim for legs
                                         if (flag3 && (!flag4) && (!flag2))
@@ -1132,11 +1101,6 @@ namespace CombatExtended
             numShotsFired++;
             if (ShooterPawn != null)
             {
-                if (CompAmmo != null && !CompAmmo.CanBeFiredNow)
-                {
-                    CompAmmo?.TryStartReload();
-                    resetRetarget();
-                }
                 if (CompReloadable != null)
                 {
                     CompReloadable.UsedOnce();

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -31,6 +31,8 @@ namespace CombatExtended
 
         public Vector3 drawPos;
 
+        private CompAmmoUser compAmmo;
+
         #endregion
 
         #region Properties
@@ -133,6 +135,17 @@ namespace CombatExtended
 
         // Whether our shooter is currently under suppressive fire
         private bool IsSuppressed => ShooterPawn?.TryGetComp<CompSuppressable>()?.isSuppressed ?? false;
+
+        public CompAmmoUser CompAmmo
+        {
+            get
+            {
+                compAmmo ??= EquipmentSource?.TryGetComp<CompAmmoUser>();
+                return compAmmo;
+            }
+        }
+
+        public override ThingDef Projectile => CompAmmo?.CurrentAmmo != null ? CompAmmo.CurAmmoProjectile : base.Projectile;
 
         #endregion
 
@@ -246,6 +259,25 @@ namespace CombatExtended
 
                 ShooterPawn.skills.Learn(SkillDefOf.Shooting, xpPerSec);
             }
+        }
+
+        public override bool Available()
+        {
+            if (!base.Available())
+            {
+                return false;
+            }
+
+            // Add check for reload
+            bool isAttacking = ShooterPawn?.CurJobDef == JobDefOf.AttackStatic || WarmingUp;
+            if (isAttacking && !(CompAmmo?.CanBeFiredNow ?? true))
+            {
+                CompAmmo?.TryStartReload();
+                resetRetarget();
+                return false;
+            }
+
+            return true;
         }
 
         public override void VerbTickCE()
@@ -379,13 +411,9 @@ namespace CombatExtended
 
         public override bool TryCastShot()
         {
-            //Reduce ammunition
-            if (CompAmmo != null)
+            if (!CompAmmo?.TryPrepareShot() ?? false)
             {
-                if (!CompAmmo.TryReduceAmmoCount(((CompAmmo.Props.ammoSet != null) ? CompAmmo.Props.ammoSet.ammoConsumedPerShot : 1) * VerbPropsCE.ammoConsumedPerShotCount))
-                {
-                    return false;
-                }
+                return false;
             }
             if (base.TryCastShot())
             {
@@ -409,10 +437,25 @@ namespace CombatExtended
             {
                 CE_Utility.GenerateAmmoCasings(projectilePropsCE, fromPawn ? drawPos : caster.DrawPos, caster.Map, AimAngle, VerbPropsCE.recoilAmount, fromPawn: fromPawn, extension: ext);
             }
-            // This needs to here for weapons without magazine to ensure their last shot plays sounds
-            if (CompAmmo != null && !CompAmmo.HasMagazine && CompAmmo.UseAmmo)
+
+            if (CompAmmo == null)
             {
-                if (!CompAmmo.Notify_ShotFired())
+                return true;
+            }
+
+            int ammoConsumedPerShot = (CompAmmo.Props.ammoSet?.ammoConsumedPerShot ?? 1) * VerbPropsCE.ammoConsumedPerShotCount;
+            CompAmmo.Notify_ShotFired(ammoConsumedPerShot);
+
+            if (ShooterPawn != null && !CompAmmo.CanBeFiredNow)
+            {
+                CompAmmo.TryStartReload();
+                resetRetarget();
+            }
+
+            // This needs to here for weapons without magazine to ensure their last shot plays sounds
+            if (!CompAmmo.HasMagazine && CompAmmo.UseAmmo)
+            {
+                if (!CompAmmo.HasAmmoOrMagazine)
                 {
                     if (VerbPropsCE.muzzleFlashScale > 0.01f)
                     {

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootMortarCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootMortarCE.cs
@@ -206,10 +206,6 @@ namespace CombatExtended
             numShotsFired++;
             if (ShooterPawn != null)
             {
-                if (CompAmmo != null && !CompAmmo.CanBeFiredNow)
-                {
-                    CompAmmo?.TryStartReload();
-                }
                 if (CompReloadable != null)
                 {
                     CompReloadable.UsedOnce();
@@ -225,13 +221,7 @@ namespace CombatExtended
             {
                 return base.TryCastShot();
             }
-            if (CompAmmo != null)
-            {
-                if (!CompAmmo.TryReduceAmmoCount(CompAmmo.Props.ammoSet.ammoConsumedPerShot * VerbPropsCE.ammoConsumedPerShotCount))
-                {
-                    return false;
-                }
-            }
+
             if (this.TryCastGlobalShot())
             {
                 return this.OnCastSuccessful();


### PR DESCRIPTION
## Changes

* Centralize ammo management for verbs within `Verb_ShootCE`
* Split ammo count check / selection and ammo consumption into separate methods
* Consume ammo in `OnCastSuccessful` rather than before attempting the shot

## References

- Closes #3500

## Reasoning

* `Verb_LaunchProjectileCE` doesn't need to know about `CompAmmo`, only `Verb_ShootCE` and derivatives do. The current system leads to reload / ammo management logic being copypasted across verb classes, which is error-prone.
* We currently check for and reduce ammo count before checking if a shot can actually be fired. For burst weapons with interruptibleBurst = true, this can cause extra ammo to be consumed without a corresponding shot being made.



## Testing

- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony - spawned in a KPV with APHE and targeted a wooden wall directly next to it. With this change, this consumes 2 bullets instead of 3. Also tested automatic reloading and out of ammo behavior with a gun-wielding colonist.
