### PR TITLE
Add VFE - Medieval 2 to loadAfter

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -91,6 +91,7 @@
 		<li>oskarpotocki.vfe.mechanoid</li>
 		<li>mlie.reinforcedmechanoid2</li>
 		<li>Trickity.Samurai.Faction</li>
+    <li>oskarpotocki.vfe.medieval2</li>
 	</loadAfter>
 
 </ModMetaData>


### PR DESCRIPTION
## Changes

There's a patch in Vanilla Factions Expanded - Medieval 2 targeting Vanilla Weapons Expanded that can potentially fail if Combat Extended is loaded after Vanilla Weapons Expanded but before Vanilla Factions Expanded - Medieval 2, which is entirely possible as Combat Extended does not complain about being loaded before that mod.

![image](https://github.com/user-attachments/assets/6a4898bf-7581-4d98-98b5-c3032ca07d19)

These patches in Vanilla Factions Expanded - Medieval 2 fail because in this scenario, the mod tries to patch verbs that Combat Extended has replaced.

![image](https://github.com/user-attachments/assets/f9a0f6af-7ad0-43f9-ac60-419708e47c77)

This error does not happen when Combat Extended is loaded after both mods.

## Reasoning

Why did you choose to implement things this way, e.g.
- errors sob sob

## Testing

Check tests you have performed:
- [ ] Compiles without warnings - Change does not require a recompile
- [X] Game runs without errors
- [X] Playtested a colony (specify how long) - Two minutes, made sure the game booted fine without errors
