### PR TITLE
Grimworld Multi-patch - Traders

### DIFF
--- a/Defs/Ammo/Advanced/12mmRailgun.xml
+++ b/Defs/Ammo/Advanced/12mmRailgun.xml
@@ -33,6 +33,7 @@
 			<li>CE_AutoEnableTrade</li>
 			<li>CE_AutoEnableCrafting_FabricationBench</li>
 			<li>CE_AutoEnableCrafting_TableMachining</li>
+      <li>CE_40K_MediumAmmo</li>
 			<!-- Railgun ammo isn't handloaded because it contains no propellant, and the sabots must be precision-machined anyway -->
 		</tradeTags>
 		<thingCategories>

--- a/Defs/Ammo/Advanced/12mmRailgun.xml
+++ b/Defs/Ammo/Advanced/12mmRailgun.xml
@@ -33,7 +33,7 @@
 			<li>CE_AutoEnableTrade</li>
 			<li>CE_AutoEnableCrafting_FabricationBench</li>
 			<li>CE_AutoEnableCrafting_TableMachining</li>
-      <li>CE_40K_MediumAmmo</li>
+    		<li>CE_40K_MediumAmmo</li>
 			<!-- Railgun ammo isn't handloaded because it contains no propellant, and the sabots must be precision-machined anyway -->
 		</tradeTags>
 		<thingCategories>

--- a/Defs/Ammo/Grenade/40x46mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x46mmGrenade.xml
@@ -34,7 +34,7 @@
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
 			<li>CE_AutoEnableCrafting_TableMachining</li>
-      <li>CE_40K_HeavyAmmo</li>
+    		<li>CE_40K_HeavyAmmo</li>
 		</tradeTags>
 		<thingCategories>
 			<li>Ammo40x46mmGrenades</li>

--- a/Defs/Ammo/Grenade/40x46mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x46mmGrenade.xml
@@ -34,6 +34,7 @@
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
 			<li>CE_AutoEnableCrafting_TableMachining</li>
+      <li>CE_40K_HeavyAmmo</li>
 		</tradeTags>
 		<thingCategories>
 			<li>Ammo40x46mmGrenades</li>

--- a/Defs/Ammo/HighCaliber/20x102mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/20x102mmNATO.xml
@@ -33,7 +33,7 @@
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
 			<li>CE_AutoEnableCrafting</li>
-      <li>CE_40K_HeavyAmmo</li>
+    		<li>CE_40K_HeavyAmmo</li>
 		</tradeTags>
 		<thingCategories>
 			<li>Ammo20x102mmNATO</li>

--- a/Defs/Ammo/HighCaliber/20x102mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/20x102mmNATO.xml
@@ -33,6 +33,7 @@
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
 			<li>CE_AutoEnableCrafting</li>
+      <li>CE_40K_HeavyAmmo</li>
 		</tradeTags>
 		<thingCategories>
 			<li>Ammo20x102mmNATO</li>

--- a/Defs/Ammo/Modded/Warhammer 40k/Autoguns.xml
+++ b/Defs/Ammo/Modded/Warhammer 40k/Autoguns.xml
@@ -35,6 +35,7 @@
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
 			<li>CE_AutoEnableCrafting</li>
+      <li>CE_40K_Ammo</li>
 		</tradeTags>
 		<thingCategories>
 			<li>Ammo825mmLong</li>

--- a/Defs/Ammo/Modded/Warhammer 40k/Autoguns.xml
+++ b/Defs/Ammo/Modded/Warhammer 40k/Autoguns.xml
@@ -35,7 +35,7 @@
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
 			<li>CE_AutoEnableCrafting</li>
-      <li>CE_40K_Ammo</li>
+      		<li>CE_40K_Ammo</li>
 		</tradeTags>
 		<thingCategories>
 			<li>Ammo825mmLong</li>

--- a/Defs/Ammo/Modded/Warhammer 40k/Bolter.xml
+++ b/Defs/Ammo/Modded/Warhammer 40k/Bolter.xml
@@ -47,7 +47,7 @@
 			<li>CE_AutoEnableTrade</li>
 			<li>CE_AutoEnableCrafting</li>
 			<li>CE_AutoEnableCrafting_GWAmmoBench</li>
-      <li>CE_40K_MediumAmmo</li>
+    		<li>CE_40K_MediumAmmo</li>
 		</tradeTags>
 		<thingCategories>
 			<li>AmmoBolter75</li>

--- a/Defs/Ammo/Modded/Warhammer 40k/Bolter.xml
+++ b/Defs/Ammo/Modded/Warhammer 40k/Bolter.xml
@@ -47,6 +47,7 @@
 			<li>CE_AutoEnableTrade</li>
 			<li>CE_AutoEnableCrafting</li>
 			<li>CE_AutoEnableCrafting_GWAmmoBench</li>
+      <li>CE_40K_MediumAmmo</li>
 		</tradeTags>
 		<thingCategories>
 			<li>AmmoBolter75</li>
@@ -109,7 +110,7 @@
 		<ammoClass>Kraken</ammoClass>
 		<cookOffProjectile>Bullet_Bolter75_Kraken</cookOffProjectile>
 	</ThingDef>
-	
+
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoBolter75Base">
 		<defName>Ammo_Bolter75_Tempest</defName>
 		<label>.75 cal bolter shell (Tempest)</label>
@@ -184,7 +185,7 @@
 			<damageAmountBase>49</damageAmountBase>
 			<armorPenetrationSharp>15</armorPenetrationSharp>
 			<armorPenetrationBlunt>39.494</armorPenetrationBlunt>
-			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>			
+			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
@@ -211,7 +212,7 @@
 			</secondaryDamage>
 		</projectile>
 	</ThingDef>
-	
+
 	<ThingDef ParentName="BaseBolter75Bullet">
 		<defName>Bullet_Bolter75_Tempest</defName>
 		<label>.75 cal bolt (tempest)</label>
@@ -282,7 +283,7 @@
 			<damageAmountBase>49</damageAmountBase>
 			<armorPenetrationSharp>16.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>43.44</armorPenetrationBlunt>
-			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>			
+			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
@@ -309,7 +310,7 @@
 			</secondaryDamage>
 		</projectile>
 	</ThingDef>
