### PR TITLE
Add supports for Polarisbloc fan made port Mods for 1.5 

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -388,8 +388,7 @@
 		<li IfModActive="Mlie.CutePenguin">ModPatches/Penguin</li>
 		<li IfModActive="Sov.WarcasketWeapons">ModPatches/Persona Warcasket Weapons</li>
 		<li IfModActive="Vanya.Polarisbloc.CoreLab,Vanya.Polarisbloc.CoreLab.tmp">ModPatches/Polarisbloc Core Lab</li>
-		<li IfModActive="Vanya.Polarisbloc.SecurityForce">ModPatches/Polarisbloc Security Force</li>
-		<li IfModActive="Vanya.Polarisbloc.SecurityForce.tmp">ModPatches/Polarisbloc Security Force</li>
+		<li IfModActive="Vanya.Polarisbloc.SecurityForce,Vanya.Polarisbloc.SecurityForce.tmp">ModPatches/Polarisbloc Security Force</li>
 		<li IfModActive="milk.poleepkwaupdate, GHOST.Poleepkwa">ModPatches/Poleepkwa Race</li>
 		<li IfModActive="BotchJob.PossessedWeapons">ModPatches/Possessed Weapons</li>
 		<li IfModActive="JangoDsoul.T45b.PowerArmor">ModPatches/PowerArmour T-45b</li>

--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -387,8 +387,7 @@
 		<li IfModActive="shauaputa.pawnboldrace">ModPatches/Pawnbold Race</li>
 		<li IfModActive="Mlie.CutePenguin">ModPatches/Penguin</li>
 		<li IfModActive="Sov.WarcasketWeapons">ModPatches/Persona Warcasket Weapons</li>
-		<li IfModActive="Vanya.Polarisbloc.CoreLab">ModPatches/Polarisbloc Core Lab</li>
-    <li IfModActive="Vanya.Polarisbloc.CoreLab.tmp">ModPatches/Polarisbloc Core Lab</li>
+		<li IfModActive="Vanya.Polarisbloc.CoreLab,Vanya.Polarisbloc.CoreLab.tmp">ModPatches/Polarisbloc Core Lab</li>
 		<li IfModActive="Vanya.Polarisbloc.SecurityForce">ModPatches/Polarisbloc Security Force</li>
 		<li IfModActive="Vanya.Polarisbloc.SecurityForce.tmp">ModPatches/Polarisbloc Security Force</li>
 		<li IfModActive="milk.poleepkwaupdate, GHOST.Poleepkwa">ModPatches/Poleepkwa Race</li>

--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -388,7 +388,9 @@
 		<li IfModActive="Mlie.CutePenguin">ModPatches/Penguin</li>
 		<li IfModActive="Sov.WarcasketWeapons">ModPatches/Persona Warcasket Weapons</li>
 		<li IfModActive="Vanya.Polarisbloc.CoreLab">ModPatches/Polarisbloc Core Lab</li>
+    <li IfModActive="Vanya.Polarisbloc.CoreLab.tmp">ModPatches/Polarisbloc Core Lab</li>
 		<li IfModActive="Vanya.Polarisbloc.SecurityForce">ModPatches/Polarisbloc Security Force</li>
+		<li IfModActive="Vanya.Polarisbloc.SecurityForce.tmp">ModPatches/Polarisbloc Security Force</li>
 		<li IfModActive="milk.poleepkwaupdate, GHOST.Poleepkwa">ModPatches/Poleepkwa Race</li>
 		<li IfModActive="BotchJob.PossessedWeapons">ModPatches/Possessed Weapons</li>
 		<li IfModActive="JangoDsoul.T45b.PowerArmor">ModPatches/PowerArmour T-45b</li>


### PR DESCRIPTION
Polarisbloc CoreLab and SecurityForce mods does not have official 1.5 version, and there're fan made ports for 1.5. But the mod ids have changed in order to keep both mods alive on disk.

## Additions

Describe new functionality added by your code, e.g.
- Make CE work with Polarisbloc CoreLab tmp port https://steamcommunity.com/workshop/filedetails/?id=3225348593
- Make CE work with Polarisbloc Security Force tmp port https://steamcommunity.com/sharedfiles/filedetails/?id=3225387996

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Add a line for Vanya.Polarisbloc.CoreLab.tmp in LoadFolders.xml
- Add a line for Vanya.Polarisbloc.SecurityForce.tmp in LoadFolders.xml

## References

Links to the associated issues or other related pull requests, e.g.
- Issues not created yet

## Reasoning

Why did you choose to implement things this way, e.g.
- Since 1.4 version of Polarisbloc mods are already officially supported, the fan made ports could be easily supported with the same files, just need to add a line to support the new mod ids.

## Alternatives

Describe alternative implementations you have considered, e.g.
- Nothing else yet.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
