### PR TITLE
Rotating turret and Fire arc restriction

### DIFF
--- a/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
@@ -1,457 +1,471 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
 
-	<ThingDef Name="TurretBase" ParentName="BuildingBase" Abstract="True">
-		<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
-		<drawerType>MapMeshAndRealTime</drawerType>
-		<graphicData>
-			<graphicClass>Graphic_Single</graphicClass>
-			<damageData>
-				<rect>(0.2,0.2,0.6,0.6)</rect>
-			</damageData>
-			<drawSize>(3,3)</drawSize>
-		</graphicData>
-		<altitudeLayer>Building</altitudeLayer>
-		<tradeability>All</tradeability>
-		<techLevel>Industrial</techLevel>
-		<statBases>
-			<MaxHitPoints>100</MaxHitPoints>
-			<Flammability>0.7</Flammability>
-			<Beauty>-60</Beauty>
-		</statBases>
-		<comps>
-			<li Class="CompProperties_Forbiddable" />
-		</comps>
-		<tickerType>Normal</tickerType>
-		<passability>PassThroughOnly</passability>
-		<pathCost>50</pathCost>
-		<fillPercent>0.85</fillPercent>
-		<castEdgeShadows>false</castEdgeShadows>
-		<hasTooltip>true</hasTooltip>
-		<terrainAffordanceNeeded>Light</terrainAffordanceNeeded>
-		<building>
-			<ai_combatDangerous>true</ai_combatDangerous>
-			<turretBurstCooldownTime>1</turretBurstCooldownTime>
-		</building>
-		<placeWorkers>
-			<li>PlaceWorker_TurretTop</li>
-			<li>PlaceWorker_ShowTurretRadius</li>
-		</placeWorkers>
-		<tradeTags>
-			<li>CE_Turret</li>
-		</tradeTags>
-		<thingCategories>
-			<li>BuildingsSecurity</li>
-		</thingCategories>
-	</ThingDef>
+  <ThingDef Name="TurretBase" ParentName="BuildingBase" Abstract="True">
+    <thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+    <drawerType>MapMeshAndRealTime</drawerType>
+    <graphicData>
+      <graphicClass>Graphic_Single</graphicClass>
+      <damageData>
+        <rect>(0.2,0.2,0.6,0.6)</rect>
+      </damageData>
+      <drawSize>(3,3)</drawSize>
+    </graphicData>
+    <altitudeLayer>Building</altitudeLayer>
+    <tradeability>All</tradeability>
+    <techLevel>Industrial</techLevel>
+    <statBases>
+      <MaxHitPoints>100</MaxHitPoints>
+      <Flammability>0.7</Flammability>
+      <Beauty>-60</Beauty>
+    </statBases>
+    <comps>
+      <li Class="CompProperties_Forbiddable" />
+    </comps>
+    <tickerType>Normal</tickerType>
+    <passability>PassThroughOnly</passability>
+    <pathCost>50</pathCost>
+    <fillPercent>0.85</fillPercent>
+    <castEdgeShadows>false</castEdgeShadows>
+    <hasTooltip>true</hasTooltip>
+    <terrainAffordanceNeeded>Light</terrainAffordanceNeeded>
+    <building>
+      <ai_combatDangerous>true</ai_combatDangerous>
+      <turretBurstCooldownTime>1</turretBurstCooldownTime>
+    </building>
+    <placeWorkers>
+      <li>PlaceWorker_TurretTop</li>
+      <li>PlaceWorker_ShowTurretRadius</li>
+    </placeWorkers>
+    <tradeTags>
+      <li>CE_Turret</li>
+    </tradeTags>
+    <thingCategories>
+      <li>BuildingsSecurity</li>
+    </thingCategories>
+  </ThingDef>
 
-	<ThingDef Name="TurretAutoBase" ParentName="TurretBase" Abstract="True">
-		<designationCategory>Security</designationCategory>
-		<comps>
-			<li Class="CompProperties_Flickable" />
-			<li Class="CompProperties_Breakdownable" />
-			<li Class="CompProperties_Stunnable">
-				<affectedDamageDefs>
-					<li>EMP</li>
-				</affectedDamageDefs>
-			</li>
-		</comps>
-	</ThingDef>
+  <ThingDef Name="TurretAutoBase" ParentName="TurretBase" Abstract="True">
+    <designationCategory>Security</designationCategory>
+    <comps>
+      <li Class="CompProperties_Flickable" />
+      <li Class="CompProperties_Breakdownable" />
+      <li Class="CompProperties_Stunnable">
+        <affectedDamageDefs>
+          <li>EMP</li>
+        </affectedDamageDefs>
+      </li>
+    </comps>
+  </ThingDef>
 
-	<ThingDef Name="TurretMannedBase" ParentName="TurretBase" Abstract="True">
-		<hasInteractionCell>True</hasInteractionCell>
-		<interactionCellOffset>(0,0,-1)</interactionCellOffset>
-		<comps>
-			<li Class="CompProperties_Mannable">
-				<manWorkType>Violent</manWorkType>
-			</li>
-		</comps>
-		<recipeMaker>
-			<workSpeedStat>GeneralLaborSpeed</workSpeedStat>
-			<workSkill>Crafting</workSkill>
-			<effectWorking>Smith</effectWorking>
-			<soundWorking>Recipe_Smith</soundWorking>
-		</recipeMaker>
-	</ThingDef>
+  <ThingDef Name="TurretMannedBase" ParentName="TurretBase" Abstract="True">
+    <hasInteractionCell>True</hasInteractionCell>
+    <interactionCellOffset>(0,0,-1)</interactionCellOffset>
+    <comps>
+      <li Class="CompProperties_Mannable">
+        <manWorkType>Violent</manWorkType>
+      </li>
+    </comps>
+    <recipeMaker>
+      <workSpeedStat>GeneralLaborSpeed</workSpeedStat>
+      <workSkill>Crafting</workSkill>
+      <effectWorking>Smith</effectWorking>
+      <soundWorking>Recipe_Smith</soundWorking>
+    </recipeMaker>
+  </ThingDef>
 
-	<ThingDef Name="TurretMannedCraftableBase" ParentName="TurretMannedBase" Abstract="True">
-		<statBases>
-			<WorkToMake>10000</WorkToMake>
-		</statBases>
-		<recipeMaker>
-			<workSpeedStat>GeneralLaborSpeed</workSpeedStat>
-			<workSkill>Crafting</workSkill>
-			<effectWorking>Smith</effectWorking>
-			<soundWorking>Recipe_Smith</soundWorking>
-			<recipeUsers>
-				<li>TableMachining</li>
-			</recipeUsers>
-			<unfinishedThingDef>UnfinishedTurretGun</unfinishedThingDef>
-		</recipeMaker>
-	</ThingDef>
+  <ThingDef Name="TurretMannedCraftableBase" ParentName="TurretMannedBase" Abstract="True">
+    <statBases>
+      <WorkToMake>10000</WorkToMake>
+    </statBases>
+    <recipeMaker>
+      <workSpeedStat>GeneralLaborSpeed</workSpeedStat>
+      <workSkill>Crafting</workSkill>
+      <effectWorking>Smith</effectWorking>
+      <soundWorking>Recipe_Smith</soundWorking>
+      <recipeUsers>
+        <li>TableMachining</li>
+      </recipeUsers>
+      <unfinishedThingDef>UnfinishedTurretGun</unfinishedThingDef>
+    </recipeMaker>
+  </ThingDef>
 
-	<ThingDef Name="TurretMannedBuildableBase" ParentName="TurretBase" Abstract="True">
-		<designationCategory>Security</designationCategory>
-		<hasInteractionCell>True</hasInteractionCell>
-		<interactionCellOffset>(0,0,-1)</interactionCellOffset>
-		<comps>
-			<li Class="CompProperties_Mannable">
-				<manWorkType>Violent</manWorkType>
-			</li>
-		</comps>
-	</ThingDef>
+  <ThingDef Name="TurretMannedBuildableBase" ParentName="TurretBase" Abstract="True">
+    <designationCategory>Security</designationCategory>
+    <hasInteractionCell>True</hasInteractionCell>
+    <interactionCellOffset>(0,0,-1)</interactionCellOffset>
+    <comps>
+      <li Class="CompProperties_Mannable">
+        <manWorkType>Violent</manWorkType>
+      </li>
+    </comps>
+  </ThingDef>
 
-	<!--=============== Blaster Turret ===============-->
+  <!--=============== Blaster Turret ===============-->
 
