### PR TITLE
Add Xen's Spirit Wolf support

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -629,6 +629,7 @@
 		<li IfModActive="Thek.WTB">ModPatches/Waster Toxic Breather</li>
 		<li IfModActive="Kyrrisayo.WeaponsPlus">ModPatches/Weapons+</li>
 		<li IfModActive="Owlchemist.Windows">ModPatches/Windows</li>
+		<li IfModActive="forestfey.SpiritWolf">ModPatches/Xen's Spirit Wolf</li>
 		<li IfModActive="Mlie.XennRace">ModPatches/Xenn</li>
 		<li IfModActive="Albion.Xenohumans">ModPatches/Xenohumans</li>
 		<li IfModActive="AveryTheKitty.XenohumansAnthromorphs">ModPatches/Xenohumans - Anthromorphs</li>

--- a/ModPatches/Xen's Spirit Wolf/Patches/Xen's Spirit Wolf/ThingDefs_Races.xml
+++ b/ModPatches/Xen's Spirit Wolf/Patches/Xen's Spirit Wolf/ThingDefs_Races.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- ========== Spirit Wolf ========== -->
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="XenSpiritWolf"]</xpath>
+		<value>
+			<li Class="CombatExtended.RacePropertiesExtensionCE">
+				<bodyShape>Quadruped</bodyShape>
+			</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="XenSpiritWolf"]/statBases/MoveSpeed</xpath>
+		<value>
+			<MoveSpeed>7.2</MoveSpeed>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="XenSpiritWolf"]/statBases</xpath>
+		<value>
+			<MeleeDodgeChance>0.33</MeleeDodgeChance>
+			<MeleeCritChance>0.12</MeleeCritChance>
+			<MeleeParryChance>0.07</MeleeParryChance>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="XenSpiritWolf"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>left claw</label>
+					<capacities>
+						<li>Scratch</li>
+					</capacities>
+					<power>6</power>
+					<cooldownTime>0.75</cooldownTime>
+					<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+					<surpriseAttack>
+						<extraMeleeDamages>
+							<li>
+								<def>Stun</def>
+								<amount>20</amount>
+							</li>
+						</extraMeleeDamages>
+					</surpriseAttack>
+					<armorPenetrationBlunt>0.450</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.07</armorPenetrationSharp>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>right claw</label>
+					<capacities>
+						<li>Scratch</li>
+					</capacities>
+					<power>6</power>
+					<cooldownTime>0.75</cooldownTime>
+					<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+					<surpriseAttack>
+						<extraMeleeDamages>
+							<li>
+								<def>Stun</def>
+								<amount>20</amount>
+							</li>
+						</extraMeleeDamages>
+					</surpriseAttack>
+					<armorPenetrationBlunt>0.450</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.07</armorPenetrationSharp>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<capacities>
+						<li>Bite</li>
+					</capacities>
+					<power>23</power>
+					<cooldownTime>1.7</cooldownTime>
+					<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+					<surpriseAttack>
+						<extraMeleeDamages>
+							<li>
+								<def>Stun</def>
+								<amount>20</amount>
+							</li>
+						</extraMeleeDamages>
+					</surpriseAttack>
+					<armorPenetrationSharp>0.55</armorPenetrationSharp>
+					<armorPenetrationBlunt>4.225</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>1</power>
+					<cooldownTime>1.2</cooldownTime>
+					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					<chanceFactor>0.2</chanceFactor>
+					<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Xen's Spirit Wolf/Patches/Xen's Spirit Wolf/ThingDefs_Races.xml
+++ b/ModPatches/Xen's Spirit Wolf/Patches/Xen's Spirit Wolf/ThingDefs_Races.xml
@@ -22,6 +22,8 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="XenSpiritWolf"]/statBases</xpath>
 		<value>
+			<ArmorRating_Blunt>0.24</ArmorRating_Blunt>
+			<ArmorRating_Sharp>0.16</ArmorRating_Sharp>		
 			<MeleeDodgeChance>0.33</MeleeDodgeChance>
 			<MeleeCritChance>0.12</MeleeCritChance>
 			<MeleeParryChance>0.07</MeleeParryChance>
@@ -37,7 +39,7 @@
 					<capacities>
 						<li>Scratch</li>
 					</capacities>
-					<power>6</power>
+					<power>16</power>
 					<cooldownTime>0.75</cooldownTime>
 					<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
 					<surpriseAttack>
@@ -48,15 +50,15 @@
 							</li>
 						</extraMeleeDamages>
 					</surpriseAttack>
