### PR TITLE
Fix race condition in AmmoInjector

### DIFF
--- a/Source/CombatExtended/CombatExtended/AmmoGeneralizer.cs
+++ b/Source/CombatExtended/CombatExtended/AmmoGeneralizer.cs
@@ -171,6 +171,7 @@ namespace CombatExtended
                         def.jobString = ext.genericJobString;
                     }
                 }
+                Log.Message("Combat Extended :: Generalizer enabled");
             }
         }
     }

--- a/Source/CombatExtended/CombatExtended/AmmoInjector.cs
+++ b/Source/CombatExtended/CombatExtended/AmmoInjector.cs
@@ -19,7 +19,6 @@ namespace CombatExtended
      *
      * Call Inject() on game start and whenever ammo system setting is changed.
      */
-    [StaticConstructorOnStartup]
     public static class AmmoInjector
     {
 
@@ -40,12 +39,6 @@ namespace CombatExtended
         }
         */
 
-        static AmmoInjector()
-        {
-            Inject();
-            AddRemoveCaliberFromGunRecipes();
-        }
-
         public static void Inject()
         {
             if (InjectAmmos())
@@ -57,6 +50,7 @@ namespace CombatExtended
                 Log.Error("Combat Extended :: Ammo injector failed to get injected");
             }
             ThingSetMakerUtility.Reset();   // Reset pool of spawnable ammos for quests, etc.
+            AddRemoveCaliberFromGunRecipes();
         }
 
         public static bool InjectAmmos()


### PR DESCRIPTION
## Changes

- Changed ammoInjector to no longer use a SCOS and only inject ammo with a LongEvent.
- Added a log to generalizer to more easily check execution order.

## Reasoning

- SCOS was initializing the class earlier than the LongEvent, which led to injection running twice, once in the constructor, and once in said LongEvent.
- Builds made with the github actions were causing that SCOS to run before the generalizer, causing non-generic hyperlinks to appear in descriptions.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
