### PR TITLE
SOS 2 starting scenarios patch fix

### DIFF
--- a/ModPatches/Save Our Ship 2/Patches/Save Our Ship 2/Scenarios_SOS2.xml
+++ b/ModPatches/Save Our Ship 2/Patches/Save Our Ship 2/Scenarios_SOS2.xml
@@ -22,6 +22,18 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ScenarioDef[defName="SoSDerelict"]/scenario/parts/li[thingDef="Apparel_AdvancedHelmet"]</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ScenarioDef[defName="SoSDerelict"]/scenario/parts/li[thingDef="Apparel_FlakVest"]</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ScenarioDef[defName="SoSDerelict"]/scenario/parts/li[thingDef="Apparel_FlakPants"]</xpath>
+	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ScenarioDef[defName="SoSDungeon"]/scenario/parts</xpath>
 		<value>
@@ -36,6 +48,18 @@
 				<count>60</count>
 			</li>
 		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ScenarioDef[defName="SoSDungeon"]/scenario/parts/li[thingDef="Apparel_AdvancedHelmet"]</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ScenarioDef[defName="SoSDungeon"]/scenario/parts/li[thingDef="Apparel_FlakVest"]</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ScenarioDef[defName="SoSDungeon"]/scenario/parts/li[thingDef="Apparel_FlakPants"]</xpath>
 	</Operation>
 
 </Patch>


### PR DESCRIPTION
Similar to default crashlanded scenario, SOS2 starting scenarios need vanilla armor removal, as it causes ignore-able stuffing red errors if starting unedited scenario. Or worse, scenario editor broken badly if scenario is edited before start, which is a frequent case for those scenarios.

## Changes

Fix to Save Our Ship 2 compatibility patch, specifically for scenarios.

## Testing

Check tests you have performed:
- [x] As those are only XML patches, playtested starting SOS2 Derelict Ship and Derelict station scenarios. In both cases, using edit scenario option no longer causes broken editor. And in both cases game can be normally started, as expected.