-					<armorPenetrationBlunt>0.450</armorPenetrationBlunt>
-					<armorPenetrationSharp>0.07</armorPenetrationSharp>
+					<armorPenetrationBlunt>3.350</armorPenetrationBlunt>
+					<armorPenetrationSharp>1</armorPenetrationSharp>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>right claw</label>
 					<capacities>
 						<li>Scratch</li>
 					</capacities>
-					<power>6</power>
+					<power>16</power>
 					<cooldownTime>0.75</cooldownTime>
 					<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
 					<surpriseAttack>
@@ -67,15 +69,16 @@
 							</li>
 						</extraMeleeDamages>
 					</surpriseAttack>
-					<armorPenetrationBlunt>0.450</armorPenetrationBlunt>
-					<armorPenetrationSharp>0.07</armorPenetrationSharp>
+					<armorPenetrationBlunt>3.350</armorPenetrationBlunt>
+					<armorPenetrationSharp>1</armorPenetrationSharp>
 				</li>
 				<li Class="CombatExtended.ToolCE">
+					<label>fangs</label>
 					<capacities>
 						<li>Bite</li>
 					</capacities>
-					<power>23</power>
-					<cooldownTime>1.7</cooldownTime>
+					<power>30</power>
+					<cooldownTime>1.72</cooldownTime>
 					<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
 					<surpriseAttack>
 						<extraMeleeDamages>
@@ -85,21 +88,45 @@
 							</li>
 						</extraMeleeDamages>
 					</surpriseAttack>
-					<armorPenetrationSharp>0.55</armorPenetrationSharp>
-					<armorPenetrationBlunt>4.225</armorPenetrationBlunt>
+					<chanceFactor>0.9</chanceFactor>
+					<armorPenetrationSharp>1.75</armorPenetrationSharp>
+					<armorPenetrationBlunt>9.15</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>head</label>
 					<capacities>
 						<li>Blunt</li>
 					</capacities>
-					<power>1</power>
-					<cooldownTime>1.2</cooldownTime>
+					<power>8</power>
+					<cooldownTime>3.2</cooldownTime>
 					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 					<chanceFactor>0.2</chanceFactor>
-					<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+					<armorPenetrationBlunt>2.350</armorPenetrationBlunt>
 				</li>
 			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="XenSpiritWolf"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="XenSpiritWolf"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="XenSpiritWolf"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>4035</Durability>
+				<Regenerates>true</Regenerates>
+				<RegenInterval>600</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<MinArmorPct>0.5</MinArmorPct>
+			</li>
 		</value>
 	</Operation>
 

--- a/ModPatches/Xen's Spirit Wolf/Patches/Xen's Spirit Wolf/ThingDefs_Races.xml
+++ b/ModPatches/Xen's Spirit Wolf/Patches/Xen's Spirit Wolf/ThingDefs_Races.xml
@@ -24,9 +24,9 @@
 		<value>
 			<ArmorRating_Blunt>0.24</ArmorRating_Blunt>
 			<ArmorRating_Sharp>0.16</ArmorRating_Sharp>		
-			<MeleeDodgeChance>0.33</MeleeDodgeChance>
-			<MeleeCritChance>0.12</MeleeCritChance>
-			<MeleeParryChance>0.07</MeleeParryChance>
+			<MeleeDodgeChance>0.24</MeleeDodgeChance>
+			<MeleeCritChance>0.24</MeleeCritChance>
+			<MeleeParryChance>0.13</MeleeParryChance>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Races/Races_Humanlike.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Humanlike.xml
@@ -89,7 +89,7 @@
 				<compClass>CombatExtended.CompPawnGizmo</compClass>
 			</li>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
-				<Durability>500</Durability>
+				<Durability>500</Durability> <!-- 250 * (body size + HP scale) -->
 				<Regenerates>true</Regenerates>
 				<RegenInterval>600</RegenInterval>
 				<RegenValue>5</RegenValue>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -605,6 +605,7 @@ Weapons+	|
 WWII German Uniforms - V's Edit |
 WWII Soviet Faction	|
 Windows |
+Xen's Spirit Wolf	|
 Xenn Race	|
 Xenohumans - Anthromorphs |
 Xenohumans Expanded |


### PR DESCRIPTION
## Additions

Added support for Xen's Spirit Wolf mod.

## Reasoning

- Similar to the warg, but a bit faster.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [X] Game runs without errors
- [X] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
