### PR TITLE
Remove Sidearms from Pirate Drifters

### DIFF
--- a/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -398,7 +398,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/PawnKindDef[defName="Drifter" or defName="Scavenger"]</xpath>
+		<xpath>Defs/PawnKindDef[defName="Scavenger"]</xpath>
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>


### PR DESCRIPTION
## Changes
- Remove sidearms from pirate drifters.

## Reasoning
- Drifters are melee pawns, they have no use for another knife.

## Alternatives
- Double knife madness.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