-	
+
 	<ThingDef ParentName="BaseBolter75Bullet">
 		<defName>Bullet_Bolter75_Tempest_Relic</defName>
 		<label>.75 cal bolt (tempest)</label>

--- a/Defs/Ammo/Modded/Warhammer 40k/Bolter_Small.xml
+++ b/Defs/Ammo/Modded/Warhammer 40k/Bolter_Small.xml
@@ -33,7 +33,7 @@
 			<li>CE_AutoEnableTrade</li>
 			<li>CE_AutoEnableCrafting</li>
 			<li>CE_AutoEnableCrafting_GWAmmoBench</li>
-      <li>CE_40K_MediumAmmo</li>
+     		 <li>CE_40K_MediumAmmo</li>
 		</tradeTags>
 		<thingCategories>
 			<li>AmmoBolter50</li>

--- a/Defs/Ammo/Modded/Warhammer 40k/Bolter_Small.xml
+++ b/Defs/Ammo/Modded/Warhammer 40k/Bolter_Small.xml
@@ -33,6 +33,7 @@
 			<li>CE_AutoEnableTrade</li>
 			<li>CE_AutoEnableCrafting</li>
 			<li>CE_AutoEnableCrafting_GWAmmoBench</li>
+      <li>CE_40K_MediumAmmo</li>
 		</tradeTags>
 		<thingCategories>
 			<li>AmmoBolter50</li>
@@ -81,7 +82,7 @@
 		<ammoClass>Kraken</ammoClass>
 		<cookOffProjectile>Bullet_Bolter50_Kraken</cookOffProjectile>
 	</ThingDef>
-	
+
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoBolter50Base">
 		<defName>Ammo_Bolter50_Tempest</defName>
 		<label>.50 cal bolter shell (Tempest)</label>
@@ -163,7 +164,7 @@
 			</secondaryDamage>
 		</projectile>
 	</ThingDef>
-	
+
 	<ThingDef ParentName="BaseBolter50Bullet">
 		<defName>Bullet_Bolter50_Tempest</defName>
 		<label>.50 cal bolt (tempest)</label>

--- a/Defs/Ammo/Modded/Warhammer 40k/HeavyBolter.xml
+++ b/Defs/Ammo/Modded/Warhammer 40k/HeavyBolter.xml
@@ -33,7 +33,8 @@
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
 			<li>CE_AutoEnableCrafting</li>
-			<li>CE_AutoEnableCrafting_GWAmmoBench</li>			
+			<li>CE_AutoEnableCrafting_GWAmmoBench</li>
+      <li>CE_40K_HeavyAmmo</li>
 		</tradeTags>
 		<thingCategories>
 			<li>AmmoBolter998</li>
@@ -96,7 +97,7 @@
 		<ammoClass>Kraken</ammoClass>
 		<cookOffProjectile>Bullet_Bolter998_Kraken</cookOffProjectile>
 	</ThingDef>
-	
+
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoBolter998Base">
 		<defName>Ammo_Bolter998_Tempest</defName>
 		<label>.998 cal bolter shell (Tempest)</label>
@@ -171,7 +172,7 @@
 			<damageAmountBase>58</damageAmountBase>
 			<armorPenetrationSharp>17.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>59.81</armorPenetrationBlunt>
-			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>			
+			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
@@ -198,7 +199,7 @@
 			</secondaryDamage>
 		</projectile>
 	</ThingDef>
-	
+
 	<ThingDef ParentName="BaseBolter998Bullet">
 		<defName>Bullet_Bolter998_Tempest</defName>
 		<label>.998 cal bolt (Tempest)</label>
@@ -430,7 +431,7 @@
 		</products>
 		<workAmount>48000</workAmount>
 	</RecipeDef>
-	
+
 	<RecipeDef ParentName="AmmoRecipeBase">
 		<defName>MakeAmmo_Bolter998_Tempest</defName>
 		<label>make .998 Cal Bolter (tempest) shell x200</label>

--- a/Defs/Ammo/Modded/Warhammer 40k/HeavyBolter.xml
+++ b/Defs/Ammo/Modded/Warhammer 40k/HeavyBolter.xml
@@ -34,7 +34,7 @@
 			<li>CE_AutoEnableTrade</li>
 			<li>CE_AutoEnableCrafting</li>
 			<li>CE_AutoEnableCrafting_GWAmmoBench</li>
-      <li>CE_40K_HeavyAmmo</li>
+    		<li>CE_40K_HeavyAmmo</li>
 		</tradeTags>
 		<thingCategories>
 			<li>AmmoBolter998</li>

--- a/Defs/Ammo/Modded/Warhammer 40k/LasGun.xml
+++ b/Defs/Ammo/Modded/Warhammer 40k/LasGun.xml
@@ -55,7 +55,7 @@
 			<li>CE_AutoEnableCrafting_FabricationBench</li>
 			<li>CE_AutoEnableCrafting_TableMachining</li>
 			<li>CE_AutoEnableCrafting_GWAmmoBench</li>
-      <li>CE_Lasgun_Ammo</li>
+      <li>CE_40K_Ammo</li>
 		</tradeTags>
 		<thingCategories>
 			<li>AmmoLasgunPowerPack</li>

--- a/Defs/Ammo/Modded/Warhammer 40k/LasGun.xml
+++ b/Defs/Ammo/Modded/Warhammer 40k/LasGun.xml
@@ -55,7 +55,7 @@
 			<li>CE_AutoEnableCrafting_FabricationBench</li>
 			<li>CE_AutoEnableCrafting_TableMachining</li>
 			<li>CE_AutoEnableCrafting_GWAmmoBench</li>
-      <li>CE_40K_Ammo</li>
+    		<li>CE_40K_Ammo</li>
 		</tradeTags>
 		<thingCategories>
 			<li>AmmoLasgunPowerPack</li>

--- a/Defs/Ammo/Modded/Warhammer 40k/LasGun.xml
+++ b/Defs/Ammo/Modded/Warhammer 40k/LasGun.xml
@@ -55,6 +55,7 @@
 			<li>CE_AutoEnableCrafting_FabricationBench</li>
 			<li>CE_AutoEnableCrafting_TableMachining</li>
 			<li>CE_AutoEnableCrafting_GWAmmoBench</li>
+      <li>CE_Lasgun_Ammo</li>
 		</tradeTags>
 		<thingCategories>
 			<li>AmmoLasgunPowerPack</li>

