### PR TITLE
Replace PlaceWorkers list with different PlaceWorkers list. VFEMediev…

### DIFF
--- a/ModPatches/Vanilla Factions Expanded - Medieval 2/Patches/Vanilla Factions Expanded - Medieval 2/ThingDefs_Buildings/VFEM2_ThingDefs_Buldings_Security.xml
+++ b/ModPatches/Vanilla Factions Expanded - Medieval 2/Patches/Vanilla Factions Expanded - Medieval 2/ThingDefs_Buildings/VFEM2_ThingDefs_Buldings_Security.xml
@@ -21,7 +21,7 @@
 	</Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/ThingDef[defName="VFEM2_Turret_WallMountedArquebus"]/placeWorkers</xpath>
+    <xpath>Defs/ThingDef[defName="VFEM2_Turret_WallMountedArbalest" or defName="VFEM2_Turret_WallMountedArquebus"]/placeWorkers</xpath>
     <value>
       <placeWorkers>
         <li>PlaceWorker_ShowTurretRadius</li>

--- a/ModPatches/Vanilla Factions Expanded - Medieval 2/Patches/Vanilla Factions Expanded - Medieval 2/ThingDefs_Buildings/VFEM2_ThingDefs_Buldings_Security.xml
+++ b/ModPatches/Vanilla Factions Expanded - Medieval 2/Patches/Vanilla Factions Expanded - Medieval 2/ThingDefs_Buildings/VFEM2_ThingDefs_Buldings_Security.xml
@@ -20,6 +20,16 @@
 		</value>
 	</Operation>
 
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="VFEM2_Turret_WallMountedArquebus"]/placeWorkers</xpath>
+    <value>
+      <placeWorkers>
+        <li>PlaceWorker_ShowTurretRadius</li>
+        <li>PlaceWorker_TurretTop</li>
+      </placeWorkers>
+    </value>
+  </Operation>
+
 	<!-- ========== Arbalest - Weapon ========== -->
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>VFEM2_Gun_ArbalestTurret</defName>


### PR DESCRIPTION

## Additions

Added PatchOperationReplace to replace PlaceWorkers for VFEM2_Turret_WallMountedArquebus, which were causing a NullReferenceException while trying to place the building. Specifically VFEMedieval.PlaceWorker_ShowTurretRadius

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #3731

## Reasoning

Vanilla Expanded's custom PlaceWorker was a sloppy fix on their end and has no value, so replacing it with the vanilla one loses no functionality.

## Alternatives

Harmony patch VFEMedieval.PlaceWorker_ShowTurretRadius to also look for Verb_ShootCE. Might maintain better compatibility if they expand the functionality of their class.

## Testing

Check tests you have performed:
- [ X ] Compiles without warnings
- [ X ] Game runs without errors
- [ X ] (For compatibility patches) ...with and without patched mod loaded
- [ X ] Playtested a colony (specify how long) about 45 seconds, long enough to place the turret and fire it without error. No other testing done, this was a single-issue update to an existing patch.