-	<ThingDef ParentName="TurretAutoBase">
-		<defName>Turret_Blaster</defName>
-		<label>charge blaster auto-turret</label>
-		<constructionSkillPrerequisite>8</constructionSkillPrerequisite>
-		<graphicData>
-			<texPath>Things/Building/Turrets/MachineGunBase</texPath>
-			<shadowData>
-				<volume>(0.27,0.25,0.27)</volume>
-				<offset>(0,0,0)</offset>
-			</shadowData>
-		</graphicData>
-		<uiIconPath>UI/Icons/Turrets/ChargeBlaster_uiIcon</uiIconPath>
-		<statBases>
-			<WorkToBuild>23000</WorkToBuild>
-			<MaxHitPoints>150</MaxHitPoints>
-			<Mass>20</Mass>
-			<Bulk>25</Bulk>
-			<AimingAccuracy>0.75</AimingAccuracy>
-			<ShootingAccuracyTurret>1.25</ShootingAccuracyTurret>
-			<NightVisionEfficiency>0.5</NightVisionEfficiency>
-		</statBases>
-		<techLevel>Spacer</techLevel>
-		<comps>
-			<li Class="CompProperties_Power">
-				<compClass>CompPowerTrader</compClass>
-				<basePowerConsumption>400</basePowerConsumption>
-			</li>
-		</comps>
-		<description>Automatic turret equipped with a charge blaster.</description>
-		<costList>
-			<Steel>125</Steel>
-			<Plasteel>40</Plasteel>
-			<ComponentIndustrial>6</ComponentIndustrial>
-			<ComponentSpacer>1</ComponentSpacer>
-		</costList>
-		<building>
-			<turretGunDef>Gun_BlasterTurret</turretGunDef>
-			<ai_combatDangerous>true</ai_combatDangerous>
-		</building>
-		<designatorDropdown>CE_AutoTurrets</designatorDropdown>
-		<placeWorkers>
-			<li>PlaceWorker_TurretTop</li>
-			<li>PlaceWorker_ShowTurretRadius</li>
-		</placeWorkers>
-		<researchPrerequisites>
-			<li>CE_ChargeTurret</li>
-		</researchPrerequisites>
-		<minifiedDef>MinifiedThing</minifiedDef>
-	</ThingDef>
+  <ThingDef ParentName="TurretAutoBase">
+    <defName>Turret_Blaster</defName>
+    <label>charge blaster auto-turret</label>
+    <constructionSkillPrerequisite>8</constructionSkillPrerequisite>
+    <graphicData>
+      <texPath>Things/Building/Turrets/MachineGunBase</texPath>
+      <shadowData>
+        <volume>(0.27,0.25,0.27)</volume>
+        <offset>(0,0,0)</offset>
+      </shadowData>
+    </graphicData>
+    <uiIconPath>UI/Icons/Turrets/ChargeBlaster_uiIcon</uiIconPath>
+    <statBases>
+      <WorkToBuild>23000</WorkToBuild>
+      <MaxHitPoints>150</MaxHitPoints>
+      <Mass>20</Mass>
+      <Bulk>25</Bulk>
+      <AimingAccuracy>0.75</AimingAccuracy>
+      <ShootingAccuracyTurret>1.25</ShootingAccuracyTurret>
+      <NightVisionEfficiency>0.5</NightVisionEfficiency>
+    </statBases>
+    <techLevel>Spacer</techLevel>
+    <comps>
+      <li Class="CompProperties_Power">
+        <compClass>CompPowerTrader</compClass>
+        <basePowerConsumption>400</basePowerConsumption>
+      </li>
+    </comps>
+    <description>Automatic turret equipped with a charge blaster.</description>
+    <costList>
+      <Steel>125</Steel>
+      <Plasteel>40</Plasteel>
+      <ComponentIndustrial>6</ComponentIndustrial>
+      <ComponentSpacer>1</ComponentSpacer>
+    </costList>
+    <building>
+      <turretGunDef>Gun_BlasterTurret</turretGunDef>
+      <ai_combatDangerous>true</ai_combatDangerous>
+    </building>
+    <designatorDropdown>CE_AutoTurrets</designatorDropdown>
+    <placeWorkers>
+      <li>PlaceWorker_TurretTop</li>
+      <li>PlaceWorker_ShowTurretRadius</li>
+    </placeWorkers>
+    <researchPrerequisites>
+      <li>CE_ChargeTurret</li>
+    </researchPrerequisites>
+    <minifiedDef>MinifiedThing</minifiedDef>
+  </ThingDef>
 
-	<!--=============== Heavy Turret ===============-->
+  <!--=============== Heavy Turret ===============-->
 
-	<ThingDef ParentName="TurretAutoBase">
-		<defName>Turret_Heavy</defName>
-		<label>heavy auto-turret</label>
-		<constructionSkillPrerequisite>6</constructionSkillPrerequisite>
-		<graphicData>
-			<texPath>Things/Building/Turrets/MachineGunBase</texPath>
-			<shadowData>
-				<volume>(0.27,0.25,0.27)</volume>
-				<offset>(0,0,0)</offset>
-			</shadowData>
-		</graphicData>
-		<uiIconPath>UI/Icons/Turrets/HeavyAutoTurret_uiIcon</uiIconPath>
-		<statBases>
-			<WorkToBuild>40000</WorkToBuild>
-			<MaxHitPoints>350</MaxHitPoints>
-			<Flammability>0.5</Flammability>
-			<Mass>60</Mass>
-			<Bulk>80</Bulk>
-			<AimingAccuracy>0.5</AimingAccuracy>
-			<ShootingAccuracyTurret>1</ShootingAccuracyTurret>
-		</statBases>
-		<description>Plated automatic turret equiped with a high caliber machine gun. Very resistant to damage.</description>
-		<costList>
-			<Steel>275</Steel>
-			<ComponentIndustrial>8</ComponentIndustrial>
-		</costList>
-		<building>
-			<ai_combatDangerous>true</ai_combatDangerous>
-			<turretGunDef>Gun_HeavyTurret</turretGunDef>
-		</building>
-		<designatorDropdown>CE_AutoTurrets</designatorDropdown>
-		<placeWorkers>
-			<li>PlaceWorker_TurretTop</li>
-			<li>PlaceWorker_ShowTurretRadius</li>
-		</placeWorkers>
-		<terrainAffordanceNeeded>Medium</terrainAffordanceNeeded>
-		<comps>
-			<li Class="CompProperties_Power">
-				<compClass>CompPowerTrader</compClass>
-				<basePowerConsumption>300</basePowerConsumption>
-			</li>
-		</comps>
-		<minifiedDef>MinifiedThing</minifiedDef>
-		<researchPrerequisites>
-			<li>CE_HeavyTurret</li>
-		</researchPrerequisites>
-	</ThingDef>
+  <ThingDef ParentName="TurretAutoBase">
+    <defName>Turret_Heavy</defName>
+    <label>heavy auto-turret</label>
+    <constructionSkillPrerequisite>6</constructionSkillPrerequisite>
+    <graphicData>
+      <texPath>Things/Building/Turrets/MachineGunBase</texPath>
+      <shadowData>
+        <volume>(0.27,0.25,0.27)</volume>
+        <offset>(0,0,0)</offset>
+      </shadowData>
+    </graphicData>
+    <uiIconPath>UI/Icons/Turrets/HeavyAutoTurret_uiIcon</uiIconPath>
+    <statBases>
+      <WorkToBuild>40000</WorkToBuild>
+      <MaxHitPoints>350</MaxHitPoints>
+      <Flammability>0.5</Flammability>
+      <Mass>60</Mass>
+      <Bulk>80</Bulk>
+      <AimingAccuracy>0.5</AimingAccuracy>
+      <ShootingAccuracyTurret>1</ShootingAccuracyTurret>
+    </statBases>
+    <description>Plated automatic turret equiped with a high caliber machine gun. Very resistant to damage.</description>
+    <costList>
+      <Steel>275</Steel>
+      <ComponentIndustrial>8</ComponentIndustrial>
+    </costList>
+    <building>
+      <ai_combatDangerous>true</ai_combatDangerous>
+      <turretGunDef>Gun_HeavyTurret</turretGunDef>
+    </building>
+    <designatorDropdown>CE_AutoTurrets</designatorDropdown>
+    <placeWorkers>
+      <li>PlaceWorker_TurretTop</li>
+      <li>PlaceWorker_ShowTurretRadius</li>
+    </placeWorkers>
+    <terrainAffordanceNeeded>Medium</terrainAffordanceNeeded>
+    <comps>
+      <li Class="CompProperties_Power">
+        <compClass>CompPowerTrader</compClass>
+        <basePowerConsumption>300</basePowerConsumption>
+      </li>
+    </comps>
+    <minifiedDef>MinifiedThing</minifiedDef>
+    <researchPrerequisites>
+      <li>CE_HeavyTurret</li>
+    </researchPrerequisites>
+  </ThingDef>
 
