### PR TITLE
Fix multiplayer desyncs related to the Loadout manager

### DIFF
--- a/Source/CombatExtended/CombatExtended/Loadouts/GameComp_LoadoutManager.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/GameComp_LoadoutManager.cs
@@ -311,7 +311,7 @@ namespace CombatExtended
             return label;
         }
 
-        internal static Loadout GetLoadoutById(int id)
+        public static Loadout GetLoadoutById(int id)
         {
             if (_current == null)
             {

--- a/Source/CombatExtended/CombatExtended/Loadouts/Loadout.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/Loadout.cs
@@ -105,6 +105,13 @@ namespace CombatExtended
                 return _slots.Sum(slot => slot.mass * slot.count);
             }
         }
+        public int UniqueID
+        {
+            get
+            {
+                return uniqueID;
+            }
+        }
 
         #endregion Properties
 

--- a/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
+++ b/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
@@ -147,15 +147,12 @@ namespace CombatExtended.Compatibility.MultiplayerAPI
         {
             if (sync.isWriting)
             {
-                sync.Write(LoadoutManager.Loadouts.IndexOf(loadout));
+                sync.Write(loadout.UniqueID);
             }
             else
             {
-                var index = sync.Read<int>();
-                if (index >= 0)
-                {
-                    loadout = LoadoutManager.Loadouts[index];
-                }
+                var id = sync.Read<int>();
+                loadout = LoadoutManager.GetLoadoutById(id);
             }
         }
 


### PR DESCRIPTION
## Changes

- sync Loadout using its uniqueID instead of its index in the Loadout list
  - had to make public reading the uniqueID and getting a loadout by id, as the multiplayer sync workers live in another dll
- sync loadout label on every label change instead of on current loadout change or window close

## Reasoning

Tested it a bit, and it seemed the desyncs were related to a combination of:
- label sync is infrequent
- the loadouts are synced by index
- the loadouts are sorted by label

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
