### PR TITLE
Fixed throwing knives recipe having wrong amounts

### DIFF
--- a/ModPatches/Vanilla Weapons Expanded/Defs/Vanilla Weapons Expanded/Ammo/Recipes.xml
+++ b/ModPatches/Vanilla Weapons Expanded/Defs/Vanilla Weapons Expanded/Ammo/Recipes.xml
@@ -43,7 +43,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>14</count>
+				<count>10</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -52,7 +52,7 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<VWE_Throwing_Knives>14</VWE_Throwing_Knives>
+			<VWE_Throwing_Knives>10</VWE_Throwing_Knives>
 		</products>
 		<recipeUsers>
 			<li>FueledSmithy</li>


### PR DESCRIPTION
## Changes

The 10x recipe for throwing knives from Vanilla Weapons Expanded uses 14 steel and produces 14 throwing knives. Fixed the recipe to output 10 knives and consume 10 steel.

## Reasoning


https://github.com/user-attachments/assets/06c9c290-7f58-4ed8-af7d-01b2e3cc0340



## Alternatives

Describe alternative implementations you have considered, e.g.
- Make the recipe x14:
  - Really awkward number

## Testing

Check tests you have performed:
- [ ] Compiles without warnings - Changes did not require a recompile
- [X] Game runs without errors
- [X] Playtested a colony (specify how long) - About five minutes, just changed two values and made sure they worked