--- a/Defs/Ammo/Modded/Warhammer 40k/MeltaGun.xml
+++ b/Defs/Ammo/Modded/Warhammer 40k/MeltaGun.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
-	
+
 	<ThingCategoryDef>
 		<defName>AmmoMeltaGun</defName>
 		<label>melta canister</label>
@@ -20,7 +20,7 @@
 	<!-- ==================== Ammo ========================== -->
 		<ThingDef Class="CombatExtended.AmmoDef" ParentName="SpacerMediumAmmoBase">
 		<defName>Ammo_MeltaGun</defName>
-		<label>Meltagun Ammo Canister</label> 
+		<label>Meltagun Ammo Canister</label>
 		<description>Canister of Pyrum-petrol fuel for Meltaguns</description>
 		<statBases>
 			<Mass>0.09</Mass>
@@ -31,6 +31,7 @@
 			<li>CE_AutoEnableTrade</li>
 			<li>CE_AutoEnableCrafting_FabricationBench</li>
 			<li>CE_AutoEnableCrafting_GWAmmoBench</li>
+      <li>CE_40K_MediumAmmo</li>
 		</tradeTags>
 		<ammoClass>Melta</ammoClass>
 		<graphicData>

--- a/Defs/Ammo/Modded/Warhammer 40k/MeltaGun.xml
+++ b/Defs/Ammo/Modded/Warhammer 40k/MeltaGun.xml
@@ -31,7 +31,7 @@
 			<li>CE_AutoEnableTrade</li>
 			<li>CE_AutoEnableCrafting_FabricationBench</li>
 			<li>CE_AutoEnableCrafting_GWAmmoBench</li>
-      <li>CE_40K_MediumAmmo</li>
+    		<li>CE_40K_MediumAmmo</li>
 		</tradeTags>
 		<ammoClass>Melta</ammoClass>
 		<graphicData>

--- a/Defs/Ammo/Modded/Warhammer 40k/PlasmaCannon.xml
+++ b/Defs/Ammo/Modded/Warhammer 40k/PlasmaCannon.xml
@@ -74,7 +74,7 @@
 			<li>CE_AutoEnableTrade</li>
 			<li>CE_AutoEnableCrafting</li>
 			<li>CE_AutoEnableCrafting_GWAmmoBench</li>
-      <li>CE_40K_MediumAmmo</li>
+    		<li>CE_40K_MediumAmmo</li>
 		</tradeTags>
 		<thingCategories>
 			<li>AmmoPlasmaCannon</li>

--- a/Defs/Ammo/Modded/Warhammer 40k/PlasmaCannon.xml
+++ b/Defs/Ammo/Modded/Warhammer 40k/PlasmaCannon.xml
@@ -73,7 +73,8 @@
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
 			<li>CE_AutoEnableCrafting</li>
-			<li>CE_AutoEnableCrafting_GWAmmoBench</li>			
+			<li>CE_AutoEnableCrafting_GWAmmoBench</li>
+      <li>CE_40K_MediumAmmo</li>
 		</tradeTags>
 		<thingCategories>
 			<li>AmmoPlasmaCannon</li>
@@ -290,7 +291,7 @@
 				<explosionSound>MortarBomb_Explode</explosionSound>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 			</li>
-		</comps>		
+		</comps>
 		<modExtensions>
 			<li Class="ProjectileImpactFX.EffectProjectileExtension">
 				<AutoAssign>false</AutoAssign>

--- a/Defs/Ammo/Other/Flamethrower.xml
+++ b/Defs/Ammo/Other/Flamethrower.xml
@@ -33,6 +33,7 @@
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
 			<li>CE_AutoEnableCrafting_DrugLab</li>
+      <li>CE_40K_HeavyAmmo</li>
 		</tradeTags>
 		<thingCategories>
 			<li>AmmoFlamethrower</li>
@@ -88,7 +89,7 @@
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="FlamethrowerBase" MayRequire="Ludeon.Rimworld.Anomaly">
 		<defName>Ammo_Flamethrower_Bioferrite</defName>
 		<label>infused chemfuel</label>
-		<description>Fuel for a flamethrower that burns at incredibly high temperature, leaving behind no puddles of fuel.\n\nAn infusion of crystalline bioferrite attacks organic matter on a cellular level, disrupting regeneration and weakening tissue.</description>	
+		<description>Fuel for a flamethrower that burns at incredibly high temperature, leaving behind no puddles of fuel.\n\nAn infusion of crystalline bioferrite attacks organic matter on a cellular level, disrupting regeneration and weakening tissue.</description>
 		<graphicData>
 			<texPath>Things/Ammo/FuelTank/Bioferrite</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -275,7 +276,7 @@
 		<fixedIngredientFilter>
 			<thingDefs>
 				<li>Bioferrite</li>
-				<li>Chemfuel</li>				
+				<li>Chemfuel</li>
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>

--- a/Defs/Ammo/Other/Flamethrower.xml
+++ b/Defs/Ammo/Other/Flamethrower.xml
@@ -33,7 +33,7 @@
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
 			<li>CE_AutoEnableCrafting_DrugLab</li>
-      <li>CE_40K_HeavyAmmo</li>
+    		<li>CE_40K_HeavyAmmo</li>
 		</tradeTags>
 		<thingCategories>
 			<li>AmmoFlamethrower</li>

--- a/Defs/Ammo/Pistols/454Casull.xml
+++ b/Defs/Ammo/Pistols/454Casull.xml
@@ -53,7 +53,7 @@
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
 			<li>CE_AutoEnableCrafting</li>
-      <li>CE_40K_Ammo</li>
+    		<li>CE_40K_Ammo</li>
 		</tradeTags>
 		<thingCategories>
 			<li>Ammo454Casull</li>

--- a/Defs/Ammo/Pistols/454Casull.xml
+++ b/Defs/Ammo/Pistols/454Casull.xml
@@ -53,6 +53,7 @@
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
 			<li>CE_AutoEnableCrafting</li>
+      <li>CE_40K_Ammo</li>
 		</tradeTags>
 		<thingCategories>
 			<li>Ammo454Casull</li>

--- a/Defs/Ammo/Pistols/45ACP.xml
+++ b/Defs/Ammo/Pistols/45ACP.xml
@@ -47,7 +47,7 @@
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
 			<li>CE_AutoEnableCrafting</li>
