### PR TITLE
Replace non-ascii chars in CE_Settings_CreateCasingsFilth keys.

### DIFF
--- a/Languages/ChineseSimplified/Keyed/ModMenu.xml
+++ b/Languages/ChineseSimplified/Keyed/ModMenu.xml
@@ -25,9 +25,9 @@
 	<CE_Settings_ShowCasings_Desc>武器开火会显示弹壳掉落的效果。禁用以提高性能。</CE_Settings_ShowCasings_Desc>
 
 	<!-- EN: Create shell casing filth -->
-	<CE_Settings_СreateCasingsFilth_Title>启用弹壳污秽</CE_Settings_СreateCasingsFilth_Title>
+	<CE_Settings_CreateCasingsFilth_Title>启用弹壳污秽</CE_Settings_CreateCasingsFilth_Title>
 	<!-- EN: Firing weapons will create cleanable filth of dropped casings. -->
-	<CE_Settings_СreateCasingsFilth_Desc>在武器射击时会产生由抛壳产生的可清洗污渍。</CE_Settings_СreateCasingsFilth_Desc>
+	<CE_Settings_CreateCasingsFilth_Desc>在武器射击时会产生由抛壳产生的可清洗污渍。</CE_Settings_CreateCasingsFilth_Desc>
 
 	<!-- EN: Show combat taunts -->
 	<CE_Settings_ShowTaunts_Title>显示战斗嘲讽</CE_Settings_ShowTaunts_Title>

--- a/Languages/English/Keyed/ModMenu.xml
+++ b/Languages/English/Keyed/ModMenu.xml
@@ -17,8 +17,8 @@
 	<CE_Settings_ShowCasings_Title>Show shell casings</CE_Settings_ShowCasings_Title>
 	<CE_Settings_ShowCasings_Desc>Firing weapons will display a dropped casing effect.</CE_Settings_ShowCasings_Desc>
 
-	<CE_Settings_СreateCasingsFilth_Title>Create shell casing filth</CE_Settings_СreateCasingsFilth_Title>
-	<CE_Settings_СreateCasingsFilth_Desc>Firing weapons will create cleanable filth of dropped casings.</CE_Settings_СreateCasingsFilth_Desc>
+	<CE_Settings_CreateCasingsFilth_Title>Create shell casing filth</CE_Settings_CreateCasingsFilth_Title>
+	<CE_Settings_CreateCasingsFilth_Desc>Firing weapons will create cleanable filth of dropped casings.</CE_Settings_CreateCasingsFilth_Desc>
 
 	<CE_Settings_ShowTaunts_Title>Show combat taunts</CE_Settings_ShowTaunts_Title>
 	<CE_Settings_ShowTaunts_Desc>Pawns will display text-based taunts during combat.</CE_Settings_ShowTaunts_Desc>

--- a/Languages/PortugueseBrazilian/Keyed/ModMenu.xml
+++ b/Languages/PortugueseBrazilian/Keyed/ModMenu.xml
@@ -17,8 +17,8 @@
 	<CE_Settings_ShowCasings_Title>Mostrar estojos de munição</CE_Settings_ShowCasings_Title>
 	<CE_Settings_ShowCasings_Desc>Disparar armas exibirá um efeito de estojo caído.</CE_Settings_ShowCasings_Desc>
 
-	<CE_Settings_СreateCasingsFilth_Title>Criar sujeira de estojos</CE_Settings_СreateCasingsFilth_Title>
-	<CE_Settings_СreateCasingsFilth_Desc>Disparar armas criará sujeira limpável de estojos caídos.</CE_Settings_СreateCasingsFilth_Desc>
+	<CE_Settings_CreateCasingsFilth_Title>Criar sujeira de estojos</CE_Settings_CreateCasingsFilth_Title>
+	<CE_Settings_CreateCasingsFilth_Desc>Disparar armas criará sujeira limpável de estojos caídos.</CE_Settings_CreateCasingsFilth_Desc>
 
 	<CE_Settings_ShowTaunts_Title>Mostrar provocação de combate</CE_Settings_ShowTaunts_Title>
 	<CE_Settings_ShowTaunts_Desc>Os personagens exibirão provocações baseadas em texto durante o combate.</CE_Settings_ShowTaunts_Desc>

--- a/Languages/Russian/Keyed/ModMenu.xml
+++ b/Languages/Russian/Keyed/ModMenu.xml
@@ -11,8 +11,8 @@
 	<CE_Settings_ShowCasings_Title>Показывать гильзы снарядов</CE_Settings_ShowCasings_Title>
 	<CE_Settings_ShowCasings_Desc>Показывать гильзы при стрельбе. Отключение повысит производительность.</CE_Settings_ShowCasings_Desc>
 
-	<CE_Settings_СreateCasingsFilth_Title>Создавать гильзы на земле</CE_Settings_СreateCasingsFilth_Title>
-	<CE_Settings_СreateCasingsFilth_Desc>Стрельба из оружия создаёт грязь в виде брошенных гильз.</CE_Settings_СreateCasingsFilth_Desc>
+	<CE_Settings_CreateCasingsFilth_Title>Создавать гильзы на земле</CE_Settings_CreateCasingsFilth_Title>
+	<CE_Settings_CreateCasingsFilth_Desc>Стрельба из оружия создаёт грязь в виде брошенных гильз.</CE_Settings_CreateCasingsFilth_Desc>
 
 	<CE_Settings_ShowTaunts_Title>Показать боевые насмешки</CE_Settings_ShowTaunts_Title>
 	<CE_Settings_ShowTaunts_Desc>В ходе боя у пешек будут отображаться текстовые насмешки.</CE_Settings_ShowTaunts_Desc>

--- a/Source/CombatExtended/CombatExtended/Settings.cs
+++ b/Source/CombatExtended/CombatExtended/Settings.cs
@@ -216,7 +216,7 @@ namespace CombatExtended
             list.Gap();
             list.CheckboxLabeled("CE_Settings_PartialStats_Title".Translate(), ref partialstats, "CE_Settings_PartialStats_Desc".Translate());
             list.CheckboxLabeled("CE_Settings_ShowCasings_Title".Translate(), ref showCasings, "CE_Settings_ShowCasings_Desc".Translate());
-            list.CheckboxLabeled("CE_Settings_СreateCasingsFilth_Title".Translate(), ref createCasingsFilth, "CE_Settings_СreateCasingsFilth_Desc".Translate());
+            list.CheckboxLabeled("CE_Settings_CreateCasingsFilth_Title".Translate(), ref createCasingsFilth, "CE_Settings_CreateCasingsFilth_Desc".Translate());
             list.CheckboxLabeled("CE_Settings_RecoilAnim_Title".Translate(), ref recoilAnim, "CE_Settings_RecoilAnim_Desc".Translate());
             list.CheckboxLabeled("CE_Settings_ShowTaunts_Title".Translate(), ref showTaunts, "CE_Settings_ShowTaunts_Desc".Translate());
             list.CheckboxLabeled("CE_Settings_AllowMeleeHunting_Title".Translate(), ref allowMeleeHunting, "CE_Settings_AllowMeleeHunting_Desc".Translate());


### PR DESCRIPTION
## Changes

- Replace cyrillic chars in translation keys to ascii version

## Reasoning

- Translation keys should have ascii-chars only;
- Non-ascii translation keys are not searchable;
- It may not display correctly in text editors if user don't have a font with cyrillic charset;
- Might be copy-paste error that no one noticed.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] CE Settings dialog
