### PR TITLE
Removal of CarryingCapacity notes from RH2 patches

### DIFF
--- a/ModPatches/RH2 Faction - Gruppa Krovi/Patches/Apparel_Gruppa_Krovi.xml
+++ b/ModPatches/RH2 Faction - Gruppa Krovi/Patches/Apparel_Gruppa_Krovi.xml
@@ -462,7 +462,6 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "RNApparel_Backpack_JuggernautMkII"]/equippedStatOffsets/CarryingCapacity </xpath>
 		<value>
-			<CarryingCapacity>25</CarryingCapacity>
 			<CarryBulk>60</CarryBulk>
 		</value>
 	</Operation>

--- a/ModPatches/RH2 Rimmu-Nation² - Clothing/Patches/RH2 Rimmu-Nation² - Clothing/Backpacks_CE.xml
+++ b/ModPatches/RH2 Rimmu-Nation² - Clothing/Patches/RH2 Rimmu-Nation² - Clothing/Backpacks_CE.xml
@@ -233,7 +233,6 @@
 			or defName = "RNApparel_Backpack_WarriorPegasus"
 			]/equippedStatOffsets </xpath>
 		<value>
-			<CarryingCapacity>5</CarryingCapacity>
 			<CarryBulk>40</CarryBulk>
 		</value>
 	</Operation>
@@ -242,7 +241,6 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName = "RNApparel_Backpack_LBT0101JJ"]/equippedStatOffsets</xpath>
 		<value>
-			<CarryingCapacity>10</CarryingCapacity>
 			<CarryBulk>47.5</CarryBulk>
 		</value>
 	</Operation>
@@ -251,7 +249,6 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName = "RNApparel_Backpack_MOLLE2UCP"]/equippedStatOffsets</xpath>
 		<value>
-			<CarryingCapacity>30</CarryingCapacity>
 			<CarryBulk>60</CarryBulk>
 		</value>
 	</Operation>
@@ -259,7 +256,6 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName = "RNApparel_Backpack_AzimutSSKangaroo" or defName = "RNApparel_Backpack_BerghausVulcanIV"]/equippedStatOffsets</xpath>
 		<value>
-			<CarryingCapacity>25</CarryingCapacity>
 			<CarryBulk>60</CarryBulk>
 		</value>
 	</Operation>
@@ -267,7 +263,6 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName = "RNApparel_Backpack_NorthFaceTerra65L"]/equippedStatOffsets</xpath>
 		<value>
-			<CarryingCapacity>20</CarryingCapacity>
 			<CarryBulk>55</CarryBulk>
 		</value>
 	</Operation>

--- a/ModPatches/Spartan Foundry/Patches/Spartan Foundry/Apparel_Armors.xml
+++ b/ModPatches/Spartan Foundry/Patches/Spartan Foundry/Apparel_Armors.xml
@@ -674,7 +674,6 @@
 				<ToxicEnvironmentResistance>0.5</ToxicEnvironmentResistance>
 				<MoveSpeed>0.4</MoveSpeed>
 				<WorkSpeedGlobal>0.1</WorkSpeedGlobal>
-				<CarryingCapacity>30</CarryingCapacity>
 				<HuntingStealth>1</HuntingStealth>
 			</equippedStatOffsets>
 		</value>


### PR DESCRIPTION
## Additions


## Changes
what it says on the tin
## References

## Reasoning

## Alternatives


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
