### PR TITLE
Patch [AV] Mechtech

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -71,6 +71,7 @@
 		<li IfModActive="Odz.40k.ImperialGuard.DKOK">ModPatches/Astra Militarum Regimentum - Krieg</li>
 		<li IfModActive="Knorke.40k.ImperialGuard.DKOK.OfficerHelmet">ModPatches/Astra Militarum Regimentum - Krieg Officer Helmet</li>
 		<li IfModActive="Flyingstar.AutoMortarsUnofficial">ModPatches/Auto-Mortars</li>
+		<li IfModActive="veltaris.mechtech">ModPatches/AV Mechtech</li>
 		<li IfModActive="veltaris.mechqueen">ModPatches/AV Work Queen</li>
 		<li IfModActive="automatic.autocleaner">ModPatches/Autocleaner</li>
 		<li IfModActive="Heymyteamrules.BeastManTribes">ModPatches/Beast Man Tribes</li>

--- a/ModPatches/AV Mechtech/Patches/AV Mechtech/CompanionSphere.xml
+++ b/ModPatches/AV Mechtech/Patches/AV Mechtech/CompanionSphere.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="AV_Mech_Companion"]</xpath>
 		<value>
@@ -8,11 +9,10 @@
 			</li>
 		</value>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="AV_Mech_Companion"]/statBases</xpath>
 		<value>
-			<ArmorRating_Heat>0.5</ArmorRating_Heat>
 			<CarryWeight>75</CarryWeight>
 			<CarryBulk>50</CarryBulk>
 			<MeleeDodgeChance>0.02</MeleeDodgeChance>
@@ -26,7 +26,7 @@
 		<xpath>Defs/ThingDef[defName="AV_Mech_Companion"]/comps</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
-				<Durability>200</Durability>
+				<Durability>425</Durability>
 				<Regenerates>true</Regenerates>
 				<RegenInterval>1250</RegenInterval>
 				<RegenValue>5</RegenValue>
@@ -43,4 +43,5 @@
 			</li>
 		</value>
 	</Operation>
+
 </Patch>

--- a/ModPatches/AV Mechtech/Patches/AV Mechtech/CompanionSphere.xml
+++ b/ModPatches/AV Mechtech/Patches/AV Mechtech/CompanionSphere.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="AV_Mech_Companion"]</xpath>
+		<value>
+			<li Class="CombatExtended.RacePropertiesExtensionCE">
+				<bodyShape>Vehicle</bodyShape>
+			</li>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="AV_Mech_Companion"]/statBases</xpath>
+		<value>
+			<ArmorRating_Heat>0.5</ArmorRating_Heat>
+			<CarryWeight>75</CarryWeight>
+			<CarryBulk>50</CarryBulk>
+			<MeleeDodgeChance>0.02</MeleeDodgeChance>
+			<MeleeCritChance>0.22</MeleeCritChance>
+			<MeleeParryChance>0.64</MeleeParryChance>
+			<MaxHitPoints>150</MaxHitPoints>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="AV_Mech_Companion"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>200</Durability>
+				<Regenerates>true</Regenerates>
+				<RegenInterval>1250</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<Repairable>true</Repairable>
+				<RepairIngredients>
+					<Steel>5</Steel>
+					<Plasteel>5</Plasteel>
+				</RepairIngredients>
+				<RepairTime>300</RepairTime>
+				<RepairValue>200</RepairValue>
+				<CanOverHeal>true</CanOverHeal>
+				<MaxOverHeal>460</MaxOverHeal>
+				<MinArmorPct>0.5</MinArmorPct>
+			</li>
+		</value>
+	</Operation>
+</Patch>

--- a/ModPatches/AV Mechtech/Patches/AV Mechtech/Fluoid.xml
+++ b/ModPatches/AV Mechtech/Patches/AV Mechtech/Fluoid.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="AV_Mech_Fluoid"]</xpath>
+		<value>
+			<li Class="CombatExtended.RacePropertiesExtensionCE">
+				<bodyShape>Humanoid</bodyShape>
+			</li>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="AV_Mech_Fluoid"]/statBases</xpath>
+		<value>
+			<ArmorRating_Heat>0.5</ArmorRating_Heat>
+			<CarryWeight>45</CarryWeight>
+			<CarryBulk>35</CarryBulk>
+			<AimingAccuracy>1.3</AimingAccuracy>
+			<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
+			<MeleeDodgeChance>0.02</MeleeDodgeChance>
+			<MeleeCritChance>0.22</MeleeCritChance>
+			<MeleeParryChance>0.64</MeleeParryChance>
+			<MaxHitPoints>400</MaxHitPoints>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="AV_Mech_Fluoid"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>250</Durability>
+				<Regenerates>true</Regenerates>
+				<RegenInterval>1250</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<Repairable>true</Repairable>
+				<RepairIngredients>
+					<Steel>5</Steel>
+					<Plasteel>5</Plasteel>
+				</RepairIngredients>
+				<RepairTime>300</RepairTime>
+				<RepairValue>200</RepairValue>
+				<CanOverHeal>true</CanOverHeal>
+				<MaxOverHeal>460</MaxOverHeal>
+				<MinArmorPct>0.5</MinArmorPct>
+			</li>
+		</value>
+	</Operation>
+</Patch>

