### PR TITLE
Ammo that causes weapon deteoriation

### DIFF
--- a/Defs/Ammo/Other/Flare.xml
+++ b/Defs/Ammo/Other/Flare.xml
@@ -18,6 +18,7 @@
 		<ammoTypes>
 			<Ammo_Flare>Bullet_Flare</Ammo_Flare>
 			<Ammo_FlareBioferrite MayRequire="Ludeon.RimWorld.Anomaly">Bullet_FlareBioferrite</Ammo_FlareBioferrite>
+			<Ammo_12Gauge_Buck>Bullet_12Gauge_Buck_SB_Overpressure</Ammo_12Gauge_Buck>
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
 
@@ -212,6 +213,25 @@
 				</FleckDatas>
 			</li>
 		</comps>
+	</ThingDef>
+
+	<ThingDef ParentName="Base12GaugeBullet">
+		<defName>Bullet_12Gauge_Buck_SB_Overpressure</defName>
+		<label>buckshot pellet</label>
+		<graphicData>
+			<texPath>Things/Projectile/Shotgun_Pellet</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<speed>75</speed>
+			<damageAmountBase>7</damageAmountBase>
+			<pelletCount>9</pelletCount>
+			<armorPenetrationSharp>3.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>3.46</armorPenetrationBlunt>
+			<spreadMult>11.0</spreadMult>
+			<weaponDeteriorationChance>1</weaponDeteriorationChance>
+			<weaponDeteriorationHP>70~100</weaponDeteriorationHP>
+		</projectile>
 	</ThingDef>
 
 	<!-- ==================== Recipes ========================== -->

--- a/Defs/Ammo/Rifle/556x45mmNATO.xml
+++ b/Defs/Ammo/Rifle/556x45mmNATO.xml
@@ -20,6 +20,7 @@
 			<Ammo_556x45mmNATO_Incendiary>Bullet_556x45mmNATO_Incendiary</Ammo_556x45mmNATO_Incendiary>
 			<Ammo_556x45mmNATO_HE>Bullet_556x45mmNATO_HE</Ammo_556x45mmNATO_HE>
 			<Ammo_556x45mmNATO_Sabot>Bullet_556x45mmNATO_Sabot</Ammo_556x45mmNATO_Sabot>
+			<Ammo_12Gauge_Buck>Bullet_556x45mmNATO_APPlus</Ammo_12Gauge_Buck>
 		</ammoTypes>
 		<similarTo>AmmoSet_RifleIntermediate</similarTo>
 	</CombatExtended.AmmoSetDef>
@@ -171,6 +172,18 @@
 			<damageAmountBase>9</damageAmountBase>
 			<armorPenetrationSharp>12</armorPenetrationSharp>
 			<armorPenetrationBlunt>34.18</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base556x45mmNATOBullet">
+		<defName>Bullet_556x45mmNATO_APPlus</defName>
+		<label>5.56mm NATO bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>9</damageAmountBase>
+			<armorPenetrationSharp>12</armorPenetrationSharp>
+			<armorPenetrationBlunt>34.18</armorPenetrationBlunt>
+			<weaponDeteriorationChance>0.5</weaponDeteriorationChance>
+			<weaponDeteriorationHP>0~2</weaponDeteriorationHP>
 		</projectile>
 	</ThingDef>
 

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectilePropertiesCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectilePropertiesCE.cs
@@ -67,6 +67,9 @@ namespace CombatExtended
         public float collideDistance = 1f;
         public float impactChance = 1f;
 
+        public FloatRange weaponDeteriorationHP = new FloatRange(1f, 1f);
+        public float weaponDeteriorationChance = 0f;
+
         public float Gravity => CE_Utility.GravityConst * gravityFactor;
         public ThingDef CIWSVersion;
         public System.Type trajectoryWorker;


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Adds a way to damage the weapon each time it shoots a certain ammo type
- Adds 2 fields: 
`weaponDeteriorationHP` - how many points of damage the weapon will take per each shot. Picks random number in range. Decimals roll as a chance to deal 1 damage, because item HP is an integer number.
`weaponDeteriorationChance`- chance that deterioration happens from 0.00 to 1.00.
- Reduced by weapon toughness

## Reasoning

Why did you choose to implement things this way, e.g.
- Allows a new way to add ammo gimmicks, new way to balance ammo crafting for expensive weapons
- Allows putting 12ga into a flare gun and having it explode in your hands
- Allows making overpressured ammo

## Alternatives

Describe alternative implementations you have considered, e.g.
- 

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
