### PR TITLE
Check for unreserved item stack count before giving loadout update jobs

### DIFF
--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_UpdateLoadout.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_UpdateLoadout.cs
@@ -290,24 +290,25 @@ namespace CombatExtended
             }
         }
 
-        private static int GetUnreservedStackCount(LocalTargetInfo target, ReservationLayerDef layer = null)
+        /// <summary>
+        /// Gets the unreserved stack count of a Thing.
+        /// </summary>
+        /// <param name="target">The Thing for which to get the unreserved stack count.</param>
+        /// <returns>Returns 0 if the target is not a Thing, is not on a Map, or all of its stack is reserved. Otherwise returns the unreserved stack count of a target.</returns>
+        private static int GetUnreservedStackCount(Thing thing)
         {
-            var reservations = target.Thing?.Map?.reservationManager.ReservationsReadOnly;
+            var reservations = thing.Map?.reservationManager.ReservationsReadOnly;
             if (reservations == null)
             {
                 return 0;
             }
 
-            int stackCount = target.Thing.stackCount;
+            int stackCount = thing.stackCount;
 
             for (int i = 0; stackCount > 0 && i < reservations.Count(); ++i)
             {
                 var reservation = reservations[i];
-                if (reservation.Target.Thing != target.Thing)
-                {
-                    continue;
-                }
-                if (layer != null && reservation.Layer != layer)
+                if (reservation.Target.Thing != thing)
                 {
                     continue;
                 }

--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_UpdateLoadout.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_UpdateLoadout.cs
@@ -304,7 +304,6 @@ namespace CombatExtended
             }
 
             int stackCount = thing.stackCount;
-
             for (int i = 0; stackCount > 0 && i < reservations.Count(); ++i)
             {
                 var reservation = reservations[i];


### PR DESCRIPTION
## Changes

- Will use the item's unreserved stack count instead of the current stack count in the UpdateLoadout JobGiver when giving jobs to pickup or equip items. 

## References

- https://discord.com/channels/278818534069501953/324222101550661663/1323104384539693087

## Reasoning

- The pickup job throws exceptions when it fails to reserve an item right after starting.

## Testing

- [x] Compiles without warnings;
- [x] Game runs without errors;
- [ ] Playtested a colony.

## Additional testing
- The issue can be replicated with, for example, assigning two pawns a loadout that requires more ammo for both than is currently available and ordering both to rearm. With this change, the first pawn to get the rearm job should pick up the most ammo, and no exception should be thrown.
