### PR TITLE
Clean up various stats

### DIFF
--- a/Defs/Stats/Stats_NightVision.xml
+++ b/Defs/Stats/Stats_NightVision.xml
@@ -66,7 +66,7 @@
 
 	<StatDef ParentName="EquipmentNightVisionBase">
 		<defName>NightVisionEfficiency_Weapon</defName>
-		<label>night vision efficiency</label>
+		<label>weapon night vision efficiency</label>
 		<description>The effect of a weapon's optics on the wielder's ability to overcome the effects of darkness for the purpose of firing accurately.</description>
 		<category>Weapon</category>
 		<parts>
@@ -76,7 +76,7 @@
 
 	<StatDef ParentName="EquipmentNightVisionBase">
 		<defName>NightVisionEfficiency_Apparel</defName>
-		<label>night vision efficiency</label>
+		<label>apparel night vision efficiency</label>
 		<description>The effect of apparel items on a creature's ability to overcome the effects of darkness for the purpose of making ranged attacks.</description>
 		<category>Apparel</category>
 	</StatDef>

--- a/Defs/Stats/Stats_Weapons_Ranged.xml
+++ b/Defs/Stats/Stats_Weapons_Ranged.xml
@@ -152,6 +152,7 @@
 		<parts>
 			<li Class="CombatExtended.StatPart_Attachments" />
 		</parts>
+		<alwaysHide>True</alwaysHide>
 	</StatDef>
 
 	<StatDef>
@@ -165,6 +166,7 @@
 		<parts>
 			<li Class="CombatExtended.StatPart_Attachments" />
 		</parts>
+		<alwaysHide>True</alwaysHide>
 	</StatDef>
 
 	<StatDef>

--- a/Languages/English/Keyed/Stats.xml
+++ b/Languages/English/Keyed/Stats.xml
@@ -9,5 +9,7 @@
 	<CE_StatsReport_WeaponToughness_StuffEffect>Additional material toughness multiplier:</CE_StatsReport_WeaponToughness_StuffEffect>
 	<CE_StatsReport_WeaponToughness_HolderEffect>Wielder skill effect:</CE_StatsReport_WeaponToughness_HolderEffect>
 	<CE_Long_Range_Radio>Long range radio</CE_Long_Range_Radio>
+	<CE_StatPart_MinimaExplanation>Picks the lowest value of available</CE_StatPart_MinimaExplanation>
+	<CE_StatPart_MaximaExplanation>Picks the highest value of available</CE_StatPart_MaximaExplanation>
 
 </LanguageData>

--- a/Source/CombatExtended/CombatExtended/StatParts/Base/StatPart_StatSelect.cs
+++ b/Source/CombatExtended/CombatExtended/StatParts/Base/StatPart_StatSelect.cs
@@ -103,9 +103,40 @@ namespace CombatExtended
 
         public override string ExplanationPart(StatRequest req)
         {
-            if (req.HasThing && req.Pawn != null)
+            if (req.HasThing && req.Thing is Pawn pawn)
             {
-                return "";
+                string result = "";
+                if (apparelStat != null)
+                {
+                    float value = 0;
+                    ThingOwner<Apparel> wornApparel = pawn.apparel.wornApparel;
+                    if (sumApparelsStat)
+                    {
+                        for (int i = 0; i < wornApparel.Count; i++)
+                        {
+                            value += GetEquipmentStat(wornApparel[i], apparelStat);
+                        }
+                    }
+                    else
+                    {
+                        for (int i = 0; i < wornApparel.Count; i++)
+                        {
+                            value = Select(value, GetEquipmentStat(wornApparel[i], apparelStat));
+                        }
+                    }
+                    result += apparelStat.LabelCap + ": " + value.ToStringPercent() + "\n";
+                }
+                if (weaponStat != null)
+                {
+                    result += weaponStat.LabelCap + ": " + (pawn.equipment.Primary != null
+                        ? GetEquipmentStat(pawn.equipment.Primary, weaponStat).ToStringPercent()
+                        : "0%") + "\n";
+                }
+                if (implantStat != null)
+                {
+                    result += implantStat.LabelCap + ": " + pawn.GetStatValue(implantStat).ToStringPercent() + "\n";
+                }
+                return result;
             }
             return null;
         }

