### PR TITLE
EM Metals Patch for Generic Ammo

### DIFF
--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/HighCaliber/20x102mmNATO.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/HighCaliber/20x102mmNATO.xml
@@ -2,7 +2,7 @@
 <Patch>
 	<!-- Armor-piercing -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_20x102mmNATO_AP"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_20x102mmNATO_AP" or defName="MakeAmmo_Autocannon_AP"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -43,7 +43,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_20x102mmNATO_AP"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_20x102mmNATO_AP" or defName="MakeAmmo_Autocannon_AP"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>
@@ -56,7 +56,7 @@
 
 	<!-- Armor-piercing incendiary -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_20x102mmNATO_Incendiary"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_20x102mmNATO_Incendiary" or defName="MakeAmmo_Autocannon_Incendiary"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -105,7 +105,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_20x102mmNATO_Incendiary"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_20x102mmNATO_Incendiary" or defName="MakeAmmo_Autocannon_Incendiary"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>
@@ -118,7 +118,7 @@
 
 	<!-- High-8 -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_20x102mmNATO_HE"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_20x102mmNATO_HE" or defName="MakeAmmo_Autocannon_HE"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -167,7 +167,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_20x102mmNATO_HE"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_20x102mmNATO_HE" or defName="MakeAmmo_Autocannon_HE"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>
@@ -180,7 +180,7 @@
 
 	<!-- Sabot -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_20x102mmNATO_Sabot"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_20x102mmNATO_Sabot" or defName="MakeAmmo_Autocannon_Sabot"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -213,7 +213,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_20x102mmNATO_Sabot"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_20x102mmNATO_Sabot" or defName="MakeAmmo_Autocannon_Sabot"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/HighCaliber/338Lapua.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/HighCaliber/338Lapua.xml
@@ -2,7 +2,7 @@
 <Patch>
 	<!-- Full Metal Jacket -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_338Lapua_FMJ"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_338Lapua_FMJ" or defName="MakeAmmo_RifleMagnum_FMJ"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -43,7 +43,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_338Lapua_FMJ"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_338Lapua_FMJ" or defName="MakeAmmo_RifleMagnum_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>
@@ -56,7 +56,7 @@
 
 	<!-- Armor-piercing -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_338Lapua_AP"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_338Lapua_AP" or defName="MakeAmmo_RifleMagnum_AP"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -97,7 +97,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_338Lapua_AP"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_338Lapua_AP" or defName="MakeAmmo_RifleMagnum_AP"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>
@@ -110,7 +110,7 @@
 
 	<!-- Armor-piercing incendiary -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_338Lapua_Incendiary"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_338Lapua_Incendiary" or defName="MakeAmmo_RifleMagnum_Incendiary"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -159,7 +159,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_338Lapua_Incendiary"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_338Lapua_Incendiary" or defName="MakeAmmo_RifleMagnum_Incendiary"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>
@@ -172,7 +172,7 @@
 
 	<!-- High-8 -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_338Lapua_HE"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_338Lapua_HE" or defName="MakeAmmo_RifleMagnum_HE"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -221,7 +221,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_338Lapua_HE"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_338Lapua_HE" or defName="MakeAmmo_RifleMagnum_HE"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>
@@ -234,7 +234,7 @@
 
 	<!-- Sabot -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_338Lapua_Sabot"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_338Lapua_Sabot" or defName="MakeAmmo_RifleMagnum_Sabot"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -267,7 +267,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_338Lapua_Sabot"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_338Lapua_Sabot" or defName="MakeAmmo_RifleMagnum_Sabot"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/HighCaliber/50BMG.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/HighCaliber/50BMG.xml
@@ -2,7 +2,7 @@
 <Patch>
 	<!-- Full Metal Jacket -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_50BMG_FMJ"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_50BMG_FMJ" or defName="MakeAmmo_AntiMateriel_FMJ"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -43,7 +43,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_50BMG_FMJ"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_50BMG_FMJ" or defName="MakeAmmo_AntiMateriel_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>
@@ -56,7 +56,7 @@
 
 	<!-- Armor-piercing -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_50BMG_AP"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_50BMG_AP" or defName="MakeAmmo_AntiMateriel_AP"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -97,7 +97,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_50BMG_AP"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_50BMG_AP" or defName="MakeAmmo_AntiMateriel_AP"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>