-	<!--=============== Medium Turret ===============-->
+  <!--=============== Medium Turret ===============-->
 
-	<ThingDef ParentName="TurretAutoBase">
-		<defName>Turret_Medium</defName>
-		<label>medium auto-turret</label>
-		<constructionSkillPrerequisite>6</constructionSkillPrerequisite>
-		<graphicData>
-			<texPath>Things/Building/Turrets/MachineGunBase</texPath>
-			<shadowData>
-				<volume>(0.27,0.25,0.27)</volume>
-				<offset>(0,0,0)</offset>
-			</shadowData>
-		</graphicData>
-		<uiIconPath>UI/Icons/Turrets/MediumAutoTurret_uiIcon</uiIconPath>
-		<statBases>
-			<WorkToBuild>20000</WorkToBuild>
-			<MaxHitPoints>200</MaxHitPoints>
-			<Flammability>0.6</Flammability>
-			<Mass>30</Mass>
-			<Bulk>40</Bulk>
-			<AimingAccuracy>0.5</AimingAccuracy>
-			<ShootingAccuracyTurret>0.75</ShootingAccuracyTurret>
-		</statBases>
-		<description>Automatic turret equiped with a full powered cartridge machine gun. Fairly resistant to damage.</description>
-		<costList>
-			<Steel>150</Steel>
-			<ComponentIndustrial>8</ComponentIndustrial>
-		</costList>
-		<building>
-			<ai_combatDangerous>true</ai_combatDangerous>
-			<turretGunDef>Gun_MediumTurret</turretGunDef>
-		</building>
-		<designatorDropdown>CE_AutoTurrets</designatorDropdown>
-		<placeWorkers>
-			<li>PlaceWorker_TurretTop</li>
-			<li>PlaceWorker_ShowTurretRadius</li>
-		</placeWorkers>
-		<comps>
-			<li Class="CompProperties_Power">
-				<compClass>CompPowerTrader</compClass>
-				<basePowerConsumption>150</basePowerConsumption>
-			</li>
-		</comps>
-		<minifiedDef>MinifiedThing</minifiedDef>
-		<researchPrerequisites>
-			<li>GunTurrets</li>
-			<li>PrecisionRifling</li>
-		</researchPrerequisites>
-	</ThingDef>
+  <ThingDef ParentName="TurretAutoBase">
+    <defName>Turret_Medium</defName>
+    <label>medium auto-turret</label>
+    <constructionSkillPrerequisite>6</constructionSkillPrerequisite>
+    <graphicData>
+      <texPath>Things/Building/Turrets/MachineGunBase</texPath>
+      <shadowData>
+        <volume>(0.27,0.25,0.27)</volume>
+        <offset>(0,0,0)</offset>
+      </shadowData>
+    </graphicData>
+    <uiIconPath>UI/Icons/Turrets/MediumAutoTurret_uiIcon</uiIconPath>
+    <statBases>
+      <WorkToBuild>20000</WorkToBuild>
+      <MaxHitPoints>200</MaxHitPoints>
+      <Flammability>0.6</Flammability>
+      <Mass>30</Mass>
+      <Bulk>40</Bulk>
+      <AimingAccuracy>0.5</AimingAccuracy>
+      <ShootingAccuracyTurret>0.75</ShootingAccuracyTurret>
+    </statBases>
+    <description>Automatic turret equiped with a full powered cartridge machine gun. Fairly resistant to damage.</description>
+    <costList>
+      <Steel>150</Steel>
+      <ComponentIndustrial>8</ComponentIndustrial>
+    </costList>
+    <building>
+      <ai_combatDangerous>true</ai_combatDangerous>
+      <turretGunDef>Gun_MediumTurret</turretGunDef>
+    </building>
+    <designatorDropdown>CE_AutoTurrets</designatorDropdown>
+    <placeWorkers>
+      <li>PlaceWorker_TurretTop</li>
+      <li>PlaceWorker_ShowTurretRadius</li>
+    </placeWorkers>
+    <comps>
+      <li Class="CompProperties_Power">
+        <compClass>CompPowerTrader</compClass>
+        <basePowerConsumption>150</basePowerConsumption>
+      </li>
+    </comps>
+    <minifiedDef>MinifiedThing</minifiedDef>
+    <researchPrerequisites>
+      <li>GunTurrets</li>
+      <li>PrecisionRifling</li>
+    </researchPrerequisites>
+  </ThingDef>
 
-	<!--=============== KPV ===============-->
+  <!--=============== KPV ===============-->
 
-	<ThingDef ParentName="TurretMannedBuildableBase">
-		<defName>Turret_KPV</defName>
-		<label>KPV machine gun</label>
-		<constructionSkillPrerequisite>7</constructionSkillPrerequisite>
-		<graphicData>
-			<texPath>Things/Building/Turrets/KPV_base</texPath>
-			<drawSize>(2,2)</drawSize>
-			<shadowData>
-				<volume>(0.27,0.25,0.6)</volume>
-				<offset>(0,0,0)</offset>
-			</shadowData>
-		</graphicData>
-		<uiIconPath>UI/Icons/Turrets/KPV_uiIcon</uiIconPath>
-		<statBases>
-			<MaxHitPoints>150</MaxHitPoints>
-			<WorkToBuild>25000</WorkToBuild>
-			<Mass>88</Mass>
-			<Bulk>100</Bulk>
-		</statBases>
-		<description>KPV heavy machine gun mounted on a tripod.</description>
-		<costList>
-			<Steel>275</Steel>
-			<ComponentIndustrial>6</ComponentIndustrial>
-		</costList>
-		<building>
-			<turretGunDef>Gun_KPV</turretGunDef>
-			<ai_combatDangerous>true</ai_combatDangerous>
-			<turretBurstCooldownTime>0.37</turretBurstCooldownTime>
-			<buildingTags>
-				<li>CE_TurretHeavy</li>
-			</buildingTags>
-		</building>
-		<designatorDropdown>CE_ModernMannedTurrets</designatorDropdown>
-		<placeWorkers>
-			<li>PlaceWorker_TurretTop</li>
-			<li>PlaceWorker_ShowTurretRadius</li>
-		</placeWorkers>
-		<terrainAffordanceNeeded>Medium</terrainAffordanceNeeded>
-		<researchPrerequisites>
-			<li>CE_TurretHeavyWeapons</li>
-			<li>PrecisionRifling</li>
-		</researchPrerequisites>
-		<minifiedDef>MinifiedThing</minifiedDef>
-	</ThingDef>
+  <ThingDef ParentName="TurretMannedBuildableBase">
+    <defName>Turret_KPV</defName>
+    <label>KPV machine gun</label>
+    <constructionSkillPrerequisite>7</constructionSkillPrerequisite>
+    <graphicData>
+      <texPath>Things/Building/Turrets/KPV_base</texPath>
+      <drawSize>(2,2)</drawSize>
+      <shadowData>
+        <volume>(0.27,0.25,0.6)</volume>
+        <offset>(0,0,0)</offset>
+      </shadowData>
+    </graphicData>
+    <uiIconPath>UI/Icons/Turrets/KPV_uiIcon</uiIconPath>
+    <statBases>
+      <MaxHitPoints>150</MaxHitPoints>
+      <WorkToBuild>25000</WorkToBuild>
+      <Mass>88</Mass>
+      <Bulk>100</Bulk>
+    </statBases>
+    <description>KPV heavy machine gun mounted on a tripod.</description>
+    <costList>
+      <Steel>275</Steel>
+      <ComponentIndustrial>6</ComponentIndustrial>
+    </costList>
+    <building>
+      <turretGunDef>Gun_KPV</turretGunDef>
+      <ai_combatDangerous>true</ai_combatDangerous>
+      <turretBurstCooldownTime>0.37</turretBurstCooldownTime>
+      <buildingTags>
+        <li>CE_TurretHeavy</li>
+      </buildingTags>
+    </building>
+    <designatorDropdown>CE_ModernMannedTurrets</designatorDropdown>
+    <placeWorkers>
+      <li>PlaceWorker_TurretTop</li>
+      <li>PlaceWorker_ShowTurretRadius</li>
+    </placeWorkers>
+    <terrainAffordanceNeeded>Medium</terrainAffordanceNeeded>
+    <researchPrerequisites>
+      <li>CE_TurretHeavyWeapons</li>
+      <li>PrecisionRifling</li>
+    </researchPrerequisites>
+    <minifiedDef>MinifiedThing</minifiedDef>
+  </ThingDef>
 
