### PR TITLE
Fix linebreak typo

### DIFF
--- a/Defs/Ammo/Other/Flamethrower.xml
+++ b/Defs/Ammo/Other/Flamethrower.xml
@@ -65,7 +65,7 @@
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="FlamethrowerBase">
 		<defName>Ammo_Flamethrower_Prometheum</defName>
 		<label>jellied prometheum</label>
-		<description>Fuel for a flamethrower./n/This mixture applies a sticky coating of extremely flammable prometheum to target.</description>
+		<description>Fuel for a flamethrower.\n\nThis mixture applies a sticky coating of extremely flammable prometheum to target.</description>
 		<graphicData>
 			<texPath>Things/Ammo/FuelTank/Prometheum</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -88,7 +88,7 @@
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="FlamethrowerBase" MayRequire="Ludeon.Rimworld.Anomaly">
 		<defName>Ammo_Flamethrower_Bioferrite</defName>
 		<label>infused chemfuel</label>
-		<description>Fuel for a flamethrower that burns at incredibly high temperature, leaving behind no puddles of fuel./n/An infusion of crystalline bioferrite attacks organic matter on a cellular level, disrupting regeneration and weakening tissue.</description>	
+		<description>Fuel for a flamethrower that burns at incredibly high temperature, leaving behind no puddles of fuel.\n\nAn infusion of crystalline bioferrite attacks organic matter on a cellular level, disrupting regeneration and weakening tissue.</description>	
 		<graphicData>
 			<texPath>Things/Ammo/FuelTank/Bioferrite</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>

--- a/Languages/ChineseSimplified/DefInjected/ThingDef/Flamethrower.xml
+++ b/Languages/ChineseSimplified/DefInjected/ThingDef/Flamethrower.xml
@@ -3,8 +3,8 @@
 	
 	<!-- EN: infused chemfuel -->
 	<Ammo_Flamethrower_Bioferrite.label>火焰喷射器燃料 (活铁)</Ammo_Flamethrower_Bioferrite.label>
-	<!-- EN: Fuel for a flamethrower that burns at incredibly high temperature, leaving behind no puddles of fuel./n/An infusion of crystalline bioferrite attacks organic matter on a cellular level, disrupting regeneration and weakening tissue. -->
-	<Ammo_Flamethrower_Bioferrite.description>一种用于火焰喷射器的燃料，燃烧时温度极高，并且不会留下任何燃料残余。/n/含有活铁的浸渍物质能够在细胞层面攻击有机物，干扰再生并削弱组织。</Ammo_Flamethrower_Bioferrite.description>
+	<!-- EN: Fuel for a flamethrower that burns at incredibly high temperature, leaving behind no puddles of fuel.\n\nAn infusion of crystalline bioferrite attacks organic matter on a cellular level, disrupting regeneration and weakening tissue. -->
+	<Ammo_Flamethrower_Bioferrite.description>一种用于火焰喷射器的燃料，燃烧时温度极高，并且不会留下任何燃料残余。\n\n含有活铁的浸渍物质能够在细胞层面攻击有机物，干扰再生并削弱组织。</Ammo_Flamethrower_Bioferrite.description>
 	
 	<!-- EN: jellied chemfuel -->
 	<Ammo_Flamethrower_Napalm.label>火焰喷射器燃料 (凝胶化合燃料)</Ammo_Flamethrower_Napalm.label>
@@ -13,7 +13,7 @@
 	
 	<!-- EN: jellied prometheum -->
 	<Ammo_Flamethrower_Prometheum.label>火焰喷射器燃料 (苯基液体燃料)</Ammo_Flamethrower_Prometheum.label>
-	<!-- EN: Fuel for a flamethrower./n/This mixture applies a sticky coating of extremely flammable prometheum to target. -->
+	<!-- EN: Fuel for a flamethrower.\n\nThis mixture applies a sticky coating of extremely flammable prometheum to target. -->
 	<Ammo_Flamethrower_Prometheum.description>火焰喷射器使用的燃油。</Ammo_Flamethrower_Prometheum.description>
 	
 	<!-- EN: infused chemfuel stream -->


### PR DESCRIPTION
## Changes
- Fix a typo in the flamethrower description that causes a malformed linebreak.

## Reasoning
- Noticed it in MysteriousFawx's video, and will not be able to sleep if I don't fix it.
  - Seriously, it's been like that for months! How has nobody pointed it out?

## Alternatives
- Shame and insanity.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