@@ -110,7 +110,7 @@
 
 	<!-- Armor-piercing incendiary -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_50BMG_Incendiary"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_50BMG_Incendiary" or defName="MakeAmmo_AntiMateriel_Incendiary"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -159,7 +159,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_50BMG_Incendiary"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_50BMG_Incendiary" or defName="MakeAmmo_AntiMateriel_Incendiary"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>
@@ -172,7 +172,7 @@
 
 	<!-- High-8 -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_50BMG_HE"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_50BMG_HE" or defName="MakeAmmo_AntiMateriel_HE"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -221,7 +221,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_50BMG_HE"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_50BMG_HE" or defName="MakeAmmo_AntiMateriel_HE"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>
@@ -234,7 +234,7 @@
 
 	<!-- Sabot -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_50BMG_Sabot"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_50BMG_Sabot" or defName="MakeAmmo_AntiMateriel_Sabot"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -267,7 +267,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_50BMG_Sabot"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_50BMG_Sabot" or defName="MakeAmmo_AntiMateriel_Sabot"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_44Magnum.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_44Magnum.xml
@@ -2,7 +2,7 @@
 <Patch>
 	<!-- Full Metal Jacket -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_44Magnum_FMJ"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_44Magnum_FMJ" or defName="MakeAmmo_PistolMagnum_FMJ"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -43,7 +43,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_44Magnum_FMJ"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_44Magnum_FMJ" or defName="MakeAmmo_PistolMagnum_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>
@@ -55,7 +55,7 @@
 	</Operation>
 	<!-- Hollow Point -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_44Magnum_HP"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_44Magnum_HP" or defName="MakeAmmo_PistolMagnum_HP"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -96,7 +96,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_44Magnum_HP"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_44Magnum_HP" or defName="MakeAmmo_PistolMagnum_HP"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>
@@ -108,7 +108,7 @@
 	</Operation>
 	<!-- Armor-piercing -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_44Magnum_AP"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_44Magnum_AP" or defName="MakeAmmo_PistolMagnum_AP"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -149,7 +149,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_44Magnum_AP"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_44Magnum_AP" or defName="MakeAmmo_PistolMagnum_AP"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_45ACP.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_45ACP.xml
@@ -2,7 +2,7 @@
 <Patch>
 	<!-- Full Metal Jacket -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_45ACP_FMJ"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_45ACP_FMJ" or defName="MakeAmmo_45ACP_FMJ"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -43,7 +43,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_45ACP_FMJ"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_45ACP_FMJ" or defName="MakeAmmo_45ACP_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>
@@ -55,7 +55,7 @@
 	</Operation>
 	<!-- Hollow Point -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_45ACP_HP"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_45ACP_HP" or defName="MakeAmmo_45ACP_HP"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -96,7 +96,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_45ACP_HP"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_45ACP_HP" or defName="MakeAmmo_45ACP_HP"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>
@@ -108,7 +108,7 @@
 	</Operation>
 	<!-- Armor-piercing -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_45ACP_AP"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_45ACP_AP" or defName="MakeAmmo_45ACP_AP"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -149,7 +149,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_45ACP_AP"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_45ACP_AP" or defName="MakeAmmo_45ACP_AP"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_45ACP.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Pistol/Patch_45ACP.xml
@@ -2,7 +2,7 @@
 <Patch>
 	<!-- Full Metal Jacket -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_45ACP_FMJ" or defName="MakeAmmo_45ACP_FMJ"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_45ACP_FMJ" or defName="MakeAmmo_Pistol_FMJ"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -43,7 +43,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_45ACP_FMJ" or defName="MakeAmmo_45ACP_FMJ"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_45ACP_FMJ" or defName="MakeAmmo_Pistol_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>
@@ -55,7 +55,7 @@
 	</Operation>
 	<!-- Hollow Point -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_45ACP_HP" or defName="MakeAmmo_45ACP_HP"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_45ACP_HP" or defName="MakeAmmo_Pistol_HP"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -96,7 +96,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_45ACP_HP" or defName="MakeAmmo_45ACP_HP"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_45ACP_HP" or defName="MakeAmmo_Pistol_HP"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>
