### PR TITLE
Virtualize autoloader target acquision

### DIFF
--- a/Source/CombatExtended/CombatExtended/Building_AmmoContainerCE/Building_AutoloaderCE.cs
+++ b/Source/CombatExtended/CombatExtended/Building_AmmoContainerCE/Building_AutoloaderCE.cs
@@ -8,6 +8,7 @@ using CombatExtended.AI;
 using CombatExtended.Compatibility;
 using Mono.Unix.Native;
 using RimWorld;
+using RimWorld.Planet;
 using UnityEngine;
 using Verse;
 using Verse.AI;
@@ -50,7 +51,7 @@ namespace CombatExtended
 
         public bool shouldBeOn => ShouldBeOn();
 
-        public bool ShouldBeOn(bool failureNotify = false)
+        public virtual bool ShouldBeOn(bool failureNotify = false)
         {
             if (manningRequiredButUnmanned)
             {
@@ -341,12 +342,16 @@ namespace CombatExtended
             return stringBuilder.ToString().TrimEndNewlines();
         }
 
-        public bool TryActiveReload()
+        public virtual List<Thing> TurretsToReload()
         {
             List<Thing> adjThings = new List<Thing>();
             GenAdjFast.AdjacentThings8Way(this, adjThings);
+            return adjThings;
+        }
 
-            foreach (Thing building in adjThings)
+        public bool TryActiveReload()
+        {
+            foreach (Thing building in TurretsToReload())
             {
                 if (building is Building_TurretGunCE turret && (turret.GetAmmo().EmptyMagazine || turret.currentTargetInt == LocalTargetInfo.Invalid) && StartReload(turret.GetAmmo()))
                 {


### PR DESCRIPTION
## Changes

Made the find-turret code in autoloaders separate and virtual

## Reasoning

Just in case I or someone else decided to make an autoloader that doesn't always load every adjacent turret, instead with different logic.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] Playtested a colony (specify how long)