--- a/Source/CombatExtended/CombatExtended/StatParts/StatPart_Bipod.cs
+++ b/Source/CombatExtended/CombatExtended/StatParts/StatPart_Bipod.cs
@@ -17,42 +17,57 @@ namespace CombatExtended
     {
         public override void TransformValue(StatRequest req, ref float val)
         {
-            var varA = req.Thing.TryGetComp<BipodComp>();
             if (Controller.settings.BipodMechanics)
             {
-                if (varA != null)
+                if (req.HasThing)
                 {
-                    if (varA.IsSetUpRn == true)
+                    var varA = req.Thing.TryGetComp<BipodComp>();
+                    if (varA != null)
                     {
-                        val *= varA.Props.recoilMulton;
-                    }
-                    else
-                    {
-                        val *= varA.Props.recoilMultoff;
+                        if (varA.IsSetUpRn)
+                        {
+                            val *= varA.Props.recoilMulton;
+                        }
+                        else
+                        {
+                            val *= varA.Props.recoilMultoff;
+                        }
                     }
                 }
+                else if (req.Def is ThingDef reqDef)
+                {
+                    var bipodProps = reqDef.GetCompProperties<CompProperties_BipodComp>();
+                    val *= bipodProps?.recoilMulton ?? 1f;
+                }
             }
-
         }
 
         public override string ExplanationPart(StatRequest req)
         {
-            var varA = req.Thing.TryGetComp<BipodComp>();
-            if (varA != null)
+            if (Controller.settings.BipodMechanics)
             {
-                if (varA.IsSetUpRn == true)
+                if (req.HasThing)
                 {
-                    return "Bipod IS set up -" + " x".Colorize(Color.green) + varA.Props.recoilMulton.ToString().Colorize(Color.green);
+                    var varA = req.Thing.TryGetComp<BipodComp>();
+                    if (varA != null)
+                    {
+                        if (varA.IsSetUpRn)
+                        {
+                            return "Bipod IS set up -" + " x".Colorize(ColorLibrary.Green) + varA.Props.recoilMulton.ToString().Colorize(ColorLibrary.Green);
+                        }
+                        else
+                        {
+                            return "Bipod is NOT set up -" + " x".Colorize(ColorLibrary.LogError) + varA.Props.recoilMultoff.ToString().Colorize(ColorLibrary.LogError);
+                        }
+                    }
                 }
-                else
+                else if (req.Def is ThingDef reqDef)
                 {
-                    return "Bipod is NOT set up -" + " x".Colorize(Color.red) + varA.Props.recoilMultoff.ToString().Colorize(Color.red);
+                    var bipodProps = reqDef.GetCompProperties<CompProperties_BipodComp>();
+                    if (bipodProps != null) return "Bipod IS set up -" + " x".Colorize(ColorLibrary.Green) + bipodProps.recoilMulton.ToString().Colorize(ColorLibrary.Green);
                 }
             }
-            else
-            {
-                return "";
-            }
+            return null;
         }
     }
 
@@ -61,19 +76,27 @@ namespace CombatExtended
     {
         public override void TransformValue(StatRequest req, ref float val)
         {
-            var varA = req.Thing.TryGetComp<BipodComp>();
             if (Controller.settings.BipodMechanics)
             {
-                if (varA != null)
+                if (req.HasThing)
                 {
-                    if (varA.IsSetUpRn == true)
+                    var varA = req.Thing.TryGetComp<BipodComp>();
+                    if (varA != null)
                     {
-                        val *= varA.Props.swayMult;
+                        if (varA.IsSetUpRn)
+                        {
+                            val *= varA.Props.swayMult;
+                        }
+                        else
+                        {
+                            val *= varA.Props.swayPenalty;
+                        }
                     }
-                    else
-                    {
-                        val *= varA.Props.swayPenalty;
-                    }
+                }
+                else if (req.Def is ThingDef reqDef)
+                {
+                    var bipodProps = reqDef.GetCompProperties<CompProperties_BipodComp>();
+                    val *= bipodProps?.swayMult ?? 1f;
                 }
             }
 
@@ -81,22 +104,30 @@ namespace CombatExtended
 
         public override string ExplanationPart(StatRequest req)
         {
-            var varA = req.Thing.TryGetComp<BipodComp>();
-            if (varA != null)
+            if (Controller.settings.BipodMechanics)
             {
-                if (varA.IsSetUpRn == true)
+                if (req.HasThing)
                 {
-                    return "Bipod IS set up -" + " x".Colorize(Color.green) + varA.Props.swayMult.ToString().Colorize(Color.green);
+                    var varA = req.Thing.TryGetComp<BipodComp>();
+                    if (varA != null)
+                    {
+                        if (varA.IsSetUpRn)
+                        {
+                            return "Bipod IS set up -" + " x".Colorize(ColorLibrary.Green) + varA.Props.swayMult.ToString().Colorize(ColorLibrary.Green);
+                        }
+                        else
+                        {
+                            return "Bipod is NOT set up -" + " x".Colorize(ColorLibrary.LogError) + varA.Props.swayPenalty.ToString().Colorize(ColorLibrary.LogError);
+                        }
+                    }
                 }
-                else
+                else if (req.Def is ThingDef reqDef)
                 {
-                    return "Bipod is NOT set up - " + "x".Colorize(Color.red) + varA.Props.swayPenalty.ToString().Colorize(Color.red);
+                    var bipodProps = reqDef.GetCompProperties<CompProperties_BipodComp>();
+                    if (bipodProps != null) return "Bipod IS set up -" + " x".Colorize(ColorLibrary.Green) + bipodProps.swayPenalty.ToString().Colorize(ColorLibrary.Green);
                 }
             }
-            else
-            {
-                return "";
-            }
+            return null;
         }
     }
 }