@@ -108,7 +108,7 @@
 	</Operation>
 	<!-- Armor-piercing -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_45ACP_AP" or defName="MakeAmmo_45ACP_AP"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_45ACP_AP" or defName="MakeAmmo_Pistol_AP"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -149,7 +149,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_45ACP_AP" or defName="MakeAmmo_45ACP_AP"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_45ACP_AP" or defName="MakeAmmo_Pistol_AP"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_556x45mmNATO.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_556x45mmNATO.xml
@@ -2,7 +2,7 @@
 <Patch>
 	<!-- Full Metal Jacket -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_556x45mmNATO_FMJ"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_556x45mmNATO_FMJ" or defName="MakeAmmo_RifleIntermediate_FMJ"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -43,7 +43,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_556x45mmNATO_FMJ"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_556x45mmNATO_FMJ" or defName="MakeAmmo_RifleIntermediate_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>
@@ -56,7 +56,7 @@
 
 	<!-- Hollow Point -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_556x45mmNATO_HP"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_556x45mmNATO_HP" or defName="MakeAmmo_RifleIntermediate_HP"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -97,7 +97,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_556x45mmNATO_HP"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_556x45mmNATO_HP" or defName="MakeAmmo_RifleIntermediate_HP"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>
@@ -110,7 +110,7 @@
 
 	<!-- Armor-piercing -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_556x45mmNATO_AP"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_556x45mmNATO_AP" or defName="MakeAmmo_RifleIntermediate_AP"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -151,7 +151,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_556x45mmNATO_AP"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_556x45mmNATO_AP" or defName="MakeAmmo_RifleIntermediate_AP"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>
@@ -164,7 +164,7 @@
 
 	<!-- Armor-piercing incendiary -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_556x45mmNATO_Incendiary"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_556x45mmNATO_Incendiary" or defName="MakeAmmo_RifleIntermediate_Incendiary"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -213,7 +213,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_556x45mmNATO_Incendiary"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_556x45mmNATO_Incendiary" or defName="MakeAmmo_RifleIntermediate_Incendiary"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>
@@ -226,7 +226,7 @@
 
 	<!-- High-8 -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_556x45mmNATO_HE"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_556x45mmNATO_HE" or defName="MakeAmmo_RifleIntermediate_HE"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -275,7 +275,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_556x45mmNATO_HE"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_556x45mmNATO_HE" or defName="MakeAmmo_RifleIntermediate_HE"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>
@@ -288,7 +288,7 @@
 
 	<!-- Sabot -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_556x45mmNATO_Sabot"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_556x45mmNATO_Sabot" or defName="MakeAmmo_RifleIntermediate_Sabot"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -321,7 +321,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_556x45mmNATO_Sabot"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_556x45mmNATO_Sabot" or defName="MakeAmmo_RifleIntermediate_Sabot"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_762x51mmNATO.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Rifle/Patch_762x51mmNATO.xml
@@ -2,7 +2,7 @@
 <Patch>
 	<!-- Full Metal Jacket -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x51mmNATO_FMJ"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x51mmNATO_FMJ" or defName="MakeAmmo_Rifle_FMJ"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -43,7 +43,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x51mmNATO_FMJ"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x51mmNATO_FMJ" or defName="MakeAmmo_Rifle_FMJ"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>
@@ -56,7 +56,7 @@
 
 	<!-- Hollow Point -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x51mmNATO_HP"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x51mmNATO_HP" or defName="MakeAmmo_Rifle_HP"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -97,7 +97,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x51mmNATO_HP"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x51mmNATO_HP" or defName="MakeAmmo_Rifle_HP"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>
@@ -110,7 +110,7 @@
 
 	<!-- Armor-piercing -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x51mmNATO_AP"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x51mmNATO_AP" or defName="MakeAmmo_Rifle_AP"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -151,7 +151,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x51mmNATO_AP"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x51mmNATO_AP" or defName="MakeAmmo_Rifle_AP"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>
@@ -164,7 +164,7 @@
 
 	<!-- Armor-piercing incendiary -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x51mmNATO_Incendiary"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x51mmNATO_Incendiary" or defName="MakeAmmo_Rifle_Incendiary"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -213,7 +213,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x51mmNATO_Incendiary"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x51mmNATO_Incendiary" or defName="MakeAmmo_Rifle_Incendiary"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>
