### PR TITLE
Add slug AmmoSetDefs to shotgun calibers

### DIFF
--- a/Defs/Ammo/Shotgun/10Gauge.xml
+++ b/Defs/Ammo/Shotgun/10Gauge.xml
@@ -21,6 +21,17 @@
 		</ammoTypes>
 		<similarTo>AmmoSet_Shotgun</similarTo>
 	</CombatExtended.AmmoSetDef>
+	
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_10Gauge_Slug</defName>
+		<label>10 Gauge</label>
+		<ammoTypes>
+			<Ammo_10Gauge_Slug>Bullet_10Gauge_Slug</Ammo_10Gauge_Slug>
+			<Ammo_10Gauge_Beanbag>Bullet_10Gauge_Beanbag</Ammo_10Gauge_Beanbag>
+			<Ammo_10Gauge_ElectroSlug>Bullet_10Gauge_ElectroSlug</Ammo_10Gauge_ElectroSlug>
+		</ammoTypes>
+		<similarTo>AmmoSet_Shotgun</similarTo>
+	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->
 

--- a/Defs/Ammo/Shotgun/12Gauge.xml
+++ b/Defs/Ammo/Shotgun/12Gauge.xml
@@ -33,6 +33,17 @@
 		</ammoTypes>
 		<similarTo>AmmoSet_Shotgun</similarTo>
 	</CombatExtended.AmmoSetDef>
+	
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_12Gauge_Slug</defName>
+		<label>12 Gauge</label>
+		<ammoTypes>
+			<Ammo_12Gauge_Slug>Bullet_12Gauge_Slug</Ammo_12Gauge_Slug>
+			<Ammo_12Gauge_Beanbag>Bullet_12Gauge_Beanbag</Ammo_12Gauge_Beanbag>
+			<Ammo_12Gauge_ElectroSlug>Bullet_12Gauge_ElectroSlug</Ammo_12Gauge_ElectroSlug>
+		</ammoTypes>
+		<similarTo>AmmoSet_Shotgun</similarTo>
+	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->
 

--- a/Defs/Ammo/Shotgun/16Gauge.xml
+++ b/Defs/Ammo/Shotgun/16Gauge.xml
@@ -21,6 +21,17 @@
 		</ammoTypes>
 		<similarTo>AmmoSet_Shotgun</similarTo>
 	</CombatExtended.AmmoSetDef>
+	
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_16Gauge_Slug</defName>
+		<label>16 Gauge</label>
+		<ammoTypes>
+			<Ammo_16Gauge_Slug>Bullet_16Gauge_Slug</Ammo_16Gauge_Slug>
+			<Ammo_16Gauge_Beanbag>Bullet_16Gauge_Beanbag</Ammo_16Gauge_Beanbag>
+			<Ammo_16Gauge_ElectroSlug>Bullet_16Gauge_ElectroSlug</Ammo_16Gauge_ElectroSlug>
+		</ammoTypes>
+		<similarTo>AmmoSet_Shotgun</similarTo>
+	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->
 

--- a/Defs/Ammo/Shotgun/20Gauge.xml
+++ b/Defs/Ammo/Shotgun/20Gauge.xml
@@ -21,6 +21,17 @@
 		</ammoTypes>
 		<similarTo>AmmoSet_Shotgun</similarTo>
 	</CombatExtended.AmmoSetDef>
+	
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_20Gauge_Slug</defName>
+		<label>20 Gauge</label>
+		<ammoTypes>
+			<Ammo_20Gauge_Slug>Bullet_20Gauge_Slug</Ammo_20Gauge_Slug>
+			<Ammo_20Gauge_Beanbag>Bullet_20Gauge_Beanbag</Ammo_20Gauge_Beanbag>
+			<Ammo_20Gauge_ElectroSlug>Bullet_20Gauge_ElectroSlug</Ammo_20Gauge_ElectroSlug>
+		</ammoTypes>
+		<similarTo>AmmoSet_Shotgun</similarTo>
+	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->
 

--- a/Defs/Ammo/Shotgun/23x75mmR.xml
+++ b/Defs/Ammo/Shotgun/23x75mmR.xml
@@ -21,6 +21,17 @@
 		</ammoTypes>
 		<similarTo>AmmoSet_Shotgun</similarTo>
 	</CombatExtended.AmmoSetDef>
+	
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_23x75mmR_Slug</defName>
+		<label>23x75mmR</label>
+		<ammoTypes>
+			<Ammo_23x75mmR_Slug>Bullet_23x75mmR_Slug</Ammo_23x75mmR_Slug>
+			<Ammo_23x75mmR_Beanbag>Bullet_23x75mmR_Beanbag</Ammo_23x75mmR_Beanbag>
+			<Ammo_23x75mmR_ElectroSlug>Bullet_23x75mmR_ElectroSlug</Ammo_23x75mmR_ElectroSlug>
+		</ammoTypes>
+		<similarTo>AmmoSet_Shotgun</similarTo>
+	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->
 

--- a/Defs/Ammo/Shotgun/410Bore.xml
+++ b/Defs/Ammo/Shotgun/410Bore.xml
@@ -33,6 +33,17 @@
 		</ammoTypes>
 		<similarTo>AmmoSet_RevolverShotgun</similarTo>
 	</CombatExtended.AmmoSetDef>
+	
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_410Bore_Slug</defName>
+		<label>.410 bore</label>
+		<ammoTypes>
+			<Ammo_410Bore_Slug>Bullet_410Bore_Slug</Ammo_410Bore_Slug>
+			<Ammo_410Bore_Beanbag>Bullet_410Bore_Beanbag</Ammo_410Bore_Beanbag>
+			<Ammo_410Bore_ElectroSlug>Bullet_410Bore_ElectroSlug</Ammo_410Bore_ElectroSlug>
+		</ammoTypes>
+		<similarTo>AmmoSet_Shotgun</similarTo>
+	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->
 


### PR DESCRIPTION
## Additions
- Added slug specific AmmoSetDefs for all shotgun calibers, intended for use in slug guns.

## Reasoning
- Certain shotguns (slug guns) are rifled* and intended to only be loaded with slugs. While they _can_ fire buckshot, they would suffer from wildly inaccurate spread patterns from the rifling, and are basically unusable with the unintended ammunition.
- Slug guns are commonly scoped, and are quite accurate at longer ranges. Currently however, modders adding scoped slug guns have to also deal with "sniper buckshot" as a result of the increased range and lowered spread, which as explained would not be realistic.

*Note: Yes the KS-23 has a rifled barrel. It also sucks IRL. The CE Armory KS-23 is statted no differently from an ordinary shotgun and therefore doesn't need to use the new AmmoSet.

## Alternatives
- Suffer not a modder to live.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
