### PR TITLE
Patch Huscarl Armor

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -236,6 +236,7 @@
 		<li IfModActive="zal.highcaliber">ModPatches/High Caliber</li>
 		<li IfModActive="Mlie.HighTechLaboratoryFacilities">ModPatches/High Tech Laboratory Facilities</li>
 		<li IfModActive="Hive.Armory.Geminingen">ModPatches/Hive Armory</li>
+		<li IfModActive="odz.huscarlpowerarmor">ModPatches/Huscarl - Power Armor</li>
 		<li IfModActive="zal.hyena">ModPatches/Hyena (Continued)</li>
 		<li IfModActive="Ayameduki.HARIdhale">ModPatches/Idhale Race</li>
 		<li IfModActive="detvisor.impactweaponry">ModPatches/Impact Weaponry</li>

--- a/ModPatches/Huscarl - Power Armor/Patches/Huscarl - Power Armor/Huscarl_Armor.xml
+++ b/ModPatches/Huscarl - Power Armor/Patches/Huscarl - Power Armor/Huscarl_Armor.xml
@@ -1,0 +1,225 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- ========== Huscarl Armor ========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="ODZ_HuscarlPlate"]/statBases/Mass</xpath>
+		<value>
+			<Mass>50</Mass>
+			<Bulk>100</Bulk>
+			<WornBulk>15</WornBulk>
+			<Flammability>0</Flammability>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[@Name="ApparelArmorPowerBase"]/statBases/MaxHitPoints</xpath>
+		<value>
+			<MaxHitPoints>580</MaxHitPoints>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="ODZ_HuscarlPlate"]/statBases/StuffEffectMultiplierArmor</xpath>
+		<value>
+			<StuffEffectMultiplierArmor>3.5</StuffEffectMultiplierArmor>
+			<ArmorRating_Sharp>16.5</ArmorRating_Sharp> <!-- Add a base armor value to reduce armor range across different materials. -->
+			<ArmorRating_Blunt>37</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="ODZ_HuscarlPlate"]/costList</xpath>
+		<value>
+			<DevilstrandCloth>40</DevilstrandCloth>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="ODZ_HuscarlPlate"]/equippedStatOffsets/MoveSpeed</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="ODZ_HuscarlPlate"]/equippedStatOffsets</xpath>
+		<value>
+			<CarryWeight>70</CarryWeight>
+			<CarryBulk>10</CarryBulk>
+			<ShootingAccuracyPawn>0.05</ShootingAccuracyPawn>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="ODZ_HuscarlPlate"]/equippedStatOffsets/ToxicEnvironmentResistance</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="ODZ_HuscarlPlate"]/equippedStatOffsets/ToxicEnvironmentResistance</xpath>
+			<value>
+				<ToxicEnvironmentResistance>0.50</ToxicEnvironmentResistance>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="ODZ_HuscarlPlate"]/equippedStatOffsets</xpath>
+			<value>
+				<ToxicEnvironmentResistance>0.50</ToxicEnvironmentResistance>
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="ODZ_HuscarlPlate"]</xpath>
+		<value>
+			<li Class="CombatExtended.PartialArmorExt">
+				<stats>
+					<li>
+						<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+						<parts>
+							<li>Neck</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+						<parts>
+							<li>Neck</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+						<parts>
+							<li>Arm</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+						<parts>
+							<li>Arm</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.70</ArmorRating_Sharp>
+						<parts>
+							<li>Hand</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.70</ArmorRating_Blunt>
+						<parts>
+							<li>Hand</li>
+						</parts>
+					</li>
+				</stats>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- ========== Huscarl Helmet ========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="ODZ_HuscarlHelm"]/statBases/Mass</xpath>
+		<value>
+			<Mass>5</Mass>
+			<Bulk>5</Bulk>
+			<WornBulk>1</WornBulk>
+			<NightVisionEfficiency_Apparel>0.5</NightVisionEfficiency_Apparel>
+			<Flammability>0</Flammability>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="ODZ_HuscarlHelm"]/statBases/MaxHitPoints</xpath>
+		<value>
+			<MaxHitPoints>280</MaxHitPoints>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="ODZ_HuscarlHelm"]/statBases/StuffEffectMultiplierArmor</xpath>
+		<value>
+			<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
+			<ArmorRating_Sharp>11</ArmorRating_Sharp> <!-- Add a base armor value to reduce armor range across different materials. -->
+			<ArmorRating_Blunt>27</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="ODZ_HuscarlHelm"]/equippedStatOffsets</xpath>
+		<value>
+			<AimingAccuracy>0.1</AimingAccuracy>
+			<SmokeSensitivity>-1</SmokeSensitivity>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="ODZ_HuscarlHelm"]/equippedStatOffsets/ToxicEnvironmentResistance</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="ODZ_HuscarlHelm"]/equippedStatOffsets/ToxicEnvironmentResistance</xpath>
+			<value>
+				<ToxicEnvironmentResistance>0.50</ToxicEnvironmentResistance>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="ODZ_HuscarlHelm"]/equippedStatOffsets</xpath>
+			<value>
+				<ToxicEnvironmentResistance>0.50</ToxicEnvironmentResistance>
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="ODZ_HuscarlHelm"]/costList/Plasteel</xpath>
+		<value>
+			<Plasteel>10</Plasteel>
+			<DevilstrandCloth>10</DevilstrandCloth>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="ODZ_HuscarlHelm"]/apparel</xpath>
+		<value>
+			<immuneToToxGasExposure>true</immuneToToxGasExposure>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="ODZ_HuscarlHelm"]</xpath>
+		<value>
+			<li Class="CombatExtended.PartialArmorExt">
+				<stats>
+					<li>
+						<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+						<parts>
+							<li>Eye</li>
+							<li>Nose</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+						<parts>
+							<li>Eye</li>
+							<li>Nose</li>
+						</parts>
+					</li>
+				</stats>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- ========== Huscarl Gambeson ========== -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="ODZ_HuscarlGambeson"]/statBases</xpath>
+		<value>
+			<Bulk>8</Bulk>
+			<WornBulk>3</WornBulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="ODZ_HuscarlGambeson"]/statBases/StuffEffectMultiplierArmor</xpath>
+		<value>
+			<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
+			<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
+			<ArmorRating_Blunt>1</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Huscarl - Power Armor/Patches/Huscarl - Power Armor/Huscarl_Armor.xml
+++ b/ModPatches/Huscarl - Power Armor/Patches/Huscarl - Power Armor/Huscarl_Armor.xml
@@ -24,8 +24,8 @@
 		<xpath>Defs/ThingDef[defName="ODZ_HuscarlPlate"]/statBases/StuffEffectMultiplierArmor</xpath>
 		<value>
 			<StuffEffectMultiplierArmor>3.5</StuffEffectMultiplierArmor>
