### PR TITLE
Increased melee fighter hit chance

### DIFF
--- a/Anomaly/Patches/ThingDefs_Races/Races_Entities_Misc.xml
+++ b/Anomaly/Patches/ThingDefs_Races/Races_Entities_Misc.xml
@@ -94,6 +94,7 @@
 			<MeleeDodgeChance>0.16</MeleeDodgeChance>
 			<MeleeCritChance>0.12</MeleeCritChance>
 			<MeleeParryChance>0.09</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 
@@ -258,6 +259,7 @@
 			<MeleeDodgeChance>0.17</MeleeDodgeChance>
 			<MeleeCritChance>0.08</MeleeCritChance>
 			<MeleeParryChance>0.06</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 
@@ -381,6 +383,7 @@
 			<MeleeDodgeChance>0.23</MeleeDodgeChance>
 			<MeleeCritChance>0.28</MeleeCritChance>
 			<MeleeParryChance>0.09</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 
@@ -703,6 +706,7 @@
 			<MeleeDodgeChance>0.06</MeleeDodgeChance>
 			<MeleeCritChance>0.11</MeleeCritChance>
 			<MeleeParryChance>0.23</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Heavy.xml
+++ b/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Heavy.xml
@@ -49,6 +49,7 @@
 			<MeleeDodgeChance>0.02</MeleeDodgeChance>
 			<MeleeCritChance>0.23</MeleeCritChance>
 			<MeleeParryChance>0.53</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 			<MaxHitPoints>300</MaxHitPoints>
 		</value>
 	</Operation>

--- a/Ideology/Patches/ThingDefs_Misc/Race_Animal_Dryads.xml
+++ b/Ideology/Patches/ThingDefs_Misc/Race_Animal_Dryads.xml
@@ -108,6 +108,7 @@
 			<MeleeDodgeChance>0.5</MeleeDodgeChance>
 			<MeleeCritChance>0.25</MeleeCritChance>
 			<MeleeParryChance>0.30</MeleeParryChance>
+			<MeleeHitChance>6</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Arctic_Lion.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Arctic_Lion.xml
@@ -16,6 +16,7 @@
 			<MeleeDodgeChance>0.3</MeleeDodgeChance>
 			<MeleeCritChance>0.34</MeleeCritChance>
 			<MeleeParryChance>0.14</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Black_Hive.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Black_Hive.xml
@@ -139,6 +139,7 @@
 			<MeleeDodgeChance>0.08</MeleeDodgeChance>
 			<MeleeCritChance>0.18</MeleeCritChance>
 			<MeleeParryChance>0.15</MeleeParryChance>
+			<MeleeHitChance>4</MeleeHitChance>
 			<Suppressability>0.25</Suppressability>
 		</value>
 	</Operation>
@@ -253,6 +254,7 @@
 			<MeleeDodgeChance>0.09</MeleeDodgeChance>
 			<MeleeCritChance>0.45</MeleeCritChance>
 			<MeleeParryChance>0.25</MeleeParryChance>
+			<MeleeHitChance>4</MeleeHitChance>
 			<Suppressability>0.2</Suppressability>
 		</value>
 	</Operation>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Bloodshrimp.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Bloodshrimp.xml
@@ -23,6 +23,7 @@
 			<MeleeDodgeChance>0.01</MeleeDodgeChance>
 			<MeleeCritChance>0.20</MeleeCritChance>
 			<MeleeParryChance>0.28</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_DarkBeast.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_DarkBeast.xml
@@ -30,6 +30,7 @@
 			<MeleeDodgeChance>0.1</MeleeDodgeChance>
 			<MeleeCritChance>0.21</MeleeCritChance>
 			<MeleeParryChance>0.24</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_DarkVandal.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_DarkVandal.xml
@@ -16,6 +16,7 @@
 			<MeleeDodgeChance>0.12</MeleeDodgeChance>
 			<MeleeCritChance>0.3</MeleeCritChance>
 			<MeleeParryChance>0.1</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_DuskProwler.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_DuskProwler.xml
@@ -16,6 +16,7 @@
 			<MeleeDodgeChance>0.9</MeleeDodgeChance>
 			<MeleeCritChance>0.27</MeleeCritChance>
 			<MeleeParryChance>0.1</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_FrostLynx.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_FrostLynx.xml
@@ -15,6 +15,7 @@
 			<MeleeDodgeChance>0.26</MeleeDodgeChance>
 			<MeleeCritChance>0.20</MeleeCritChance>
 			<MeleeParryChance>0.07</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_FungalHusk.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_FungalHusk.xml
@@ -15,6 +15,7 @@
 			<MeleeDodgeChance>0.17</MeleeDodgeChance>
 			<MeleeCritChance>0.33</MeleeCritChance>
 			<MeleeParryChance>0.2</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Genix.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Genix.xml
@@ -15,6 +15,7 @@
 			<MeleeDodgeChance>0.26</MeleeDodgeChance>
 			<MeleeCritChance>0.20</MeleeCritChance>
 			<MeleeParryChance>0.07</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Nightling.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Nightling.xml
@@ -17,6 +17,7 @@
 			<MeleeDodgeChance>0.37</MeleeDodgeChance>
 			<MeleeCritChance>0.18</MeleeCritChance>
 			<MeleeParryChance>0.08</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Raptor_Shrimp.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Raptor_Shrimp.xml
@@ -23,6 +23,7 @@
 			<MeleeDodgeChance>0.12</MeleeDodgeChance>
 			<MeleeCritChance>0.34</MeleeCritChance>
 			<MeleeParryChance>0.4</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Ravager.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Ravager.xml
@@ -31,6 +31,7 @@
 			<MeleeDodgeChance>0.01</MeleeDodgeChance>
 			<MeleeCritChance>0.36</MeleeCritChance>
 			<MeleeParryChance>0.2</MeleeParryChance>
+			<MeleeHitChance>4</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_RipperHound.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_RipperHound.xml
@@ -15,6 +15,7 @@
 			<MeleeDodgeChance>0.25</MeleeDodgeChance>
 			<MeleeCritChance>0.1</MeleeCritChance>
 			<MeleeParryChance>0.11</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_SandLion.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_SandLion.xml
@@ -16,6 +16,7 @@
 			<MeleeDodgeChance>0.56</MeleeDodgeChance>
 			<MeleeCritChance>0.24</MeleeCritChance>
 			<MeleeParryChance>0.14</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Thermadon.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Thermadon.xml
