### PR TITLE
Update MeleeMedieval.xml to include new Guard Baton

### DIFF
--- a/ModPatches/Dark Ages - Medieval Tools/Patches/Dark Ages - Medieval Tools/MeleeMedieval.xml
+++ b/ModPatches/Dark Ages - Medieval Tools/Patches/Dark Ages - Medieval Tools/MeleeMedieval.xml
@@ -308,4 +308,66 @@
 		</value>
 	</Operation>
 
+  <!-- GuardBaton -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="DA_MeleeWeapon_GuardBaton"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>handle</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>1</power>
+					<cooldownTime>1.1</cooldownTime>
+					<chanceFactor>0.6</chanceFactor>
+					<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>5.0</power>
+					<extraMeleeDamages>
+						<li>
+							<def>Stun</def>
+							<amount>5</amount>
+							<chance>0.6</chance>
+						</li>
+					</extraMeleeDamages>
+					<cooldownTime>1.5</cooldownTime>
+					<chanceFactor>1.12</chanceFactor>
+					<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="DA_MeleeWeapon_GuardBaton"]/statBases</xpath>
+		<value>
+			<Bulk>3</Bulk>
+			<MeleeCounterParryBonus>1</MeleeCounterParryBonus>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="DA_MeleeWeapon_GuardBaton"]/equippedStatOffsets</xpath>
+		<value>
+			<MeleeCritChance>0.44</MeleeCritChance>
+			<MeleeParryChance>0.20</MeleeParryChance>
+			<MeleeDodgeChance>0.3</MeleeDodgeChance>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="DA_MeleeWeapon_GuardBaton"]/weaponTags</xpath>
+		<value>
+			<li>CE_OneHandedWeapon</li>
+		</value>
+	</Operation>
+  
 </Patch>


### PR DESCRIPTION
CE patch Guard Baton, a Medieval stun baton

## Additions

Describe new functionality added by your code, e.g.
CE patch Dark Ages: Medieval Tools  weapon "Guard Baton"
Kept stun ability
Added normal CE defs based on other tools already patched and other "stun" weapons CEed

## Changes

Describe adjustments to existing features made in this merge, e.g.
No Changes sides CE additions to existing patchs/items

## References

Links to the associated issues or other related pull requests, e.g.
No Mod Request at the time of patch

## Reasoning

Why did you choose to implement things this way, e.g.

Noticed it wasnt patch after it got added, been trying to clean up and figured id give this a update

## Alternatives

Describe alternative implementations you have considered, e.g.
N/A

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long) 5 mins
