### PR TITLE
Patch Grimworld - Scattered Sons

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -215,6 +215,7 @@
 		<li IfModActive="Grimworld.Vehicles">ModPatches/GrimWorld Imperial Vehicles</li>
 		<li IfModActive="Grimworld.Lasguns">ModPatches/Grimworld Lasguns</li>
 		<li IfModActive="Grimworld.Melee">ModPatches/Grimworld Melee</li>
+		<li IfModActive="grimworld.scatteredsons">ModPatches/GrimWorld Scattered Sons</li>		
 		<li IfModActive="grimworld.talonOfTheEmperor">ModPatches/GrimWorld Talons of the Emperor</li>
 		<li IfModActive="TenMoe.GFCL">ModPatches/Girls Frontline Apparel Pack</li>
 		<li IfModActive="RicoFox233.GirlsFrontline.404Team">ModPatches/Girls Frontline Styles 404 Team</li>

--- a/ModPatches/GrimWorld Scattered Sons/Patches/GrimWorld Scattered Sons/CE_Patch_Armors.xml
+++ b/ModPatches/GrimWorld Scattered Sons/Patches/GrimWorld Scattered Sons/CE_Patch_Armors.xml
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<!-- ========== Guilliman's Armor ========== -->
+
+	<!-- Armor -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="GW_SM_ChapterMasterArmor" or defName="GW_SM_GuillimanArmor"]/statBases</xpath>
+		<value>
+			<Bulk>250</Bulk>
+			<WornBulk>30</WornBulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="GW_SM_ChapterMasterArmor" or defName="GW_SM_GuillimanArmor"]</xpath>
+		<value>
+			<equippedStatOffsets>
+				<CarryWeight>140</CarryWeight>
+				<CarryBulk>110</CarryBulk>
+			</equippedStatOffsets>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GW_SM_ChapterMasterArmor" or defName="GW_SM_GuillimanArmor"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>90</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GW_SM_ChapterMasterArmor" or defName="GW_SM_GuillimanArmor"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>615</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<!-- Shoulders -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="GW_SM_ChapterMasterShoulderPads" or defName="GW_SM_GuillimanShoulderPads"]/statBases</xpath>
+		<value>
+			<Bulk>20</Bulk>
+			<WornBulk>5</WornBulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GW_SM_ChapterMasterShoulderPads" or defName="GW_SM_GuillimanShoulderPads"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>48</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GW_SM_ChapterMasterShoulderPads" or defName="GW_SM_GuillimanShoulderPads"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>65</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<!-- Backpack -->
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="GW_SM_ChapterMasterBackpack" or defName="GW_SM_GuillimanBackpack"]/statBases</xpath>
+		<value>
+			<Bulk>12</Bulk>
+			<WornBulk>8</WornBulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="GW_SM_ChapterMasterBackpack" or defName="GW_SM_GuillimanBackpack"]/equippedStatOffsets</xpath>
+		<value>
+			<CarryWeight>100</CarryWeight>
+			<CarryBulk>90</CarryBulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GW_SM_ChapterMasterBackpack" or defName="GW_SM_GuillimanBackpack"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>26</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GW_SM_ChapterMasterBackpack" or defName="GW_SM_GuillimanBackpack"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>64</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<!-- ========== Lion's Armor ========== -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="GW_SM_ImperialWardenrArmor" or defName="GW_SM_LionArmor"]/statBases</xpath>
+		<value>
+			<Bulk>250</Bulk>
+			<WornBulk>30</WornBulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="GW_SM_ImperialWardenrArmor" or defName="GW_SM_LionArmor"]</xpath>
+		<value>
+			<equippedStatOffsets>
+				<CarryWeight>140</CarryWeight>
+				<CarryBulk>110</CarryBulk>
+			</equippedStatOffsets>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GW_SM_ImperialWardenrArmor" or defName="GW_SM_LionArmor"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>90</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GW_SM_ImperialWardenrArmor" or defName="GW_SM_LionArmor"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>615</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<!-- Shoulders -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="GW_SM_ImperialWardenrShoulderPads" or defName="GW_SM_LionArmorShoulderPads"]/statBases</xpath>
+		<value>
+			<Bulk>20</Bulk>
+			<WornBulk>5</WornBulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GW_SM_ImperialWardenrShoulderPads" or defName="GW_SM_LionArmorShoulderPads"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>48</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GW_SM_ImperialWardenrShoulderPads" or defName="GW_SM_LionArmorShoulderPads"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>65</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<!-- Backpack -->
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="GW_SM_ImperialWardenrBackpack" or defName="GW_SM_LionArmorBackpack"]/statBases</xpath>
+		<value>
+			<Bulk>12</Bulk>
+			<WornBulk>8</WornBulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="GW_SM_ImperialWardenrBackpack" or defName="GW_SM_LionArmorBackpack"]/equippedStatOffsets</xpath>
+		<value>
+			<CarryWeight>100</CarryWeight>
+			<CarryBulk>90</CarryBulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GW_SM_ImperialWardenrBackpack" or defName="GW_SM_LionArmorBackpack"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>26</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GW_SM_ImperialWardenrBackpack" or defName="GW_SM_LionArmorBackpack"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>64</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/GrimWorld Scattered Sons/Patches/GrimWorld Scattered Sons/CE_Patch_Armors_Helmets.xml
+++ b/ModPatches/GrimWorld Scattered Sons/Patches/GrimWorld Scattered Sons/CE_Patch_Armors_Helmets.xml
@@ -24,13 +24,6 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[@Name="GW_ScatteredSonsHelmetBase"]/statBases</xpath>
-		<value>
-			<NightVisionEfficiency_Apparel>0.9</NightVisionEfficiency_Apparel>
-		</value>
-	</Operation>
-
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[@Name="GW_ScatteredSonsHelmetBase"]</xpath>
 		<value>