-      <li>CE_40K_Ammo</li>
+    		<li>CE_40K_Ammo</li>
 		</tradeTags>
 		<thingCategories>
 			<li>Ammo45ACP</li>

--- a/Defs/Ammo/Pistols/45ACP.xml
+++ b/Defs/Ammo/Pistols/45ACP.xml
@@ -47,6 +47,7 @@
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
 			<li>CE_AutoEnableCrafting</li>
+      <li>CE_40K_Ammo</li>
 		</tradeTags>
 		<thingCategories>
 			<li>Ammo45ACP</li>

--- a/Defs/Ammo/Rifle/3006Springfield.xml
+++ b/Defs/Ammo/Rifle/3006Springfield.xml
@@ -35,6 +35,7 @@
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
 			<li>CE_AutoEnableCrafting</li>
+      <li>CE_40K_Ammo</li>
 		</tradeTags>
 		<thingCategories>
 			<li>Ammo3006Springfield</li>

--- a/Defs/Ammo/Rifle/3006Springfield.xml
+++ b/Defs/Ammo/Rifle/3006Springfield.xml
@@ -35,7 +35,7 @@
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
 			<li>CE_AutoEnableCrafting</li>
-      <li>CE_40K_Ammo</li>
+      		<li>CE_40K_Ammo</li>
 		</tradeTags>
 		<thingCategories>
 			<li>Ammo3006Springfield</li>

--- a/Defs/Ammo/Rocket/84x246mmR.xml
+++ b/Defs/Ammo/Rocket/84x246mmR.xml
@@ -37,6 +37,7 @@
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
 			<li>CE_AutoEnableCrafting_TableMachining</li>
+      <li>CE_40K_HeavyAmmo</li>
 		</tradeTags>
 		<thingCategories>
 			<li>Ammo84x246mmR</li>

--- a/Defs/Ammo/Rocket/84x246mmR.xml
+++ b/Defs/Ammo/Rocket/84x246mmR.xml
@@ -37,7 +37,7 @@
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
 			<li>CE_AutoEnableCrafting_TableMachining</li>
-      <li>CE_40K_HeavyAmmo</li>
+    		<li>CE_40K_HeavyAmmo</li>
 		</tradeTags>
 		<thingCategories>
 			<li>Ammo84x246mmR</li>

--- a/Defs/Ammo/Shotgun/10Gauge.xml
+++ b/Defs/Ammo/Shotgun/10Gauge.xml
@@ -21,7 +21,7 @@
 		</ammoTypes>
 		<similarTo>AmmoSet_Shotgun</similarTo>
 	</CombatExtended.AmmoSetDef>
-	
+
 	<CombatExtended.AmmoSetDef>
 		<defName>AmmoSet_10Gauge_Slug</defName>
 		<label>10 Gauge</label>
@@ -44,6 +44,7 @@
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
 			<li>CE_AutoEnableCrafting</li>
+      <li>CE_40K_Ammo</li>
 		</tradeTags>
 		<thingCategories>
 			<li>Ammo10Gauge</li>

--- a/Defs/Ammo/Shotgun/10Gauge.xml
+++ b/Defs/Ammo/Shotgun/10Gauge.xml
@@ -44,7 +44,7 @@
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
 			<li>CE_AutoEnableCrafting</li>
-      <li>CE_40K_Ammo</li>
+    		<li>CE_40K_Ammo</li>
 		</tradeTags>
 		<thingCategories>
 			<li>Ammo10Gauge</li>

--- a/Defs/Ammo/Shotgun/23x75mmR.xml
+++ b/Defs/Ammo/Shotgun/23x75mmR.xml
@@ -44,7 +44,7 @@
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
 			<li>CE_AutoEnableCrafting</li>
-      <li>CE_40K_Ammo</li>
+      		<li>CE_40K_Ammo</li>
 		</tradeTags>
 		<thingCategories>
 			<li>Ammo23x75mmR</li>

--- a/Defs/Ammo/Shotgun/23x75mmR.xml
+++ b/Defs/Ammo/Shotgun/23x75mmR.xml
@@ -21,7 +21,7 @@
 		</ammoTypes>
 		<similarTo>AmmoSet_Shotgun</similarTo>
 	</CombatExtended.AmmoSetDef>
-	
+
 	<CombatExtended.AmmoSetDef>
 		<defName>AmmoSet_23x75mmR_Slug</defName>
 		<label>23x75mmR</label>
@@ -44,6 +44,7 @@
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
 			<li>CE_AutoEnableCrafting</li>
+      <li>CE_40K_Ammo</li>
 		</tradeTags>
 		<thingCategories>
 			<li>Ammo23x75mmR</li>

--- a/ModPatches/GrimWorld Talons of the Emperor/Patches/GrimWorld Talons of the Emperor/CE_Patch_Traders.xml
+++ b/ModPatches/GrimWorld Talons of the Emperor/Patches/GrimWorld Talons of the Emperor/CE_Patch_Traders.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/TraderKindDef[defName="GW_TotE_TraderBase"]/stockGenerators</xpath>
+    <value>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_40K_Ammo</tradeTag>
+        <countRange>
+          <min>500</min>
+          <max>2000</max>
+        </countRange>
+        <thingDefCountRange>
+          <min>4</min>
+          <max>7</max>
+        </thingDefCountRange>
+      </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_40K_MediumAmmo</tradeTag>
+        <countRange>
+          <min>30</min>
+          <max>120</max>
+        </countRange>
+        <thingDefCountRange>
+          <min>5</min>
+          <max>8</max>
+        </thingDefCountRange>
+      </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_40K_HeavyAmmo</tradeTag>
+        <countRange>
+          <min>10</min>
+          <max>50</max>
+        </countRange>
+        <thingDefCountRange>
+          <min>3</min>
+          <max>6</max>
+        </thingDefCountRange>
+      </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_40K_ExoticAmmo</tradeTag>
+        <countRange>
+          <min>10</min>
+          <max>50</max>
+        </countRange>
+        <thingDefCountRange>
+          <min>1</min>
+          <max>2</max>
+        </thingDefCountRange>
+      </li>
+      <li Class="StockGenerator_Category">
+        <categoryDef>Ammo</categoryDef>
+        <thingDefCountRange>
+          <min>0</min>
+          <max>0</max>
+        </thingDefCountRange>
+      </li>
+    </value>
+  </Operation>
+</Patch>