--- a/ModPatches/AV Mechtech/Patches/AV Mechtech/Fluoid.xml
+++ b/ModPatches/AV Mechtech/Patches/AV Mechtech/Fluoid.xml
@@ -1,5 +1,42 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
+
+	<!-- ======= AV Light Mech ======= -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[@Name="AV_LightMechanoid"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>4</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[@Name="AV_LightMechanoid"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>2</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[@Name="AV_LightMechanoid"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>5</power>
+					<cooldownTime>3.0</cooldownTime>
+					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+					<armorPenetrationBlunt>5.8</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<!-- ======= Fluoid ======= -->
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="AV_Mech_Fluoid"]</xpath>
 		<value>
@@ -8,11 +45,24 @@
 			</li>
 		</value>
 	</Operation>
-	
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AV_Mech_Fluoid"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>2</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AV_Mech_Fluoid"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>2</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="AV_Mech_Fluoid"]/statBases</xpath>
 		<value>
-			<ArmorRating_Heat>0.5</ArmorRating_Heat>
 			<CarryWeight>45</CarryWeight>
 			<CarryBulk>35</CarryBulk>
 			<AimingAccuracy>1.3</AimingAccuracy>
@@ -28,7 +78,7 @@
 		<xpath>Defs/ThingDef[defName="AV_Mech_Fluoid"]/comps</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
-				<Durability>250</Durability>
+				<Durability>425</Durability>
 				<Regenerates>true</Regenerates>
 				<RegenInterval>1250</RegenInterval>
 				<RegenValue>5</RegenValue>
@@ -45,4 +95,5 @@
 			</li>
 		</value>
 	</Operation>
+
 </Patch>

--- a/ModPatches/AV Mechtech/Patches/AV Mechtech/RoyalLancer.xml
+++ b/ModPatches/AV Mechtech/Patches/AV Mechtech/RoyalLancer.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="AV_Mech_Royallancer"]</xpath>
+		<value>
+			<li Class="CombatExtended.RacePropertiesExtensionCE">
+				<bodyShape>Humanoid</bodyShape>
+			</li>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="AV_Mech_Royallancer"]/statBases</xpath>
+		<value>
+			<ArmorRating_Heat>0.5</ArmorRating_Heat>
+			<CarryWeight>45</CarryWeight>
+			<CarryBulk>35</CarryBulk>
+			<AimingAccuracy>1.3</AimingAccuracy>
+			<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
+			<MeleeDodgeChance>0.02</MeleeDodgeChance>
+			<MeleeCritChance>0.22</MeleeCritChance>
+			<MeleeParryChance>0.64</MeleeParryChance>
+			<MaxHitPoints>400</MaxHitPoints>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AV_Mech_Royallancer"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>45</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AV_Mech_Royallancer"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>20</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AV_Mech_Royallancer"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>15</power>
+					<cooldownTime>2.0</cooldownTime>
+					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+					<armorPenetrationBlunt>2.4</armorPenetrationBlunt>
+					<chanceFactor>0.2</chanceFactor>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="AV_Mech_Royallancer"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>1850</Durability>
+				<Regenerates>true</Regenerates>
+				<RegenInterval>1250</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<Repairable>true</Repairable>
+				<RepairIngredients>
+					<Steel>5</Steel>
+					<Plasteel>5</Plasteel>
+				</RepairIngredients>
+				<RepairTime>300</RepairTime>
+				<RepairValue>200</RepairValue>
+				<CanOverHeal>true</CanOverHeal>
+				<MaxOverHeal>460</MaxOverHeal>
+				<MinArmorPct>0.5</MinArmorPct>
+				<MinArmorValueSharp>6.5</MinArmorValueSharp>
+				<MinArmorValueBlunt>5.4</MinArmorValueBlunt>
+			</li>
+		</value>
+	</Operation>
+</Patch>