@@ -54,7 +47,7 @@
 		</value>
 	</Operation>
 
-	<!-- ============ Custodes Shield Host Helmet ============ -->
+	<!-- ============ Helmets ============ -->
 
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[
@@ -68,6 +61,7 @@
 		defName="GW_SM_LionArmorHelmet"
 		]/statBases</xpath>
 		<value>
+			<NightVisionEfficiency_Apparel>0.9</NightVisionEfficiency_Apparel>
 			<Bulk>15</Bulk>
 			<WornBulk>2.5</WornBulk>
 		</value>

--- a/ModPatches/GrimWorld Scattered Sons/Patches/GrimWorld Scattered Sons/CE_Patch_Armors_Helmets.xml
+++ b/ModPatches/GrimWorld Scattered Sons/Patches/GrimWorld Scattered Sons/CE_Patch_Armors_Helmets.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	
+	<!-- ============ Base ============ -->
+	
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[@Name="GW_ScatteredSonsHelmetBase"]/apparel/layers/li[text()="EyeCover"]</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[@Name="GW_ScatteredSonsHelmetBase"]/apparel/immuneToToxGasExposure</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[@Name="GW_ScatteredSonsHelmetBase"]/apparel</xpath>
+			<value>
+				<immuneToToxGasExposure>true</immuneToToxGasExposure>
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[@Name="GW_ScatteredSonsHelmetBase"]/equippedStatOffsets</xpath>
+		<value>
+			<SmokeSensitivity>-1</SmokeSensitivity>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[@Name="GW_ScatteredSonsHelmetBase"]/statBases</xpath>
+		<value>
+			<NightVisionEfficiency_Apparel>0.9</NightVisionEfficiency_Apparel>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[@Name="GW_ScatteredSonsHelmetBase"]</xpath>
+		<value>
+			<li Class="CombatExtended.PartialArmorExt">
+				<stats>
+					<li>
+						<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+						<parts>
+							<li>Eye</li>
+
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+						<parts>
+							<li>Eye</li>
+						</parts>
+					</li>
+				</stats>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- ============ Custodes Shield Host Helmet ============ -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[
+		defName="GW_SM_ChapterMasterHelmet" or
+		defName="GW_SM_GuillimanHelmet" or
+		defName="GW_SM_ImperialWardenHood" or
+		defName="GW_SM_ImperialWardenHooded" or
+		defName="GW_SM_ImperialWardenHelmet" or
+		defName="GW_SM_LionArmorHood" or
+		defName="GW_SM_LionArmorHooded" or
+		defName="GW_SM_LionArmorHelmet"
+		]/statBases</xpath>
+		<value>
+			<Bulk>15</Bulk>
+			<WornBulk>2.5</WornBulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[
+		defName="GW_SM_ChapterMasterHelmet" or
+		defName="GW_SM_GuillimanHelmet" or
+		defName="GW_SM_ImperialWardenHood" or
+		defName="GW_SM_ImperialWardenHooded" or
+		defName="GW_SM_ImperialWardenHelmet" or
+		defName="GW_SM_LionArmorHood" or
+		defName="GW_SM_LionArmorHooded" or
+		defName="GW_SM_LionArmorHelmet"
+		]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>60</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[
+		defName="GW_SM_ChapterMasterHelmet" or
+		defName="GW_SM_GuillimanHelmet" or
+		defName="GW_SM_ImperialWardenHood" or
+		defName="GW_SM_ImperialWardenHooded" or
+		defName="GW_SM_ImperialWardenHelmet" or
+		defName="GW_SM_LionArmorHood" or
+		defName="GW_SM_LionArmorHooded" or
+		defName="GW_SM_LionArmorHelmet"
+		]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>136</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/GrimWorld Scattered Sons/Patches/GrimWorld Scattered Sons/CE_Patch_Hediffs.xml
+++ b/ModPatches/GrimWorld Scattered Sons/Patches/GrimWorld Scattered Sons/CE_Patch_Hediffs.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<!-- Hediffs -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/HediffDef[defName="GWPA_Rallied" or defName="GW_SM_GuillimanArmor"]/stages/li/statFactors</xpath>
+		<value>
+			<Suppressability>-0.25</Suppressability>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/GrimWorld Scattered Sons/Patches/GrimWorld Scattered Sons/CE_Patch_Melee_Weapons.xml
+++ b/ModPatches/GrimWorld Scattered Sons/Patches/GrimWorld Scattered Sons/CE_Patch_Melee_Weapons.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<!-- === Lion Sword === -->
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="GW_SS_LionSword"]/statBases</xpath>
+		<value>
+			<Bulk>15</Bulk>
+			<MeleeCounterParryBonus>1.33</MeleeCounterParryBonus>
+			<ToughnessRating>30</ToughnessRating>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="GW_SS_LionSword"]/weaponTags</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="GW_SS_LionSword"]</xpath>
+			<value>
+				<weaponTags />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="GW_SS_LionSword"]/weaponTags</xpath>
+		<value>
+			<li>CE_OneHandedWeapon</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="GW_SS_LionSword"]/equippedStatOffsets</xpath>
+		<value>
+			<MeleeCritChance>0.33</MeleeCritChance>
+			<MeleeParryChance>0.7</MeleeParryChance>
+			<MeleeDodgeChance>0.3</MeleeDodgeChance>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GW_SS_LionSword"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>point</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>68</power>
+					<cooldownTime>2.3</cooldownTime>
+					<armorPenetrationBlunt>14</armorPenetrationBlunt>
+					<armorPenetrationSharp>206</armorPenetrationSharp>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>blade</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>94</power>
+					<cooldownTime>2.4</cooldownTime>
+					<armorPenetrationBlunt>22</armorPenetrationBlunt>
+					<armorPenetrationSharp>142</armorPenetrationSharp>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<!-- === Flame Sword === -->
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="GW_SM_Melee_FlameSword"]/statBases</xpath>
+		<value>
+			<Bulk>15</Bulk>
+			<MeleeCounterParryBonus>1.33</MeleeCounterParryBonus>
+			<ToughnessRating>30</ToughnessRating>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="GW_SM_Melee_FlameSword"]/weaponTags</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="GW_SM_Melee_FlameSword"]</xpath>
+			<value>
+				<weaponTags />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="GW_SM_Melee_FlameSword"]/weaponTags</xpath>
+		<value>
+			<li>CE_OneHandedWeapon</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="GW_SM_Melee_FlameSword"]/equippedStatOffsets</xpath>
+		<value>
+			<MeleeCritChance>0.27</MeleeCritChance>
+			<MeleeParryChance>0.66</MeleeParryChance>
+			<MeleeDodgeChance>0.33</MeleeDodgeChance>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GW_SM_Melee_FlameSword"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>point</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>98</power>
+					<cooldownTime>2.3</cooldownTime>
+					<armorPenetrationBlunt>20</armorPenetrationBlunt>
+					<armorPenetrationSharp>268</armorPenetrationSharp>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>blade</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>124</power>
+					<cooldownTime>2.4</cooldownTime>
+					<armorPenetrationBlunt>36 </armorPenetrationBlunt>
+					<armorPenetrationSharp>154</armorPenetrationSharp>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/GrimWorld Scattered Sons/Patches/GrimWorld Scattered Sons/CE_Patch_Shield.xml
+++ b/ModPatches/GrimWorld Scattered Sons/Patches/GrimWorld Scattered Sons/CE_Patch_Shield.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<!-- Shield -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GM_SS_ShieldLionsW" or defName="GM_SS_ShieldLionsC"]/statBases/StuffEffectMultiplierArmor</xpath>
+		<value>
+			<StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>
+		</value>
+	</Operation>
+	
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -265,6 +265,7 @@ GrimWorld 40,000 - Angels of Death |
 GrimWorld 40,000 - Core Imperialis |
 GrimWorld 40,000 - Hammer of the Imperium |
 GrimWorld 40,000 - Imperial Vehicles of Grimworld |
+GrimWorld 40,000 - Scattered Sons |
 GrimWorld 40,000 - Talons of the Emperor |
 Gulden Mod  |
 Half Dragons    |


### PR DESCRIPTION
## Additions
- New patch for armor, melee weapons, abilities, and pawnkinds added by Grimworld Scattered Sons.

## References
- Close #3613 

## Reasoning
- Patched along the same lines as various other Grimworld mods. Equipment is generally superior, since Primarchs presumably have the absolute best of the best.

## Alternatives
- Different balancing scheme, I suppose.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
