### PR TITLE
Exclude melee from wall frags

### DIFF
--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
@@ -471,6 +471,7 @@ namespace CombatExtended
             damageInfo.SetWeaponBodyPartGroup(bodyPartGroupDef);
             damageInfo.SetWeaponHediff(hediffDef);
             damageInfo.SetAngle(direction);
+            damageInfo.SetTool(tool);
             yield return damageInfo;
             if (this.tool != null && this.tool.extraMeleeDamages != null)
             {

--- a/Source/CombatExtended/Harmony/Harmony_DamageWorker.cs
+++ b/Source/CombatExtended/Harmony/Harmony_DamageWorker.cs
@@ -20,7 +20,7 @@ namespace CombatExtended.HarmonyCE
             {
                 return true;
             }
-            if (victim.def.useHitPoints && dinfo.Def.harmsHealth && dinfo.Def != DamageDefOf.Mining)
+            if (victim.def.useHitPoints && dinfo.Def.harmsHealth && dinfo.tool == null && dinfo.Def != DamageDefOf.Mining)
             {
                 if (victim.def.category == ThingCategory.Building)
                 {


### PR DESCRIPTION
## Changes

- Melee attacks now no longer create fragments when the fragments from walls are enabled

## Reasoning

- Using melee to break buildings/debris carries disproportionate risk with the setting enabled.
- Melee attacks *should* be the only instances of damage where the tool isn't null, so shouldn't affect anything else.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Gunshots still make the wall ouchies
- [ ] Playtested a colony (specify how long)
