### PR TITLE
Add null checks for animal night vision

### DIFF
--- a/Source/CombatExtended/CombatExtended/Building_AmmoContainerCE/Building_AutoloaderCE.cs
+++ b/Source/CombatExtended/CombatExtended/Building_AmmoContainerCE/Building_AutoloaderCE.cs
@@ -438,7 +438,7 @@ namespace CombatExtended
                 int ammoCount = Mathf.Min(CompAmmoUser.CurMagCount, TargetAmmoUser.MissingToFullMagazine);
                 TargetAmmoUser.CurMagCount += ammoCount;
                 CompAmmoUser.CurMagCount -= ammoCount;
-            };
+            }
             TargetTurret.SetReloading(false);
             TargetTurret = null;
             TryActiveReload();

--- a/Source/CombatExtended/CombatExtended/Comps_CCL/CompPawnGizmo.cs
+++ b/Source/CombatExtended/CombatExtended/Comps_CCL/CompPawnGizmo.cs
@@ -50,7 +50,7 @@ namespace CombatExtended
                         }
                     }
                 }
-            };
+            }
         }
     }
 }

--- a/Source/CombatExtended/CombatExtended/StatParts/Base/StatPart_StatSelect.cs
+++ b/Source/CombatExtended/CombatExtended/StatParts/Base/StatPart_StatSelect.cs
@@ -109,17 +109,17 @@ namespace CombatExtended
                 if (apparelStat != null)
                 {
                     float value = 0;
-                    ThingOwner<Apparel> wornApparel = pawn.apparel.wornApparel;
+                    ThingOwner<Apparel> wornApparel = pawn.apparel?.wornApparel;
                     if (sumApparelsStat)
                     {
-                        for (int i = 0; i < wornApparel.Count; i++)
+                        for (int i = 0; i < wornApparel?.Count; i++)
                         {
                             value += GetEquipmentStat(wornApparel[i], apparelStat);
                         }
                     }
                     else
                     {
-                        for (int i = 0; i < wornApparel.Count; i++)
+                        for (int i = 0; i < wornApparel?.Count; i++)
                         {
                             value = Select(value, GetEquipmentStat(wornApparel[i], apparelStat));
                         }
@@ -128,7 +128,7 @@ namespace CombatExtended
                 }
                 if (weaponStat != null)
                 {
-                    result += weaponStat.LabelCap + ": " + (pawn.equipment.Primary != null
+                    result += weaponStat.LabelCap + ": " + (pawn.equipment?.Primary != null
                         ? GetEquipmentStat(pawn.equipment.Primary, weaponStat).ToStringPercent()
                         : "0%") + "\n";
                 }


### PR DESCRIPTION
## Changes

- Added null checks for apparel and equipment in night vision stat explanations, because animals don't have these trackers.
- Also removed a couple of stray semicolons that somehow haven't tripped the style checker in months. (?????)

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Quickstart only)
