### PR TITLE
Check WeaponPlatform before get stat

### DIFF
--- a/Source/CombatExtended/CombatExtended/AI/Toils/Toils_CombatCE.cs
+++ b/Source/CombatExtended/CombatExtended/AI/Toils/Toils_CombatCE.cs
@@ -36,7 +36,8 @@ namespace CombatExtended.AI
                     return;
                 }
                 startTick = GenTicks.TicksGame;
-                reloadingTime = Mathf.CeilToInt(compAmmo.parent.GetStatValue(CE_StatDefOf.ReloadTime).SecondsToTicks() / driver.pawn.GetStatValue(CE_StatDefOf.ReloadSpeed));
+                WeaponPlatform platform = compAmmo.parent as WeaponPlatform;
+                reloadingTime = Mathf.CeilToInt((platform?.GetStatValue(CE_StatDefOf.ReloadTime) ?? compAmmo.Props.reloadTime).SecondsToTicks() / driver.pawn.GetStatValue(CE_StatDefOf.ReloadSpeed));
             });
             waitToil.tickAction = () =>
             {

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -782,9 +782,9 @@ namespace CombatExtended
             {
                 return;
             }
-            float recoil = ((VerbPropertiesCE)weaponDef.verbs[0]).recoilAmount;
+            float recoil = ((VerbPropertiesCE)shootVerb.verbProps).recoilAmount;
 
-            float recoilRelaxation = weaponDef.verbs[0].burstShotCount > 1 ? weaponDef.verbs[0].ticksBetweenBurstShots : weaponDef.GetStatValueDef(StatDefOf.RangedWeapon_Cooldown) * 20f;
+            float recoilRelaxation = shootVerb.verbProps.burstShotCount > 1 ? shootVerb.verbProps.ticksBetweenBurstShots : weaponDef.GetStatValueDef(StatDefOf.RangedWeapon_Cooldown) * 20f;
 
             recoil = Math.Min(recoil * recoil, 20) * RecoilMagicNumber * Mathf.Clamp((float)Math.Log10(recoilRelaxation), 0.1f, 10);
 

--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
@@ -59,7 +59,8 @@ namespace CombatExtended
         {
             get
             {
-                return (int)parent.GetStatValue(CE_StatDefOf.MagazineCapacity);
+                WeaponPlatform platform = parent as WeaponPlatform;
+                return (int)(platform?.GetStatValue(CE_StatDefOf.MagazineCapacity) ?? Props.magazineSize);
             }
         }
 
@@ -83,7 +84,8 @@ namespace CombatExtended
         {
             get
             {
-                return (int)parent.GetStatValue(CE_StatDefOf.AmmoGenPerMagOverride);
+                WeaponPlatform platform = parent as WeaponPlatform;
+                return (int)(platform?.GetStatValue(CE_StatDefOf.AmmoGenPerMagOverride) ?? Props.AmmoGenPerMagOverride);
             }
         }
         public int CurMagCount

--- a/Source/CombatExtended/CombatExtended/Comps/CompFireModes.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompFireModes.cs
@@ -146,7 +146,7 @@ namespace CombatExtended
             availableFireModes.Clear();
             availableAimModes.Add(AimMode.AimedShot);
             // Calculate available fire modes
-            if (parent.GetStatValue(CE_StatDefOf.BurstShotCount) > 1 || Props.noSingleShot)
+            if (Verb.verbProps.burstShotCount > 1 || Props.noSingleShot)
             {
                 availableFireModes.Add(FireMode.AutoFire);
             }

--- a/Source/CombatExtended/CombatExtended/Jobs/JobDriver_Reload.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobDriver_Reload.cs
@@ -188,7 +188,8 @@ namespace CombatExtended
             bool hasCasing = true;
             waitToil.initAction = () => waitToil.actor.pather.StopDead();
             waitToil.defaultCompleteMode = ToilCompleteMode.Delay;
-            waitToil.defaultDuration = Mathf.CeilToInt(weapon.GetStatValue(CE_StatDefOf.ReloadTime).SecondsToTicks() / pawn.GetStatValue(CE_StatDefOf.ReloadSpeed));
+            WeaponPlatform platform = weapon as WeaponPlatform;
+            waitToil.defaultDuration = Mathf.CeilToInt((platform?.GetStatValue(CE_StatDefOf.ReloadTime) ?? compReloader.Props.reloadTime).SecondsToTicks() / pawn.GetStatValue(CE_StatDefOf.ReloadSpeed));
             //If we're 30 ticks through the reload timer or if reload was too fast, before it completes, drop casings if dropcasingwhenreload.
             waitToil.AddPreTickAction(() =>
             {

--- a/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_BipodDisplay.cs
+++ b/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_BipodDisplay.cs
@@ -40,7 +40,7 @@ namespace CombatExtended
 
         public VerbPropertiesCE verbPropsCE(StatRequest req)
         {
-            var result = (VerbPropertiesCE)req.Thing?.def.verbs.Find(x => x is VerbPropertiesCE);
+            var result = req.Thing.TryGetComp<CompEquippable>()?.PrimaryVerb?.verbProps as VerbPropertiesCE;
 
             if (result == null)
             {

--- a/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_Magazine.cs
+++ b/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_Magazine.cs
@@ -72,7 +72,7 @@ namespace CombatExtended
             }
             if (req.HasThing)
             {
-                return (int)req.Thing.GetStatValue(CE_StatDefOf.MagazineCapacity);
+                return (int)(compAmmo?.MagSize ?? req.Thing.GetStatValue(CE_StatDefOf.MagazineCapacity));
             }
             return GunDef(req)?.GetCompProperties<CompProperties_AmmoUser>()?.magazineSize ?? 0;
         }

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -74,9 +74,10 @@ namespace CombatExtended
             get
             {
                 float shotsPerBurst = base.ShotsPerBurst;
-                if (EquipmentSource != null)
+                WeaponPlatform platform = this.WeaponPlatform;
+                if (platform != null)
                 {
-                    float modified = EquipmentSource.GetStatValue(CE_StatDefOf.BurstShotCount);
+                    float modified = platform.GetStatValue(CE_StatDefOf.BurstShotCount);
                     if (modified > 0)
                     {
                         shotsPerBurst = modified;
@@ -191,14 +192,17 @@ namespace CombatExtended
             }
         }
 
+        public WeaponPlatform WeaponPlatform => EquipmentSource as WeaponPlatform;
+
         public float RecoilAmount
         {
             get
             {
                 float recoil = VerbPropsCE.recoilAmount;
-                if (EquipmentSource != null)
+                WeaponPlatform platform = this.WeaponPlatform;
+                if (platform != null)
                 {
-                    float modified = EquipmentSource.GetStatValue(CE_StatDefOf.Recoil);
+                    float modified = platform.GetStatValue(CE_StatDefOf.Recoil);
                     if (modified > 0)
                     {
                         recoil = modified;

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -192,9 +192,10 @@ namespace CombatExtended
                 }
             }
             float burstShotCount = VerbPropsCE.burstShotCount;
-            if (EquipmentSource != null && (!EquipmentSource.TryGetComp<CompUnderBarrel>()?.usingUnderBarrel ?? false))
+            WeaponPlatform platform = WeaponPlatform;
+            if (platform != null && (!platform.TryGetComp<CompUnderBarrel>()?.usingUnderBarrel ?? false))
             {
-                float modified = EquipmentSource.GetStatValue(CE_StatDefOf.BurstShotCount);
+                float modified = platform.GetStatValue(CE_StatDefOf.BurstShotCount);
                 if (modified > 0)
                 {
                     burstShotCount = modified;

--- a/Source/CombatExtended/Harmony/Harmony_Verb.cs
+++ b/Source/CombatExtended/Harmony/Harmony_Verb.cs
@@ -74,9 +74,10 @@ namespace CombatExtended.HarmonyCE
         private static int GetTicksBetweenBurstShots(Verb verb)
         {
             float ticksBetweenBurstShots = verb.verbProps.ticksBetweenBurstShots;
-            if (verb is Verb_LaunchProjectileCE && verb.EquipmentSource != null)
+            WeaponPlatform platform = verb.EquipmentSource as WeaponPlatform;
+            if (verb is Verb_LaunchProjectileCE && platform != null)
             {
-                float modified = verb.EquipmentSource.GetStatValue(CE_StatDefOf.TicksBetweenBurstShots);
+                float modified = platform.GetStatValue(CE_StatDefOf.TicksBetweenBurstShots);
                 if (modified > 0)
                 {
                     ticksBetweenBurstShots = modified;


### PR DESCRIPTION
## Additions
- more compatiblity with [RW-Modularization Weapon](https://github.com/RW-NodeTree/RW_ModularizationWeapon)

## Changes
- Add checker befor get stat, reduce systemic differences betwen vanilla.

## Reasoning
- If there has not only one props in `ThingDef.verbs`, it will let weapon use error parm. because stat value can only has one value in def.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