-			<ArmorRating_Sharp>16.5</ArmorRating_Sharp> <!-- Add a base armor value to reduce armor range across different materials. -->
-			<ArmorRating_Blunt>37</ArmorRating_Blunt>
+			<ArmorRating_Sharp>12</ArmorRating_Sharp> <!-- Add a base armor value to reduce armor range across different materials. -->
+			<ArmorRating_Blunt>30</ArmorRating_Blunt>
 		</value>
 	</Operation>
 
@@ -135,8 +135,8 @@
 		<xpath>Defs/ThingDef[defName="ODZ_HuscarlHelm"]/statBases/StuffEffectMultiplierArmor</xpath>
 		<value>
 			<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
-			<ArmorRating_Sharp>11</ArmorRating_Sharp> <!-- Add a base armor value to reduce armor range across different materials. -->
-			<ArmorRating_Blunt>27</ArmorRating_Blunt>
+			<ArmorRating_Sharp>8</ArmorRating_Sharp> <!-- Add a base armor value to reduce armor range across different materials. -->
+			<ArmorRating_Blunt>20</ArmorRating_Blunt>
 		</value>
 	</Operation>
 

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -278,6 +278,7 @@ Heyra the Horned    |
 High Caliber	|
 High Tech Laboratory Facilities	|
 Hive Armory |
+Huscarl - Power Armor   |
 Hyena (Continued) |
 Idhale Race	|
 Impact Weaponry	|


### PR DESCRIPTION
## Additions
- Patch for [Huscarl Armor mod](https://steamcommunity.com/sharedfiles/filedetails/?id=3427511463&searchtext=huscarl).
  - Spacer power armor + helm
  - Gambeson

## References
Closes #3712 

## Reasoning
- Power armor patched as slightly cruder than vanilla power armor, per mod description.
  - Stuffable, though most armor from a base stat value to avoid too much disparity in armor values due to material.
  - Slightly inferior bonuses and protection in exchange for being slightly cheaper and higher HP.
- Gambeson the same as CE Armor stats, but only covering torso.

## Alternatives
- Different balancing scheme.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
