### PR TITLE
Patches - Supernatural Weapons

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -651,6 +651,7 @@
 		<li IfModActive="Ayameduki.HARXenoorca">ModPatches/Xenoorca Race</li>
 		<li IfModActive="MrKociak.YetAnotherProstheticExpansionModCore">ModPatches/YetAnotherProsthetics - Core</li>
 		<li IfModActive="brrainz.zombieland">ModPatches/Zombieland</li>
+		<li IfModActive="Artemiish.SupernaturalWeapons">ModPatches/Supernatural Weapons</li>
 		<!-- Mod Patches (Assemblies) -->
 		<li IfModActive="rwmt.Multiplayer">ModPatches/Multiplayer</li>
 		<li IfModActive="smashphil.neceros.srtsexpanded">ModPatches/SRTS</li>

--- a/ModPatches/Supernatural Weapons/Defs/Supernatural Weapons/Ammo.xml
+++ b/ModPatches/Supernatural Weapons/Defs/Supernatural Weapons/Ammo.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Defs>	
+	
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_Artemiish_SNBulletAmmo</defName>
+		<label>cursed silver bullets</label>
+		<ammoTypes>
+			<Artemiish_SNBulletAmmo>Bullet_Artemiish_SNBulletAmmo</Artemiish_SNBulletAmmo>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
+	
+	<!-- ================== Projectiles ================== -->
+	
+	<ThingDef ParentName="Base44MagnumBullet">
+		<defName>Bullet_Artemiish_SNBulletAmmo</defName>
+		<label>.44 Magnum cursed silver bullet (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>15</damageAmountBase>
+			<armorPenetrationSharp>6</armorPenetrationSharp>
+			<armorPenetrationBlunt>23.280</armorPenetrationBlunt>
+			<damageDef>Artemiish_SNBullet</damageDef>
+		</projectile>
+	</ThingDef>
+	
+</Defs>

--- a/ModPatches/Supernatural Weapons/Patches/Supernatural Weapons/Patches.xml
+++ b/ModPatches/Supernatural Weapons/Patches/Supernatural Weapons/Patches.xml
@@ -1,0 +1,212 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+
+	<!-- ==================== Knife ========================== -->
+
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Artemiish_SNKnife"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>handle</label>
+					<capacities>
+						<li>Poke</li>
+					</capacities>
+					<power>2</power>
+					<chanceFactor>0.1</chanceFactor>
+					<cooldownTime>1.44</cooldownTime>
+					<armorPenetrationBlunt>0.425</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>blade</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>12</power>
+					<cooldownTime>1.35</cooldownTime>
+					<armorPenetrationBlunt>0.612</armorPenetrationBlunt>
+					<armorPenetrationSharp>2.45</armorPenetrationSharp>
+					<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>point</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>12</power>
+					<cooldownTime>1.44</cooldownTime>
+					<armorPenetrationBlunt>0.425</armorPenetrationBlunt>
+					<armorPenetrationSharp>8.5</armorPenetrationSharp>
+					<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Artemiish_SNKnife"]/statBases</xpath>
+		<value>
+			<Bulk>1</Bulk>
+			<MeleeCounterParryBonus>0.15</MeleeCounterParryBonus>
+			<!-- <StuffEffectMultiplierToughness>1</StuffEffectMultiplierToughness> --><!-- Same as apaprel thickness multiplier but for toughness -->
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Artemiish_SNKnife"]</xpath>
+		<value>
+			<equippedStatOffsets>
+				<MeleeCritChance>0.5</MeleeCritChance>
+				<MeleeParryChance>0.15</MeleeParryChance>
+				<MeleeDodgeChance>0.05</MeleeDodgeChance>
+			</equippedStatOffsets>
+		</value>
+	</Operation>
+
+	<!-- Add tags -->
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="Artemiish_SNKnife"]/weaponTags</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Artemiish_SNKnife"]</xpath>
+			<value>
+				<weaponTags />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Artemiish_SNKnife"]/weaponTags</xpath>
+		<value>
+			<li>CE_OneHandedWeapon</li>
+		</value>
+	</Operation>
+
+
+	<!-- ==================== Revolver ========================== -->
+
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Artemiish_SNRevolver"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>grip</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>2</power>
+					<cooldownTime>1.54</cooldownTime>
+					<chanceFactor>1.5</chanceFactor>
+					<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>muzzle</label>
+					<capacities>
+						<li>Poke</li>
+					</capacities>
+					<power>2</power>
+					<cooldownTime>1.54</cooldownTime>
+					<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Artemiish_SNRevolver</defName>
+		<statBases>
+			<Mass>1.39</Mass>
+			<RangedWeapon_Cooldown>0.49</RangedWeapon_Cooldown>
+			<SightsEfficiency>0.7</SightsEfficiency>
+			<ShotSpread>0.16</ShotSpread>
+			<SwayFactor>1.39</SwayFactor>
+			<Bulk>2.79</Bulk>
+			<!-- <ToughnessRating>2.5</ToughnessRating> -->
+			<!-- Base toughness rating of a weapon -->
+		</statBases>
+		<Properties>
+			<recoilAmount>2.96</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_Artemiish_SNBulletAmmo</defaultProjectile>
+			<warmupTime>0.6</warmupTime>
+			<range>12</range>
+			<soundCast>Shot_Revolver</soundCast>
+			<soundCastTail>GunTail_Light</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>5</magazineSize>
+			<reloadTime>4.1</reloadTime>
+			<ammoSet>AmmoSet_Artemiish_SNBulletAmmo</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aiUseBurstMode>FALSE</aiUseBurstMode>
+			<aiAimMode>Snapshot</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>CE_Sidearm</li>
+			<li>CE_OneHandedWeapon</li>
+		</weaponTags>
+	</Operation>
+	
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="Artemiish_SNRevolver"]</xpath>
+		<value>
+			<li Class="CombatExtended.GunDrawExtension">
+				<DrawSize>1.00,1.00</DrawSize><!-- Keeping for documentation purposes -->
+				<DrawOffset>0.0,-0.04</DrawOffset>
+				<DropCasingWhenReload>true</DropCasingWhenReload>
+				<AdvancedCasingVariables>true</AdvancedCasingVariables>
+				<CasingRotationRandomRange>20</CasingRotationRandomRange>
+				<!--You'll want a lower casing speed and longer casing life time for this case-->
+				<CasingOffset>-0.1,0.05</CasingOffset>
+				<CasingSpeedOverrideRange>1.5~2</CasingSpeedOverrideRange>
+				<!--Reload drop casings doesn't follow aiming angle. negative 135 degrees make it eject up left.-->
+				<CasingAngleOffset>-135</CasingAngleOffset>
+				<CasingLifeTimeMultiplier>2</CasingLifeTimeMultiplier>
+			</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Artemiish_SNRevolver"]/comps/li[compClass="MVCF.Comps.Comp_VerbProps"]</xpath>
+	</Operation>
+	
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Artemiish_SNRevolver"]/descriptionHyperlinks/ThingDef[text()="Artemiish_SNBulletAmmo"]</xpath>
+	</Operation>
+
+
+	<!-- ==================== Ammo ========================== -->
+	
+	
+	<Operation Class="PatchOperationAttributeSet">
+		<xpath>Defs/ThingDef[defName="Artemiish_SNBulletAmmo"]</xpath>
+		<attribute>Class</attribute>
+		<value>CombatExtended.AmmoDef</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Artemiish_SNBulletAmmo"]/descriptionHyperlinks/ThingDef[text()="Artemiish_SNRevolver"]</xpath>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Artemiish_SNBulletAmmo"]</xpath>
+		<value>
+			<ammoClass>FullMetalJacket</ammoClass>
+			<cookOffProjectile>Bullet_Artemiish_SNBulletAmmo</cookOffProjectile>
+			<thingCategories>
+				<li>Ammo44Magnum</li>
+			</thingCategories>
+		</value>
+	</Operation>
+	
+</Patch>
+	


### PR DESCRIPTION
## Additions

Compatibility with Supernatural Weapons

## Changes

See above
Also, the original mod already had an ammo system via MVCF, I replaced it with a CE one.

## References

This PR, I guess?

## Reasoning

I didn't think the two separate ammo systems would mesh well, with all the inventory management stuff CE does.

## Alternatives

Allowing the revolver to shoot normal .44 Magnum in addition to its special ammo.  I decided it wasn't thematically appropriate, but it's not something I'm super against if someone else thinks it would be better.

## Testing

Check tests you have performed:
- [x] Compiles without warnings    (no compiling here, this patch is xml only)
- [x] Game runs without errors    (only error is from the original mod without this patch, something about ideo relics)
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)    (about half an hour, testing the weapons against various pawns)
