### PR TITLE
Update House Sanguine Patch

### DIFF
--- a/ModPatches/DD House Sanguin/Patches/DD House Sanguin/Mods/RimFantasy - Medeival Overhaul/Blood Weapons.xml
+++ b/ModPatches/DD House Sanguin/Patches/DD House Sanguin/Mods/RimFantasy - Medeival Overhaul/Blood Weapons.xml
@@ -3,7 +3,7 @@
 
 	<Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>RimFantasy - Medieval Overhaul Edition</li>
+			<li>RimFantasy: Medieval Overhaul Edition</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Fixes the find mod as Rimfantasy name changed

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[[3591](https://github.com/CombatExtended-Continued/CombatExtended/issues/3591)]

## Alternatives

Describe alternative implementations you have considered, e.g.
- Suffer

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (just to ensure the weapons with House Sanguine + Rimfantasy are being patched)
