### PR TITLE
Fix ammo handling for magless weapons

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
@@ -360,6 +360,8 @@ namespace CombatExtended
                     ammoToBeDeleted = null;
                     CompInventory.UpdateInventory();
                 }
+
+                return;
             }
 
             if (curMagCountInt <= 0)


### PR DESCRIPTION



## Changes
Don't try to decrement ammo count in the magazine for weapons that don't have a magazine.

## Testing

- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony - tested that no errors occur and ammo (if applicable) is correctly consumed for a bolt-action rifle, a recurve bow, a triple rocket launcher and a burst-firing kpv.