-	<!--=============== M240B ===============-->
+  <!--=============== M240B ===============-->
 
-	<ThingDef ParentName="TurretMannedBuildableBase">
-		<defName>Turret_M240B</defName>
-		<label>M240B</label>
-		<constructionSkillPrerequisite>6</constructionSkillPrerequisite>
-		<graphicData>
-			<texPath>Things/Building/Turrets/M240_base</texPath>
-			<drawSize>(2,2)</drawSize>
-			<shadowData>
-				<volume>(0.27,0.25,0.45)</volume>
-				<offset>(0,0,0)</offset>
-			</shadowData>
-		</graphicData>
-		<uiIconPath>UI/Icons/Turrets/M240B_uiIcon</uiIconPath>
-		<statBases>
-			<WorkToBuild>16000</WorkToBuild>
-			<Mass>16.5</Mass>
-			<Bulk>20</Bulk>
-		</statBases>
-		<description>M240B medium machine gun mounted on a tripod.</description>
-		<costList>
-			<Steel>150</Steel>
-			<ComponentIndustrial>6</ComponentIndustrial>
-		</costList>
-		<building>
-			<turretGunDef>Gun_M240B</turretGunDef>
-			<ai_combatDangerous>true</ai_combatDangerous>
-			<turretBurstCooldownTime>0.36</turretBurstCooldownTime>
-		</building>
-		<designatorDropdown>CE_ModernMannedTurrets</designatorDropdown>
-		<placeWorkers>
-			<li>PlaceWorker_TurretTop</li>
-			<li>PlaceWorker_ShowTurretRadius</li>
-		</placeWorkers>
-		<minifiedDef>MinifiedThing</minifiedDef>
-		<researchPrerequisites>
-			<li>PrecisionRifling</li>
-		</researchPrerequisites>
-	</ThingDef>
+  <ThingDef ParentName="TurretMannedBuildableBase">
+    <defName>Turret_M240B</defName>
+    <label>M240B</label>
+    <constructionSkillPrerequisite>6</constructionSkillPrerequisite>
+    <graphicData>
+      <texPath>Things/Building/Turrets/M240_base</texPath>
+      <drawSize>(2,2)</drawSize>
+      <shadowData>
+        <volume>(0.27,0.25,0.45)</volume>
+        <offset>(0,0,0)</offset>
+      </shadowData>
+    </graphicData>
+    <uiIconPath>UI/Icons/Turrets/M240B_uiIcon</uiIconPath>
+    <statBases>
+      <WorkToBuild>16000</WorkToBuild>
+      <Mass>16.5</Mass>
+      <Bulk>20</Bulk>
+    </statBases>
+    <description>M240B medium machine gun mounted on a tripod.</description>
+    <costList>
+      <Steel>150</Steel>
+      <ComponentIndustrial>6</ComponentIndustrial>
+    </costList>
+    <building>
+      <turretGunDef>Gun_M240B</turretGunDef>
+      <ai_combatDangerous>true</ai_combatDangerous>
+      <turretBurstCooldownTime>0.36</turretBurstCooldownTime>
+    </building>
+    <designatorDropdown>CE_ModernMannedTurrets</designatorDropdown>
+    <placeWorkers>
+      <li>PlaceWorker_TurretTop</li>
+      <li>PlaceWorker_ShowTurretRadius</li>
+    </placeWorkers>
+    <minifiedDef>MinifiedThing</minifiedDef>
+    <researchPrerequisites>
+      <li>PrecisionRifling</li>
+    </researchPrerequisites>
+  </ThingDef>
 
-	<!--=============== AGS-30 ===============-->
+  <!--=============== AGS-30 ===============-->
 
-	<ThingDef ParentName="TurretMannedBuildableBase">
-		<defName>Turret_AGSThirty</defName>
-		<label>AGS-30</label>
-		<constructionSkillPrerequisite>6</constructionSkillPrerequisite>
-		<graphicData>
-			<texPath>Things/Building/Turrets/AGS30_base</texPath>
-			<drawSize>(2,2)</drawSize>
-			<shadowData>
-				<volume>(0.27,0.25,0.35)</volume>
-				<offset>(0,0,0)</offset>
-			</shadowData>
-		</graphicData>
-		<uiIconPath>UI/Icons/Turrets/AGS30_uiIcon</uiIconPath>
-		<statBases>
-			<WorkToBuild>17000</WorkToBuild>
-			<Mass>16</Mass>
-			<Bulk>20</Bulk>
-		</statBases>
-		<description>Lightweight automatic grenade launcher mounted on a tripod.</description>
-		<costList>
-			<Steel>115</Steel>
-			<ComponentIndustrial>5</ComponentIndustrial>
-		</costList>
-		<building>
-			<turretGunDef>Gun_AGSThirty</turretGunDef>
-			<ai_combatDangerous>true</ai_combatDangerous>
-			<turretBurstCooldownTime>0.40</turretBurstCooldownTime>
-		</building>
-		<designatorDropdown>CE_MediumMannedTurrets</designatorDropdown>
-		<placeWorkers>
-			<li>PlaceWorker_TurretTop</li>
-			<li>PlaceWorker_ShowTurretRadius</li>
-		</placeWorkers>
-		<researchPrerequisites>
-			<li>CE_TurretHeavyWeapons</li>
-			<li>CE_Launchers</li>
-		</researchPrerequisites>
-		<minifiedDef>MinifiedThing</minifiedDef>
-	</ThingDef>
+  <ThingDef ParentName="TurretMannedBuildableBase">
+    <defName>Turret_AGSThirty</defName>
+    <label>AGS-30</label>
+    <constructionSkillPrerequisite>6</constructionSkillPrerequisite>
+    <graphicData>
+      <texPath>Things/Building/Turrets/AGS30_base</texPath>
+      <drawSize>(2,2)</drawSize>
+      <shadowData>
+        <volume>(0.27,0.25,0.35)</volume>
+        <offset>(0,0,0)</offset>
+      </shadowData>
+    </graphicData>
+    <uiIconPath>UI/Icons/Turrets/AGS30_uiIcon</uiIconPath>
+    <statBases>
+      <WorkToBuild>17000</WorkToBuild>
+      <Mass>16</Mass>
+      <Bulk>20</Bulk>
+    </statBases>
+    <description>Lightweight automatic grenade launcher mounted on a tripod.</description>
+    <costList>
+      <Steel>115</Steel>
+      <ComponentIndustrial>5</ComponentIndustrial>
+    </costList>
+    <building>
+      <turretGunDef>Gun_AGSThirty</turretGunDef>
+      <ai_combatDangerous>true</ai_combatDangerous>
+      <turretBurstCooldownTime>0.40</turretBurstCooldownTime>
+    </building>
+    <designatorDropdown>CE_MediumMannedTurrets</designatorDropdown>
+    <placeWorkers>
+      <li>PlaceWorker_TurretTop</li>
+      <li>PlaceWorker_ShowTurretRadius</li>
+    </placeWorkers>
+    <researchPrerequisites>
+      <li>CE_TurretHeavyWeapons</li>
+      <li>CE_Launchers</li>
+    </researchPrerequisites>
+    <minifiedDef>MinifiedThing</minifiedDef>
+  </ThingDef>
 
-	<!--=============== Flak cannon ===============-->
+  <!--=============== Flak cannon ===============-->
 