--- a/ModPatches/GrimWorld Talons of the Emperor/Patches/GrimWorld Talons of the Emperor/CE_Patch_Traders.xml
+++ b/ModPatches/GrimWorld Talons of the Emperor/Patches/GrimWorld Talons of the Emperor/CE_Patch_Traders.xml
@@ -1,59 +1,61 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
-  <Operation Class="PatchOperationAdd">
-    <xpath>Defs/TraderKindDef[defName="GW_TotE_TraderBase"]/stockGenerators</xpath>
-    <value>
-      <li Class="StockGenerator_Tag">
-        <tradeTag>CE_40K_Ammo</tradeTag>
-        <countRange>
-          <min>500</min>
-          <max>2000</max>
-        </countRange>
-        <thingDefCountRange>
-          <min>4</min>
-          <max>7</max>
-        </thingDefCountRange>
-      </li>
-      <li Class="StockGenerator_Tag">
-        <tradeTag>CE_40K_MediumAmmo</tradeTag>
-        <countRange>
-          <min>30</min>
-          <max>120</max>
-        </countRange>
-        <thingDefCountRange>
-          <min>5</min>
-          <max>8</max>
-        </thingDefCountRange>
-      </li>
-      <li Class="StockGenerator_Tag">
-        <tradeTag>CE_40K_HeavyAmmo</tradeTag>
-        <countRange>
-          <min>10</min>
-          <max>50</max>
-        </countRange>
-        <thingDefCountRange>
-          <min>3</min>
-          <max>6</max>
-        </thingDefCountRange>
-      </li>
-      <li Class="StockGenerator_Tag">
-        <tradeTag>CE_40K_ExoticAmmo</tradeTag>
-        <countRange>
-          <min>10</min>
-          <max>50</max>
-        </countRange>
-        <thingDefCountRange>
-          <min>1</min>
-          <max>2</max>
-        </thingDefCountRange>
-      </li>
-      <li Class="StockGenerator_Category">
-        <categoryDef>Ammo</categoryDef>
-        <thingDefCountRange>
-          <min>0</min>
-          <max>0</max>
-        </thingDefCountRange>
-      </li>
-    </value>
-  </Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/TraderKindDef[defName="GW_TotE_TraderBase"]/stockGenerators</xpath>
+		<value>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>CE_40K_Ammo</tradeTag>
+				<countRange>
+					<min>500</min>
+					<max>2000</max>
+				</countRange>
+				<thingDefCountRange>
+					<min>4</min>
+					<max>7</max>
+				</thingDefCountRange>
+			</li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>CE_40K_MediumAmmo</tradeTag>
+				<countRange>
+					<min>30</min>
+					<max>120</max>
+				</countRange>
+				<thingDefCountRange>
+					<min>5</min>
+					<max>8</max>
+				</thingDefCountRange>
+			</li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>CE_40K_HeavyAmmo</tradeTag>
+				<countRange>
+					<min>10</min>
+					<max>50</max>
+				</countRange>
+				<thingDefCountRange>
+					<min>3</min>
+					<max>6</max>
+				</thingDefCountRange>
+			</li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>CE_40K_ExoticAmmo</tradeTag>
+				<countRange>
+					<min>10</min>
+					<max>50</max>
+				</countRange>
+				<thingDefCountRange>
+					<min>1</min>
+					<max>2</max>
+				</thingDefCountRange>
+			</li>
+			<li Class="StockGenerator_Category">
+				<categoryDef>Ammo</categoryDef>
+				<thingDefCountRange>
+					<min>0</min>
+					<max>0</max>
+				</thingDefCountRange>
+			</li>
+		</value>
+	</Operation>
+
 </Patch>

--- a/ModPatches/Grimworld Angels of Death/Patches/Grimworld Angels of Death/CE_Patch_Traders.xml
+++ b/ModPatches/Grimworld Angels of Death/Patches/Grimworld Angels of Death/CE_Patch_Traders.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/TraderKindDef[defName="GW_AM_Trader_Caravan"]/stockGenerators</xpath>
+    <xpath>Defs/TraderKindDef[defName="GW_SM_Trader_Caravan"]/stockGenerators</xpath>
     <value>
       <li Class="StockGenerator_Tag">
         <tradeTag>CE_40K_Ammo</tradeTag>
@@ -46,7 +46,7 @@
     </value>
   </Operation>
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/TraderKindDef[defName="GW_AM_Trader"]/stockGenerators</xpath>
+    <xpath>Defs/TraderKindDef[defName="GW_SM_Trader"]/stockGenerators</xpath>
     <value>
       <li Class="StockGenerator_Tag">
         <tradeTag>CE_40K_Ammo</tradeTag>
@@ -79,6 +79,17 @@
         <thingDefCountRange>
           <min>3</min>
           <max>6</max>
+        </thingDefCountRange>
+      </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_40K_ExoticAmmo</tradeTag>
+        <countRange>
+          <min>10</min>
+          <max>50</max>
+        </countRange>
+        <thingDefCountRange>
+          <min>1</min>
+          <max>2</max>
         </thingDefCountRange>
       </li>
       <li Class="StockGenerator_Category">

