### PR TITLE
Patch Update for Evolved Organs Redux - author removed def

### DIFF
--- a/ModPatches/EvolvedOrgansRedux/Patches/EvolvedOrgansRedux/Brain_Evo_CE.xml
+++ b/ModPatches/EvolvedOrgansRedux/Patches/EvolvedOrgansRedux/Brain_Evo_CE.xml
@@ -14,18 +14,4 @@
 			</statOffsets>
 		</value>
 	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/HediffDef[defName="EVOR_Hediff_Brain_ReptilianFrontalCortex"]/stages/li[1]/statOffsets/MeleeDodgeChance</xpath>
-		<value>
-			<MeleeDodgeChance>0.12</MeleeDodgeChance>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/HediffDef[defName="EVOR_Hediff_Brain_ReptilianFrontalCortex"]/stages/li[1]/statOffsets/MeleeHitChance</xpath>
-		<value>
-			<MeleeHitChance>0.5</MeleeHitChance>
-		</value>
-	</Operation>
 </Patch>


### PR DESCRIPTION
## Changes

EVOR_Hediff_Brain_ReptilianFrontalCortex patches removed, as def is commented out in Steam release

## References

https://discord.com/channels/278818534069501953/324222101550661663/1334461968303652924

## Reasoning

Prevents Patch errors

## Alternatives

Could comment it out instead, in case mod author re-implements the hediff

## Testing

Check tests you have performed:
- [ X ] Compiles without warnings
- [ X ] Game runs without errors
- [ X ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