@@ -30,6 +30,7 @@
 			<MeleeDodgeChance>0.1</MeleeDodgeChance>
 			<MeleeCritChance>0.2</MeleeCritChance>
 			<MeleeParryChance>0.2</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Thunderbeast.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Thunderbeast.xml
@@ -30,6 +30,7 @@
 			<MeleeDodgeChance>0.1</MeleeDodgeChance>
 			<MeleeCritChance>0.16</MeleeCritChance>
 			<MeleeParryChance>0.15</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Windbeast.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Windbeast.xml
@@ -29,6 +29,7 @@
 			<MeleeDodgeChance>0.1</MeleeDodgeChance>
 			<MeleeCritChance>0.16</MeleeCritChance>
 			<MeleeParryChance>0.15</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Alpha Genes/Patches/Alpha Genes/ThingDefs_Races/Races_OcularSlinger.xml
+++ b/ModPatches/Alpha Genes/Patches/Alpha Genes/ThingDefs_Races/Races_OcularSlinger.xml
@@ -94,6 +94,7 @@
 						<MeleeDodgeChance>0.1</MeleeDodgeChance>
 						<MeleeCritChance>0.4</MeleeCritChance>
 						<MeleeParryChance>0.4</MeleeParryChance>
+						<MeleeHitChance>3</MeleeHitChance>
 					</value>
 				</li>
 

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Guttersnipe.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Guttersnipe.xml
@@ -24,6 +24,7 @@
 						<MeleeDodgeChance>0.1</MeleeDodgeChance>
 						<MeleeCritChance>0.05</MeleeCritChance>
 						<MeleeParryChance>0.05</MeleeParryChance>
+						<MeleeHitChance>6</MeleeHitChance>
 						<MaxHitPoints>200</MaxHitPoints>
 					</value>
 				</li>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvAura.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvAura.xml
@@ -27,6 +27,7 @@
 							<MeleeDodgeChance>0.66</MeleeDodgeChance>
 							<MeleeCritChance>0.3</MeleeCritChance>
 							<MeleeParryChance>0.33</MeleeParryChance>
+							<MeleeHitChance>7</MeleeHitChance>
 							<MaxHitPoints>200</MaxHitPoints>
 						</statBases>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvDaggersnout.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvDaggersnout.xml
@@ -24,6 +24,7 @@
 						<MeleeDodgeChance>0.08</MeleeDodgeChance>
 						<MeleeCritChance>0.27</MeleeCritChance>
 						<MeleeParryChance>0.18</MeleeParryChance>
+						<MeleeHitChance>7</MeleeHitChance>
 					</value>
 				</li>
 

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEAura.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEAura.xml
@@ -25,6 +25,7 @@
 							<MeleeDodgeChance>0.5</MeleeDodgeChance>
 							<MeleeCritChance>0.24</MeleeCritChance>
 							<MeleeParryChance>0.33</MeleeParryChance>
+							<MeleeHitChance>6</MeleeHitChance>
 							<MaxHitPoints>200</MaxHitPoints>
 						</statBases>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEDaggersnout.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEDaggersnout.xml
@@ -24,6 +24,7 @@
 						<MeleeDodgeChance>0.08</MeleeDodgeChance>
 						<MeleeCritChance>0.24</MeleeCritChance>
 						<MeleeParryChance>0.18</MeleeParryChance>
+						<MeleeHitChance>6</MeleeHitChance>
 					</value>
 				</li>
 

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Aura.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Aura.xml
@@ -32,6 +32,7 @@
 							<MeleeDodgeChance>0.66</MeleeDodgeChance>
 							<MeleeCritChance>0.3</MeleeCritChance>
 							<MeleeParryChance>0.33</MeleeParryChance>
+							<MeleeHitChance>7</MeleeHitChance>
 							<MaxHitPoints>200</MaxHitPoints>
 						</value>
 					</li>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Daggersnout.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Daggersnout.xml
@@ -30,6 +30,7 @@
 							<MeleeDodgeChance>0.08</MeleeDodgeChance>
 							<MeleeCritChance>0.27</MeleeCritChance>
 							<MeleeParryChance>0.18</MeleeParryChance>
+							<MeleeHitChance>7</MeleeHitChance>
 						</value>
 					</li>
 

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Aura.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Aura.xml
@@ -16,6 +16,7 @@
 			<MeleeDodgeChance>0.5</MeleeDodgeChance>
 			<MeleeCritChance>0.24</MeleeCritChance>
 			<MeleeParryChance>0.33</MeleeParryChance>
+			<MeleeHitChance>6</MeleeHitChance>
 			<MaxHitPoints>200</MaxHitPoints>
 		</value>
 	</Operation>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Daggersnout.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Daggersnout.xml
@@ -16,6 +16,7 @@
 			<MeleeDodgeChance>0.08</MeleeDodgeChance>
 			<MeleeCritChance>0.24</MeleeCritChance>
 			<MeleeParryChance>0.18</MeleeParryChance>
+			<MeleeHitChance>6</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Alpha Mythology/Patches/Alpha Mythology/AM_CE_Patch_Races.xml
+++ b/ModPatches/Alpha Mythology/Patches/Alpha Mythology/AM_CE_Patch_Races.xml
@@ -76,6 +76,7 @@
 			<MeleeDodgeChance>0.10</MeleeDodgeChance>
 			<MeleeCritChance>0.26</MeleeCritChance>
 			<MeleeParryChance>0.13</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 
@@ -173,6 +174,7 @@
 			<MeleeDodgeChance>0.19</MeleeDodgeChance>
 			<MeleeCritChance>0.18</MeleeCritChance>
 			<MeleeParryChance>0.17</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 			<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 			<AimingAccuracy>1.0</AimingAccuracy>
 		</value>
@@ -333,6 +335,7 @@
 			<MeleeDodgeChance>0.13</MeleeDodgeChance>
 			<MeleeCritChance>0.28</MeleeCritChance>
 			<MeleeParryChance>0.15</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 
@@ -471,6 +474,7 @@
 			<MeleeDodgeChance>0.09</MeleeDodgeChance>
 			<MeleeCritChance>0.48</MeleeCritChance>
 			<MeleeParryChance>0.27</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 			<ShootingAccuracyPawn>1.4</ShootingAccuracyPawn>
 			<AimingAccuracy>0.9</AimingAccuracy>
 		</value>
@@ -1269,6 +1273,7 @@
 			<MeleeDodgeChance>0.16</MeleeDodgeChance>
 			<MeleeCritChance>0.31</MeleeCritChance>
 			<MeleeParryChance>0.22</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 			<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 			<AimingAccuracy>1.0</AimingAccuracy>
 		</value>