-	<ThingDef ParentName="TurretMannedBuildableBase">
-		<defName>Turret_Flak</defName>
-		<label>90mm flak turret</label>
-		<description>Old school anti-aircraft cannon. Ineffective against modern aviation but still popular on rimworlds for use against entrenched enemies and vehicles.</description>
-		<constructionSkillPrerequisite>8</constructionSkillPrerequisite>
-		<graphicData>
-			<texPath>Things/Building/Turrets/FlakTurret_Base</texPath>
-			<shadowData>
-				<offset>(-0.13,-0.87,-0.1)</offset>
-				<volume>(0.5,0.4,1.05)</volume>
-			</shadowData>
-		</graphicData>
-		<uiIconPath>UI/Icons/Turrets/FlakTurret_uiIcon</uiIconPath>
-		<fillPercent>1</fillPercent>
-		<statBases>
-			<MaxHitPoints>500</MaxHitPoints>
-			<Flammability>0.4</Flammability>
-			<WorkToBuild>45000</WorkToBuild>
-			<Mass>1000</Mass>
-			<Bulk>1000</Bulk>
-		</statBases>
-		<costList>
-			<Steel>500</Steel>
-			<ComponentIndustrial>5</ComponentIndustrial>
-		</costList>
-		<costListForDifficulty>
-			<difficultyVar>classicMortars</difficultyVar>
-			<invert>true</invert>
-			<costList>
-				<ComponentIndustrial>5</ComponentIndustrial>
-				<ReinforcedBarrel>1</ReinforcedBarrel>
-				<Steel>350</Steel>
-			</costList>
-		</costListForDifficulty>
-		<building>
-			<turretGunDef>Gun_FlakTurret</turretGunDef>
-			<ai_combatDangerous>true</ai_combatDangerous>
-			<turretTopDrawSize>4</turretTopDrawSize>
-			<turretBurstCooldownTime>2.5</turretBurstCooldownTime>
-		</building>
-		<designatorDropdown>CE_HeavyMannedTurrets</designatorDropdown>
-		<placeWorkers>
-			<li>PlaceWorker_TurretTop</li>
-			<li>PlaceWorker_ShowTurretRadius</li>
-		</placeWorkers>
-		<terrainAffordanceNeeded>Heavy</terrainAffordanceNeeded>
-		<size>(3,3)</size>
-		<interactionCellOffset>(-1,0,-1)</interactionCellOffset>
-		<minifiedDef>MinifiedThing</minifiedDef>
-		<researchPrerequisites>
-			<li>CE_TurretHeavyWeapons</li>
-		</researchPrerequisites>
-		<designationCategory>Security</designationCategory>
-		<damageMultipliers>
-			<li>
-				<damageDef>Bomb</damageDef>
-				<multiplier>0.66</multiplier>
-			</li>
-			<li>
-				<damageDef>Bomb_Secondary</damageDef>
-				<multiplier>0.66</multiplier>
-			</li>
-			<li>
-				<damageDef>Bullet</damageDef>
-				<multiplier>0.66</multiplier>
-			</li>
-		</damageMultipliers>		
-	</ThingDef>
+  <ThingDef ParentName="TurretMannedBuildableBase">
+    <defName>Turret_Flak</defName>
+    <label>90mm flak turret</label>
+    <description>Old school anti-aircraft cannon. Ineffective against modern aviation but still popular on rimworlds for use against entrenched enemies and vehicles.</description>
+    <constructionSkillPrerequisite>8</constructionSkillPrerequisite>
+    <graphicData>
+      <texPath>Things/Building/Turrets/FlakTurret_Base</texPath>
+      <shadowData>
+        <offset>(-0.13,-0.87,-0.1)</offset>
+        <volume>(0.5,0.4,1.05)</volume>
+      </shadowData>
+    </graphicData>
+    <uiIconPath>UI/Icons/Turrets/FlakTurret_uiIcon</uiIconPath>
+    <fillPercent>1</fillPercent>
+    <statBases>
+      <MaxHitPoints>500</MaxHitPoints>
+      <Flammability>0.4</Flammability>
+      <WorkToBuild>45000</WorkToBuild>
+      <Mass>1000</Mass>
+      <Bulk>1000</Bulk>
+    </statBases>
+    <costList>
+      <Steel>500</Steel>
+      <ComponentIndustrial>5</ComponentIndustrial>
+    </costList>
+    <costListForDifficulty>
+      <difficultyVar>classicMortars</difficultyVar>
+      <invert>true</invert>
+      <costList>
+        <ComponentIndustrial>5</ComponentIndustrial>
+        <ReinforcedBarrel>1</ReinforcedBarrel>
+        <Steel>350</Steel>
+      </costList>
+    </costListForDifficulty>
+    <building>
+      <turretGunDef>Gun_FlakTurret</turretGunDef>
+      <ai_combatDangerous>true</ai_combatDangerous>
+      <turretTopDrawSize>4</turretTopDrawSize>
+      <turretBurstCooldownTime>2.5</turretBurstCooldownTime>
+    </building>
+    <designatorDropdown>CE_HeavyMannedTurrets</designatorDropdown>
+    <placeWorkers>
+      <li>PlaceWorker_TurretTop</li>
+      <li>PlaceWorker_ShowTurretRadius</li>
+    </placeWorkers>
+    <terrainAffordanceNeeded>Heavy</terrainAffordanceNeeded>
+    <size>(3,3)</size>
+    <interactionCellOffset>(-1,0,-1)</interactionCellOffset>
+    <minifiedDef>MinifiedThing</minifiedDef>
+    <researchPrerequisites>
+      <li>CE_TurretHeavyWeapons</li>
+    </researchPrerequisites>
+    <designationCategory>Security</designationCategory>
+    <damageMultipliers>
+      <li>
+        <damageDef>Bomb</damageDef>
+        <multiplier>0.66</multiplier>
+      </li>
+      <li>
+        <damageDef>Bomb_Secondary</damageDef>
+        <multiplier>0.66</multiplier>
+      </li>
+      <li>
+        <damageDef>Bullet</damageDef>
+        <multiplier>0.66</multiplier>
+      </li>
+    </damageMultipliers>
+
+    <comps>
+      <li Class="CombatExtended.CompProperties_FireArc">
+        <spanRange>10~135</spanRange>
+        <maxSpanDeviation>135</maxSpanDeviation>
+      </li>
+    </comps>
+
+    <modExtensions>
+      <li Class="CombatExtended.NonSnapTurretExtension">
+        <speed>0.2</speed>
+        <angleWeightMultiplier>2</angleWeightMultiplier>
+      </li>
+    </modExtensions>
+  </ThingDef>
 
 </Defs>

--- a/Source/CombatExtended/CombatExtended/Comps/BipodComp.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/BipodComp.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;

