### PR TITLE
Add missing nouns to stuff category defs

### DIFF
--- a/Defs/StuffCategoryDefs/StuffCategories.xml
+++ b/Defs/StuffCategoryDefs/StuffCategories.xml
@@ -4,16 +4,19 @@
 	<StuffCategoryDef>
 		<defName>Steeled</defName>
 		<label>steeled</label>
+    <noun>steeled</noun>
 	</StuffCategoryDef>
 
 	<StuffCategoryDef>
 		<defName>Metallic_Weapon</defName>
 		<label>metallic</label>
+    <noun>metallic</noun>
 	</StuffCategoryDef>
 
 	<StuffCategoryDef>
 		<defName>SoftArmor</defName>
 		<label>soft armor</label>
+    <noun>soft armor</noun>
 	</StuffCategoryDef>
 
 </Defs>


### PR DESCRIPTION
## Additions

Added missing nouns for stuff category defs.

## Reasoning

Fixes this:
![image](https://github.com/user-attachments/assets/23d638c2-b700-4dc1-968a-817b4cc1d4ec)
Noun is used to represent stuffable categories in most contexts, not the label.
![image](https://github.com/user-attachments/assets/39a8c55d-b4c0-4079-88c0-1c8e25d779c0)

## Testing

Check tests you have performed:
- [ ] Compiles without warnings - This change does not require a recompile
- [X] Game runs without errors
- [X] Playtested a colony (specify how long) - Like five minutes to take the above screenshots.