@@ -226,7 +226,7 @@
 
 	<!-- High-8 -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x51mmNATO_HE"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x51mmNATO_HE" or defName="MakeAmmo_Rifle_HE"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -275,7 +275,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x51mmNATO_HE"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x51mmNATO_HE" or defName="MakeAmmo_Rifle_HE"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>
@@ -288,7 +288,7 @@
 
 	<!-- Sabot -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x51mmNATO_Sabot"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x51mmNATO_Sabot" or defName="MakeAmmo_Rifle_Sabot"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -321,7 +321,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x51mmNATO_Sabot"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x51mmNATO_Sabot" or defName="MakeAmmo_Rifle_Sabot"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Sabot.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Sabot.xml
@@ -3,6 +3,11 @@
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[
+			defName="MakeAmmo_Rifle_Sabot" or
+			defName="MakeAmmo_RifleIntermediate_Sabot" or
+			defName="MakeAmmo_RifleMagnum_Sabot" or
+			defName="MakeAmmo_Autocannon_Sabot" or
+			defName="MakeAmmo_AntiMateriel_Sabot" or
 			defName="MakeAmmo_127x55mm_Sabot" or
 			defName="MakeAmmo_3006Springfield_Sabot" or
 			defName="MakeAmmo_300AACBlackout_Sabot" or
@@ -45,6 +50,11 @@
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RecipeDef[
+			defName="MakeAmmo_Rifle_Sabot" or
+			defName="MakeAmmo_RifleIntermediate_Sabot" or
+			defName="MakeAmmo_RifleMagnum_Sabot" or
+			defName="MakeAmmo_Autocannon_Sabot" or
+			defName="MakeAmmo_AntiMateriel_Sabot" or
 			defName="MakeAmmo_127x55mm_Sabot" or
 			defName="MakeAmmo_3006Springfield_Sabot" or
 			defName="MakeAmmo_300AACBlackout_Sabot" or

--- a/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Shotgun/12Gauge.xml
+++ b/ModPatches/Expanded Materials - Metals/Patches/Expanded Materials - Metals/Ammo/Shotgun/12Gauge.xml
@@ -2,7 +2,7 @@
 <Patch>
 	<!-- Buckshot -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_12Gauge_Buck"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_12Gauge_Buck" or defName="MakeAmmo_Shotgun_Buck"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -35,7 +35,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_12Gauge_Buck"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_12Gauge_Buck" or defName="MakeAmmo_Shotgun_Buck"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>
@@ -48,7 +48,7 @@
 
 	<!-- Slug -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_12Gauge_Slug"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_12Gauge_Slug" or defName="MakeAmmo_Shotgun_Slug"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -81,7 +81,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_12Gauge_Slug"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_12Gauge_Slug" or defName="MakeAmmo_Shotgun_Slug"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>
@@ -94,7 +94,7 @@
 
 	<!-- Beanbag -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_12Gauge_Beanbag"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_12Gauge_Beanbag" or defName="MakeAmmo_Shotgun_Beanbag"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -135,7 +135,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_12Gauge_Beanbag"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_12Gauge_Beanbag" or defName="MakeAmmo_Shotgun_Beanbag"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>
@@ -148,7 +148,7 @@
 
 	<!-- ElectroSlug -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_12Gauge_ElectroSlug"]/ingredients</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_12Gauge_ElectroSlug" or defName="MakeAmmo_Shotgun_ElectroSlug"]/ingredients</xpath>
 		<value>
 			<ingredients>
 				<li>
@@ -181,7 +181,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/RecipeDef[defName="MakeAmmo_12Gauge_ElectroSlug"]/fixedIngredientFilter</xpath>
+		<xpath>Defs/RecipeDef[defName="MakeAmmo_12Gauge_ElectroSlug" or defName="MakeAmmo_Shotgun_ElectroSlug"]/fixedIngredientFilter</xpath>
 		<value>
 			<fixedIngredientFilter>
 				<thingDefs>


### PR DESCRIPTION
## Additions

Added generic ammo to the corresponding non-generic ammo's patch for EM Metals


## Alternatives

Could give some or all generic ammo their own patch rather than using the same values as the non-generic ammo

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (few in-game years)
