### PR TITLE
Add generics for creep joiners

### DIFF
--- a/Anomaly/Patches/CreepjoinderDefs/Forms.xml
+++ b/Anomaly/Patches/CreepjoinderDefs/Forms.xml
@@ -13,26 +13,49 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationAdd">
+	<Operation Class="CombatExtended.PatchOperation_ConditionalGeneric">
+		<standard Class="PatchOperationAdd">
+			<xpath>Defs/CreepJoinerFormKindDef[defName="LeatheryStranger"]</xpath>
+			<value>
+				<inventoryOptions>
+					<subOptionsChooseOne>
+						<li>
+							<thingDef>Ammo_303British_FMJ</thingDef>
+							<countRange>20~40</countRange>
+						</li>
+						<li>
+							<thingDef>Ammo_303British_AP</thingDef>
+							<countRange>20~40</countRange>
+						</li>
+						<li>
+							<thingDef>Ammo_303British_HP</thingDef>
+							<countRange>20~40</countRange>
+						</li>										
+					</subOptionsChooseOne>
+				</inventoryOptions>
+			</value>
+		</standard>
+		<generic Class="PatchOperationAdd">
 		<xpath>Defs/CreepJoinerFormKindDef[defName="LeatheryStranger"]</xpath>
-		<value>
-			<inventoryOptions>
-				<subOptionsChooseOne>
-					<li>
-						<thingDef>Ammo_303British_FMJ</thingDef>
-						<countRange>20~40</countRange>
-					</li>
-					<li>
-						<thingDef>Ammo_303British_AP</thingDef>
-						<countRange>20~40</countRange>
-					</li>
-					<li>
-						<thingDef>Ammo_303British_HP</thingDef>
-						<countRange>20~40</countRange>
-					</li>										
-				</subOptionsChooseOne>
-			</inventoryOptions>
-		</value>
+			<value>
+				<inventoryOptions>
+					<subOptionsChooseOne>
+						<li>
+							<thingDef>Ammo_Rifle_FMJ</thingDef>
+							<countRange>20~40</countRange>
+						</li>
+						<li>
+							<thingDef>Ammo_Rifle_AP</thingDef>
+							<countRange>20~40</countRange>
+						</li>
+						<li>
+							<thingDef>Ammo_Rifle_HP</thingDef>
+							<countRange>20~40</countRange>
+						</li>										
+					</subOptionsChooseOne>
+				</inventoryOptions>
+			</value>
+		</generic>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
@@ -45,26 +68,49 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/CreepJoinerFormKindDef[defName="DealMaker"]</xpath>
-		<value>
-			<inventoryOptions>
-				<subOptionsChooseOne>
-					<li>
-						<thingDef>Ammo_44Magnum_FMJ</thingDef>
-						<countRange>12~24</countRange>
-					</li>
-					<li>
-						<thingDef>Ammo_44Magnum_AP</thingDef>
-						<countRange>12~24</countRange>
-					</li>
-					<li>
-						<thingDef>Ammo_44Magnum_HP</thingDef>
-						<countRange>12~24</countRange>
-					</li>										
-				</subOptionsChooseOne>
-			</inventoryOptions>
-		</value>
+	<Operation Class="CombatExtended.PatchOperation_ConditionalGeneric">
+		<standard Class="PatchOperationAdd">
+			<xpath>Defs/CreepJoinerFormKindDef[defName="DealMaker"]</xpath>
+			<value>
+				<inventoryOptions>
+					<subOptionsChooseOne>
+						<li>
+							<thingDef>Ammo_44Magnum_FMJ</thingDef>
+							<countRange>12~24</countRange>
+						</li>
+						<li>
+							<thingDef>Ammo_44Magnum_AP</thingDef>
+							<countRange>12~24</countRange>
+						</li>
+						<li>
+							<thingDef>Ammo_44Magnum_HP</thingDef>
+							<countRange>12~24</countRange>
+						</li>										
+					</subOptionsChooseOne>
+				</inventoryOptions>
+			</value>
+		</standard>
+		<generic Class="PatchOperationAdd">
+			<xpath>Defs/CreepJoinerFormKindDef[defName="DealMaker"]</xpath>
+			<value>
+				<inventoryOptions>
+					<subOptionsChooseOne>
+						<li>
+							<thingDef>Ammo_PistolMagnum_FMJ</thingDef>
+							<countRange>12~24</countRange>
+						</li>
+						<li>
+							<thingDef>Ammo_PistolMagnum_AP</thingDef>
+							<countRange>12~24</countRange>
+						</li>
+						<li>
+							<thingDef>Ammo_PistolMagnum_HP</thingDef>
+							<countRange>12~24</countRange>
+						</li>										
+					</subOptionsChooseOne>
+				</inventoryOptions>
+			</value>
+		</generic>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
@@ -84,22 +130,41 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/CreepJoinerFormKindDef[defName="LoneGenius"]</xpath>
-		<value>
-			<inventoryOptions>
-				<subOptionsChooseOne>
-					<li>
-						<thingDef>Ammo_6x24mmCharged</thingDef>
-						<countRange>60~120</countRange>
-					</li>
-					<li>
-						<thingDef>Ammo_6x24mmCharged_AP</thingDef>
-						<countRange>60~120</countRange>
-					</li>					
-				</subOptionsChooseOne>
-			</inventoryOptions>
-		</value>
+	<Operation Class="CombatExtended.PatchOperation_ConditionalGeneric">
+		<standard Class="PatchOperationAdd">
+			<xpath>Defs/CreepJoinerFormKindDef[defName="LoneGenius"]</xpath>
+			<value>
+				<inventoryOptions>
+					<subOptionsChooseOne>
+						<li>
+							<thingDef>Ammo_6x24mmCharged</thingDef>
+							<countRange>60~120</countRange>
+						</li>
+						<li>
+							<thingDef>Ammo_6x24mmCharged_AP</thingDef>
+							<countRange>60~120</countRange>
+						</li>					
+					</subOptionsChooseOne>
+				</inventoryOptions>
+			</value>
+		</standard>
+		<generic Class="PatchOperationAdd">
+			<xpath>Defs/CreepJoinerFormKindDef[defName="LoneGenius"]</xpath>
+			<value>
+				<inventoryOptions>
+					<subOptionsChooseOne>
+						<li>
+							<thingDef>Ammo_RifleCharged</thingDef>
+							<countRange>60~120</countRange>
+						</li>
+						<li>
+							<thingDef>Ammo_RifleCharged_AP</thingDef>
+							<countRange>60~120</countRange>
+						</li>					
+					</subOptionsChooseOne>
+				</inventoryOptions>
+			</value>
+		</generic>
 	</Operation>
 
 </Patch>

--- a/Anomaly/Patches/CreepjoinderDefs/Forms.xml
+++ b/Anomaly/Patches/CreepjoinderDefs/Forms.xml
@@ -36,7 +36,7 @@
 			</value>
 		</standard>
 		<generic Class="PatchOperationAdd">
-		<xpath>Defs/CreepJoinerFormKindDef[defName="LeatheryStranger"]</xpath>
+			<xpath>Defs/CreepJoinerFormKindDef[defName="LeatheryStranger"]</xpath>
 			<value>
 				<inventoryOptions>
 					<subOptionsChooseOne>


### PR DESCRIPTION
## Changes

- Creep joiner patches now use conditional generic patch ops.

## Testing

- [x] I launched a dev quicktest
