### PR TITLE
Add CompAmmo back to Verb_LaunchProjectileCE

### DIFF
--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -33,6 +33,7 @@ namespace CombatExtended
         protected float distance = 10f;
 
         public CompCharges compCharges = null;
+        public CompAmmoUser compAmmo = null;
 
         public CompFireModes compFireModes = null;
         public CompChangeableProjectile compChangeable = null;
@@ -138,6 +139,8 @@ namespace CombatExtended
         public float AimingAccuracy => Mathf.Min(Shooter.GetStatValue(CE_StatDefOf.AimingAccuracy), 1.5f); //equivalent of ShooterPawn?.GetStatValue(CE_StatDefOf.AimingAccuracy) ?? caster.GetStatValue(CE_StatDefOf.AimingAccuracy)
         public float SightsEfficiency => EquipmentSource?.GetStatValue(CE_StatDefOf.SightsEfficiency) ?? 1f;
         public virtual float SwayAmplitude => Mathf.Max(0, (4.5f - ShootingAccuracy) * (EquipmentSource?.GetStatValue(CE_StatDefOf.SwayFactor) ?? 1f));
+
+        public virtual CompAmmoUser CompAmmo => compAmmo ??= EquipmentSource?.TryGetComp<CompAmmoUser>();
 
         public virtual ThingDef Projectile
         {

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -31,8 +31,6 @@ namespace CombatExtended
 
         public Vector3 drawPos;
 
-        private CompAmmoUser compAmmo;
-
         #endregion
 
         #region Properties
@@ -128,14 +126,7 @@ namespace CombatExtended
         // Whether our shooter is currently under suppressive fire
         private bool IsSuppressed => ShooterPawn?.TryGetComp<CompSuppressable>()?.isSuppressed ?? false;
 
-        public CompAmmoUser CompAmmo
-        {
-            get
-            {
-                compAmmo ??= EquipmentSource?.TryGetComp<CompAmmoUser>();
-                return compAmmo;
-            }
-        }
+        public override CompAmmoUser CompAmmo => base.CompAmmo;
 
         public override ThingDef Projectile => CompAmmo?.CurrentAmmo != null ? CompAmmo.CurAmmoProjectile : base.Projectile;
 


### PR DESCRIPTION


## Changes
Add `CompAmmo` back to `Verb_LaunchProjectileCE` after it was moved to `ShootCE` in https://github.com/CombatExtended-Continued/CombatExtended/pull/3569.

## Reasoning
* Some mods such as Bill Doors' Plasma Weapons will need a recompile before being able to use the new property.

## Alternatives
Arrange for dependent mods to recompile against new CE - but there's no guarantee that'll happen in time for the release.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony - tested that plasma weapons work again