--- a/ModPatches/Grimworld Angels of Death/Patches/Grimworld Angels of Death/CE_Patch_Traders.xml
+++ b/ModPatches/Grimworld Angels of Death/Patches/Grimworld Angels of Death/CE_Patch_Traders.xml
@@ -1,104 +1,107 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
-  <Operation Class="PatchOperationAdd">
-    <xpath>Defs/TraderKindDef[defName="GW_SM_Trader_Caravan"]/stockGenerators</xpath>
-    <value>
-      <li Class="StockGenerator_Tag">
-        <tradeTag>CE_40K_Ammo</tradeTag>
-        <countRange>
-          <min>200</min>
-          <max>400</max>
-        </countRange>
-        <thingDefCountRange>
-          <min>2</min>
-          <max>4</max>
-        </thingDefCountRange>
-      </li>
-      <li Class="StockGenerator_Category">
-        <categoryDef>Ammo</categoryDef>
-        <thingDefCountRange>
-          <min>0</min>
-          <max>0</max>
-        </thingDefCountRange>
-      </li>
-      <li Class="StockGenerator_Tag">
-        <tradeTag>CE_40K_MediumAmmo</tradeTag>
-        <countRange>
-          <min>20</min>
-          <max>40</max>
-        </countRange>
-        <thingDefCountRange>
-          <min>3</min>
-          <max>6</max>
-        </thingDefCountRange>
-      </li>
-      <li Class="StockGenerator_Tag">
-        <tradeTag>CE_40K_HeavyAmmo</tradeTag>
-        <countRange>
-          <min>5</min>
-          <max>10</max>
-        </countRange>
-        <thingDefCountRange>
-          <min>0</min>
-          <max>3</max>
-        </thingDefCountRange>
-      </li>
-    </value>
-  </Operation>
-  <Operation Class="PatchOperationAdd">
-    <xpath>Defs/TraderKindDef[defName="GW_SM_Trader"]/stockGenerators</xpath>
-    <value>
-      <li Class="StockGenerator_Tag">
-        <tradeTag>CE_40K_Ammo</tradeTag>
-        <countRange>
-          <min>500</min>
-          <max>2000</max>
-        </countRange>
-        <thingDefCountRange>
-          <min>4</min>
-          <max>7</max>
-        </thingDefCountRange>
-      </li>
-      <li Class="StockGenerator_Tag">
-        <tradeTag>CE_40K_MediumAmmo</tradeTag>
-        <countRange>
-          <min>30</min>
-          <max>120</max>
-        </countRange>
-        <thingDefCountRange>
-          <min>5</min>
-          <max>8</max>
-        </thingDefCountRange>
-      </li>
-      <li Class="StockGenerator_Tag">
-        <tradeTag>CE_40K_HeavyAmmo</tradeTag>
-        <countRange>
-          <min>10</min>
-          <max>50</max>
-        </countRange>
-        <thingDefCountRange>
-          <min>3</min>
-          <max>6</max>
-        </thingDefCountRange>
-      </li>
-      <li Class="StockGenerator_Tag">
-        <tradeTag>CE_40K_ExoticAmmo</tradeTag>
-        <countRange>
-          <min>10</min>
-          <max>50</max>
-        </countRange>
-        <thingDefCountRange>
-          <min>1</min>
-          <max>2</max>
-        </thingDefCountRange>
-      </li>
-      <li Class="StockGenerator_Category">
-        <categoryDef>Ammo</categoryDef>
-        <thingDefCountRange>
-          <min>0</min>
-          <max>0</max>
-        </thingDefCountRange>
-      </li>
-    </value>
-  </Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/TraderKindDef[defName="GW_SM_Trader_Caravan"]/stockGenerators</xpath>
+		<value>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>CE_40K_Ammo</tradeTag>
+				<countRange>
+					<min>200</min>
+					<max>400</max>
+				</countRange>
+				<thingDefCountRange>
+					<min>2</min>
+					<max>4</max>
+				</thingDefCountRange>
+			</li>
+			<li Class="StockGenerator_Category">
+				<categoryDef>Ammo</categoryDef>
+				<thingDefCountRange>
+					<min>0</min>
+					<max>0</max>
+				</thingDefCountRange>
+			</li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>CE_40K_MediumAmmo</tradeTag>
+				<countRange>
+					<min>20</min>
+					<max>40</max>
+				</countRange>
+				<thingDefCountRange>
+					<min>3</min>
+					<max>6</max>
+				</thingDefCountRange>
+			</li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>CE_40K_HeavyAmmo</tradeTag>
+				<countRange>
+					<min>5</min>
+					<max>10</max>
+				</countRange>
+				<thingDefCountRange>
+					<min>0</min>
+					<max>3</max>
+				</thingDefCountRange>
+			</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/TraderKindDef[defName="GW_SM_Trader"]/stockGenerators</xpath>
+		<value>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>CE_40K_Ammo</tradeTag>
+				<countRange>
+					<min>500</min>
+					<max>2000</max>
+				</countRange>
+				<thingDefCountRange>
+					<min>4</min>
+					<max>7</max>
+				</thingDefCountRange>
+			</li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>CE_40K_MediumAmmo</tradeTag>
+				<countRange>
+					<min>30</min>
+					<max>120</max>
+				</countRange>
+				<thingDefCountRange>
+					<min>5</min>
+					<max>8</max>
+				</thingDefCountRange>
+			</li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>CE_40K_HeavyAmmo</tradeTag>
+				<countRange>
+					<min>10</min>
+					<max>50</max>
+				</countRange>
+				<thingDefCountRange>
+					<min>3</min>
+					<max>6</max>
+				</thingDefCountRange>
+			</li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>CE_40K_ExoticAmmo</tradeTag>
+				<countRange>
+					<min>10</min>
+					<max>50</max>
+				</countRange>
+				<thingDefCountRange>
+					<min>1</min>
+					<max>2</max>
+				</thingDefCountRange>
+			</li>
+			<li Class="StockGenerator_Category">
+				<categoryDef>Ammo</categoryDef>
+				<thingDefCountRange>
+					<min>0</min>
+					<max>0</max>
+				</thingDefCountRange>
+			</li>
+		</value>
+	</Operation>
+
 </Patch>

--- a/ModPatches/Grimworld Core Imperialis/Defs/Grimworld Core Imperialis/Ammo/CE_Patch_GravGunAmmo.xml
+++ b/ModPatches/Grimworld Core Imperialis/Defs/Grimworld Core Imperialis/Ammo/CE_Patch_GravGunAmmo.xml
@@ -30,6 +30,9 @@
 			<li>AmmoGravCell</li>
 		</thingCategories>
 		<stackLimit>25</stackLimit>
+    <tradeTags>
+      <li>CE_40K_ExoticAmmo</li>
+    </tradeTags>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="GravCellBase">

--- a/ModPatches/Grimworld Core Imperialis/Defs/Grimworld Core Imperialis/Ammo/CE_Patch_GravGunAmmo.xml
+++ b/ModPatches/Grimworld Core Imperialis/Defs/Grimworld Core Imperialis/Ammo/CE_Patch_GravGunAmmo.xml
@@ -30,9 +30,9 @@
 			<li>AmmoGravCell</li>
 		</thingCategories>
 		<stackLimit>25</stackLimit>
