### PR TITLE
Update VFEC shield label for historical and graphical accuracy

### DIFF
--- a/ModPatches/Vanilla Factions Expanded - Classical/Defs/Vanilla Factions Expanded - Classical/ThingDefs_Shields.xml
+++ b/ModPatches/Vanilla Factions Expanded - Classical/Defs/Vanilla Factions Expanded - Classical/ThingDefs_Shields.xml
@@ -4,7 +4,7 @@
 	<!-- Roman Shield (Scutum) -->
 	<ThingDef ParentName="ShieldBase">
 		<defName>VFEC_Shield_Heavy_CE</defName>
-		<label>kite shield</label>
+		<label>tower shield</label>
 		<description>A heavily fortified square shield that covers one's body from shin to shoulder, heavy enough to slow those wielding it at the benefit of incredible protection.</description>
 		<techLevel>Neolithic</techLevel>
 		<graphicData>


### PR DESCRIPTION
## Changes

Changed the Vanilla Factions Expanded - Classical shield label from kite shield to tower shield

## Reasoning

The Roman Scutum is a type of tower shield for infantry, kite shields taper towards the bottom and can be more easily used mounted.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
