### PR TITLE
Broaden Optoelectronics Research Descriptions to Include Electronic Weapon Sights

### DIFF
--- a/Defs/ResearchProjectDefs/ResearchProjects.xml
+++ b/Defs/ResearchProjectDefs/ResearchProjects.xml
@@ -111,7 +111,7 @@
 	<ResearchProjectDef>
 		<defName>CE_SimpleNV</defName>
 		<label>basic optoelectronics</label>
-		<description>Allows for the production of simple electro-optical devices, like night vision goggles.</description>
+		<description>Allows for the production of simple electro-optical devices, like night vision goggles and reflex sights.</description>
 		<baseCost>800</baseCost>
 		<techLevel>Industrial</techLevel>
 		<prerequisites>
@@ -121,7 +121,7 @@
 		<researchViewY>5.50</researchViewY>
 		<generalRules>
 			<rulesStrings>
-				<li>subject->night vision</li>
+				<li>subject->optoelectronics</li>
 
 				<li>subject_story->worked on developing basic light sensors</li>
 				<li>subject_story->took part in military field testing on a war-world</li>
@@ -135,7 +135,7 @@
 	<ResearchProjectDef>
 		<defName>CE_AdvancedNV</defName>
 		<label>advanced optoelectronics</label>
-		<description>Allows for the production of more advanced and specialized electro-optical devices, including better night vision goggles.</description>
+		<description>Allows for the production of more advanced and specialized electro-optical devices, including better night vision goggles and advanced digital optics.</description>
 		<baseCost>1000</baseCost>
 		<techLevel>Industrial</techLevel>
 		<prerequisites>
@@ -148,7 +148,7 @@
 		<researchViewY>5.30</researchViewY>
 		<generalRules>
 			<rulesStrings>
-				<li>subject->advanced night vision</li>
+				<li>subject->advanced optoelectronics</li>
 
 				<li>subject_story->meticulously studied the sensors of destroyed mechanoids</li>
 				<li>subject_story->uncovered an ancient cryosleep crypt containing stores of advanced armor</li>

--- a/Defs/ResearchProjectDefs/ResearchProjects.xml
+++ b/Defs/ResearchProjectDefs/ResearchProjects.xml
@@ -111,7 +111,7 @@
 	<ResearchProjectDef>
 		<defName>CE_SimpleNV</defName>
 		<label>basic optoelectronics</label>
-		<description>Allows for the production of simple electro-optical devices, like night vision goggles and reflex sights.</description>
+		<description>Allows for the production of simple electro-optical devices, like night vision goggles and reflector sights.</description>
 		<baseCost>800</baseCost>
 		<techLevel>Industrial</techLevel>
 		<prerequisites>

--- a/Defs/ResearchProjectDefs/ResearchProjects.xml
+++ b/Defs/ResearchProjectDefs/ResearchProjects.xml
@@ -39,10 +39,12 @@
 		<generalRules>
 			<rulesStrings>
 				<li>subject->grenade launchers</li>
+				<li>subject->rocket launchers launchers</li>
 
 				<li>subject_story->developed weapons to defeat heavily armored foes</li>
 				<li>subject_story->toiled in an urbworld munitions factory</li>
 				<li>subject_story->narrowly survived an assault by mechanoids and vowed to stop such attacks</li>
+				<li>subject_story->developed anti-armor tactics</li>
 
 				<li>subject_gerund->crafting grenade launchers</li>
 				<li>subject_gerund->crafting rocket launchers</li>
@@ -101,6 +103,7 @@
 				<li>subject_story->stumbled across a cache of advanced weapons</li>
 				<li>subject_story->learned to use a discarding sabot to defeat powered armor</li>
 				<li>subject_story->worked for a prolific arms dealer</li>
+				<li>subject_story->studied the aftermath of a mechanoid assault</li>
 
 				<li>subject_gerund->creating explosive ammunition</li>
 				<li>subject_gerund->crafting discarding sabots</li>
@@ -111,7 +114,7 @@
 	<ResearchProjectDef>
 		<defName>CE_SimpleNV</defName>
 		<label>basic optoelectronics</label>
-		<description>Allows for the production of simple electro-optical devices, like night vision goggles and reflector sights.</description>
+		<description>Allows for the production of simple electro-optical devices, like night vision goggles and reflex sights.</description>
 		<baseCost>800</baseCost>
 		<techLevel>Industrial</techLevel>
 		<prerequisites>
@@ -128,6 +131,8 @@
 				<li>subject_story->instructed early midworld soldiers in night combat</li>
 
 				<li>subject_gerund->crafting night vision monoculars</li>
+
+				<li>subject_gerund->conducting night assaults</li>				
 			</rulesStrings>
 		</generalRules>
 	</ResearchProjectDef>
@@ -153,8 +158,11 @@
 				<li>subject_story->meticulously studied the sensors of destroyed mechanoids</li>
 				<li>subject_story->uncovered an ancient cryosleep crypt containing stores of advanced armor</li>
 				<li>subject_story->was trained as a scout in the military of an urbworld</li>
+				<li>subject_story->worked in a military prototyping lab</li>
 
 				<li>subject_gerund->crafting night vision sets</li>
+
+				<li>subject_gerund->fabricating advanced optoelectronics</li>
 			</rulesStrings>
 		</generalRules>
 	</ResearchProjectDef>


### PR DESCRIPTION
## Changes
- As stated in the title, adds mention of reflex sights and advanced optics to the optoelectronics research description.

## Reasoning
- Certain weapons in CE Armory require optoelectronics research to craft, this simply gives an explanation why. Most notably, basic opto is used for the M7, M250, and MG338 because of their reflex sights, and advanced opto is used for the Carl Gustaf's laser rangefinder scope.
- May encourage modders and patchers to use these research projects more.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)