### PR TITLE
Equip from inventory uses CanEquip

### DIFF
--- a/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
@@ -359,14 +359,13 @@ namespace CombatExtended
                     if (eq != null && eq.TryGetComp<CompEquippable>() != null)
                     {
                         CompInventory compInventory = SelPawnForGear.TryGetComp<CompInventory>();
-                        CompBiocodable compBiocoded = eq.TryGetComp<CompBiocodable>();
                         if (compInventory != null)
                         {
                             FloatMenuOption equipOption;
                             string eqLabel = GenLabel.ThingLabel(eq.def, eq.Stuff, 1);
-                            if (compBiocoded != null && compBiocoded.Biocoded && compBiocoded.CodedPawn != SelPawnForGear)
+                            if (!EquipmentUtility.CanEquip(eq, SelPawnForGear, out var reason))
                             {
-                                equipOption = new FloatMenuOption("CannotEquip".Translate(eqLabel) + ": " + "BiocodedCodedForSomeoneElse".Translate(), null);
+                                equipOption = new FloatMenuOption("CannotEquip".Translate(eqLabel) + ": " + reason, null);
                             }
                             else if (SelPawnForGear.IsQuestLodger() && !EquipmentUtility.QuestLodgerCanEquip(eq, SelPawnForGear))
                             {


### PR DESCRIPTION
## Changes

Changed the biocoded check in ITab_Inventory to use EquipmentUtility.CanEquip instead.

## Reasoning

I expect most mods that fiddle with equipment restrictions do their job by patching CanEquip. Ours don't use it, which means ours can bypass it.

## Alternatives

Bruh

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Told a John Doe to equip Nydia's bow from his inventory, and sucessfully failed)