--- a/Source/CombatExtended/CombatExtended/Comps/CompFireArc.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompFireArc.cs
@@ -1,0 +1,207 @@
+﻿using System;
+using System.Collections.Generic;
+using Verse;
+using UnityEngine;
+
+namespace CombatExtended
+{
+    public class CompFireArc : ThingComp
+    {
+        public CompProperties_FireArc Props => props as CompProperties_FireArc;
+
+        public float CenterAngle => Editing ? NewCenterAngle : CurrentCenterAngle;
+
+        public float Span => Editing ? NewSpan : CurrentSpan;
+
+        public float LineLength => Editing ? EditingLineLength : Props.lineLength;
+
+
+        float NewCenterAngle;
+        float NewSpan;
+        float EditingLineLength;
+        float EditingSpanLineLength;
+
+        bool Editing = false;
+        bool EditingSpan = false;
+
+        float cachedDiagonal;
+
+        float DiagonalLength
+        {
+            get
+            {
+                if (cachedDiagonal == 0)
+                {
+                    cachedDiagonal = parent.def.size.x * parent.def.size.z / 2;
+                }
+                return cachedDiagonal;
+            }
+        }
+
+
+        public float CurrentCenterAngle = 0;
+
+        public float CurrentSpan = -1;
+
+        Vector3 MousePos => MousePosYto0 + Altitide;
+        Vector3 MousePosYto0 => UI.MouseMapPosition().Yto0();
+
+        Vector3 Altitide => Vector3.up * 10;
+
+        float effectiveLeftSpan => Mathf.Max(CenterAngle - Span / 2, maxLeftSpan);
+        float effectiveRightSpan => Mathf.Min(CenterAngle + Span / 2, maxRightSpan);
+
+        float maxLeftSpan => -Props.maxSpanDeviation;
+        float maxRightSpan => Props.maxSpanDeviation;
+
+        public Vector3 Left => Vector3.forward.RotatedBy(effectiveLeftSpan + parent.Rotation.AsAngle);
+        public Vector3 Right => Vector3.forward.RotatedBy(effectiveRightSpan + parent.Rotation.AsAngle);
+
+        public bool WithinFireArc(LocalTargetInfo tgt)
+        {
+            var angle = Vector3.SignedAngle(Vector3.forward.RotatedBy(parent.Rotation.AsAngle), (tgt.CenterVector3 - parent.DrawPos).Yto0(), Vector3.up);
+            return angle > effectiveLeftSpan && angle < effectiveRightSpan;
+        }
+
+        public override void PostDrawExtraSelectionOverlays()
+        {
+            var drawPos = parent.DrawPos.Yto0();
+            if (Editing)
+            {
+                EditingLineLength = Vector3.Distance(drawPos, MousePosYto0);
+                NewCenterAngle = Vector3.SignedAngle(Vector3.forward, (MousePosYto0 - drawPos).RotatedBy(-parent.Rotation.AsAngle), Vector3.up);
+                if (Props.maxSpanDeviation < 180) { Mathf.Clamp(NewCenterAngle, maxLeftSpan, maxRightSpan); }
+                else { Mathf.Clamp(NewCenterAngle, -180, 180); }
+
+                drawPos += Altitide;
+
+                GenDraw.DrawLineBetween(drawPos, MousePos);
+
+                if (Input.GetMouseButtonDown(1))
+                {
+                    Editing = false;
+                    EditingSpan = false;
+                }
+
+                if (Input.GetMouseButtonDown(0))
+                {
+                    CurrentCenterAngle = NewCenterAngle;
+                    CurrentSpan = NewSpan;
+                    Editing = false;
+                    EditingSpan = false;
+                    if (parent is Building_TurretGunCE fa)
+                    {
+                        fa.PostAdjustFireArc();
+                    }
+                }
+
+                if (Input.GetMouseButtonDown(2))
+                {
+                    EditingSpan = !EditingSpan;
+                    EditingSpanLineLength = Props.spanRange.Span / (NewSpan - Props.spanRange.min) * (EditingLineLength - DiagonalLength);
+                }
+                if (EditingSpan)
+                {
+                    var l = (EditingLineLength - DiagonalLength) / EditingSpanLineLength;
+                    NewSpan = Mathf.Lerp(Props.spanRange.min, Props.spanRange.max, l);
+
+                    var norm = Vector3.right.RotatedBy(NewCenterAngle);
+                    var ext = Vector3.forward.RotatedBy(CenterAngle);
+
+                    var ext2 = ext * DiagonalLength;
+                    GenDraw.DrawLineBetween(drawPos + ext2 - norm, drawPos + ext2 + norm, color: SimpleColor.Red);
+                    ext *= EditingSpanLineLength + DiagonalLength;
+                    GenDraw.DrawLineBetween(drawPos + ext - norm, drawPos + ext + norm, color: SimpleColor.Red);
+                    GenDraw.DrawLineBetween(drawPos, drawPos + ext);
+                }
+                if (Props.maxSpanDeviation < 180)
+                {
+                    var leftBound = Vector3.forward.RotatedBy(maxLeftSpan + parent.Rotation.AsAngle) * (LineLength + 1);
+                    var rightBound = Vector3.forward.RotatedBy(maxRightSpan + parent.Rotation.AsAngle) * (LineLength + 1);
+                    GenDraw.DrawLineBetween(drawPos, drawPos + leftBound, color: SimpleColor.Red);
+                    GenDraw.DrawLineBetween(drawPos, drawPos + rightBound, color: SimpleColor.Red);
+                    DrawCircleOutline(drawPos, LineLength + 1, maxLeftSpan, maxRightSpan, 0, SimpleColor.Red);
+                }
+            }
+            else
+            {
+                drawPos += Altitide;
+            }
+            GenDraw.DrawLineBetween(drawPos, drawPos + Left * LineLength);
+            GenDraw.DrawLineBetween(drawPos, drawPos + Right * LineLength);
+
+            DrawCircleOutline(drawPos, LineLength, effectiveLeftSpan, effectiveRightSpan, CenterAngle);
+        }
+
+        public override IEnumerable<Gizmo> CompGetGizmosExtra()
+        {
+            Command_Action Edit = new Command_Action();
+            Edit.defaultLabel = "L";
+            Edit.defaultDesc = "Right click to save change\nLeft click to cancel change\nMiddle click to edit span";
+            Edit.icon = ContentFinder<Texture2D>.Get("UI/Commands/Halt", true);
+            Edit.action = delegate
+            {
+                Editing = true;
+                NewSpan = CurrentSpan;
+            };
+            yield return Edit;
+        }
+
+        public override string CompInspectStringExtra()
+        {
+            return $"Arc of fire: {(int)effectiveLeftSpan}~{(int)effectiveRightSpan}";
+        }
+
+        public override void PostExposeData()
+        {
+            Scribe_Values.Look(ref CurrentCenterAngle, "CurrentCenterAngle");
+            Scribe_Values.Look(ref CurrentSpan, "CurrentSpan");
+        }
+
+        public override void PostSpawnSetup(bool respawningAfterLoad)
+        {
+            if (CurrentSpan < 0) { CurrentSpan = Props.spanRange.max; }
+        }
+
+        public void DrawCircleOutline(Vector3 center, float radius, float spanL, float spanR, float startingAngle = 0, SimpleColor color = SimpleColor.White)
+        {
+            startingAngle = -spanR + 90 - parent.Rotation.AsAngle;
+            startingAngle *= Mathf.Deg2Rad;
+
+            float spanf = (spanR - spanL) / 360;
+            int stepCount = Mathf.Clamp(Mathf.RoundToInt(24f * radius * spanf), 12, 48);
+            float step = (float)Math.PI * 2f * spanf / stepCount;
+
+            Vector3 vector = center;
+            Vector3 a = center;
+            for (int i = 0; i < stepCount + 2; i++)
+            {
+                if (i >= 2)
+                {
+                    GenDraw.DrawLineBetween(a, vector, color);
+                }
+
+                a = vector;
+                vector = center;
+                vector.x += Mathf.Cos(startingAngle) * radius;
+                vector.z += Mathf.Sin(startingAngle) * radius;
+                startingAngle += step;
+            }
+        }
+    }
+
+
+
+    public class CompProperties_FireArc : CompProperties
+    {
+        public CompProperties_FireArc()
+        {
+            compClass = typeof(CompFireArc);
+        }
+        public FloatRange spanRange = new FloatRange(0, 360);
+
+        public float maxSpanDeviation = 180;
+
+        public float lineLength = 3;
+    }
+}

--- a/Source/CombatExtended/CombatExtended/Defs/NonSnapTurretExtension.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/NonSnapTurretExtension.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Verse;
+
+namespace CombatExtended
+{
+    public class NonSnapTurretExtension : DefModExtension
+    {
+        public float speed = 1f;
+
+        public float preferedAngleRange = -1;
+
+        public float angleWeightMultiplier = 1;
+
+        public float minAngleWeight = 0.1f;
+
+        public float TweakWeight(float weight, float angle)
+        {
+            if (angle < minAngleWeight || angle < preferedAngleRange) { angle = minAngleWeight; }
+            angle *= angleWeightMultiplier;
+            return weight / angle;
+        }
+    }
+}

--- a/Source/CombatExtended/CombatExtended/Things/Building_TurretGunCE.cs
+++ b/Source/CombatExtended/CombatExtended/Things/Building_TurretGunCE.cs
@@ -480,6 +480,12 @@ namespace CombatExtended
             {
                 targetScanFlags |= TargetScanFlags.NeedNonBurning;
             }
