### PR TITLE
Heavy auto turrets tech prerequisite tweak

### DIFF
--- a/Defs/ResearchProjectDefs/ResearchProjects_Turrets.xml
+++ b/Defs/ResearchProjectDefs/ResearchProjects_Turrets.xml
@@ -38,9 +38,6 @@
 			<li>PrecisionRifling</li>
 		</prerequisites>
 		<requiredResearchBuilding>HiTechResearchBench</requiredResearchBuilding>
-		<requiredResearchFacilities>
-			<li>MultiAnalyzer</li>
-		</requiredResearchFacilities>
 		<researchViewX>11</researchViewX>
 		<researchViewY>3.1</researchViewY>
 		<generalRules>


### PR DESCRIPTION
## Changes

- Removed the multi-analyzer building requirement from researching heavy auto-turrets research project.

## Reasoning

- As seen in the screenshot below, the tech is placed and supposed to be unlocked before multi-analyzer tech and is also blocking access to autocannon turrets which are originally meant to be a microelectronics research. Apart from that the tech itself already has three prerequisites with the main one being precision rifling so another gate in front of it is unnecessary in my opinion. Auto KPV turrets are also not advanced enough to warrant a multi-analyzer to research.
![image](https://github.com/user-attachments/assets/ba7e194f-eb5b-4227-9bb3-2b2298beb39e)

## Alternatives

- Leave things be or shuffle things around? It seems not needed in my opinion.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