--- a/Source/CombatExtended/CombatExtended/StatParts/StatPart_Bipod.cs
+++ b/Source/CombatExtended/CombatExtended/StatParts/StatPart_Bipod.cs
@@ -64,7 +64,7 @@ namespace CombatExtended
                 else if (req.Def is ThingDef reqDef)
                 {
                     var bipodProps = reqDef.GetCompProperties<CompProperties_BipodComp>();
-                    if (bipodProps != null) return "Bipod IS set up -" + " x".Colorize(ColorLibrary.Green) + bipodProps.recoilMulton.ToString().Colorize(ColorLibrary.Green);
+                    if (bipodProps != null) { return "Bipod IS set up -" + " x".Colorize(ColorLibrary.Green) + bipodProps.recoilMulton.ToString().Colorize(ColorLibrary.Green); }
                 }
             }
             return null;
@@ -124,7 +124,7 @@ namespace CombatExtended
                 else if (req.Def is ThingDef reqDef)
                 {
                     var bipodProps = reqDef.GetCompProperties<CompProperties_BipodComp>();
-                    if (bipodProps != null) return "Bipod IS set up -" + " x".Colorize(ColorLibrary.Green) + bipodProps.swayPenalty.ToString().Colorize(ColorLibrary.Green);
+                    if (bipodProps != null) { return "Bipod IS set up -" + " x".Colorize(ColorLibrary.Green) + bipodProps.swayPenalty.ToString().Colorize(ColorLibrary.Green); }
                 }
             }
             return null;

--- a/Source/CombatExtended/CombatExtended/StatParts/StatPart_StatMaxima.cs
+++ b/Source/CombatExtended/CombatExtended/StatParts/StatPart_StatMaxima.cs
@@ -15,5 +15,10 @@ namespace CombatExtended
         {
             return Mathf.Max(first, second);
         }
+
+        public override string ExplanationPart(StatRequest req)
+        {
+            return "Picks the highest value of available: \n\n" + base.ExplanationPart(req);
+        }
     }
 }

--- a/Source/CombatExtended/CombatExtended/StatParts/StatPart_StatMaxima.cs
+++ b/Source/CombatExtended/CombatExtended/StatParts/StatPart_StatMaxima.cs
@@ -18,7 +18,7 @@ namespace CombatExtended
 
         public override string ExplanationPart(StatRequest req)
         {
-            return "Picks the highest value of available: \n\n" + base.ExplanationPart(req);
+            return "CE_StatPart_MaximaExplanation".Translate() + ": \n\n" + base.ExplanationPart(req);
         }
     }
 }

--- a/Source/CombatExtended/CombatExtended/StatParts/StatPart_StatMinima.cs
+++ b/Source/CombatExtended/CombatExtended/StatParts/StatPart_StatMinima.cs
@@ -2,6 +2,7 @@
 using System.Runtime.CompilerServices;
 using RimWorld;
 using UnityEngine;
+using Verse;
 
 namespace CombatExtended
 {
@@ -15,7 +16,7 @@ namespace CombatExtended
 
         public override string ExplanationPart(StatRequest req)
         {
-            return "Picks the lowest value of available: \n\n" + base.ExplanationPart(req);
+            return "CE_StatPart_MinimaExplanation".Translate() + ": \n\n" + base.ExplanationPart(req);
         }
     }
 }

--- a/Source/CombatExtended/CombatExtended/StatParts/StatPart_StatMinima.cs
+++ b/Source/CombatExtended/CombatExtended/StatParts/StatPart_StatMinima.cs
@@ -12,5 +12,10 @@ namespace CombatExtended
         {
             return Mathf.Min(first, second);
         }
+
+        public override string ExplanationPart(StatRequest req)
+        {
+            return "Picks the lowest value of available: \n\n" + base.ExplanationPart(req);
+        }
     }
 }

--- a/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_BipodDisplay.cs
+++ b/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_BipodDisplay.cs
@@ -89,7 +89,7 @@ namespace CombatExtended
 
                 }
 