--- a/ModPatches/Call of Cthulhu - Cosmic Horrors/Patches/Call of Cthulhu - Cosmic Horrors/PawnKindDefs_CosmicHorrors/CH_KindsChthonian.xml
+++ b/ModPatches/Call of Cthulhu - Cosmic Horrors/Patches/Call of Cthulhu - Cosmic Horrors/PawnKindDefs_CosmicHorrors/CH_KindsChthonian.xml
@@ -16,6 +16,7 @@
 			<MeleeDodgeChance>0.01</MeleeDodgeChance>
 			<MeleeCritChance>0.9</MeleeCritChance>
 			<MeleeParryChance>0.5</MeleeParryChance>
+			<MeleeHitChance>6</MeleeHitChance>
 			<ArmorRating_Sharp>14</ArmorRating_Sharp>
 			<ArmorRating_Blunt>32</ArmorRating_Blunt>
 			<SmokeSensitivity>0</SmokeSensitivity>

--- a/ModPatches/Call of Cthulhu - Cosmic Horrors/Patches/Call of Cthulhu - Cosmic Horrors/PawnKindDefs_CosmicHorrors/CH_KindsCthulhids.xml
+++ b/ModPatches/Call of Cthulhu - Cosmic Horrors/Patches/Call of Cthulhu - Cosmic Horrors/PawnKindDefs_CosmicHorrors/CH_KindsCthulhids.xml
@@ -16,6 +16,7 @@
 			<MeleeDodgeChance>0.08</MeleeDodgeChance>
 			<MeleeCritChance>0.68</MeleeCritChance>
 			<MeleeParryChance>0.5</MeleeParryChance>
+			<MeleeHitChance>6</MeleeHitChance>
 			<SmokeSensitivity>0</SmokeSensitivity>
 		</value>
 	</Operation>

--- a/ModPatches/Call of Cthulhu - Cosmic Horrors/Patches/Call of Cthulhu - Cosmic Horrors/PawnKindDefs_CosmicHorrors/CH_KindsDarkYoung.xml
+++ b/ModPatches/Call of Cthulhu - Cosmic Horrors/Patches/Call of Cthulhu - Cosmic Horrors/PawnKindDefs_CosmicHorrors/CH_KindsDarkYoung.xml
@@ -16,6 +16,7 @@
 			<MeleeDodgeChance>0.1</MeleeDodgeChance>
 			<MeleeCritChance>0.48</MeleeCritChance>
 			<MeleeParryChance>0.25</MeleeParryChance>
+			<MeleeHitChance>6</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Call of Cthulhu - Cosmic Horrors/Patches/Call of Cthulhu - Cosmic Horrors/PawnKindDefs_CosmicHorrors/CH_KindsDeepOne.xml
+++ b/ModPatches/Call of Cthulhu - Cosmic Horrors/Patches/Call of Cthulhu - Cosmic Horrors/PawnKindDefs_CosmicHorrors/CH_KindsDeepOne.xml
@@ -16,6 +16,7 @@
 			<MeleeDodgeChance>0.24</MeleeDodgeChance>
 			<MeleeCritChance>0.25</MeleeCritChance>
 			<MeleeParryChance>0.28</MeleeParryChance>
+			<MeleeHitChance>6</MeleeHitChance>
 			<SmokeSensitivity>0.25</SmokeSensitivity>
 		</value>
 	</Operation>

--- a/ModPatches/Call of Cthulhu - Cosmic Horrors/Patches/Call of Cthulhu - Cosmic Horrors/PawnKindDefs_CosmicHorrors/CH_KindsMiGo.xml
+++ b/ModPatches/Call of Cthulhu - Cosmic Horrors/Patches/Call of Cthulhu - Cosmic Horrors/PawnKindDefs_CosmicHorrors/CH_KindsMiGo.xml
@@ -17,6 +17,7 @@
 			<MeleeCritChance>0.22</MeleeCritChance>
 			<MeleeParryChance>0.8</MeleeParryChance>
 			<SmokeSensitivity>0.5</SmokeSensitivity>
+			<MeleeHitChance>6</MeleeHitChance>
 			<AimingAccuracy>1.0</AimingAccuracy>
 			<ShootingAccuracyPawn>2</ShootingAccuracyPawn>
 			<Suppressability>0.2</Suppressability>
@@ -99,7 +100,7 @@
 			<li>
 				<compClass>CombatExtended.CompPawnGizmo</compClass>
 			</li>
-			<li Class="CombatExtended.CompProperties_Suppressable"/>
+			<li Class="CombatExtended.CompProperties_Suppressable" />
 		</value>
 	</Operation>
 

--- a/ModPatches/Call of Cthulhu - Cosmic Horrors/Patches/Call of Cthulhu - Cosmic Horrors/PawnKindDefs_CosmicHorrors/CH_KindsShoggoths.xml
+++ b/ModPatches/Call of Cthulhu - Cosmic Horrors/Patches/Call of Cthulhu - Cosmic Horrors/PawnKindDefs_CosmicHorrors/CH_KindsShoggoths.xml
@@ -15,6 +15,7 @@
 		<value>
 			<MeleeDodgeChance>0.12</MeleeDodgeChance>
 			<MeleeCritChance>0.68</MeleeCritChance>
+			<MeleeHitChance>6</MeleeHitChance>
 			<SmokeSensitivity>0</SmokeSensitivity>
 		</value>
 	</Operation>
@@ -24,6 +25,7 @@
 		<value>
 			<MeleeDodgeChance>0.12</MeleeDodgeChance>
 			<MeleeCritChance>1</MeleeCritChance>
+			<MeleeHitChance>6</MeleeHitChance>
 			<SmokeSensitivity>0</SmokeSensitivity>
 		</value>
 	</Operation>
@@ -33,6 +35,7 @@
 		<value>
 			<MeleeDodgeChance>0.35</MeleeDodgeChance>
 			<MeleeCritChance>0.38</MeleeCritChance>
+			<MeleeHitChance>6</MeleeHitChance>
 			<SmokeSensitivity>0</SmokeSensitivity>
 		</value>
 	</Operation>

--- a/ModPatches/Call of Cthulhu - Cosmic Horrors/Patches/Call of Cthulhu - Cosmic Horrors/PawnKindDefs_CosmicHorrors/CH_KindsStarVampire.xml
+++ b/ModPatches/Call of Cthulhu - Cosmic Horrors/Patches/Call of Cthulhu - Cosmic Horrors/PawnKindDefs_CosmicHorrors/CH_KindsStarVampire.xml
@@ -16,6 +16,7 @@
 			<MeleeDodgeChance>0.9</MeleeDodgeChance>
 			<MeleeCritChance>0.7</MeleeCritChance>
 			<MeleeParryChance>0.5</MeleeParryChance>
