### PR TITLE
Added explicit type conversion method to be used on SOS2 side

### DIFF
--- a/Source/SOS2Compat/SOS2Compat/Building_ShipTurretCE.cs
+++ b/Source/SOS2Compat/SOS2Compat/Building_ShipTurretCE.cs
@@ -17,10 +17,11 @@ namespace CombatExtended.Compatibility.SOS2Compat
         #endregion
         public bool GroundDefenseMode;
 
-        // Allows conversion of Building_ShipTurretCE into Building_ShipTurret as the SaveOurShip2.ShipCombatProjectile class which is used in Verb_ShootShipCE requires a Building_ShipTurret to be passed into its constructor.
-        public static implicit operator Building_ShipTurret(Building_ShipTurretCE turretCE)
+        // Explicit type conversion that will be used in SOS2 code for turrets added to heat net turrets list.
+        // Also allows conversion of Building_ShipTurretCE into Building_ShipTurret as the SaveOurShip2.ShipCombatProjectile class which is used in Verb_ShootShipCE requires a Building_ShipTurret to be passed into its constructor.
+        public Building_ShipTurret ToBuilding_ShipTurret()
         {
-            return new ShipTurretWrapperCE(turretCE);
+            return new ShipTurretWrapperCE(this);
         }
 
         #region Shared

--- a/Source/SOS2Compat/SOS2Compat/Verb_ShootShipCE.cs
+++ b/Source/SOS2Compat/SOS2Compat/Verb_ShootShipCE.cs
@@ -417,7 +417,7 @@ namespace CombatExtended.Compatibility.SOS2Compat
             }
             ShipCombatProjectile proj = new ShipCombatProjectile
             {
-                turret = turret,
+                turret = turret.ToBuilding_ShipTurret(),
                 target = target,
                 range = 0,
                 //rangeAtStart = mapComp.Range,


### PR DESCRIPTION
## Changes

Changed implicit cast operator to explicit type conversion function. That function is now used on SOS 2 side to make selecting ship turrets from tactical console (via gizmos) feature work properly

## References
SOS2 side changes, split into 2 PRs:

https://github.com/Bqr1s/SaveOurShip2/commit/135e1d9a7da9298af97e1fd98fbbe360880b62a2
https://github.com/Bqr1s/SaveOurShip2/commit/473c6da79e36c9ec65558da759eed58f5bbd3293

## Reasoning

Implicit type cast operator won't work on SOS2 side, so it was replaced with named function, to make calls via reflection more readable

## Alternatives

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] When both SOS2 and CE updated, feature works
- [x] When only SOS2 is updated and CE does not have new added function, feature does not work, but no log errors or other inconveniences
When only CE is updated, feature is not expected to work, because main fix body is on SOS2 side, not tested.
feature = when tactical console is selected, all connected turrets have separate gizmos to select turrets of the given type. Tested for all types of weapons (torpedo, spinal, railgun, laser, plasma, cannon)
Just in case: tested on local build.