-                result += "\n" + "CE_BipodStatWhenSetUp".Translate().Colorize(Color.green) + "\n";
+                result += "\n" + "CE_BipodStatWhenSetUp".Translate().Colorize(ColorLibrary.Green) + "\n";
 
                 result += CE_StatDefOf.Recoil.label + ": " + Math.Round((VerbPropsCE.recoilAmount * BipodCompProps.recoilMulton), 2);
                 result += "\n";
@@ -103,7 +103,7 @@ namespace CombatExtended
                 result += "CE_BipodStatWarmUp".Translate() + ": " + (BipodCompProps.warmupMult * VerbPropsCE.warmupTime);
                 result += "\n" + "\n";
 
-                result += "CE_BipodStatWhenNotSetUp".Translate().Colorize(Color.red) + "\n";
+                result += "CE_BipodStatWhenNotSetUp".Translate().Colorize(ColorLibrary.LogError) + "\n";
 
                 result += CE_StatDefOf.Recoil.label + ": " + Math.Round((VerbPropsCE.recoilAmount * BipodCompProps.recoilMultoff), 2);
 
@@ -132,13 +132,13 @@ namespace CombatExtended
                     return base.GetExplanationFinalizePart(req, numberSense, finalVal);
                 }
 
-                string result = "CE_BipodSetupTime".Translate() + BipodCompProps.ticksToSetUp + " ticks (" + (BipodCompProps.ticksToSetUp / 60) + "s)" + "\n" + "Stats when set up: ".Colorize(Color.green) + "\n";
+                string result = "CE_BipodSetupTime".Translate() + BipodCompProps.ticksToSetUp + " ticks (" + (BipodCompProps.ticksToSetUp / 60) + "s)" + "\n" + "Stats when set up: ".Colorize(ColorLibrary.Green) + "\n";
 
-                result += CE_StatDefOf.Recoil.label + ": " + (VerbPropsCE.recoilAmount * BipodCompProps.recoilMulton);
+                result += CE_StatDefOf.Recoil.label + ": " + Math.Round((VerbPropsCE.recoilAmount * BipodCompProps.recoilMulton), 2);
 
                 result += "\n";
 
-                result += CE_StatDefOf.SwayFactor.label + ": " + (((ThingDef)(req.Def)).statBases.Find(x => x.stat == CE_StatDefOf.SwayFactor).value * BipodCompProps.swayPenalty);
+                result += CE_StatDefOf.SwayFactor.label + ": " + Math.Round((((ThingDef)(req.Def)).statBases.Find(x => x.stat == CE_StatDefOf.SwayFactor).value * BipodCompProps.swayMult), 2);
 
                 result += "\n";
 
@@ -150,13 +150,13 @@ namespace CombatExtended
 
                 result += "\n" + "\n";
 
-                result += "CE_BipodStatWhenNotSetUp".Translate().Colorize(Color.red) + "\n";
+                result += "CE_BipodStatWhenNotSetUp".Translate().Colorize(ColorLibrary.LogError) + "\n";
 
-                result += CE_StatDefOf.Recoil.label + ": " + (VerbPropsCE.recoilAmount * BipodCompProps.recoilMultoff);
+                result += CE_StatDefOf.Recoil.label + ": " + Math.Round((VerbPropsCE.recoilAmount * BipodCompProps.recoilMultoff), 2);
 
                 result += "\n";
 
-                result += CE_StatDefOf.SwayFactor.label + ": " + (((ThingDef)(req.Def)).statBases.Find(x => x.stat == CE_StatDefOf.SwayFactor).value * BipodCompProps.swayPenalty);
+                result += CE_StatDefOf.SwayFactor.label + ": " + Math.Round((((ThingDef)(req.Def)).statBases.Find(x => x.stat == CE_StatDefOf.SwayFactor).value * BipodCompProps.swayPenalty), 2);
 
                 result += "\n";
 


### PR DESCRIPTION
## Additions

- Duplicate fire rate and burst shot count stats are hidden on weapons, they were already displayed from verb props.
- Info tabs of weapons with items without a Thing reference (i.e. from research or crafting screens) now displays bipod stats correctly.
- Sway and Recoil values on those weapons now also default to 'set up' values, if bipods are enabled.
- Tweaked the colors of bipod stat explanations to use more muted colors.
- Added explanation for Night Vision stat calculations.
- Changed apparel and weapon night vision labels to make the explanation clearer.

## Reasoning

- No point in showing the same data twice.
- Better to show the stats of the weapon set up, since that's how it's meant to be used.
- Previous bipod stat colors were too bright.
- Apparel and weapon night vision stats were impossible to tell apart due to using the same names.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] Playtested a colony (specify how long)