+			<MeleeHitChance>6</MeleeHitChance>
 			<SmokeSensitivity>0</SmokeSensitivity>
 		</value>
 	</Operation>

--- a/ModPatches/RH2 Faction - VOID/Patches/RH2 Faction - VOID/Monsters/Races.xml
+++ b/ModPatches/RH2 Faction - VOID/Patches/RH2 Faction - VOID/Monsters/Races.xml
@@ -27,6 +27,7 @@
 			<MeleeDodgeChance>0.08</MeleeDodgeChance>
 			<MeleeCritChance>0.8</MeleeCritChance>
 			<MeleeParryChance>1.33</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 
@@ -127,6 +128,7 @@
 			<MeleeDodgeChance>0.18</MeleeDodgeChance>
 			<MeleeCritChance>2.0</MeleeCritChance>
 			<MeleeParryChance>1.4</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 
@@ -224,6 +226,7 @@
 			<MeleeDodgeChance>0.33</MeleeDodgeChance>
 			<MeleeCritChance>2.0</MeleeCritChance>
 			<MeleeParryChance>1.11</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 
@@ -324,6 +327,7 @@
 			<MeleeDodgeChance>0.36</MeleeDodgeChance>
 			<MeleeCritChance>2.0</MeleeCritChance>
 			<MeleeParryChance>1.4</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 
@@ -432,6 +436,7 @@
 			<MeleeDodgeChance>0.08</MeleeDodgeChance>
 			<MeleeCritChance>0.48</MeleeCritChance>
 			<MeleeParryChance>0.37</MeleeParryChance>
+			<MeleeHitChance>6</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/RH2 Faction - VOID/Patches/RH2 Faction - VOID/Monsters/Races_Evolved.xml
+++ b/ModPatches/RH2 Faction - VOID/Patches/RH2 Faction - VOID/Monsters/Races_Evolved.xml
@@ -18,6 +18,7 @@
 			<MeleeDodgeChance>0.2</MeleeDodgeChance>
 			<MeleeCritChance>1.82</MeleeCritChance>
 			<MeleeParryChance>0.37</MeleeParryChance>
+			<MeleeHitChance>6</MeleeHitChance>
 		</value>
 	</Operation>
 
@@ -118,6 +119,7 @@
 			<MeleeDodgeChance>0.25</MeleeDodgeChance>
 			<MeleeCritChance>2.0</MeleeCritChance>
 			<MeleeParryChance>0.37</MeleeParryChance>
+			<MeleeHitChance>6</MeleeHitChance>
 		</value>
 	</Operation>
 
@@ -218,6 +220,7 @@
 			<MeleeDodgeChance>0.5</MeleeDodgeChance>
 			<MeleeCritChance>2.0</MeleeCritChance>
 			<MeleeParryChance>0.37</MeleeParryChance>
+			<MeleeHitChance>6</MeleeHitChance>
 		</value>
 	</Operation>
 
@@ -318,6 +321,7 @@
 			<MeleeDodgeChance>0.59</MeleeDodgeChance>
 			<MeleeCritChance>2.0</MeleeCritChance>
 			<MeleeParryChance>2.0</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 
@@ -417,6 +421,7 @@
 			<MeleeDodgeChance>0.56</MeleeDodgeChance>
 			<MeleeCritChance>2.0</MeleeCritChance>
 			<MeleeParryChance>1.87</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 
@@ -514,6 +519,7 @@
 			<MeleeDodgeChance>0.66</MeleeDodgeChance>
 			<MeleeCritChance>2.0</MeleeCritChance>
 			<MeleeParryChance>1.11</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 
@@ -614,6 +620,7 @@
 			<MeleeDodgeChance>0.05</MeleeDodgeChance>
 			<MeleeCritChance>0.56</MeleeCritChance>
 			<MeleeParryChance>1.87</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 
@@ -714,6 +721,7 @@
 			<MeleeDodgeChance>0.67</MeleeDodgeChance>
 			<MeleeCritChance>2.0</MeleeCritChance>
 			<MeleeParryChance>2.0</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 
@@ -814,6 +822,7 @@
 			<MeleeDodgeChance>0.18</MeleeDodgeChance>
 			<MeleeCritChance>0.21</MeleeCritChance>
 			<MeleeParryChance>1.16</MeleeParryChance>
+			<MeleeHitChance>6</MeleeHitChance>
 		</value>
 	</Operation>
 
@@ -914,6 +923,7 @@
 			<MeleeDodgeChance>0.09</MeleeDodgeChance>
 			<MeleeCritChance>0.07</MeleeCritChance>
 			<MeleeParryChance>0.16</MeleeParryChance>
+			<MeleeHitChance>6</MeleeHitChance>
 		</value>
 	</Operation>
 
@@ -1013,6 +1023,7 @@
 			<MeleeDodgeChance>0.15</MeleeDodgeChance>
 			<MeleeCritChance>0.25</MeleeCritChance>
 			<MeleeParryChance>0.29</MeleeParryChance>
+			<MeleeHitChance>6</MeleeHitChance>
 		</value>
 	</Operation>
 
@@ -1113,6 +1124,7 @@
 			<MeleeDodgeChance>0.08</MeleeDodgeChance>
 			<MeleeCritChance>0.09</MeleeCritChance>
 			<MeleeParryChance>0.32</MeleeParryChance>
+			<MeleeHitChance>6</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/ReGrowth - Wastelands/Patches/ReGrowth - Wastelands/Rimclaw.xml
+++ b/ModPatches/ReGrowth - Wastelands/Patches/ReGrowth - Wastelands/Rimclaw.xml
@@ -29,6 +29,7 @@
 			<MeleeDodgeChance>0.5</MeleeDodgeChance>
 			<MeleeCritChance>0.46</MeleeCritChance>
 			<MeleeParryChance>0.78</MeleeParryChance>
+			<MeleeHitChance>4</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Reinforced Mechanoid 2/Patches/Reinforced Mechanoid 2/ThingDefs_Races/RM_Races_Mechanoids.xml
+++ b/ModPatches/Reinforced Mechanoid 2/Patches/Reinforced Mechanoid 2/ThingDefs_Races/RM_Races_Mechanoids.xml
@@ -80,7 +80,7 @@
 		</value>
 	</Operation>
 
