### PR TITLE
Hide disabled ammo from research

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_ResearchPrerequisitesUtility.cs
+++ b/Source/CombatExtended/Harmony/Harmony_ResearchPrerequisitesUtility.cs
@@ -14,6 +14,7 @@ namespace CombatExtended
             {
                 pair.second.RemoveWhere(x => x is AmmoDef ammoDef && ammoDef.menuHidden);
             }
+            input.RemoveWhere(x => x.second.NullOrEmpty());
             return input;
         }
     }

--- a/Source/CombatExtended/Harmony/Harmony_ResearchPrerequisitesUtility.cs
+++ b/Source/CombatExtended/Harmony/Harmony_ResearchPrerequisitesUtility.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using HarmonyLib;
+using RimWorld;
+using Verse;
+
+namespace CombatExtended
+{
+    [HarmonyPatch(typeof(ResearchPrerequisitesUtility), nameof(ResearchPrerequisitesUtility.UnlockedDefsGroupedByPrerequisites))]
+    public class Harmony_ResearchPrerequisitesUtility
+    {
+        public static List<Pair<ResearchPrerequisitesUtility.UnlockedHeader, List<Def>>> Postfix(List<Pair<ResearchPrerequisitesUtility.UnlockedHeader, List<Def>>> input)
+        {
+            foreach (var pair in input)
+            {
+                pair.second.RemoveWhere(x => x is AmmoDef ammoDef && ammoDef.menuHidden);
+            }
+            return input;
+        }
+    }
+}


### PR DESCRIPTION
## Additions

- Disabled ammo now no longer shows up in research

## Reasoning

- Cleans up the research screen

## Alternatives

- Answer more questions about the Tomahawk Missile

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] It works with generic mode
