### PR TITLE
Patch Mantis Race

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -287,6 +287,7 @@
 		<li IfModActive="Killathon.MechHumanlikes.MilitaryTiers">ModPatches/MH Military Tiers</li>
 		<li IfModActive="EL.MOW">ModPatches/Machines of War</li>
 		<li IfModActive="DetVisor.Makeshiftweapons">ModPatches/Makeshift Melee Weapons</li>
+		<li IfModActive="goudaquiche.LtfMantisRace">ModPatches/Mantis Race</li>
 		<li IfModActive="Sig.MantodeanRace">ModPatches/Mantodean Insectoid Race</li>
 		<li IfModActive="SutSutMan.MarilyntheMinchoWorshipperWitch">ModPatches/Marilyn the Mincho Worshipper Witch</li>
 		<li IfModActive="RaZim.ZGFMartens">ModPatches/Martens - Nature's Most Adorable Assassins</li>

--- a/ModPatches/Mantis Race/Patches/Mantis Race/Bodies_Mantis.xml
+++ b/ModPatches/Mantis Race/Patches/Mantis Race/Bodies_Mantis.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- ==================== Mantis ==================== -->
+
+	<!-- Add Armor Coverage -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/BodyDef[defName="Mantis"]/corePart/groups</xpath>
+		<value>
+			<li>CoveredByNaturalArmor</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/BodyDef[defName="Mantis"]/corePart/parts/li[def="Neck"]/groups</xpath>
+		<value>
+			<li>CoveredByNaturalArmor</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/BodyDef[defName="Mantis"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/groups</xpath>
+		<value>
+			<li>CoveredByNaturalArmor</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/BodyDef[defName="Mantis"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Antenna"]/groups</xpath>
+		<value>
+			<li>CoveredByNaturalArmor</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/BodyDef[defName="Mantis"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Jaw"]/groups</xpath>
+		<value>
+			<li>CoveredByNaturalArmor</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/BodyDef[defName="Mantis"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]/groups</xpath>
+		<value>
+			<li>CoveredByNaturalArmor</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/BodyDef[defName="Mantis"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Ear"]/groups</xpath>
+		<value>
+			<li>CoveredByNaturalArmor</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/BodyDef[defName="Mantis"]/corePart/parts/li[def="Shoulder"]/groups</xpath>
+		<value>
+			<li>CoveredByNaturalArmor</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/BodyDef[defName="Mantis"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/groups</xpath>
+		<value>
+			<li>CoveredByNaturalArmor</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/BodyDef[defName="Mantis"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Hand"]/groups</xpath>
+		<value>
+			<li>CoveredByNaturalArmor</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/BodyDef[defName="Mantis"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Hand"]/parts/li[def="BodyPart_LTF_RightClaws"]/groups</xpath>
+		<value>
+			<li>CoveredByNaturalArmor</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/BodyDef[defName="Mantis"]/corePart/parts/li[def="Leg"]/groups</xpath>
+		<value>
+			<li>CoveredByNaturalArmor</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/BodyDef[defName="Mantis"]/corePart/parts/li[def="Leg"]/parts/li[def="Foot"]/groups</xpath>
+		<value>
+			<li>CoveredByNaturalArmor</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/BodyDef[defName="Mantis"]/corePart/parts/li[def="Leg"]/parts/li[def="Foot"]/parts/li[def="Toe"]/groups</xpath>
+		<value>
+			<li>CoveredByNaturalArmor</li>
+		</value>
+	</Operation>
+
+
+</Patch>

--- a/ModPatches/Mantis Race/Patches/Mantis Race/Hediff_Mantis.xml
+++ b/ModPatches/Mantis Race/Patches/Mantis Race/Hediff_Mantis.xml
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- Plasteel Claws -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/HediffDef[@Name="Hediff_LTF_PlasteelClaws"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>claw</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>12</power>
+					<cooldownTime>1.29</cooldownTime>
+					<armorPenetrationSharp>8.35</armorPenetrationSharp>
+					<armorPenetrationBlunt>12.35</armorPenetrationBlunt>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>claw</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>9</power>
+					<cooldownTime>1.59</cooldownTime>
+					<armorPenetrationSharp>10.65</armorPenetrationSharp>
+					<armorPenetrationBlunt>12.35</armorPenetrationBlunt>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<!-- Over Claws -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/HediffDef[@Name="Hediff_LTF_OverClaws"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>edge</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>18</power>
+					<cooldownTime>1.29</cooldownTime>
+					<armorPenetrationSharp>10.65</armorPenetrationSharp>
+					<armorPenetrationBlunt>14.8</armorPenetrationBlunt>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>claw point</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>14</power>
+					<cooldownTime>1.59</cooldownTime>
+					<armorPenetrationSharp>14.65</armorPenetrationSharp>
+					<armorPenetrationBlunt>12.4</armorPenetrationBlunt>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>blade flat</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>8</power>
+					<cooldownTime>1.59</cooldownTime>
+					<armorPenetrationBlunt>8.8</armorPenetrationBlunt>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<!-- Steel Claws -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/HediffDef[@Name="Hediff_LTF_SteelClaws"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>claw</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>10</power>
+					<cooldownTime>1.29</cooldownTime>
+					<armorPenetrationSharp>7.14</armorPenetrationSharp>
+					<armorPenetrationBlunt>10.85</armorPenetrationBlunt>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>claw</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>5</power>
+					<cooldownTime>1.59</cooldownTime>
+					<armorPenetrationSharp>9.65</armorPenetrationSharp>
+					<armorPenetrationBlunt>8.3</armorPenetrationBlunt>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<!-- Wooden Claws -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/HediffDef[@Name="Hediff_LTF_WoodenClaws"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>claw</label>
+					<capacities>
+						<li>Scratch</li>
+					</capacities>
+					<power>8</power>
+					<cooldownTime>1.39</cooldownTime>
+					<armorPenetrationSharp>3.26</armorPenetrationSharp>
+					<armorPenetrationBlunt>6.4</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>claw</label>
+					<capacities>
+						<li>Poke</li>
+					</capacities>
+					<power>4</power>
+					<cooldownTime>1.59</cooldownTime>
+					<armorPenetrationSharp>9.65</armorPenetrationSharp>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<!-- Wooden Shields -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/HediffDef[@Name="Hediff_LTF_WoodenShields"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>plank</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>6.2</power>
+					<cooldownTime>2.16</cooldownTime>
+					<armorPenetrationBlunt>6.4</armorPenetrationBlunt>					
+					<surpriseAttack>
+						<extraMeleeDamages>
+							<li>
+								<def>Stun</def>
+								<amount>5</amount>
+							</li>
+						</extraMeleeDamages>
+					</surpriseAttack>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>corner</label>
+					<capacities>
+						<li>Poke</li>
+					</capacities>
+					<power>4.8</power>
+					<cooldownTime>1.94</cooldownTime>
+					<armorPenetrationBlunt>6.4</armorPenetrationBlunt>	
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<!-- ToxiClaws -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/HediffDef[@Name="Hediff_LTF_ToxiClaws"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>claw</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>14</power>
+					<cooldownTime>1.29</cooldownTime>
+					<armorPenetrationSharp>8.35</armorPenetrationSharp>
+					<armorPenetrationBlunt>12.35</armorPenetrationBlunt>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>toxic device</label>
+					<capacities>
+						<li>ToxicBite</li>
+					</capacities>
+					<power>9</power>
+					<cooldownTime>1.59</cooldownTime>
+					<armorPenetrationSharp>10.65</armorPenetrationSharp>
+					<armorPenetrationBlunt>12.35</armorPenetrationBlunt>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Mantis Race/Patches/Mantis Race/PawnKind_Mantis.xml
+++ b/ModPatches/Mantis Race/Patches/Mantis Race/PawnKind_Mantis.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- Civilian Base -->
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/PawnKindDef[@Name="MantisCivBase"]</xpath>
+		<value>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>3</min>
+					<max>4</max>
+				</primaryMagazineCount>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- Military Base -->
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/PawnKindDef[@Name="MantisMilBase"]</xpath>
+		<value>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>4</min>
+					<max>6</max>
+				</primaryMagazineCount>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- Mantis Spacer Soldier -->
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/PawnKindDef[defName="MantisSpaceSoldier"]</xpath>
+		<value>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>6</min>
+					<max>8</max>
+				</primaryMagazineCount>		
+			</li>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Mantis Race/Patches/Mantis Race/Race_Mantis.xml
+++ b/ModPatches/Mantis Race/Patches/Mantis Race/Race_Mantis.xml
@@ -113,6 +113,16 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Mantis"]/alienRace/raceRestriction</xpath>
+		<value>
+			<blackApparelList>
+				<li>CE_Apparel_BallisticShield</li>
+				<li>CE_Apparel_MeleeShield</li>
+			</blackApparelList>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Mantis"]/comps</xpath>
 		<value>
 			<li>

--- a/ModPatches/Mantis Race/Patches/Mantis Race/Race_Mantis.xml
+++ b/ModPatches/Mantis Race/Patches/Mantis Race/Race_Mantis.xml
@@ -17,7 +17,9 @@
 			<MeleeCritChance>1.05</MeleeCritChance>
 			<MeleeParryChance>1.05</MeleeParryChance>
 			<Suppressability>1</Suppressability>
-			<SmokeSensitivity>1</SmokeSensitivity>			
+			<SmokeSensitivity>1</SmokeSensitivity>
+			<ReloadSpeed>0.85</ReloadSpeed>
+			<AimingAccuracy>0.9</AimingAccuracy>
 		</value>
 	</Operation>
 

--- a/ModPatches/Mantis Race/Patches/Mantis Race/Race_Mantis.xml
+++ b/ModPatches/Mantis Race/Patches/Mantis Race/Race_Mantis.xml
@@ -30,7 +30,7 @@
 					<capacities>
 						<li>Blunt</li>
 					</capacities>
-					<power>1.2</power>
+					<power>3</power>
 					<cooldownTime>1.33</cooldownTime>
 					<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
 					<surpriseAttack>
@@ -48,7 +48,7 @@
 					<capacities>
 						<li>Blunt</li>
 					</capacities>
-					<power>1.2</power>
+					<power>3</power>
 					<cooldownTime>1.33</cooldownTime>
 					<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
 					<surpriseAttack>
@@ -58,7 +58,7 @@
 								<amount>14</amount>
 							</li>
 						</extraMeleeDamages>
-					</surpriseAttack>					
+					</surpriseAttack>
 					<armorPenetrationBlunt>0.175</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
@@ -66,7 +66,7 @@
 					<capacities>
 						<li>Cut</li>
 					</capacities>
-					<power>18</power>
+					<power>9</power>
 					<cooldownTime>1.33</cooldownTime>
 					<linkedBodyPartsGroup>LeftHandClawsGroup</linkedBodyPartsGroup>
 					<armorPenetrationSharp>6.85</armorPenetrationSharp>
@@ -77,7 +77,7 @@
 					<capacities>
 						<li>Cut</li>
 					</capacities>
-					<power>18</power>
+					<power>9</power>
 					<cooldownTime>1.33</cooldownTime>
 					<linkedBodyPartsGroup>RightHandClawsGroup</linkedBodyPartsGroup>
 					<armorPenetrationSharp>6.85</armorPenetrationSharp>
@@ -88,7 +88,7 @@
 					<capacities>
 						<li>Bite</li>
 					</capacities>
-					<power>9</power>
+					<power>6</power>
 					<cooldownTime>1.5</cooldownTime>
 					<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
 					<armorPenetrationSharp>0.24</armorPenetrationSharp>

--- a/ModPatches/Mantis Race/Patches/Mantis Race/Race_Mantis.xml
+++ b/ModPatches/Mantis Race/Patches/Mantis Race/Race_Mantis.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Mantis"]</xpath>
+		<value>
+			<li Class="CombatExtended.RacePropertiesExtensionCE">
+				<bodyShape>Humanoid</bodyShape>
+			</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Mantis"]/statBases/MeleeDodgeChance</xpath>
+		<value>
+			<MeleeDodgeChance>1.05</MeleeDodgeChance>
+			<MeleeCritChance>1.05</MeleeCritChance>
+			<MeleeParryChance>1.05</MeleeParryChance>
+			<Suppressability>1</Suppressability>
+			<SmokeSensitivity>1</SmokeSensitivity>			
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Mantis"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>left fist</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>1.2</power>
+					<cooldownTime>1.33</cooldownTime>
+					<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+					<surpriseAttack>
+						<extraMeleeDamages>
+							<li>
+								<def>Stun</def>
+								<amount>14</amount>
+							</li>
+						</extraMeleeDamages>
+					</surpriseAttack>					
+					<armorPenetrationBlunt>0.175</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>right fist</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>1.2</power>
+					<cooldownTime>1.33</cooldownTime>
+					<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+					<surpriseAttack>
+						<extraMeleeDamages>
+							<li>
+								<def>Stun</def>
+								<amount>14</amount>
+							</li>
+						</extraMeleeDamages>
+					</surpriseAttack>					
+					<armorPenetrationBlunt>0.175</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>left claw</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>18</power>
+					<cooldownTime>1.33</cooldownTime>
+					<linkedBodyPartsGroup>LeftHandClawsGroup</linkedBodyPartsGroup>
+					<armorPenetrationSharp>6.85</armorPenetrationSharp>
+					<armorPenetrationBlunt>10.35</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>right claw</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>18</power>
+					<cooldownTime>1.33</cooldownTime>
+					<linkedBodyPartsGroup>RightHandClawsGroup</linkedBodyPartsGroup>
+					<armorPenetrationSharp>6.85</armorPenetrationSharp>
+					<armorPenetrationBlunt>10.35</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>teeth</label>
+					<capacities>
+						<li>Bite</li>
+					</capacities>
+					<power>9</power>
+					<cooldownTime>1.5</cooldownTime>
+					<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+					<armorPenetrationSharp>0.24</armorPenetrationSharp>
+					<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+				</li>						
+				<li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>2.8</power>
+					<cooldownTime>4.49</cooldownTime>
+					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					<chanceFactor>0.2</chanceFactor>
+					<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>					
+					<armorPenetrationBlunt>0.95</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Mantis"]/comps</xpath>
+		<value>
+			<li>
+				<compClass>CombatExtended.CompPawnGizmo</compClass>
+			</li>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>500</Durability> <!-- 250 * (body size + HP scale) -->
+				<Regenerates>true</Regenerates>
+				<RegenInterval>600</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<MinArmorPct>0.5</MinArmorPct>
+			</li>
+			<li Class="CombatExtended.CompProperties_Suppressable" />
+			<li>
+				<compClass>CombatExtended.CompAmmoGiver</compClass>
+			</li>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Mantis Race/Patches/Mantis Race/Scenarios.xml
+++ b/ModPatches/Mantis Race/Patches/Mantis Race/Scenarios.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ScenarioDef[defName="MantissTribeScenario"]/scenario/parts</xpath>
+		<value>
+			<li Class="ScenPart_StartingThing_Defined">
+				<def>StartingThing_Defined</def>
+				<thingDef>Ammo_12Gauge_Buck</thingDef>
+				<count>60</count>
+			</li>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Mantis Race/Patches/Mantis Race/ThingDefs_Items_Claws.xml
+++ b/ModPatches/Mantis Race/Patches/Mantis Race/ThingDefs_Items_Claws.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- Artficial Claw Base -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[@Name="LTF_SyntClaws"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>handle</label>
+					<capacities>
+						<li>Poke</li>
+					</capacities>
+					<power>1</power>
+					<chanceFactor>0.33</chanceFactor>
+					<cooldownTime>1.26</cooldownTime>
+					<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>sharpwave</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>10</power>
+					<cooldownTime>1.18</cooldownTime>
+					<armorPenetrationBlunt>0.36</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.32</armorPenetrationSharp>
+					<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<!-- Natural Claw Base -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[@Name="LTF_MantisNaturalClaws"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>handle</label>
+					<capacities>
+						<li>Poke</li>
+					</capacities>
+					<power>1</power>
+					<chanceFactor>0.33</chanceFactor>
+					<cooldownTime>1.26</cooldownTime>
+					<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>blade</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>8</power>
+					<cooldownTime>1.18</cooldownTime>
+					<armorPenetrationBlunt>0.36</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.34</armorPenetrationSharp>
+					<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>point</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>9</power>
+					<cooldownTime>1.2</cooldownTime>
+					<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.73</armorPenetrationSharp>
+					<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -310,6 +310,7 @@ Logann Race	|
 Logistics_Mechanoid |
 Machines of War |
 Makeshift Melee Weapons |
+Mantis Race |
 Marilyn the Mincho Worshipper Witch |
 Mass Effect - Playable Geth |
 Martens - Nature's Most Adorable Assassins  |


### PR DESCRIPTION
## Additions
- Patch for the Mantis Race mod.
  - Adds a new, melee-focused race and their body as well as a scenario, pawnkinds, and prosthetics.
  - **Known issue:** The mantis claws, antenna, and other parts rendered specially by HAR appear over top of the ballistic shield. Unfortunately, I couldn't find an easy way to change this, so I made the mantis unable to use those shields.

## References
Closes #636 (at long last)

## Reasoning
- The Mantises excel in melee, and so their base melee attacks are borrowed from the various insectoids (with the AP toned down). The prosthetics follow similar lines, upgrading this as appropriate.

## Alternatives
- Could leave it unpatched for another few years.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
