### PR TITLE
Update RBSE Patch

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -405,7 +405,7 @@
 		<li IfModActive="arquebus.psyblasters">ModPatches/PsyBlasters</li>
 		<li IfModActive="detvisor.pulseweaponry">ModPatches/Pulse Weaponry</li>
 		<li IfModActive="Mlie.PulsefireTurret">ModPatches/Pulsefire Turret</li>
-		<li IfModActive="Rah.RBSE">ModPatches/RBSE</li>
+		<li IfModActive="Rah.RBSE,Rah.RBSEHC">ModPatches/RBSE</li>
 		<li IfModActive="RH.DOOM">ModPatches/RH2 DOOM</li>
 		<li IfModActive="RH2.Faction.Bounty.Hunters">ModPatches/RH2 Faction - Bounty Hunters</li>
 		<li IfModActive="RH2.Faction.Gruppa.Krovi">ModPatches/RH2 Faction - Gruppa Krovi</li>

--- a/ModPatches/RBSE/Defs/RBSE/Cure CE Scars.xml
+++ b/ModPatches/RBSE/Defs/RBSE/Cure CE Scars.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
-	<RecipeDef ParentName="SurgeryOld">
+
+	<RecipeDef ParentName="SurgeryFlesh">
 		<defName>CureInjuryBlast</defName>
 		<label>cure blast</label>
 		<description>Cure blast.</description>
@@ -28,5 +29,16 @@
 		</skillRequirements>
 		<removesHediff>Blast</removesHediff>
 		<researchPrerequisite>RegenerativeMedicine</researchPrerequisite>
+		<!-- From RBSE's `SurgeryOld` Base, duplicated to avoid a load order requirement. -->
+		<effectWorking>Surgery</effectWorking>
+        <soundWorking>Recipe_Surgery</soundWorking>
+        <workSpeedStat>MedicalOperationSpeed</workSpeedStat>
+        <workSkill>Medicine</workSkill>
+        <workSkillLearnFactor>18</workSkillLearnFactor>
+        <recipeUsers>
+            <li>Human</li>
+            <li MayRequire="Ludeon.RimWorld.Anomaly">CreepJoiner</li>
+        </recipeUsers>
 	</RecipeDef>
+
 </Defs>

--- a/ModPatches/RBSE/Patches/RBSE/Bionics.xml
+++ b/ModPatches/RBSE/Patches/RBSE/Bionics.xml
@@ -1,7 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
-	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/HediffDef[defName="SimpleProstheticHand" or defName="SimpleProstheticArm"]/comps/li[@Class="HediffCompProperties_VerbGiver"]</xpath>
+
+	<!-- ========== Simple Prosthetics ========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/HediffDef[defName="SimpleProstheticHand"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>fist</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>1</power>
+					<cooldownTime>1.26</cooldownTime>
+					<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
 	</Operation>
 
 	<!-- ========== Bionics ========== -->


### PR DESCRIPTION
## Additions
- Add an entry for RBSE Hardcore Edition to the LoadFolders.xml.
  - The Hardcore Edition has the same contents are the regular version, just with higher resource costs.

## Changes
- Remove use of RBSE's `SurgeryOld` as a parent and use a vanilla parent instead, and copy necessary fields from the former directly to the RecipeDef.
- Remove a patch the removed the verb from the simple prosthetic hand and arm. Patch the simple prosthetic hand.

## Reasoning
- Using the RBSE `SurgeryOld` would require adding a load order requirement, as the parent is otherwise "missing" if CE is loaded before RBSE. For the purpose of a single RecipeDef, it introduces fewer potential complications to just copy a few lines over.
- Unclear on the original intention here.

## Alternatives
- Could add a load order requirement to prevent the missing parent.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