-  <Operation Class="PatchOperationConditional">
+	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="RM_Mech_Vulture"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="RM_Mech_Vulture"]</xpath>
@@ -89,7 +89,7 @@
 			</value>
 		</nomatch>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RM_Mech_Vulture"]/comps</xpath>
 		<value>
@@ -111,7 +111,7 @@
 			</li>
 		</value>
 	</Operation>
-  
+
 	<!-- ===== Mechanoid Caretaker ===== -->
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="RM_Mech_Caretaker"]</xpath>
@@ -169,7 +169,7 @@
 		</value>
 	</Operation>
 
-  <Operation Class="PatchOperationConditional">
+	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="RM_Mech_Caretaker"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="RM_Mech_Caretaker"]</xpath>
@@ -178,7 +178,7 @@
 			</value>
 		</nomatch>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RM_Mech_Caretaker"]/comps</xpath>
 		<value>
@@ -200,7 +200,7 @@
 			</li>
 		</value>
 	</Operation>
-  
+
 	<!-- ===== Mechanoid Falcon ===== -->
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="RM_Mech_Falcon"]</xpath>
@@ -280,7 +280,7 @@
 		</value>
 	</Operation>
 
-  <Operation Class="PatchOperationConditional">
+	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="RM_Mech_Falcon"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="RM_Mech_Falcon"]</xpath>
@@ -289,7 +289,7 @@
 			</value>
 		</nomatch>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RM_Mech_Falcon"]/comps</xpath>
 		<value>
@@ -311,7 +311,7 @@
 			</li>
 		</value>
 	</Operation>
-  
+
 	<!-- ===== Mechanoid Gremlin ===== -->
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="RM_Mech_Gremlin"]</xpath>
@@ -398,7 +398,7 @@
 		</value>
 	</Operation>
 
-  <Operation Class="PatchOperationAdd">
+	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RM_Mech_Gremlin"]/comps</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
@@ -419,7 +419,7 @@
 			</li>
 		</value>
 	</Operation>
-  
+
 	<!-- ===== Mechanoid Harpy ===== -->
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="RM_Mech_Harpy"]</xpath>
@@ -499,7 +499,7 @@
 		</value>
 	</Operation>
 
-  <Operation Class="PatchOperationConditional">
+	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="RM_Mech_Harpy"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="RM_Mech_Harpy"]</xpath>
@@ -508,7 +508,7 @@
 			</value>
 		</nomatch>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RM_Mech_Harpy"]/comps</xpath>
 		<value>
@@ -530,7 +530,7 @@
 			</li>
 		</value>
 	</Operation>
-  
+
 	<!-- ===== Mechanoid Ranger ===== -->
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="RM_Mech_Ranger"]</xpath>
@@ -610,7 +610,7 @@
 		</value>
 	</Operation>
 
-  <Operation Class="PatchOperationConditional">
+	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="RM_Mech_Ranger"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="RM_Mech_Ranger"]</xpath>
@@ -619,7 +619,7 @@
 			</value>
 		</nomatch>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RM_Mech_Ranger"]/comps</xpath>
 		<value>
@@ -641,7 +641,7 @@
 			</li>
 		</value>
 	</Operation>
-  
+
 	<!-- ===== Mechanoid Zealot ===== -->
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="RM_Mech_Zealot"]</xpath>
@@ -721,7 +721,7 @@
 		</value>
 	</Operation>
 
-  <Operation Class="PatchOperationConditional">
+	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="RM_Mech_Zealot"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="RM_Mech_Zealot"]</xpath>
@@ -730,7 +730,7 @@
 			</value>
 		</nomatch>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RM_Mech_Zealot"]/comps</xpath>
 		<value>
@@ -752,7 +752,7 @@
 			</li>
 		</value>
 	</Operation>
-  
+
 	<!-- ===== Mechanoid Marshal ===== -->
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="RM_Mech_Marshal"]</xpath>
@@ -773,6 +773,7 @@
 			<MeleeDodgeChance>0.11</MeleeDodgeChance>
 			<MeleeCritChance>0.12</MeleeCritChance>
 			<MeleeParryChance>0.09</MeleeParryChance>
+			<MeleeHitChance>6</MeleeHitChance>
 			<MaxHitPoints>200</MaxHitPoints>
 		</value>
 	</Operation>
@@ -871,7 +872,7 @@
 		</value>
 	</Operation>
 
-  <Operation Class="PatchOperationConditional">
+	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="RM_Mech_Marshal"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="RM_Mech_Marshal"]</xpath>
@@ -880,7 +881,7 @@
 			</value>
 		</nomatch>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RM_Mech_Marshal"]/comps</xpath>
 		<value>
@@ -902,7 +903,7 @@
 			</li>
 		</value>
 	</Operation>
-  
+
 	<!-- ===== Mechanoid Sentinel ===== -->
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="RM_Mech_Sentinel"]</xpath>
@@ -995,7 +996,7 @@
 		</value>
 	</Operation>
 
-  <Operation Class="PatchOperationConditional">
+	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="RM_Mech_Sentinel"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="RM_Mech_Sentinel"]</xpath>
@@ -1004,7 +1005,7 @@
 			</value>
 		</nomatch>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RM_Mech_Sentinel"]/comps</xpath>
 		<value>
@@ -1026,7 +1027,7 @@
 			</li>
 		</value>
 	</Operation>
-  
+
 	<!-- ===== Mechanoid Behemoth ===== -->
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="RM_Mech_Behemoth"]</xpath>
@@ -1108,7 +1109,7 @@
 		</value>
 	</Operation>
 
-  <Operation Class="PatchOperationConditional">
+	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="RM_Mech_Behemoth"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="RM_Mech_Behemoth"]</xpath>
@@ -1117,7 +1118,7 @@
 			</value>
 		</nomatch>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RM_Mech_Behemoth"]/comps</xpath>
 		<value>
@@ -1139,7 +1140,7 @@
 			</li>
 		</value>
 	</Operation>
-  
+
 	<!-- ===== Mechanoid Wraith ===== -->
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="RM_Mech_Wraith"]</xpath>
@@ -1197,7 +1198,7 @@
 		</value>
 	</Operation>
 
-  <Operation Class="PatchOperationConditional">
+	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="RM_Mech_Wraith"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="RM_Mech_Wraith"]</xpath>
@@ -1206,7 +1207,7 @@
 			</value>
 		</nomatch>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RM_Mech_Wraith"]/comps</xpath>
 		<value>
@@ -1286,7 +1287,7 @@
 		</value>
 	</Operation>
 