-    <tradeTags>
-      <li>CE_40K_ExoticAmmo</li>
-    </tradeTags>
+		<tradeTags>
+			<li>CE_40K_ExoticAmmo</li>
+		</tradeTags>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="GravCellBase">

--- a/ModPatches/Grimworld Core Imperialis/Patches/CE_Patch_Traders.xml
+++ b/ModPatches/Grimworld Core Imperialis/Patches/CE_Patch_Traders.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/TraderKindDef[defName="HP_Orbital_RogueTrader"]/stockGenerators</xpath>
+    <value>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_40K_Ammo</tradeTag>
+        <countRange>
+          <min>1000</min>
+          <max>3000</max>
+        </countRange>
+        <price>Cheap</price>
+        <thingDefCountRange>
+          <min>6</min>
+          <max>12</max>
+        </thingDefCountRange>
+      </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_40K_MediumAmmo</tradeTag>
+        <countRange>
+          <min>175</min>
+          <max>500</max>
+        </countRange>
+        <price>Cheap</price>
+        <thingDefCountRange>
+          <min>5</min>
+          <max>10</max>
+        </thingDefCountRange>
+      </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_40K_HeavyAmmo</tradeTag>
+        <countRange>
+          <min>100</min>
+          <max>250</max>
+        </countRange>
+        <price>Cheap</price>
+        <thingDefCountRange>
+          <min>4</min>
+          <max>8</max>
+        </thingDefCountRange>
+      </li>
+      <li Class="StockGenerator_Category">
+        <categoryDef>Ammo</categoryDef>
+        <thingDefCountRange>
+          <min>0</min>
+          <max>0</max>
+        </thingDefCountRange>
+      </li>
+    </value>
+  </Operation>
+</Patch>

--- a/ModPatches/Grimworld Core Imperialis/Patches/CE_Patch_Traders.xml
+++ b/ModPatches/Grimworld Core Imperialis/Patches/CE_Patch_Traders.xml
@@ -1,51 +1,53 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
-  <Operation Class="PatchOperationAdd">
-    <xpath>Defs/TraderKindDef[defName="HP_Orbital_RogueTrader"]/stockGenerators</xpath>
-    <value>
-      <li Class="StockGenerator_Tag">
-        <tradeTag>CE_40K_Ammo</tradeTag>
-        <countRange>
-          <min>1000</min>
-          <max>3000</max>
-        </countRange>
-        <price>Cheap</price>
-        <thingDefCountRange>
-          <min>6</min>
-          <max>12</max>
-        </thingDefCountRange>
-      </li>
-      <li Class="StockGenerator_Tag">
-        <tradeTag>CE_40K_MediumAmmo</tradeTag>
-        <countRange>
-          <min>175</min>
-          <max>500</max>
-        </countRange>
-        <price>Cheap</price>
-        <thingDefCountRange>
-          <min>5</min>
-          <max>10</max>
-        </thingDefCountRange>
-      </li>
-      <li Class="StockGenerator_Tag">
-        <tradeTag>CE_40K_HeavyAmmo</tradeTag>
-        <countRange>
-          <min>100</min>
-          <max>250</max>
-        </countRange>
-        <price>Cheap</price>
-        <thingDefCountRange>
-          <min>4</min>
-          <max>8</max>
-        </thingDefCountRange>
-      </li>
-      <li Class="StockGenerator_Category">
-        <categoryDef>Ammo</categoryDef>
-        <thingDefCountRange>
-          <min>0</min>
-          <max>0</max>
-        </thingDefCountRange>
-      </li>
-    </value>
-  </Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/TraderKindDef[defName="HP_Orbital_RogueTrader"]/stockGenerators</xpath>
+		<value>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>CE_40K_Ammo</tradeTag>
+				<countRange>
+					<min>1000</min>
+					<max>3000</max>
+				</countRange>
+				<price>Cheap</price>
+				<thingDefCountRange>
+					<min>6</min>
+					<max>12</max>
+				</thingDefCountRange>
+			</li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>CE_40K_MediumAmmo</tradeTag>
+				<countRange>
+					<min>175</min>
+					<max>500</max>
+				</countRange>
+				<price>Cheap</price>
+				<thingDefCountRange>
+					<min>5</min>
+					<max>10</max>
+				</thingDefCountRange>
+			</li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>CE_40K_HeavyAmmo</tradeTag>
+				<countRange>
+					<min>100</min>
+					<max>250</max>
+				</countRange>
+				<price>Cheap</price>
+				<thingDefCountRange>
+					<min>4</min>
+					<max>8</max>
+				</thingDefCountRange>
+			</li>
+			<li Class="StockGenerator_Category">
+				<categoryDef>Ammo</categoryDef>
+				<thingDefCountRange>
+					<min>0</min>
+					<max>0</max>
+				</thingDefCountRange>
+			</li>
+		</value>
+	</Operation>
+
 </Patch>

--- a/ModPatches/Grimworld Hammer of the Imperium/Patches/Grimworld Hammer of the Imperium/CE_Patch_Traders.xml
+++ b/ModPatches/Grimworld Hammer of the Imperium/Patches/Grimworld Hammer of the Imperium/CE_Patch_Traders.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/TraderKindDef[defName="GW_AM_Trader"]/stockGenerators</xpath>
+    <value>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_Lasgun_Ammo</tradeTag>
+        <countRange>
+          <min>200</min>
+          <max>400</max>
+        </countRange>
+        <thingDefCountRange>
+          <min>1</min>
+          <max>4</max>
+        </thingDefCountRange>
+      </li>
+    </value>
+  </Operation>
+</Patch>

--- a/ModPatches/Grimworld Hammer of the Imperium/Patches/Grimworld Hammer of the Imperium/CE_Patch_Traders.xml
+++ b/ModPatches/Grimworld Hammer of the Imperium/Patches/Grimworld Hammer of the Imperium/CE_Patch_Traders.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/TraderKindDef[defName="GW_AM_Trader"]/stockGenerators</xpath>
+    <xpath>Defs/TraderKindDef[defName="GW_AM_Trader" or defName="GW_AM_Trader_Caravan"]/stockGenerators</xpath>
     <value>
       <li Class="StockGenerator_Tag">
         <tradeTag>CE_Lasgun_Ammo</tradeTag>

