### PR TITLE
Add Weapon Handling Stat Buff to Powered Exoframe

### DIFF
--- a/Defs/ThingDefs_Misc/Apparel_Carrying.xml
+++ b/Defs/ThingDefs_Misc/Apparel_Carrying.xml
@@ -510,7 +510,7 @@
 	<ThingDef ParentName="ApparelCarryGearBase">
 		<defName>CE_Apparel_ExoFrame</defName>
 		<label>powered exoframe</label>
-		<description>A powered exoframe with articulated joints, commonly used in industrial settings by workers handling heavy parts.\n\nIncreases lifting capacity, but is quite bulky to wear.</description>
+		<description>A powered exoframe with articulated joints, commonly used in industrial settings by workers handling heavy parts.\n\nIncreases lifting capacity and assists in weapon-handling, but is quite bulky to wear.</description>
 		<graphicData>
 			<texPath>Things/Apparel/Exoframe/CE_Exoframe</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -540,6 +540,7 @@
 		</statBases>
 		<equippedStatOffsets>
 			<CarryWeight>50</CarryWeight>
+			<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
 		</equippedStatOffsets>
 		<costList>
 			<Plasteel>80</Plasteel>

--- a/Defs/ThingDefs_Misc/Apparel_Carrying.xml
+++ b/Defs/ThingDefs_Misc/Apparel_Carrying.xml
@@ -510,7 +510,7 @@
 	<ThingDef ParentName="ApparelCarryGearBase">
 		<defName>CE_Apparel_ExoFrame</defName>
 		<label>powered exoframe</label>
-		<description>A powered exoframe with articulated joints, commonly used in industrial settings by workers handling heavy parts.\n\nIncreases lifting capacity and assists in weapon-handling, but is quite bulky to wear.</description>
+		<description>A powered exoframe with articulated joints, commonly used in industrial settings by workers handling heavy parts.\n\nIncreases lifting capacity and improves weapon-handling, but is quite bulky to wear.</description>
 		<graphicData>
 			<texPath>Things/Apparel/Exoframe/CE_Exoframe</texPath>
 			<graphicClass>Graphic_Single</graphicClass>

--- a/Defs/ThingDefs_Misc/Apparel_Carrying.xml
+++ b/Defs/ThingDefs_Misc/Apparel_Carrying.xml
@@ -515,6 +515,7 @@
 			<texPath>Things/Apparel/Exoframe/CE_Exoframe</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
+		<techLevel>Industrial</techLevel>
 		<generateCommonality>0.25</generateCommonality>
 		<recipeMaker>
 			<researchPrerequisite>MicroelectronicsBasics</researchPrerequisite>

--- a/Defs/ThingDefs_Misc/Apparel_Carrying.xml
+++ b/Defs/ThingDefs_Misc/Apparel_Carrying.xml
@@ -510,7 +510,7 @@
 	<ThingDef ParentName="ApparelCarryGearBase">
 		<defName>CE_Apparel_ExoFrame</defName>
 		<label>powered exoframe</label>
-		<description>A powered exoframe with articulated joints, commonly used in industrial settings by workers handling heavy parts.\n\nIncreases lifting capacity and improves weapon-handling, but is quite bulky to wear.</description>
+		<description>A powered exoframe with articulated joints, commonly used in industrial settings by workers handling heavy parts.\n\nIncreases lifting capacity and improves weapon handling, but is quite bulky to wear.</description>
 		<graphicData>
 			<texPath>Things/Apparel/Exoframe/CE_Exoframe</texPath>
 			<graphicClass>Graphic_Single</graphicClass>


### PR DESCRIPTION
## Additions
- Gives the Powered Exoframe a +0.15 weapon handling increase to represent assistance in recoil and sway management thanks to the electronic servos and motors, similar to what we already do with power armor.
- Description tweaked to reflect this change.

## Reasoning
https://discord.com/channels/278818534069501953/700236703180259358/1346990607939407934

Basically, the exoframe sits in a weird niche place where its only real purpose is to aid in carrying heavy weapons from other mods before power armor or bionics are unlocked. This change gives it a more universal reason to be used, sacrificing potential outer layer protection for an increase in handling (along with the previous benefits to carry weight).

Power armor is still better in every way, providing the same carry weight and handling bonuses alongside high protection; this change is designed to bridge the gap a little bit more while giving the exoframe a more defined purpose.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (5 minute dev test)