-  <Operation Class="PatchOperationConditional">
+	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="RM_Mech_Locust"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="RM_Mech_Locust"]</xpath>
@@ -1295,7 +1296,7 @@
 			</value>
 		</nomatch>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RM_Mech_Locust"]/comps</xpath>
 		<value>
@@ -1317,9 +1318,9 @@
 			</li>
 		</value>
 	</Operation>
-  
+
 	<!-- Matriach -->
-	
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RM_Mech_Matriarch"]/statBases</xpath>
 		<value>
@@ -1397,7 +1398,7 @@
 		</value>
 	</Operation>
 
-  <Operation Class="PatchOperationConditional">
+	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="RM_Mech_Matriarch"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="RM_Mech_Matriarch"]</xpath>
@@ -1406,7 +1407,7 @@
 			</value>
 		</nomatch>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="RM_Mech_Matriarch"]/comps</xpath>
 		<value>
@@ -1428,5 +1429,5 @@
 			</li>
 		</value>
 	</Operation>
-  
+
 </Patch>

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Races/Race_Bion.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Races/Race_Bion.xml
@@ -9,7 +9,7 @@
 			</li>
 		</value>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[@Name="BaseBion"]</xpath>
 		<value>
@@ -69,7 +69,7 @@
 			<ArmorRating_Heat>1.40</ArmorRating_Heat>
 		</value>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="Bion_Base"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -79,7 +79,7 @@
 			</value>
 		</nomatch>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Bion_Base"]/comps</xpath>
 		<value>
@@ -95,7 +95,7 @@
 			</li>
 		</value>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="Bion_Stalker"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -105,7 +105,7 @@
 			</value>
 		</nomatch>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Bion_Stalker"]/comps</xpath>
 		<value>
@@ -132,10 +132,11 @@
 			<MeleeDodgeChance>0.15</MeleeDodgeChance>
 			<MeleeCritChance>0.15</MeleeCritChance>
 			<MeleeParryChance>0.1</MeleeParryChance>
+			<MeleeHitChance>6</MeleeHitChance>
 			<SmokeSensitivity>0</SmokeSensitivity>
 		</value>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Bion_Stalker"]/statBases</xpath>
 		<value>
@@ -146,6 +147,7 @@
 			<MeleeDodgeChance>0.20</MeleeDodgeChance>
 			<MeleeCritChance>0.15</MeleeCritChance>
 			<MeleeParryChance>0.1</MeleeParryChance>
+			<MeleeHitChance>6</MeleeHitChance>
 			<SmokeSensitivity>0</SmokeSensitivity>
 		</value>
 	</Operation>
@@ -212,7 +214,7 @@
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[@Name="BaseBion"]</xpath>
 			<value>
-				<comps/>
+				<comps />
 			</value>
 		</nomatch>
 	</Operation>

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Races/Race_Bion.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Races/Race_Bion.xml
@@ -132,7 +132,7 @@
 			<MeleeDodgeChance>0.15</MeleeDodgeChance>
 			<MeleeCritChance>0.15</MeleeCritChance>
 			<MeleeParryChance>0.1</MeleeParryChance>
-			<MeleeHitChance>6</MeleeHitChance>
+			<MeleeHitChance>3</MeleeHitChance>
 			<SmokeSensitivity>0</SmokeSensitivity>
 		</value>
 	</Operation>
@@ -147,7 +147,7 @@
 			<MeleeDodgeChance>0.20</MeleeDodgeChance>
 			<MeleeCritChance>0.15</MeleeCritChance>
 			<MeleeParryChance>0.1</MeleeParryChance>
-			<MeleeHitChance>6</MeleeHitChance>
+			<MeleeHitChance>3</MeleeHitChance>
 			<SmokeSensitivity>0</SmokeSensitivity>
 		</value>
 	</Operation>

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Races/Race_FederatorMech.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Races/Race_FederatorMech.xml
@@ -9,7 +9,7 @@
 			</li>
 		</value>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mech_Federator"]/race/baseHealthScale</xpath>
 		<value>
@@ -48,12 +48,13 @@
 			<MeleeDodgeChance>0.05</MeleeDodgeChance>
 			<MeleeCritChance>0.4</MeleeCritChance>
 			<MeleeParryChance>0.3</MeleeParryChance>
+			<MeleeHitChance>6</MeleeHitChance>
 			<SmokeSensitivity>0</SmokeSensitivity>
 			<NightVisionEfficiency>0.80</NightVisionEfficiency>
 			<MeleeHitChance>1.5</MeleeHitChance>
 		</value>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="Mech_Federator"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -63,7 +64,7 @@
 			</value>
 		</nomatch>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Mech_Federator"]/comps</xpath>
 		<value>
@@ -79,7 +80,7 @@
 			</li>
 		</value>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="Mech_Federator"]</xpath>
 		<value>
@@ -160,7 +161,7 @@
 			</tools>
 		</value>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/PawnKindDef[@Name="BaseMechKind"]/ignoresPainShock</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -170,4 +171,5 @@
 			</value>
 		</nomatch>
 	</Operation>
+
 </Patch>

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Races/Race_FederatorMech.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Races/Race_FederatorMech.xml
@@ -48,10 +48,9 @@
 			<MeleeDodgeChance>0.05</MeleeDodgeChance>
 			<MeleeCritChance>0.4</MeleeCritChance>
 			<MeleeParryChance>0.3</MeleeParryChance>
-			<MeleeHitChance>6</MeleeHitChance>
+			<MeleeHitChance>3</MeleeHitChance>
 			<SmokeSensitivity>0</SmokeSensitivity>
 			<NightVisionEfficiency>0.80</NightVisionEfficiency>
-			<MeleeHitChance>1.5</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Races/Race_Hulk.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Races/Race_Hulk.xml
@@ -41,11 +41,12 @@
 			<MeleeDodgeChance>0.10</MeleeDodgeChance>
 			<MeleeCritChance>0.2</MeleeCritChance>
 			<MeleeParryChance>0.10</MeleeParryChance>
+			<MeleeHitChance>6</MeleeHitChance>
 			<SmokeSensitivity>0</SmokeSensitivity>
 			<NightVisionEfficiency>0.80</NightVisionEfficiency>
 		</value>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="Bion_Hulk"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -55,7 +56,7 @@
 			</value>
 		</nomatch>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Bion_Hulk"]/comps</xpath>
 		<value>

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Races/Race_Hulk.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Races/Race_Hulk.xml
@@ -41,7 +41,7 @@
 			<MeleeDodgeChance>0.10</MeleeDodgeChance>
 			<MeleeCritChance>0.2</MeleeCritChance>
 			<MeleeParryChance>0.10</MeleeParryChance>
