### PR TITLE
Increase penalty for firing through smoke

### DIFF
--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -57,6 +57,8 @@ namespace CombatExtended
         protected bool repeating = false;
         protected bool doRetarget = true;
 
+        protected const float smokePenaltyMultiplier = 4f; //increases penalty for shooting through smoke 
+
         #endregion
 
         #region Properties
@@ -734,6 +736,8 @@ namespace CombatExtended
                 if (cell.AnyGas(map, GasType.BlindSmoke))
                 {
                     smokeDensity += GasUtility.BlindingGasAccuracyPenalty;
+                    //increase the hardcoded vanilla blind smoke penalty
+                    smokeDensity += GasUtility.BlindingGasAccuracyPenalty * smokePenaltyMultiplier;
                 }
                 if (!roofed)
                 {

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -735,7 +735,6 @@ namespace CombatExtended
                 // TODO 1.4: Figure out how the new hardcoded gas system will work for our smoke and custom gases
                 if (cell.AnyGas(map, GasType.BlindSmoke))
                 {
-                    smokeDensity += GasUtility.BlindingGasAccuracyPenalty;
                     //increase the hardcoded vanilla blind smoke penalty
                     smokeDensity += GasUtility.BlindingGasAccuracyPenalty * smokePenaltyMultiplier;
                 }


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased penalty for shooting through smoke to 4x, buffing smoke grenades as defensive tools

## Reasoning

Why did you choose to implement things this way, e.g.
- Guns in CE are much more accurate than vanilla, so keeping vanilla debuffs from smoke is not enough to adequately protect those who hide in it. So, most veteran players tend to ignore smoke grenades (and especially 81mm smoke), aside from countering turrets.
- 4x is an eyeballed value, tested on centepede blasters to make them miss roughly 2/3 of bursts on short-medium ranges

## Alternatives

Describe alternative implementations you have considered, e.g.
- Implement thermal vision stat that helps see through smoke. Allows countering smoke if it becomes too good and makes certain guns and apparel more interesting.
- Give advanced NV goggles thermal vision to make them an alternative to wearing PA helments. Give charge sniper rifle thermals to give it an extra edge over charge lmgs in accuracy. Expands on rock-papers-scissors mechanics by making smoke a powerful defense tool, but allowing specific enemies to ignore it. Can synergise with enemies that wear smokepop belts and thermal goggles.
- retexture blind smoke to be more opaque to represent improved defense
- make black smoke harm accuracy and possibly make it block thermal vision.
- move the multiplier variable to some other class? Or harmony patch the original value instead of multiplying it here.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] test balance for different enemies.
- [ ] Playtested a colony (specify how long)
