### PR TITLE
57mm Bofors recipe typo fix

### DIFF
--- a/Defs/Ammo/Shell/57x438mmBofors.xml
+++ b/Defs/Ammo/Shell/57x438mmBofors.xml
@@ -186,8 +186,8 @@
 
 	<RecipeDef ParentName="CannonAmmoRecipeBase">
 		<defName>MakeAmmo_57x438mmBofors_AP</defName>
-		<label>make 57x438mm Bofors (AP) cartridge x25</label>
-		<description>Craft 25 57x438mm Bofors (AP) cartridges.</description>
+		<label>make 57x438mm Bofors (AP) cartridge x10</label>
+		<description>Craft 10 57x438mm Bofors (AP) cartridges.</description>
 		<jobString>Making 57x438mm Bofors (AP) cartridges.</jobString>
 		<workAmount>14640</workAmount>
 		<ingredients>
@@ -212,8 +212,8 @@
 
 	<RecipeDef ParentName="CannonAmmoRecipeBase">
 		<defName>MakeAmmo_57x438mmBofors_HE</defName>
-		<label>make 57x438mm Bofors (HE) cartridge x25</label>
-		<description>Craft 25 57x438mm Bofors (HE) cartridges.</description>
+		<label>make 57x438mm Bofors (HE) cartridge x10</label>
+		<description>Craft 10 57x438mm Bofors (HE) cartridges.</description>
 		<jobString>Making 57x438mm Bofors (HE) cartridges.</jobString>
 		<workAmount>17800</workAmount>
 		<ingredients>
@@ -256,8 +256,8 @@
 
 	<RecipeDef ParentName="CannonAmmoRecipeBase">
 		<defName>MakeAmmo_57x438mmBofors_HE_TFuzed</defName>
-		<label>make 57x438mm Bofors (Time-Fuzed) cartridge x25</label>
-		<description>Craft 25 57x438mm Bofors (Time-Fuzed) cartridges.</description>
+		<label>make 57x438mm Bofors (Time-Fuzed) cartridge x10</label>
+		<description>Craft 10 57x438mm Bofors (Time-Fuzed) cartridges.</description>
 		<jobString>Making 57x438mm Bofors (Time-Fuzed) cartridges.</jobString>
 		<researchPrerequisite Inherit="False" />
 		<researchPrerequisites>
@@ -305,8 +305,8 @@
 
 	<RecipeDef ParentName="CannonAmmoRecipeBase">
 		<defName>MakeAmmo_57x438mmBofors_Sabot</defName>
-		<label>make 57x438mm Bofors (Sabot) cartridge x25</label>
-		<description>Craft 25 57x438mm Bofors (Sabot) cartridges.</description>
+		<label>make 57x438mm Bofors (Sabot) cartridge x10</label>
+		<description>Craft 10 57x438mm Bofors (Sabot) cartridges.</description>
 		<jobString>Making 57x438mm Bofors (Sabot) cartridges.</jobString>
 		<researchPrerequisite Inherit="False" />
 		<researchPrerequisites>


### PR DESCRIPTION
## Changes

- A simple fix to recipe labels and descriptions, should be x10 instead of 25.