### PR TITLE
Fix Mp compat about StaticVerbs

### DIFF
--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileStaticCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileStaticCE.cs
@@ -34,6 +34,7 @@ namespace CombatExtended
             return base.ValidateTarget(target, showMessages) && ReloadableUtility.CanUseConsideringQueuedJobs(CasterPawn, EquipmentSource, true);
         }
 
+        [Compatibility.Multiplayer.SyncMethod]
         public override void OrderForceTarget(LocalTargetInfo target)
         {
             Job job = JobMaker.MakeJob(JobDefOf.UseVerbOnThingStatic, target);

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCEOneUseStatic.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCEOneUseStatic.cs
@@ -11,6 +11,7 @@ namespace CombatExtended
 {
     public class Verb_ShootCEOneUseStatic : Verb_ShootCEOneUse
     {
+        [Compatibility.Multiplayer.SyncMethod]
         public override void OrderForceTarget(LocalTargetInfo target)
         {
             Job job = JobMaker.MakeJob(JobDefOf.UseVerbOnThingStaticReserve, target);


### PR DESCRIPTION
## Changes

- Added MPSyncMethodAttribute to Verbs that override `OrderForceTarget`

## Reasoning

- For MP normally we sync every `OrderForceTarget` of ITargetingSource classes.  Seems Sokyran forget to sync this.
- If these are not patch, you are not able to use things that related. e.g. You'll get nullpointer error when trying to use Disruptorflarepack with CE.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
