### PR TITLE
Tweak Incinerator Warmup and Cooldown

### DIFF
--- a/Anomaly/Patches/ThingDefs_Misc/Weapons_Ranged.xml
+++ b/Anomaly/Patches/ThingDefs_Misc/Weapons_Ranged.xml
@@ -154,7 +154,7 @@
 			<ShotSpread>5.0</ShotSpread>
 			<SwayFactor>1.38</SwayFactor>
 			<Bulk>10</Bulk>
-			<RangedWeapon_Cooldown>1.49</RangedWeapon_Cooldown>
+			<RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
 		</value>
 	</Operation>
 
@@ -183,7 +183,7 @@
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_Flamethrower_Prometheum</defaultProjectile>
 					<ai_AvoidFriendlyFireRadius>3</ai_AvoidFriendlyFireRadius>
-					<warmupTime>1.1</warmupTime>
+					<warmupTime>0.6</warmupTime>
 					<range>11</range>
 					<minRange>3</minRange>
 					<ticksBetweenBurstShots>3</ticksBetweenBurstShots>

--- a/Anomaly/Patches/ThingDefs_Misc/Weapons_Ranged.xml
+++ b/Anomaly/Patches/ThingDefs_Misc/Weapons_Ranged.xml
@@ -232,7 +232,7 @@
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_Incinerator_Burst_Prometheum</defaultProjectile>
 					<ai_AvoidFriendlyFireRadius>3</ai_AvoidFriendlyFireRadius>
-					<warmupTime>1.1</warmupTime>
+					<warmupTime>0.6</warmupTime>
 					<range>11</range>
 					<minRange>3</minRange>
 					<soundCast>HissFlamethrower</soundCast>


### PR DESCRIPTION
## Changes

- Change the Incinerator's warmup time to that of SMG/shotgun type weapons, fix the absurdly high cooldown time.
## Reasoning
- Flamethrowers in CE are close-ranged spray and pray weapons, similar to a shotgun or SMG, yet they use the warm up times of full-sized rifles. This caused many situations where pawns won't fire until the target is basically inside the minimum firing range circle and getting dangerously close to the shooter.
- The incinerator for some reason had a whopping 1.1 extra seconds of cooldown time compared to the RM2. Simply set the cooldown to that of the RM2's.

## Alternatives
- "Hold still while I aim this flamethrower"

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