-			<MeleeHitChance>6</MeleeHitChance>
+			<MeleeHitChance>3</MeleeHitChance>
 			<SmokeSensitivity>0</SmokeSensitivity>
 			<NightVisionEfficiency>0.80</NightVisionEfficiency>
 		</value>

--- a/ModPatches/Rimsenal Feral/Patches/Rimsenal Feral/ThingDefs_Races/Race_Ogrons.xml
+++ b/ModPatches/Rimsenal Feral/Patches/Rimsenal Feral/ThingDefs_Races/Race_Ogrons.xml
@@ -20,6 +20,7 @@
 			<MeleeDodgeChance>0.02</MeleeDodgeChance>
 			<MeleeCritChance>0.15</MeleeCritChance>
 			<MeleeParryChance>0.35</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 			<SmokeSensitivity>0.1</SmokeSensitivity>
 		</value>
 	</Operation>
@@ -37,7 +38,7 @@
 			<ArmorRating_Blunt>12</ArmorRating_Blunt>
 		</value>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="Mutant_Ogron"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -47,7 +48,7 @@
 			</value>
 		</nomatch>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Mutant_Ogron"]/comps</xpath>
 		<value>
@@ -60,7 +61,7 @@
 			</li>
 		</value>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="Mutant_Ogron"]</xpath>
 		<value>

--- a/ModPatches/Rimsenal Feral/Patches/Rimsenal Feral/ThingDefs_Races/Race_Razortooth.xml
+++ b/ModPatches/Rimsenal Feral/Patches/Rimsenal Feral/ThingDefs_Races/Race_Razortooth.xml
@@ -19,10 +19,11 @@
 			<MeleeDodgeChance>0.25</MeleeDodgeChance>
 			<MeleeCritChance>0.18</MeleeCritChance>
 			<MeleeParryChance>0.05</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 			<SmokeSensitivity>0.4</SmokeSensitivity>
 		</value>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="Mutant_Razortooth"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -32,7 +33,7 @@
 			</value>
 		</nomatch>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Mutant_Razortooth"]/comps</xpath>
 		<value>
@@ -45,7 +46,7 @@
 			</li>
 		</value>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="Mutant_Razortooth"]</xpath>
 		<value>

--- a/ModPatches/Robotic Servitude/Patches/ThingDefs_Races/Races_Mechanoid.xml
+++ b/ModPatches/Robotic Servitude/Patches/ThingDefs_Races/Races_Mechanoid.xml
@@ -188,6 +188,7 @@
 			<MeleeDodgeChance>0.17</MeleeDodgeChance>
 			<MeleeCritChance>0.17</MeleeCritChance>
 			<MeleeParryChance>0.09</MeleeParryChance>
+			<MeleeHitChance>6</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Vanilla Animals Expanded/Patches/Vanilla Animals Expanded/AridShrubland_Animals.xml
+++ b/ModPatches/Vanilla Animals Expanded/Patches/Vanilla Animals Expanded/AridShrubland_Animals.xml
@@ -8,6 +8,7 @@
 			<MeleeDodgeChance>0.46</MeleeDodgeChance>
 			<MeleeCritChance>0.27</MeleeCritChance>
 			<MeleeParryChance>0.09</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Vanilla Animals Expanded/Patches/Vanilla Animals Expanded/Desert_Animals.xml
+++ b/ModPatches/Vanilla Animals Expanded/Patches/Vanilla Animals Expanded/Desert_Animals.xml
@@ -226,6 +226,7 @@
 			<MeleeDodgeChance>0.19</MeleeDodgeChance>
 			<MeleeCritChance>0.18</MeleeCritChance>
 			<MeleeParryChance>0.17</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Vanilla Animals Expanded/Patches/Vanilla Animals Expanded/TropicalRainforest_Animals.xml
+++ b/ModPatches/Vanilla Animals Expanded/Patches/Vanilla Animals Expanded/TropicalRainforest_Animals.xml
@@ -107,6 +107,7 @@
 			<MeleeDodgeChance>0.26</MeleeDodgeChance>
 			<MeleeCritChance>0.20</MeleeCritChance>
 			<MeleeParryChance>0.07</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 
@@ -280,6 +281,7 @@
 			<MeleeDodgeChance>0.27</MeleeDodgeChance>
 			<MeleeCritChance>0.50</MeleeCritChance>
 			<MeleeParryChance>0.15</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_AcidSpitter.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_AcidSpitter.xml
@@ -8,6 +8,7 @@
 			<MeleeDodgeChance>0.09</MeleeDodgeChance>
 			<MeleeCritChance>0.41</MeleeCritChance>
 			<MeleeParryChance>0.38</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Durapod.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Durapod.xml
@@ -8,6 +8,7 @@
 			<MeleeDodgeChance>0.08</MeleeDodgeChance>
 			<MeleeCritChance>0.12</MeleeCritChance>
 			<MeleeParryChance>0.09</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Fuelmite.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Fuelmite.xml
@@ -8,6 +8,7 @@
 			<MeleeDodgeChance>0.09</MeleeDodgeChance>
 			<MeleeCritChance>0.40</MeleeCritChance>
 			<MeleeParryChance>0.17</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Gigalocust.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Gigalocust.xml
@@ -9,6 +9,7 @@
 			<MeleeDodgeChance>0.07</MeleeDodgeChance>
 			<MeleeCritChance>0.41</MeleeCritChance>
 			<MeleeParryChance>0.19</MeleeParryChance>
+			<MeleeHitChance>4</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Hellbeetle.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Hellbeetle.xml
@@ -8,6 +8,7 @@
 			<MeleeDodgeChance>0.02</MeleeDodgeChance>
 			<MeleeCritChance>0.18</MeleeCritChance>
 			<MeleeParryChance>0.26</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Ironclad.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Ironclad.xml
@@ -9,6 +9,7 @@
 			<MeleeDodgeChance>0.03</MeleeDodgeChance>
 			<MeleeCritChance>0.26</MeleeCritChance>
 			<MeleeParryChance>0.38</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Macrofly.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Macrofly.xml
@@ -8,6 +8,7 @@
 			<MeleeDodgeChance>0.05</MeleeDodgeChance>
 			<MeleeCritChance>0.15</MeleeCritChance>
 			<MeleeParryChance>0.1</MeleeParryChance>
