### PR TITLE
Guided projectiles height fix

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -177,6 +177,7 @@ namespace CombatExtended
         public float startingTicksToImpact;
 
         public int FlightTicks = 0;
+        public float intendedTargetHeight = 0f;
 
         #endregion
 
@@ -902,6 +903,11 @@ namespace CombatExtended
                 // Check for collision
                 if (thing == intendedTargetThing || def.projectile.alwaysFreeIntercept || thing.Position.DistanceTo(OriginIV3) >= minCollisionDistance)
                 {
+                    if (thing == intendedTargetThing)
+                    {
+                        var canCollide = CanCollideWith(thing, out var dist);
+                        Log.Message($"{canCollide}, {dist}");
+                    }
                     if (!CanCollideWith(thing, out _))
                     {
                         continue;
@@ -1548,6 +1554,7 @@ namespace CombatExtended
         #region Ballistics
         public BaseTrajectoryWorker TrajectoryWorker => forcedTrajectoryWorker ?? (def.projectile as ProjectilePropertiesCE).TrajectoryWorker;
         internal BaseTrajectoryWorker forcedTrajectoryWorker;
+        
 
         public void DrawNextPositions()
         {

--- a/Source/CombatExtended/CombatExtended/Projectiles/TrajectoryWorkers/BallisticsTrajectoryWorker.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/TrajectoryWorkers/BallisticsTrajectoryWorker.cs
@@ -27,28 +27,28 @@ namespace CombatExtended
             float gravity = projectile.gravity;
             for (int ticksOffset = 1; ticksOffset <= ticksToImpact; ticksOffset++)
             {
-                yield return exactPosition = BallisticMove(currentTarget, exactPosition, speedGain, maxSpeed, ref velocity, ref shotSpeed, ref mass, ref ballisticCoefficient, ref radius, ref gravity);
+                yield return exactPosition = BallisticMove(currentTarget, projectile.intendedTargetHeight, exactPosition, speedGain, maxSpeed, ref velocity, ref shotSpeed, ref mass, ref ballisticCoefficient, ref radius, ref gravity);
             }
         }
         protected override void MoveForward(ProjectileCE projectile)
         {
-            projectile.ExactPosition = BallisticMove(projectile.intendedTarget, projectile.ExactPosition, projectile.Props.speedGain, projectile.Props.speed, ref projectile.velocity, ref projectile.shotSpeed, ref projectile.mass, ref projectile.ballisticCoefficient, ref projectile.radius, ref projectile.gravity);
+            projectile.ExactPosition = BallisticMove(projectile.intendedTarget, projectile.intendedTargetHeight, projectile.ExactPosition, projectile.Props.speedGain, projectile.Props.speed, ref projectile.velocity, ref projectile.shotSpeed, ref projectile.mass, ref projectile.ballisticCoefficient, ref projectile.radius, ref projectile.gravity);
             projectile.FlightTicks++;
         }
-        protected virtual Vector3 BallisticMove(LocalTargetInfo currentTarget, Vector3 exactPosition, float speedGain, float maxSpeed, ref Vector3 velocity, ref float shotSpeed, ref float mass, ref float ballisticCoefficient, ref float radius, ref float gravity)
+        protected virtual Vector3 BallisticMove(LocalTargetInfo currentTarget, float targetHeight, Vector3 exactPosition, float speedGain, float maxSpeed, ref Vector3 velocity, ref float shotSpeed, ref float mass, ref float ballisticCoefficient, ref float radius, ref float gravity)
         {
-            Accelerate(currentTarget, radius, ballisticCoefficient, mass, gravity, speedGain, maxSpeed, exactPosition, ref velocity, ref shotSpeed);
+            Accelerate(currentTarget, targetHeight, radius, ballisticCoefficient, mass, gravity, speedGain, maxSpeed, exactPosition, ref velocity, ref shotSpeed);
             shotSpeed = GetSpeed(velocity);
             return exactPosition + velocity;
         }
-        protected virtual void Accelerate(LocalTargetInfo currentTarget, float radius, float ballisticCoefficient, float mass, float gravity, float speedGain, float maxSpeed, Vector3 exactPosition, ref Vector3 velocity, ref float shotSpeed)
+        protected virtual void Accelerate(LocalTargetInfo currentTarget, float targetHeight, float radius, float ballisticCoefficient, float mass, float gravity, float speedGain, float maxSpeed, Vector3 exactPosition, ref Vector3 velocity, ref float shotSpeed)
         {
             AffectedByDrag(radius, shotSpeed, ballisticCoefficient, mass, ref velocity);
             AffectedByGravity(gravity, ref velocity);
-            ReactiveAcceleration(currentTarget, speedGain, maxSpeed, exactPosition, ref velocity, ref shotSpeed);
+            ReactiveAcceleration(currentTarget, targetHeight, speedGain, maxSpeed, exactPosition, ref velocity, ref shotSpeed);
         }
 
-        protected virtual void ReactiveAcceleration(LocalTargetInfo currentTarget, float speedGain, float maxSpeed, Vector3 exactPosition, ref Vector3 velocity, ref float shotSpeed)
+        protected virtual void ReactiveAcceleration(LocalTargetInfo currentTarget, float targetHeight, float speedGain, float maxSpeed, Vector3 exactPosition, ref Vector3 velocity, ref float shotSpeed)
         {
             var speedChange = Mathf.Max(Mathf.Min(maxSpeed - shotSpeed, speedGain), 0f);
             if (speedChange > 0.001f)

--- a/Source/CombatExtended/CombatExtended/Projectiles/TrajectoryWorkers/SmartRocketTrajectoryWorker.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/TrajectoryWorkers/SmartRocketTrajectoryWorker.cs
@@ -10,14 +10,15 @@ namespace CombatExtended
 {
     public class SmartRocketTrajectoryWorker : BallisticsTrajectoryWorker
     {
-        protected override void ReactiveAcceleration(LocalTargetInfo currentTarget, float speedGain, float maxSpeed, Vector3 exactPosition, ref Vector3 velocity, ref float shotSpeed)
+        protected override void ReactiveAcceleration(LocalTargetInfo currentTarget, float targetHeight, float speedGain, float maxSpeed, Vector3 exactPosition, ref Vector3 velocity, ref float shotSpeed)
         {
             if (currentTarget.ThingDestroyed)
             {
-                base.ReactiveAcceleration(currentTarget, speedGain, maxSpeed, exactPosition, ref velocity, ref shotSpeed);
+                base.ReactiveAcceleration(currentTarget, targetHeight, speedGain, maxSpeed, exactPosition, ref velocity, ref shotSpeed);
                 return;
             }
             var targetPos = currentTarget.Thing?.DrawPos ?? currentTarget.Cell.ToVector3Shifted();
+            targetPos = targetPos.WithY(targetHeight);
             var velocityChange = GetVelocity(speedGain, exactPosition, targetPos);
             shotSpeed = Mathf.Max(Mathf.Min(shotSpeed + speedGain, maxSpeed), 0f);
             velocity = GetVelocity(shotSpeed, Vector3.zero, velocity + velocityChange);

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -477,14 +477,15 @@ namespace CombatExtended
 
         public void ShiftTarget(ShiftVecReport report, bool calculateMechanicalOnly = false, bool isInstant = false)
         {
-            ShiftTarget(report, report.target.Thing?.TrueCenter() ?? report.target.Cell.ToVector3Shifted(), calculateMechanicalOnly, isInstant);
+            ShiftTarget(report, report.target.Thing?.TrueCenter() ?? report.target.Cell.ToVector3Shifted(), out _, calculateMechanicalOnly, isInstant);
         }
 
         /// <summary>
         /// Shifts the original target position in accordance with target leading, range estimation and weather/lighting effects
         /// </summary>
-        public virtual void ShiftTarget(ShiftVecReport report, Vector3 v, bool calculateMechanicalOnly = false, bool isInstant = false)
+        public virtual void ShiftTarget(ShiftVecReport report, Vector3 v, out float targetHeight, bool calculateMechanicalOnly = false, bool isInstant = false)
         {
+            targetHeight = 0f;
             if (!calculateMechanicalOnly)
             {
                 Vector3 u = caster.TrueCenter();
@@ -530,7 +531,7 @@ namespace CombatExtended
 
                 // Height difference calculations for ShotAngle
 
-                var targetHeight = GetTargetHeight(report.target, report.cover, report.roofed, v);
+                targetHeight = GetTargetHeight(report.target, report.cover, report.roofed, v);
 
                 if (!LockRotationAndAngle)
                 {
@@ -1087,7 +1088,7 @@ namespace CombatExtended
 
                 ProjectileCE projectile = SpawnProjectile();
                 GenSpawn.Spawn(projectile, shootLine.Source, caster.Map);
-                ShiftTarget(report, lastExactPos, pelletMechanicsOnly, instant);
+                ShiftTarget(report, lastExactPos, out projectile.intendedTargetHeight, pelletMechanicsOnly, instant);
 
                 //New aiming algorithm
                 projectile.canTargetSelf = false;


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Fixed guided projectile wrong target height

## Reasoning

Why did you choose to implement things this way, e.g.
- Guided projectile trajectory worker was using altitude of target as height

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (tested if guided rocket hits static and moving pawn)
