### PR TITLE
Update loading bench texture path

### DIFF
--- a/ModPatches/Grimworld Core Imperialis/Defs/Grimworld Core Imperialis/CE_Patch_Ammo_Production.xml
+++ b/ModPatches/Grimworld Core Imperialis/Defs/Grimworld Core Imperialis/CE_Patch_Ammo_Production.xml
@@ -17,7 +17,7 @@
 		<thingClass>Building_WorkTable</thingClass>
 		<description>A workstation for creating ammunition for imperium weapons.</description>
 		<graphicData>
-			<texPath>Things/Building/Bench/GW_LoadingBench</texPath>
+			<texPath>ThirdParty/Warhammer/Building/Loading Bench/GW_LoadingBench</texPath>
 			<graphicClass>Graphic_Multi</graphicClass>
 			<shaderType>CutoutComplex</shaderType>
 			<drawSize>(3.5,1.5)</drawSize>


### PR DESCRIPTION
## Changes
- Point the Imperium loading bench texture at our copy of the textures, instead of Grimworld's (which was removed in the last update).

## Reasoning
- Grimworld updated and removed the Imperium ammo bench texture that were accidentally relying on.

## Alternatives
- Suffer.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