+			<MeleeHitChance>4</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Megapede.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Megapede.xml
@@ -9,6 +9,7 @@
 			<MeleeDodgeChance>0.03</MeleeDodgeChance>
 			<MeleeCritChance>0.36</MeleeCritChance>
 			<MeleeParryChance>0.38</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Megawasp.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Megawasp.xml
@@ -8,6 +8,7 @@
 			<MeleeDodgeChance>0.05</MeleeDodgeChance>
 			<MeleeCritChance>0.27</MeleeCritChance>
 			<MeleeParryChance>0.17</MeleeParryChance>
+			<MeleeHitChance>4</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_RoyalMegascarab.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_RoyalMegascarab.xml
@@ -8,6 +8,7 @@
 			<MeleeDodgeChance>0.08</MeleeDodgeChance>
 			<MeleeCritChance>0.12</MeleeCritChance>
 			<MeleeParryChance>0.09</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_RoyalMegaspider.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_RoyalMegaspider.xml
@@ -9,6 +9,7 @@
 			<MeleeDodgeChance>0.03</MeleeDodgeChance>
 			<MeleeCritChance>0.36</MeleeCritChance>
 			<MeleeParryChance>0.38</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_RoyalSpelopede.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_RoyalSpelopede.xml
@@ -8,6 +8,7 @@
 			<MeleeDodgeChance>0.07</MeleeDodgeChance>
 			<MeleeCritChance>0.31</MeleeCritChance>
 			<MeleeParryChance>0.17</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Tankroach.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Tankroach.xml
@@ -8,6 +8,7 @@
 			<MeleeDodgeChance>0.06</MeleeDodgeChance>
 			<MeleeCritChance>0.1</MeleeCritChance>
 			<MeleeParryChance>0.09</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Teramantis.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Teramantis.xml
@@ -9,6 +9,7 @@
 			<MeleeDodgeChance>0.07</MeleeDodgeChance>
 			<MeleeCritChance>0.55</MeleeCritChance>
 			<MeleeParryChance>0.44</MeleeParryChance>
+			<MeleeHitChance>6</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Venomite.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Venomite.xml
@@ -8,6 +8,7 @@
 			<MeleeDodgeChance>0.07</MeleeDodgeChance>
 			<MeleeCritChance>0.21</MeleeCritChance>
 			<MeleeParryChance>0.19</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
+++ b/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
@@ -176,6 +176,23 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedScyther"]/statBases</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedScyther"]</xpath>
+			<value>
+				<statBases />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedScyther"]/statBases</xpath>
+		<value>
+			<MeleeHitChance>7</MeleeHitChance>
+		</value>
+	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedScyther"]/tools</xpath>
 		<value>

--- a/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid_PlayerControlled.xml
+++ b/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid_PlayerControlled.xml
@@ -112,6 +112,7 @@
 						<MeleeDodgeChance>0.15</MeleeDodgeChance>
 						<MeleeCritChance>0.14</MeleeCritChance>
 						<MeleeParryChance>0.09</MeleeParryChance>
+						<MeleeHitChance>7</MeleeHitChance>
 						<MaxHitPoints>200</MaxHitPoints>
 					</value>
 				</li>

--- a/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -191,6 +191,23 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="VFE_Mech_Scyther"]/statBases</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="VFE_Mech_Scyther"]</xpath>
+			<value>
+				<statBases />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="VFE_Mech_Scyther"]/statBases</xpath>
+		<value>
+			<MeleeHitChance>6</MeleeHitChance>
+		</value>
+	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="VFE_Mech_Scyther"]/tools</xpath>
 		<value>

--- a/ModPatches/Vanilla Ideology Expanded - Dryads/Patches/Vanilla Ideology Expanded - Dryads/ThingDefs_Races/Races_Animal_AwakenedDryads.xml
+++ b/ModPatches/Vanilla Ideology Expanded - Dryads/Patches/Vanilla Ideology Expanded - Dryads/ThingDefs_Races/Races_Animal_AwakenedDryads.xml
@@ -132,6 +132,7 @@
 			<MeleeDodgeChance>0.8</MeleeDodgeChance>
 			<MeleeCritChance>0.45</MeleeCritChance>
 			<MeleeParryChance>0.50</MeleeParryChance>
+			<MeleeHitChance>6</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Races/Races_Animal_BigCat.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_BigCat.xml
@@ -18,6 +18,7 @@
 			<MeleeDodgeChance>0.19</MeleeDodgeChance>
 			<MeleeCritChance>0.08</MeleeCritChance>
 			<MeleeParryChance>0.07</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 
@@ -137,6 +138,7 @@
 			<MeleeDodgeChance>0.21</MeleeDodgeChance>
 			<MeleeCritChance>0.05</MeleeCritChance>
 			<MeleeParryChance>0.04</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Insect.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Insect.xml
@@ -121,6 +121,7 @@
 			<MeleeDodgeChance>0.08</MeleeDodgeChance>
 			<MeleeCritChance>0.12</MeleeCritChance>
 			<MeleeParryChance>0.09</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 
@@ -211,6 +212,7 @@
 			<MeleeDodgeChance>0.07</MeleeDodgeChance>
 			<MeleeCritChance>0.31</MeleeCritChance>
 			<MeleeParryChance>0.17</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Races/Races_Animal_WildCanines.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_WildCanines.xml
@@ -27,6 +27,7 @@
 			<MeleeDodgeChance>0.23</MeleeDodgeChance>
 			<MeleeCritChance>0.20</MeleeCritChance>
 			<MeleeParryChance>0.11</MeleeParryChance>
+			<MeleeHitChance>3</MeleeHitChance>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
@@ -260,6 +260,23 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="Mech_Scyther"]/statBases</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Mech_Scyther"]</xpath>
+			<value>
+				<statBases />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Mech_Scyther"]/statBases</xpath>
+		<value>
+			<MeleeHitChance>6</MeleeHitChance>
+		</value>
+	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mech_Scyther"]/tools</xpath>
 		<value>


### PR DESCRIPTION
## Changes

- What it says on the tin, A minor increase to non-mech melee hit chance and a ~13+ melee hit chance increase for melee mechs.

## Reasoning

- With the systems in place for CE to avoid melee hits and how melee hits generally tend to miss most of the time, it's necessary to increase the base 80% melee hit chance of pawns with no melee skill.
- The base 6 melee hit chance increases the 80% base value to 93% and 3 is in the middle.
- Only prominent melee fighters have received the buff, being melee mechs like Scythers and animals like Wargs and insectoids, and also not very big melee pawns because it makes sense for their attacks to be more easily avoidable,

## Alternatives

- Miss!

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Nice to see scythers that don't whiff all the time)
