### PR TITLE
Minor VFE Deserters patch update

### DIFF
--- a/ModPatches/Vanilla Factions Expanded - Deserters/Patches/Vanilla Factions Expanded - Deserters/Buildings_Special.xml
+++ b/ModPatches/Vanilla Factions Expanded - Deserters/Patches/Vanilla Factions Expanded - Deserters/Buildings_Special.xml
@@ -75,6 +75,7 @@
 				<allowedTurrets>
 					<li>Turret_Autocannon</li>
 					<li>VFED_Turret_Palintone</li>
+					<li MayRequire="vanillaexpanded.vfesecurity">VFES_Turret_AutocannonDouble</li>
 				</allowedTurrets>
 			</li>
 		</value>

--- a/ModPatches/Vanilla Factions Expanded - Deserters/Patches/Vanilla Factions Expanded - Deserters/Things_Security.xml
+++ b/ModPatches/Vanilla Factions Expanded - Deserters/Patches/Vanilla Factions Expanded - Deserters/Things_Security.xml
@@ -7,6 +7,15 @@
 			| Defs/ThingDef[defName="Turret_RocketswarmLauncher"]/comps/li[@Class="VFED.CompProperties_BoxRefuel"]</xpath>
 	</Operation>
 
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Furniture Expanded - Security</li>
+		</mods>
+		<match Class="PatchOperationRemove">
+			<xpath>Defs/ThingDef[defName="VFES_Turret_AutocannonDouble"]/comps/li[@Class="VFED.CompProperties_BoxRefuel"]</xpath>
+		</match>
+	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="VFED_RemoteTrapIED_HighExplosive"]/comps/li[@Class="CompProperties_Explosive"]</xpath>
 		<value>


### PR DESCRIPTION
## Additions

- Patched the autocannon loader to also reload the double autocannon turret from VFE Security.

## Reasoning

- Double autocannon now also accepts a loader when Deserters is active, causing an error when spawned unpatched.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (about 40 seconds)
