### PR TITLE
Unavailable projectiles for Verb

### DIFF
--- a/Source/CombatExtended/CombatExtended/Things/Building_TurretGunCE.cs
+++ b/Source/CombatExtended/CombatExtended/Things/Building_TurretGunCE.cs
@@ -419,6 +419,10 @@ namespace CombatExtended
 
         public virtual LocalTargetInfo TryFindNewTarget()    // Core method
         {
+            if (!AttackVerb.Available())
+            {
+                return null;
+            }
             IAttackTargetSearcher attackTargetSearcher = this.TargSearcher();
             Faction faction = attackTargetSearcher.Thing.Faction;
             float range = this.AttackVerb.verbProps.range;

--- a/Source/CombatExtended/CombatExtended/Verbs/VerbPropertiesCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/VerbPropertiesCE.cs
@@ -18,5 +18,6 @@ namespace CombatExtended
         public bool ejectsCasings = true;
         public bool ignorePartialLoSBlocker = false;
         public bool interruptibleBurst = true;
+        public List<ThingDef> cantShotWith = new List<ThingDef>();
     }
 }

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -268,7 +268,7 @@ namespace CombatExtended
                 }
             }
 
-            return Projectile != null;
+            return Projectile != null && !VerbPropsCE.cantShotWith.Contains(Projectile);
         }
 
         /// <summary>


### PR DESCRIPTION

## Additions
- Projectile exclusion for verbs

## Reasoning

- Can be useful for multi-verb weapons, such as #3534: one bullet type against skyfallers only, the other - against ground targets


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
