### PR TITLE
Promt for restart on changing generic mode

### DIFF
--- a/Languages/English/Keyed/ModMenu.xml
+++ b/Languages/English/Keyed/ModMenu.xml
@@ -127,7 +127,7 @@
 
 	<!-- ========== Pop-up window ========== -->
 
-	<CE_Settings_GenericRestartPopup>Changing the generic ammo mode requires a full restart to apply.\n\nWould you like to restart now?</CE_Settings_GenericRestartPopup>
+	<CE_Settings_GenericRestartPopup>Toggling generic ammo mode requires a full restart to apply.\n\nWould you like to restart now?</CE_Settings_GenericRestartPopup>
 	<CE_Settings_AcceptRestart>Restart now</CE_Settings_AcceptRestart>
 	<CE_Settings_DeclineRestart>Continue</CE_Settings_DeclineRestart>
 	<CE_Settings_RestartTitle>Generic ammo setting has changed</CE_Settings_RestartTitle>

--- a/Languages/English/Keyed/ModMenu.xml
+++ b/Languages/English/Keyed/ModMenu.xml
@@ -125,4 +125,10 @@
 	<CE_Settings_PawnkindAutopatcher_Title>Enable pawnkind autopatcher</CE_Settings_PawnkindAutopatcher_Title>
 	<CE_Settings_PawnkindAutopatcher_Desc>Give unpatched pawnkinds equipped with a patched ranged weapon a small amount of ammunition.</CE_Settings_PawnkindAutopatcher_Desc>
 
+	<!-- ========== Pop-up window ========== -->
+
+	<CE_Settings_GenericRestartPopup>Changing the generic ammo mode requires a full restart to apply.\n\nWould you like to restart now?</CE_Settings_GenericRestartPopup>
+	<CE_Settings_AcceptRestart>Restart now</CE_Settings_AcceptRestart>
+	<CE_Settings_DeclineRestart>Continue</CE_Settings_DeclineRestart>
+	<CE_Settings_RestartTitle>Generic ammo setting has changed</CE_Settings_RestartTitle>
 </LanguageData>

--- a/Source/CombatExtended/CombatExtended/Controller.cs
+++ b/Source/CombatExtended/CombatExtended/Controller.cs
@@ -115,7 +115,7 @@ namespace CombatExtended
             }
 
             LongEventHandler.QueueLongEvent(patches.Install, "CE_LongEvent_CompatibilityPatches", false, null);
-            
+
             genericState = settings.GenericAmmo;
         }
 

--- a/Source/CombatExtended/CombatExtended/Controller.cs
+++ b/Source/CombatExtended/CombatExtended/Controller.cs
@@ -24,6 +24,7 @@ namespace CombatExtended
         public static Settings settings;
         public static Controller instance;
         public static ModContentPack content;
+        private static bool genericState;
         private static Patches patches;
         private Vector2 scrollPosition;
 
@@ -91,7 +92,6 @@ namespace CombatExtended
                 }
 
                 modPart.PostLoad(content, settings);
-
             }
 
             // Initialize loadout generator
@@ -115,12 +115,32 @@ namespace CombatExtended
             }
 
             LongEventHandler.QueueLongEvent(patches.Install, "CE_LongEvent_CompatibilityPatches", false, null);
-
+            
+            genericState = settings.GenericAmmo;
         }
 
         public override string SettingsCategory()
         {
             return "Combat Extended";
+        }
+
+        public override void WriteSettings()
+        {
+            base.WriteSettings();
+            if (settings.GenericAmmo != genericState)
+            {
+                GenericRestartPopup();
+            }
+        }
+
+        private static void GenericRestartPopup()
+        {
+            var acceptAction = new Action(() =>
+            {
+                GenCommandLine.Restart();
+            });
+            var dialog = new Dialog_MessageBox("CE_Settings_GenericRestartPopup".Translate(), "CE_Settings_AcceptRestart".Translate(), acceptAction, "CE_Settings_DeclineRestart".Translate(), null, "CE_Settings_RestartTitle".Translate(), true);
+            Find.WindowStack.Add(dialog);
         }
 
         private static void DoTutorialPopup()


### PR DESCRIPTION
## Additions

- The game now prompts for a restart when closing the settings window after toggling the generic ammo setting.

## Reasoning

- The change requires a full restart to apply properly, unlike disabling ammo, which silently re-runs the injection again.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
