### PR TITLE
Minor pistol texture fixes

### DIFF
--- a/Defs/Ammo/Pistols/38SW.xml
+++ b/Defs/Ammo/Pistols/38SW.xml
@@ -42,7 +42,7 @@
 		<defName>Ammo_38SW_FMJ</defName>
 		<label>.38 S&amp;W (FMJ)</label>
 		<graphicData>
-			<texPath>Things/Ammo/Rifle/FMJ</texPath>
+			<texPath>Things/Ammo/Revolver/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
@@ -56,7 +56,7 @@
 		<defName>Ammo_38SW_AP</defName>
 		<label>.38 S&amp;W (AP)</label>
 		<graphicData>
-			<texPath>Things/Ammo/Pistol/AP</texPath>
+			<texPath>Things/Ammo/Revolver/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
@@ -70,7 +70,7 @@
 		<defName>Ammo_38SW_HP</defName>
 		<label>.38 S&amp;W (HP)</label>
 		<graphicData>
-			<texPath>Things/Ammo/Pistol/HP</texPath>
+			<texPath>Things/Ammo/Revolver/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>

--- a/Defs/Ammo/Pistols/762x38mmR.xml
+++ b/Defs/Ammo/Pistols/762x38mmR.xml
@@ -42,7 +42,7 @@
 		<defName>Ammo_762x38mmR_FMJ</defName>
 		<label>7.62x38mmR (FMJ)</label>
 		<graphicData>
-			<texPath>Things/Ammo/Pistol/FMJ</texPath>
+			<texPath>Things/Ammo/Revolver/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
@@ -56,7 +56,7 @@
 		<defName>Ammo_762x38mmR_AP</defName>
 		<label>7.62x38mmR (AP)</label>
 		<graphicData>
-			<texPath>Things/Ammo/Pistol/AP</texPath>
+			<texPath>Things/Ammo/Revolver/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
@@ -70,7 +70,7 @@
 		<defName>Ammo_762x38mmR_HP</defName>
 		<label>7.62x38mmR (HP)</label>
 		<graphicData>
-			<texPath>Things/Ammo/Pistol/HP</texPath>
+			<texPath>Things/Ammo/Revolver/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>

--- a/Defs/Ammo/Pistols/8x22mmNambu.xml
+++ b/Defs/Ammo/Pistols/8x22mmNambu.xml
@@ -42,7 +42,7 @@
 		<defName>Ammo_8x22mmNambu_FMJ</defName>
 		<label>8x22mm Nambu (FMJ)</label>
 		<graphicData>
-			<texPath>Things/Ammo/Rifle/FMJ</texPath>
+			<texPath>Things/Ammo/Pistol/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>


### PR DESCRIPTION
## Changes

- Fixed 8x22mm Nambu using a rifle texture for FMJ
- Swapped .38S&W and 7.62x38mmR to revolver textures

## Reasoning

- Those are (at least mostly) revolver cartridges

## Testing

Check tests you have performed:
- [x] I have done exactly zero tests
