### PR TITLE
Do not spawn sustainer for projectiles that do not belong to any map

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -596,7 +596,7 @@ namespace CombatExtended
             //For explosives/bullets, equipmentDef is important
             equipmentDef = (equipment != null) ? equipment.def : null;
 
-            if (!def.projectile.soundAmbient.NullOrUndefined())
+            if (Map != null && !def.projectile.soundAmbient.NullOrUndefined())
             {
                 var info = SoundInfo.InMap(this, MaintenanceType.PerTick);
                 ambientSustainer = def.projectile.soundAmbient.TrySpawnSustainer(info);


### PR DESCRIPTION

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Ambient sustainer no longer spawns if the map is null

## Reasoning

- CIWS dummy projectile spawns sustainer for each iteration (causing lag spike)

## Alternatives

Describe alternative implementations you have considered, e.g.
- Mark projectile as dummy instead of checking map (in case we need to spawn sustainer without map)

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (tested the same save - lag spike is gone)
