### PR TITLE
Fix Pawn Generation 2HWeapon+Shield

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_PawnGenerator_GenerateGearFor.cs
+++ b/Source/CombatExtended/Harmony/Harmony_PawnGenerator_GenerateGearFor.cs
@@ -1,0 +1,33 @@
+﻿using HarmonyLib;
+using Verse;
+
+namespace CombatExtended.HarmonyCE
+{
+    [HarmonyPatch(typeof(PawnGenerator), nameof(PawnGenerator.GenerateGearFor))]
+    public static class Harmony_PawnGenerator_GenerateGearFor
+    {
+        public static void Postfix(Pawn pawn)
+        {
+            if (pawn?.equipment?.Primary is ThingWithComps weapon && weapon.IsTwoHandedWeapon())
+            {
+                if (pawn.apparel != null)
+                {
+                    var list = pawn.apparel.wornApparel;
+                    // Reverse loop to prevent removal issues
+                    for (int i = list.Count - 1; i >= 0; i--)
+                    {
+                        if (list[i] is Apparel_Shield shield)
+                        {
+                            Log.Warning($"Combat Extended :: Removing shield from {pawn.kindDef.defName} as they generated with shield and two-handed weapon.");
+                            if (!shield.Destroyed)
+                            {
+                                shield.Destroy();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- PawnGenerator.GenerateGearFor Postfix that checks if a pawn has generated with both a shield and a two-handed weapon. If so, it destroys the shield.

## Reasoning

Why did you choose to implement things this way, e.g.
- Pawns that spawn with both a two-handed weapon and a shield just stand around not doing anything productive during raids
- CE Shields are apparel and can be potentially spawned during apparel generation before two handed weapons are spawned.
- Weapons are generally more important than armor

## Alternatives

Describe alternative implementations you have considered, e.g.
- Patch on PawnWeaponGenerator.TryGenerateWeaponFor
- Leave potentially useless pawns

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Spawned pawns until receiving on purpose warning message. Confirms that the shields are being removed properly without a actual error)