+
+            if (NonSnap)
+            {
+                return (Thing)NonSnapAttackTargetFinder.BestShootTargetFromCurrentPosition(attackTargetSearcher, targetScanFlags, TurretOrientation, IsValidTarget);
+            }
+
             return (Thing)AttackTargetFinder.BestShootTargetFromCurrentPosition(
                        attackTargetSearcher,
                        targetScanFlags,

--- a/Source/CombatExtended/NonSnapAttackTargetFinder.cs
+++ b/Source/CombatExtended/NonSnapAttackTargetFinder.cs
@@ -1,0 +1,448 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using RimWorld;
+using Verse;
+using Verse.AI;
+using UnityEngine;
+
+namespace CombatExtended
+{
+    public static class NonSnapAttackTargetFinder
+    {
+        private const float FriendlyFireScoreOffsetPerHumanlikeOrMechanoid = 18f;
+
+        private const float FriendlyFireScoreOffsetPerAnimal = 7f;
+
+        private const float FriendlyFireScoreOffsetPerNonPawn = 10f;
+
+        private const float FriendlyFireScoreOffsetSelf = 40f;
+
+        private static List<IAttackTarget> tmpTargets = new List<IAttackTarget>(128);
+
+        private static List<Pair<IAttackTarget, float>> availableShootingTargets = new List<Pair<IAttackTarget, float>>();
+
+        private static List<float> tmpTargetScores = new List<float>();
+
+        private static List<bool> tmpCanShootAtTarget = new List<bool>();
+
+        public static IAttackTarget BestShootTargetFromCurrentPosition(IAttackTargetSearcher searcher, TargetScanFlags flags, Vector3 angle, Predicate<Thing> validator = null, float minDistance = 0f, float maxDistance = 9999f)
+        {
+            Verb verb = searcher.CurrentEffectiveVerb;
+            if (verb == null)
+            {
+                Log.Error("BestShootTargetFromCurrentPosition with " + searcher.ToStringSafe() + " who has no attack verb.");
+                return null;
+            }
+            return BestAttackTarget(searcher, flags, angle, validator, Mathf.Max(minDistance, verb.verbProps.minRange), Mathf.Min(maxDistance, verb.verbProps.range));
+        }
+
+        public static IAttackTarget BestAttackTarget(IAttackTargetSearcher searcher, TargetScanFlags flags, Vector3 angle, Predicate<Thing> validator = null, float minDist = 0f, float maxDist = 9999f)
+        {
+            Thing searcherThing = searcher.Thing;
+            Verb verb = searcher.CurrentEffectiveVerb;
+            if (verb == null)
+            {
+                Log.Error("BestAttackTarget with " + searcher.ToStringSafe() + " who has no attack verb.");
+                return null;
+            }
+            bool onlyTargetMachines = verb.IsEMP();
+            float minDistSquared = minDist * minDist;
+            float num = verb.verbProps.range;
+            float maxLocusDistSquared = num * num;
+            Func<IntVec3, bool> losValidator = null;
+            if ((flags & TargetScanFlags.LOSBlockableByGas) != 0)
+            {
+                losValidator = (IntVec3 vec3) => !vec3.AnyGas(searcherThing.Map, GasType.BlindSmoke);
+            }
+
+
+
+            tmpTargets.Clear();
+            tmpTargets.AddRange(searcherThing.Map.attackTargetsCache.GetPotentialTargetsFor(searcher));
+            tmpTargets.RemoveAll((IAttackTarget t) => ShouldIgnoreNoncombatant(searcherThing, t, flags));
+            bool flag = false;
+            for (int i = 0; i < tmpTargets.Count; i++)
+            {
+                IAttackTarget attackTarget = tmpTargets[i];
+                if (attackTarget.Thing.Position.InHorDistOf(searcherThing.Position, maxDist) && innerValidator(attackTarget) && CanShootAtFromCurrentPosition(attackTarget, searcher, verb))
+                {
+                    flag = true;
+                    break;
+                }
+            }
+            IAttackTarget result;
+            if (flag)
+            {
+                tmpTargets.RemoveAll((IAttackTarget x) => !x.Thing.Position.InHorDistOf(searcherThing.Position, maxDist) || !innerValidator(x));
+                result = GetRandomShootingTargetByScore(tmpTargets, searcher, verb, angle);
+            }
+            else
+            {
+                bool num2 = (flags & TargetScanFlags.NeedReachableIfCantHitFromMyPos) != 0;
+                bool flag2 = (flags & TargetScanFlags.NeedReachable) != 0;
+                result = (IAttackTarget)GenClosest.ClosestThing_Global(validator: (!num2 || flag2) ? (Thing t) => innerValidator((IAttackTarget)t) : ((Predicate<Thing>)((Thing t) => innerValidator((IAttackTarget)t) && CanShootAtFromCurrentPosition((IAttackTarget)t, searcher, verb))), center: searcherThing.Position, searchSet: tmpTargets, maxDistance: maxDist);
+            }
+            tmpTargets.Clear();
+            return result;
+
+            bool innerValidator(IAttackTarget t)
+            {
+                Thing thing = t.Thing;
+                if (t == searcher)
+                {
+                    return false;
+                }
+
+                if (minDistSquared > 0f && (searcherThing.Position - thing.Position).LengthHorizontalSquared < minDistSquared)
+                {
+                    return false;
+                }
+
+                float num3 = verb.verbProps.EffectiveMinRange(thing, searcherThing);
+                if (num3 > 0f && (searcherThing.Position - thing.Position).LengthHorizontalSquared < num3 * num3)
+                {
+                    return false;
+                }
+
+                if (!searcherThing.HostileTo(thing))
+                {
+                    return false;
+                }
+
+                if (validator != null && !validator(thing))
+                {
+                    return false;
+                }
+
+                if ((flags & TargetScanFlags.NeedNotUnderThickRoof) != 0)
+                {
+                    RoofDef roof = thing.Position.GetRoof(thing.Map);
+                    if (roof != null && roof.isThickRoof)
+                    {
+                        return false;
+                    }
+                }
+                if ((flags & TargetScanFlags.NeedLOSToAll) != 0)
+                {
+                    if (losValidator != null && (!losValidator(searcherThing.Position) || !losValidator(thing.Position)))
+                    {
+                        return false;
+                    }
+
+                    if (!searcherThing.CanSee(thing, losValidator))
+                    {
+                        if (t is Pawn)
+                        {
+                            if ((flags & TargetScanFlags.NeedLOSToPawns) != 0)
+                            {
+                                return false;
+                            }
+                        }
+                        else if ((flags & TargetScanFlags.NeedLOSToNonPawns) != 0)
+                        {
+                            return false;
+                        }
+                    }
+                }
+                if (((flags & TargetScanFlags.NeedThreat) != 0 || (flags & TargetScanFlags.NeedAutoTargetable) != 0) && t.ThreatDisabled(searcher))
+                {
+                    return false;
+                }
+
+                if ((flags & TargetScanFlags.NeedAutoTargetable) != 0 && !Verse.AI.AttackTargetFinder.IsAutoTargetable(t))
+                {
+                    return false;
+                }
+
+                if ((flags & TargetScanFlags.NeedActiveThreat) != 0 && !GenHostility.IsActiveThreatTo(t, searcher.Thing.Faction))
+                {
+                    return false;
+                }
+
+                Pawn pawn = t as Pawn;
+                if (onlyTargetMachines && pawn != null && pawn.RaceProps.IsFlesh)
+                {
+                    return false;
+                }
+
+                if ((flags & TargetScanFlags.NeedNonBurning) != 0 && thing.IsBurning())
+                {
+                    return false;
+                }
+
+                if (searcherThing.def.race != null && (int)searcherThing.def.race.intelligence >= 2)
+                {
+                    CompExplosive compExplosive = thing.TryGetComp<CompExplosive>();
+                    if (compExplosive != null && compExplosive.wickStarted)
+                    {
+                        return false;
+                    }
+                }
+                if (thing.def.size.x == 1 && thing.def.size.z == 1)
+                {
+                    if (thing.Position.Fogged(thing.Map))
+                    {
+                        return false;
+                    }
+                }
+                else
+                {
+                    bool flag3 = false;
+                    foreach (IntVec3 item in thing.OccupiedRect())
+                    {
+                        if (!item.Fogged(thing.Map))
+                        {
+                            flag3 = true;
+                            break;
+                        }
+                    }
+                    if (!flag3)
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            }
+        }
+
+        private static bool ShouldIgnoreNoncombatant(Thing searcherThing, IAttackTarget t, TargetScanFlags flags)
+        {
+            if (!(t is Pawn pawn))
+            {
+                return false;
+            }
+
+            if (pawn.IsCombatant())
+            {
+                return false;
+            }
+
+            if ((flags & TargetScanFlags.IgnoreNonCombatants) != 0)
+            {
+                return true;
+            }
+
+            if (GenSight.LineOfSightToThing(searcherThing.Position, pawn, searcherThing.Map))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private static bool CanShootAtFromCurrentPosition(IAttackTarget target, IAttackTargetSearcher searcher, Verb verb)
+        {
+            return verb?.CanHitTargetFrom(searcher.Thing.Position, target.Thing) ?? false;
+        }
+
+        private static IAttackTarget GetRandomShootingTargetByScore(List<IAttackTarget> targets, IAttackTargetSearcher searcher, Verb verb, Vector3 angle)
+        {
+            if (GetAvailableShootingTargetsByScore(targets, searcher, verb, angle).TryRandomElementByWeight((Pair<IAttackTarget, float> x) => x.Second, out var result))
+            {
+                return result.First;
+            }
+
+            return null;
+        }
+
+        private static List<Pair<IAttackTarget, float>> GetAvailableShootingTargetsByScore(List<IAttackTarget> rawTargets, IAttackTargetSearcher searcher, Verb verb, Vector3 angle)
+        {
+            availableShootingTargets.Clear();
+            if (rawTargets.Count == 0)
+            {
+                return availableShootingTargets;
+            }
+            tmpTargetScores.Clear();
+            tmpCanShootAtTarget.Clear();
+            float num = 0f;
+            IAttackTarget attackTarget = null;
+
+            for (int i = 0; i < rawTargets.Count; i++)
+            {
+                tmpTargetScores.Add(float.MinValue);
+                tmpCanShootAtTarget.Add(item: false);
+                if (rawTargets[i] == searcher)
+                {
+                    continue;
+                }
+                bool flag = CanShootAtFromCurrentPosition(rawTargets[i], searcher, verb);
+                tmpCanShootAtTarget[i] = flag;
+                if (flag)
+                {
+                    float shootingTargetScore = GetShootingTargetScore(rawTargets[i], searcher, verb, angle);
+                    tmpTargetScores[i] = shootingTargetScore;
+                    if (attackTarget == null || shootingTargetScore > num)
+                    {
+                        attackTarget = rawTargets[i];
+                        num = shootingTargetScore;
+                    }
+                }
+            }
+            for (int j = 0; j < rawTargets.Count; j++)
+            {
+                if (rawTargets[j] != searcher && tmpCanShootAtTarget[j])
+                {
+                    availableShootingTargets.Add(new Pair<IAttackTarget, float>(rawTargets[j], tmpTargetScores[j]));
+                }
+            }
+            return availableShootingTargets;
+        }
+
+        private static float GetShootingTargetScore(IAttackTarget target, IAttackTargetSearcher searcher, Verb verb, Vector3 angle)
+        {
+            float num = 60f;
+            num -= Mathf.Min((target.Thing.Position - searcher.Thing.Position).LengthHorizontal, FriendlyFireScoreOffsetSelf);
+            if (target.TargetCurrentlyAimingAt == searcher.Thing)
+            {
+                num += FriendlyFireScoreOffsetPerNonPawn;
+            }
+            if (searcher.LastAttackedTarget == target.Thing && Find.TickManager.TicksGame - searcher.LastAttackTargetTick <= 300)
+            {
+                num += FriendlyFireScoreOffsetSelf;
+            }
+            num -= CoverUtility.CalculateOverallBlockChance(target.Thing.Position, searcher.Thing.Position, searcher.Thing.Map) * 10f;
+            if (target is Pawn pawn)
+            {
+                num -= NonCombatantScore(pawn);
+                if (verb.verbProps.ai_TargetHasRangedAttackScoreOffset != 0f && pawn.CurrentEffectiveVerb != null && pawn.CurrentEffectiveVerb.verbProps.Ranged)
+                {
+                    num += verb.verbProps.ai_TargetHasRangedAttackScoreOffset;
+                }
+                if (pawn.Downed)
+                {
+                    num -= 50f;
+                }
+            }
+            num += FriendlyFireBlastRadiusTargetScoreOffset(target, searcher, verb);
+            num += FriendlyFireConeTargetScoreOffset(target, searcher, verb);
+
+            var ext = searcher.Thing.def.GetModExtension<NonSnapTurretExtension>();
+            var anglef = Vector3.Angle(angle, (target.Thing.DrawPos - searcher.Thing.DrawPos).Yto0());
+            if (ext == null)
+            {
+                if (anglef < 0.1f)
+                {
+                    anglef = 0.1f;
+                }
+
+                return num / anglef;
+            }
+            return ext.TweakWeight(num * target.TargetPriorityFactor, anglef);
+        }
+
+        private static float NonCombatantScore(Thing target)
+        {
+            if (!(target is Pawn pawn))
+            {
+                return 0f;
+            }
+            if (!pawn.IsCombatant())
+            {
+                return 50f;
+            }
+            if (pawn.DevelopmentalStage.Juvenile())
+            {
+                return 25f;
+            }
+            return 0f;
+        }
+
+        private static float FriendlyFireBlastRadiusTargetScoreOffset(IAttackTarget target, IAttackTargetSearcher searcher, Verb verb)
+        {
+            if (verb.verbProps.ai_AvoidFriendlyFireRadius <= 0f)
+            {
+                return 0f;
+            }
+            Map map = target.Thing.Map;
+            IntVec3 position = target.Thing.Position;
+            int num = GenRadial.NumCellsInRadius(verb.verbProps.ai_AvoidFriendlyFireRadius);
+            float num2 = 0f;
+            for (int i = 0; i < num; i++)
+            {
+                IntVec3 intVec = position + GenRadial.RadialPattern[i];
+                if (!intVec.InBounds(map))
+                {
+                    continue;
+                }
+                bool flag = true;
+                List<Thing> thingList = intVec.GetThingList(map);
+                for (int j = 0; j < thingList.Count; j++)
+                {
+                    if (!(thingList[j] is IAttackTarget) || thingList[j] == target)
+                    {
+                        continue;
+                    }
+                    if (flag)
+                    {
+                        if (!GenSight.LineOfSight(position, intVec, map, skipFirstCell: true))
+                        {
+                            break;
+                        }
+                        flag = false;
+                    }
+                    float num3 = ((thingList[j] == searcher) ? FriendlyFireScoreOffsetSelf : ((!(thingList[j] is Pawn)) ? 10f : (thingList[j].def.race.Animal ? FriendlyFireScoreOffsetPerAnimal : FriendlyFireScoreOffsetPerHumanlikeOrMechanoid)));
+                    num2 = ((!searcher.Thing.HostileTo(thingList[j])) ? (num2 - num3) : (num2 + num3 * 0.6f));
+                }
+            }
+            return num2;
+        }
+
+        private static float FriendlyFireConeTargetScoreOffset(IAttackTarget target, IAttackTargetSearcher searcher, Verb verb)
+        {
+            if (!(searcher.Thing is Pawn pawn))
+            {
+                return 0f;
+            }
+            if ((int)pawn.RaceProps.intelligence < 1)
+            {
+                return 0f;
+            }
+            if (pawn.RaceProps.IsMechanoid)
+            {
+                return 0f;
+            }
+            if (!(verb is Verb_Shoot verb_Shoot))
+            {
+                return 0f;
+            }
+            ThingDef defaultProjectile = verb_Shoot.verbProps.defaultProjectile;
+            if (defaultProjectile == null)
+            {
+                return 0f;
+            }
+            if (defaultProjectile.projectile.flyOverhead)
+            {
+                return 0f;
+            }
+            Map map = pawn.Map;
+            ShotReport report = ShotReport.HitReportFor(pawn, verb, (Thing)target);
+            float radius = Mathf.Max(VerbUtility.CalculateAdjustedForcedMiss(verb.verbProps.ForcedMissRadius, report.ShootLine.Dest - report.ShootLine.Source), 1.5f);
+            IEnumerable<IntVec3> enumerable = (from dest in GenRadial.RadialCellsAround(report.ShootLine.Dest, radius, useCenter: true)
+                                               where dest.InBounds(map)
+                                               select new ShootLine(report.ShootLine.Source, dest)).SelectMany((ShootLine line) => line.Points().Concat(line.Dest).TakeWhile((IntVec3 pos) => pos.CanBeSeenOverFast(map))).Distinct();
+            float num = 0f;
+            foreach (IntVec3 item in enumerable)
+            {
+                float num2 = VerbUtility.InterceptChanceFactorFromDistance(report.ShootLine.Source.ToVector3Shifted(), item);
+                if (num2 <= 0f)
+                {
+                    continue;
+                }
+                List<Thing> thingList = item.GetThingList(map);
+                for (int i = 0; i < thingList.Count; i++)
+                {
+                    Thing thing = thingList[i];
+                    if (thing is IAttackTarget && thing != target)
+                    {
+                        float num3 = ((thing == searcher) ? FriendlyFireScoreOffsetSelf : ((!(thing is Pawn)) ? 10f : (thing.def.race.Animal ? FriendlyFireScoreOffsetPerAnimal : FriendlyFireScoreOffsetPerHumanlikeOrMechanoid)));
+                        num3 *= num2;
+                        num3 = ((!searcher.Thing.HostileTo(thing)) ? (num3 * -1f) : (num3 * 0.6f));
+                        num += num3;
+                    }
+                }
+            }
+            return num;
+        }
+    }
+}


### PR DESCRIPTION
## Additions
The ability to set a turret to "non-snap", so that the turret turns at a finite speed to train on target. Weapon warm up will be ticking until 1 while turning but aiming will be prevented, and will only fire when it can turn toward target at next tick.
The ability to do so is toggled via the existance of NonSnapTurretExtension modextension in turret building's def.

Non snap turrets will prioritize targets near its current orientation, with weight adjustable in mod extension.

Turrets can have their arc of fire adjusted, with maximal and minimal amount adjustable in compprops. This behaviour is enabled via the CompFireArc comp in turret building's def

## Alternatives

Light-speed turret motors.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] Playtested a colony (specify how long)