--- a/ModPatches/AV Mechtech/Patches/AV Mechtech/RoyalLancer.xml
+++ b/ModPatches/AV Mechtech/Patches/AV Mechtech/RoyalLancer.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="AV_Mech_Royallancer"]</xpath>
 		<value>
@@ -37,7 +38,6 @@
 			<ArmorRating_Sharp>20</ArmorRating_Sharp>
 		</value>
 	</Operation>
-
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AV_Mech_Royallancer"]/tools</xpath>
@@ -82,4 +82,5 @@
 			</li>
 		</value>
 	</Operation>
+
 </Patch>

--- a/ModPatches/AV Mechtech/Patches/AV Mechtech/RoyalLancerWeapons.xml
+++ b/ModPatches/AV Mechtech/Patches/AV Mechtech/RoyalLancerWeapons.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
-		<!-- Ranged weapon patch -->
+	
+	<!-- Ranged weapon patch -->
     <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>AV_Gun_ChargeLance</defName>
 		<statBases>
@@ -74,7 +75,26 @@
 		<value>BaseGun</value>
 	</Operation>
 
-			<!-- Melee mode patching -->
+	<!-- Melee mode patching -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="AV_Gun_ChargeLance_BladesMode"]/statBases</xpath>
+		<value>
+			<Bulk>10</Bulk>
+			<MeleeCounterParryBonus>0.75</MeleeCounterParryBonus>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="AV_Gun_ChargeLance_BladesMode"]</xpath>
+		<value>
+			<equippedStatOffsets>
+				<MeleeCritChance>0.48</MeleeCritChance>
+				<MeleeParryChance>0.65</MeleeParryChance>
+				<MeleeDodgeChance>0.35</MeleeDodgeChance>
+			</equippedStatOffsets>
+		</value>
+	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AV_Gun_ChargeLance_BladesMode"]/tools</xpath>
@@ -117,22 +137,4 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="AV_Gun_ChargeLance_BladesMode"]/statBases</xpath>
-		<value>
-			<Bulk>13</Bulk>
-			<MeleeCounterParryBonus>0.75</MeleeCounterParryBonus>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="AV_Gun_ChargeLance_BladesMode"]</xpath>
-		<value>
-			<equippedStatOffsets>
-				<MeleeCritChance>0.48</MeleeCritChance>
-				<MeleeParryChance>0.65</MeleeParryChance>
-				<MeleeDodgeChance>0.35</MeleeDodgeChance>
-			</equippedStatOffsets>
-		</value>
-	</Operation>
 </Patch>

--- a/ModPatches/AV Mechtech/Patches/AV Mechtech/RoyalLancerWeapons.xml
+++ b/ModPatches/AV Mechtech/Patches/AV Mechtech/RoyalLancerWeapons.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+		<!-- Ranged weapon patch -->
+    <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>AV_Gun_ChargeLance</defName>
+		<statBases>
+			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+			<SightsEfficiency>1.5</SightsEfficiency>
+			<ShotSpread>0.05</ShotSpread>
+			<SwayFactor>1</SwayFactor>
+			<Bulk>13.00</Bulk>
+		</statBases>
+		<Properties>
+			<recoilAmount>0.92</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_5x35mmCharged</defaultProjectile>
+			<warmupTime>1.2</warmupTime>
+			<range>68</range>
+			<burstShotCount>2</burstShotCount>
+			<ticksBetweenBurstShots>12</ticksBetweenBurstShots>
+			<soundCast>ChargeLance_Fire</soundCast>
+			<soundCastTail>GunTail_Heavy</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>16</magazineSize>
+			<reloadTime>3.4</reloadTime>
+			<ammoSet>AmmoSet_5x35mmCharged</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aimedBurstShotCount>2</aimedBurstShotCount>
+			<aiUseBurstMode>TRUE</aiUseBurstMode>
+			<aiAimMode>AimedShot</aiAimMode>
+			<noSingleShot>true</noSingleShot>
+		</FireModes>
+		<weaponTags>
+			<li>CE_AI_Rifle</li>
+			<li>NoSwitch</li>
+		</weaponTags>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AV_Gun_ChargeLance"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>barrel</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>10</power>
+					<cooldownTime>1.85</cooldownTime>
+					<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="AV_Gun_ChargeLance"]</xpath>
+		<value>
+			<li Class="CombatExtended.ThingDefExtensionCE">
+				<MenuHidden>True</MenuHidden>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- Disable for player - ranged mode -->
+	<Operation Class="PatchOperationAttributeSet">
+		<xpath>Defs/ThingDef[defName="AV_Gun_ChargeLance"]</xpath>
+		<attribute>ParentName</attribute>
+		<value>BaseGun</value>
+	</Operation>
+
+			<!-- Melee mode patching -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AV_Gun_ChargeLance_BladesMode"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>Handle</label>
+					<capacities>
+						<li>Poke</li>
+					</capacities>
+					<power>8</power>
+					<chanceFactor>0.33</chanceFactor>
+					<cooldownTime>1.78</cooldownTime>
+					<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>point</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>22</power>
+					<cooldownTime>1.81</cooldownTime>
+					<armorPenetrationBlunt>3.1</armorPenetrationBlunt>
+					<armorPenetrationSharp>2.4</armorPenetrationSharp>
+					<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>edge</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>40</power>
+					<cooldownTime>1.68</cooldownTime>
+					<armorPenetrationBlunt>3.1</armorPenetrationBlunt>
+					<armorPenetrationSharp>2.9</armorPenetrationSharp>
+					<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="AV_Gun_ChargeLance_BladesMode"]/statBases</xpath>
+		<value>
+			<Bulk>13</Bulk>
+			<MeleeCounterParryBonus>0.75</MeleeCounterParryBonus>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="AV_Gun_ChargeLance_BladesMode"]</xpath>
+		<value>
+			<equippedStatOffsets>
+				<MeleeCritChance>0.48</MeleeCritChance>
+				<MeleeParryChance>0.65</MeleeParryChance>
+				<MeleeDodgeChance>0.35</MeleeDodgeChance>
+			</equippedStatOffsets>
+		</value>
+	</Operation>
+</Patch>