--- a/ModPatches/Grimworld Hammer of the Imperium/Patches/Grimworld Hammer of the Imperium/CE_Patch_Traders.xml
+++ b/ModPatches/Grimworld Hammer of the Imperium/Patches/Grimworld Hammer of the Imperium/CE_Patch_Traders.xml
@@ -1,93 +1,96 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
-  <Operation Class="PatchOperationAdd">
-    <xpath>Defs/TraderKindDef[defName="GW_AM_Trader_Caravan"]/stockGenerators</xpath>
-    <value>
-      <li Class="StockGenerator_Tag">
-        <tradeTag>CE_40K_Ammo</tradeTag>
-        <countRange>
-          <min>200</min>
-          <max>400</max>
-        </countRange>
-        <thingDefCountRange>
-          <min>2</min>
-          <max>4</max>
-        </thingDefCountRange>
-      </li>
-      <li Class="StockGenerator_Category">
-        <categoryDef>Ammo</categoryDef>
-        <thingDefCountRange>
-          <min>0</min>
-          <max>0</max>
-        </thingDefCountRange>
-      </li>
-      <li Class="StockGenerator_Tag">
-        <tradeTag>CE_40K_MediumAmmo</tradeTag>
-        <countRange>
-          <min>20</min>
-          <max>40</max>
-        </countRange>
-        <thingDefCountRange>
-          <min>3</min>
-          <max>6</max>
-        </thingDefCountRange>
-      </li>
-      <li Class="StockGenerator_Tag">
-        <tradeTag>CE_40K_HeavyAmmo</tradeTag>
-        <countRange>
-          <min>5</min>
-          <max>10</max>
-        </countRange>
-        <thingDefCountRange>
-          <min>0</min>
-          <max>3</max>
-        </thingDefCountRange>
-      </li>
-    </value>
-  </Operation>
-  <Operation Class="PatchOperationAdd">
-    <xpath>Defs/TraderKindDef[defName="GW_AM_Trader"]/stockGenerators</xpath>
-    <value>
-      <li Class="StockGenerator_Tag">
-        <tradeTag>CE_40K_Ammo</tradeTag>
-        <countRange>
-          <min>500</min>
-          <max>2000</max>
-        </countRange>
-        <thingDefCountRange>
-          <min>4</min>
-          <max>7</max>
-        </thingDefCountRange>
-      </li>
-      <li Class="StockGenerator_Tag">
-        <tradeTag>CE_40K_MediumAmmo</tradeTag>
-        <countRange>
-          <min>30</min>
-          <max>120</max>
-        </countRange>
-        <thingDefCountRange>
-          <min>5</min>
-          <max>8</max>
-        </thingDefCountRange>
-      </li>
-      <li Class="StockGenerator_Tag">
-        <tradeTag>CE_40K_HeavyAmmo</tradeTag>
-        <countRange>
-          <min>10</min>
-          <max>50</max>
-        </countRange>
-        <thingDefCountRange>
-          <min>3</min>
-          <max>6</max>
-        </thingDefCountRange>
-      </li>
-      <li Class="StockGenerator_Category">
-        <categoryDef>Ammo</categoryDef>
-        <thingDefCountRange>
-          <min>0</min>
-          <max>0</max>
-        </thingDefCountRange>
-      </li>
-    </value>
-  </Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/TraderKindDef[defName="GW_AM_Trader_Caravan"]/stockGenerators</xpath>
+		<value>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>CE_40K_Ammo</tradeTag>
+				<countRange>
+					<min>200</min>
+					<max>400</max>
+				</countRange>
+				<thingDefCountRange>
+					<min>2</min>
+					<max>4</max>
+				</thingDefCountRange>
+			</li>
+			<li Class="StockGenerator_Category">
+				<categoryDef>Ammo</categoryDef>
+				<thingDefCountRange>
+					<min>0</min>
+					<max>0</max>
+				</thingDefCountRange>
+			</li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>CE_40K_MediumAmmo</tradeTag>
+			<countRange>
+					<min>20</min>
+					<max>40</max>
+				</countRange>
+				<thingDefCountRange>
+					<min>3</min>
+					<max>6</max>
+				</thingDefCountRange>
+			</li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>CE_40K_HeavyAmmo</tradeTag>
+				<countRange>
+					<min>5</min>
+					<max>10</max>
+				</countRange>
+				<thingDefCountRange>
+					<min>0</min>
+					<max>3</max>
+				</thingDefCountRange>
+			</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/TraderKindDef[defName="GW_AM_Trader"]/stockGenerators</xpath>
+		<value>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>CE_40K_Ammo</tradeTag>
+				<countRange>
+					<min>500</min>
+					<max>2000</max>
+				</countRange>
+				<thingDefCountRange>
+					<min>4</min>
+					<max>7</max>
+				</thingDefCountRange>
+			</li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>CE_40K_MediumAmmo</tradeTag>
+				<countRange>
+					<min>30</min>
+					<max>120</max>
+				</countRange>
+				<thingDefCountRange>
+					<min>5</min>
+					<max>8</max>
+				</thingDefCountRange>
+			</li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>CE_40K_HeavyAmmo</tradeTag>
+				<countRange>
+					<min>10</min>
+					<max>50</max>
+				</countRange>
+				<thingDefCountRange>
+					<min>3</min>
+					<max>6</max>
+				</thingDefCountRange>
+			</li>
+			<li Class="StockGenerator_Category">
+				<categoryDef>Ammo</categoryDef>
+				<thingDefCountRange>
+					<min>0</min>
+					<max>0</max>
+				</thingDefCountRange>
+			</li>
+		</value>
+	</Operation>
+
 </Patch>


### PR DESCRIPTION
PR Content TBC - Currently in draft for building and testing


## Additions

Describe new functionality added by your code, e.g.
- Added 40K ammo trade tags to all ammo used by Grimworld mod weapons
- Added TraderKindDef patches for all the traders in the various Grimworld mods

## Reasoning

Why did you choose to implement things this way, e.g.
- None of the traders in the Grimworld mods would stock ammo, despite CE_AutoEnableTrade being on pretty much all the ammo tags
- Trade volumes copied over from Royalty base and caravan traders as I decided it would be the closest match to the Grimworld traders
- Trade volume for ammo for the orbital Rogue Trader copied from the orbital combat supplier

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [X] (For compatibility patches) ...with and without patched mod loaded
- [X] Playtested a colony (Used Dev tools to test each trader at least 4 times)
