### PR TITLE
Save projectile's ticks to true position, make fragment projectiles have zero ticks to true position

### DIFF
--- a/Defs/Ammo/Advanced/164x284mmDemoShell.xml
+++ b/Defs/Ammo/Advanced/164x284mmDemoShell.xml
@@ -122,6 +122,7 @@
 			<soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
 			<soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			<tickToTruePos>0</tickToTruePos>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
@@ -160,6 +161,7 @@
 			<fuze_delay>1</fuze_delay>
 			<explosionDelay>15</explosionDelay>
 			<airborneSuppressionFactor>0.25</airborneSuppressionFactor>
+			<tickToTruePos>0</tickToTruePos>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Projectiles_Fragments.xml
+++ b/Defs/Ammo/Projectiles_Fragments.xml
@@ -15,6 +15,7 @@
 			<armorPenetrationSharp>4.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>122.5</armorPenetrationBlunt>
 			<gravityFactor>5</gravityFactor>
+			<tickToTruePos>0</tickToTruePos>
 		</projectile>
 	</ThingDef>
 
@@ -32,6 +33,7 @@
 			<armorPenetrationSharp>3</armorPenetrationSharp>
 			<armorPenetrationBlunt>63.38</armorPenetrationBlunt>
 			<gravityFactor>5</gravityFactor>
+			<tickToTruePos>0</tickToTruePos>
 		</projectile>
 	</ThingDef>
 
@@ -49,6 +51,7 @@
 			<armorPenetrationSharp>2</armorPenetrationSharp>
 			<armorPenetrationBlunt>14.4</armorPenetrationBlunt>
 			<gravityFactor>5</gravityFactor>
+			<tickToTruePos>0</tickToTruePos>
 		</projectile>
 	</ThingDef>
 
@@ -67,6 +70,7 @@
 			<armorPenetrationSharp>70</armorPenetrationSharp>
 			<armorPenetrationBlunt>6.387</armorPenetrationBlunt>
 			<gravityFactor>5</gravityFactor>
+			<tickToTruePos>0</tickToTruePos>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">

--- a/ModPatches/Anty the war Ant/Defs/Anty the war Ant/Ammo_Anty.xml
+++ b/ModPatches/Anty the war Ant/Defs/Anty the war Ant/Ammo_Anty.xml
@@ -309,6 +309,7 @@
 			<preExplosionSpawnChance>0.2</preExplosionSpawnChance>
 			<explosionDelay>20</explosionDelay>
 			<gravityFactor>15</gravityFactor>
+			<tickToTruePos>0</tickToTruePos>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">

--- a/ModPatches/Grimworld Core Imperialis/Defs/Grimworld Core Imperialis/Ammo/CE_Patch_GravGunAmmo.xml
+++ b/ModPatches/Grimworld Core Imperialis/Defs/Grimworld Core Imperialis/Ammo/CE_Patch_GravGunAmmo.xml
@@ -117,6 +117,7 @@
 			<soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
 			<soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			<tickToTruePos>0</tickToTruePos>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
@@ -155,6 +156,7 @@
 			<fuze_delay>1</fuze_delay>
 			<explosionDelay>15</explosionDelay>
 			<airborneSuppressionFactor>0.25</airborneSuppressionFactor>
+			<tickToTruePos>0</tickToTruePos>
 		</projectile>
 	</ThingDef>
 

--- a/ModPatches/Maru Race/Defs/Maru Race/Ammo_Arrow_AT.xml
+++ b/ModPatches/Maru Race/Defs/Maru Race/Ammo_Arrow_AT.xml
@@ -92,6 +92,7 @@
 			<damageDef>MR_Pulse_a</damageDef>
 			<damageAmountBase>50</damageAmountBase>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			<tickToTruePos>0</tickToTruePos>
 		</projectile>
 	</ThingDef>
 

--- a/ModPatches/Miho Race/Defs/Miho Race/Ammo/Ammo_Miho_Industrial.xml
+++ b/ModPatches/Miho Race/Defs/Miho Race/Ammo/Ammo_Miho_Industrial.xml
@@ -89,6 +89,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<tickToTruePos>0</tickToTruePos>
 			<damageDef>MihoGunshotFrag</damageDef>
 			<damageAmountBase>34</damageAmountBase>
 			<speed>60</speed>
@@ -106,6 +107,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<tickToTruePos>0</tickToTruePos>
 			<damageDef>MihoGunshotFrag</damageDef>
 			<damageAmountBase>12</damageAmountBase>
 			<speed>40</speed>

--- a/ModPatches/Paniel the Automata/Defs/Paniel the Automata/Ammo_Paniel.xml
+++ b/ModPatches/Paniel the Automata/Defs/Paniel the Automata/Ammo_Paniel.xml
@@ -389,6 +389,7 @@
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 			<ai_IsIncendiary>true</ai_IsIncendiary>
+			<tickToTruePos>0</tickToTruePos>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
@@ -417,6 +418,7 @@
 			<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
 			<preExplosionSpawnChance>0.15</preExplosionSpawnChance>
 			<soundExplode>MortarIncendiary_Explode</soundExplode>
+			<tickToTruePos>0</tickToTruePos>
 		</projectile>
 	</ThingDef>
 
@@ -434,6 +436,7 @@
 			<damageAmountBase>76</damageAmountBase>
 			<flyOverhead>true</flyOverhead>
 			<explosionRadius>3.5</explosionRadius>
+			<tickToTruePos>0</tickToTruePos>
 		</projectile>
 	</ThingDef>
 
@@ -463,6 +466,7 @@
 			<postExplosionSpawnThingCount>3</postExplosionSpawnThingCount>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 			<explosionEffect>ExtinguisherExplosion</explosionEffect>
+			<tickToTruePos>0</tickToTruePos>
 		</projectile>
 	</ThingDef>
 
@@ -491,6 +495,7 @@
 			<preExplosionSpawnChance>1</preExplosionSpawnChance>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 			<explosionEffect>ExtinguisherExplosion</explosionEffect>
+			<tickToTruePos>0</tickToTruePos>
 		</projectile>
 	</ThingDef>
 

--- a/ModPatches/Rim-Effect Core/Defs/Rim-Effect Core/ME_Projectile_Damage_Ammoclass.xml
+++ b/ModPatches/Rim-Effect Core/Defs/Rim-Effect Core/ME_Projectile_Damage_Ammoclass.xml
@@ -732,6 +732,7 @@
 			<armorPenetrationSharp>7</armorPenetrationSharp>
 			<armorPenetrationBlunt>18</armorPenetrationBlunt>
 			<gravityFactor>15</gravityFactor>
+			<tickToTruePos>0</tickToTruePos>
 		</projectile>
 	</ThingDef>
 

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -360,6 +360,7 @@ namespace CombatExtended
             Scribe_Values.Look<bool>(ref castShadow, "castShadow", true);
             Scribe_Values.Look<bool>(ref lerpPosition, "lerpPosition", true);
             Scribe_Values.Look(ref ignoreRoof, "ignoreRoof", true);
+            Scribe_Values.Look(ref ticksToTruePosition, "ticksToTruePosition");
 
             //To fix landed grenades sl problem
             Scribe_Values.Look(ref exactPosition, "exactPosition");


### PR DESCRIPTION
## Changes

- Will carry the projectile ticks until true draw position through save and loads;
- Will add tickToTruePos as zero to projectiles that are used only as fragments in order to allow them to spawn at the position of the projectile which spawned them.

## Reasoning

- #3638

## Testing

- [x] Compiles without warnings;
- [x] Game runs without errors;
- [ ] Playtested a colony.