--- a/ModPatches/AV Mechtech/Patches/AV Mechtech/Scrapper.xml
+++ b/ModPatches/AV Mechtech/Patches/AV Mechtech/Scrapper.xml
@@ -47,7 +47,7 @@
 		<xpath>Defs/ThingDef[defName="AV_Mech_Scrapper"]/comps</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
-				<Durability>900</Durability>
+				<Durability>700</Durability>
 				<Regenerates>true</Regenerates>
 				<RegenInterval>1250</RegenInterval>
 				<RegenValue>5</RegenValue>

--- a/ModPatches/AV Mechtech/Patches/AV Mechtech/Scrapper.xml
+++ b/ModPatches/AV Mechtech/Patches/AV Mechtech/Scrapper.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="AV_Mech_Scrapper"]</xpath>
+		<value>
+			<li Class="CombatExtended.RacePropertiesExtensionCE">
+				<bodyShape>QuadrupedLow</bodyShape>
+			</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="AV_Mech_Scrapper"]/statBases</xpath>
+		<value>
+			<MeleeDodgeChance>0.08</MeleeDodgeChance>
+			<MeleeCritChance>0.24</MeleeCritChance>
+			<MeleeParryChance>0.18</MeleeParryChance>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AV_Mech_Scrapper"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>3</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="AV_Mech_Scrapper"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>2</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="AV_Mech_Scrapper"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="AV_Mech_Scrapper"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="AV_Mech_Scrapper"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_ArmorDurability">
+				<Durability>900</Durability>
+				<Regenerates>true</Regenerates>
+				<RegenInterval>1250</RegenInterval>
+				<RegenValue>5</RegenValue>
+				<Repairable>true</Repairable>
+				<RepairIngredients>
+					<Steel>5</Steel>
+					<Plasteel>5</Plasteel>
+				</RepairIngredients>
+				<RepairTime>300</RepairTime>
+				<RepairValue>200</RepairValue>
+				<CanOverHeal>true</CanOverHeal>
+				<MaxOverHeal>90</MaxOverHeal>
+				<MinArmorPct>0.5</MinArmorPct>
+			</li>
+		</value>
+	</Operation>
+
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -7,6 +7,7 @@ If the mod(s) you are interested in isn't on this list, first confirm that the m
 Mod |
 --- |
 [Cosplay Equipment]	Blue Archive |
+[AV] Mechtech   |
 [AV] Work Queen |
 [CP] DOOM	|
 [CP] Red Horse Furniture	|


### PR DESCRIPTION
## Additions
- Patch for [AV] Mechtech.

Same as #3672 + necessary fixes, but Visual Studio pushed it to a separate branch instead, for some reason. Could be the original PR author denied editing permissions? Not sure.

## Reasoning
- Mechs patched along similar line to existing light and medium mechs.

## Alternatives
- Different balancing scheme.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
