### PR TITLE
Patch - Vanilla Prestige Specialist Armours Reworked

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -403,7 +403,6 @@
 		<li IfModActive="pphhyy.SanguinaryAnimals">ModPatches/pphhyy Sanguinary Animals</li>
 		<li IfModActive="Pratt.RaW.WWIIWeaponsPackVanilla">ModPatches/Pratt WWII Weapons Pack</li>
 		<li IfModActive="PrestigePhoenix.maltum">ModPatches/Prestige Specialist Armor</li>
-		<li IfModActive="PrestigeSpecialistArmours.Final">ModPatches/Vanilla Prestige Specialist Armours Reworked</li>
 		<li IfModActive="botchjob.profaned">ModPatches/Profaned</li>
 		<li IfModActive="PRF.Materials">ModPatches/Project RimFactory - Materials</li>
 		<li IfModActive="DimonSever000.ProsthesesPlus13.Specific">ModPatches/Prostheses+</li>
@@ -596,6 +595,7 @@
 		<li IfModActive="VanillaExpanded.VMemesE">ModPatches/Vanilla Ideology Expanded - Memes and Structures</li>
 		<li IfModActive="VanillaExpanded.VPersonaWeaponsE">ModPatches/Vanilla Persona Weapons Expanded</li>
 		<li IfModActive="VanillaExpanded.VPlantsEMushrooms">ModPatches/Vanilla Plants Expanded - Mushrooms</li>
+		<li IfModActive="PrestigeSpecialistArmours.Final">ModPatches/Vanilla Prestige Specialist Armours Reworked</li>
 		<li IfModActive="VanillaExpanded.VPsycastsE">ModPatches/Vanilla Psycasts Expanded</li>
 		<li IfModActive="VanillaExpanded.VPE.Hemosage">ModPatches/Vanilla Psycasts Expanded - Hemosage</li>
 		<li IfModActive="Chairheir.VPERunesmith">ModPatches/Vanilla Psycasts Expanded - Runesmith</li>

--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -403,6 +403,7 @@
 		<li IfModActive="pphhyy.SanguinaryAnimals">ModPatches/pphhyy Sanguinary Animals</li>
 		<li IfModActive="Pratt.RaW.WWIIWeaponsPackVanilla">ModPatches/Pratt WWII Weapons Pack</li>
 		<li IfModActive="PrestigePhoenix.maltum">ModPatches/Prestige Specialist Armor</li>
+		<li IfModActive="PrestigeSpecialistArmours.Final">ModPatches/Vanilla Prestige Specialist Armours Reworked</li>
 		<li IfModActive="botchjob.profaned">ModPatches/Profaned</li>
 		<li IfModActive="PRF.Materials">ModPatches/Project RimFactory - Materials</li>
 		<li IfModActive="DimonSever000.ProsthesesPlus13.Specific">ModPatches/Prostheses+</li>

--- a/ModPatches/Vanilla Prestige Specialist Armours Reworked/Patches/Vanilla Prestige Specialist Armours Reworked/Apparel_Armor.xml
+++ b/ModPatches/Vanilla Prestige Specialist Armours Reworked/Patches/Vanilla Prestige Specialist Armours Reworked/Apparel_Armor.xml
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<!-- Grenadier armor -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorGrenadierPrestige"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>18</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorGrenadierPrestige"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>41</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorGrenadierPrestige"]/costList</xpath>
+		<value>
+			<DevilstrandCloth>50</DevilstrandCloth>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorGrenadierPrestige"]/verbs</xpath>
+		<value>
+			<verbs>
+				<li Class="CombatExtended.VerbPropertiesCE">
+					<label>launch 30x29mm grenade</label>
+					<verbClass>CombatExtended.Verb_LaunchProjectileStaticCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<onlyManualCast>True</onlyManualCast>
+					<warmupTime>1.5</warmupTime>
+					<range>40</range>
+					<minRange>5</minRange>
+					<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
+					<soundCast>Shot_IncendiaryLauncher</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>14</muzzleFlashScale>
+					<drawHighlightWithLineOfSight>true</drawHighlightWithLineOfSight>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+					<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
+					<defaultProjectile>Bullet_30x29mmGrenade_HE</defaultProjectile>
+					<rangedFireRulepack>Combat_RangedFire_Thrown</rangedFireRulepack>
+				</li>
+			</verbs>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorGrenadierPrestige"]/comps/li[@Class="CompProperties_ApparelReloadable"]/ammoDef</xpath>
+		<value>
+			<ammoDef>Ammo_30x29mmGrenade_HE</ammoDef>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorGrenadierPrestige"]/comps/li[@Class="CompProperties_ApparelReloadable"]/ammoCountPerCharge</xpath>
+		<value>
+			<ammoCountPerCharge>1</ammoCountPerCharge>
+		</value>
+	</Operation>
+
+	<!-- Phoenix armor -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorPhoenixPrestige"]/statBases</xpath>
+		<value>
+			<Bulk>110</Bulk>
+			<WornBulk>18</WornBulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorPhoenixPrestige"]/statBases/Flammability</xpath>
+		<value>
+			<Flammability>0</Flammability>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorPhoenixPrestige"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>26</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorPhoenixPrestige"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>55</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorPhoenixPrestige"]/costList</xpath>
+		<value>
+			<DevilstrandCloth>60</DevilstrandCloth>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorPhoenixPrestige"]/verbs</xpath>
+		<value>
+			<verbs>
+				<li Class="CombatExtended.VerbPropertiesCE">
+					<label>launch 30x64mm incendiary</label>
+					<verbClass>CombatExtended.Verb_LaunchProjectileStaticCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<onlyManualCast>True</onlyManualCast>
+					<warmupTime>1.5</warmupTime>
+					<range>40</range>
+					<minRange>5</minRange>
+					<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
+					<soundCast>Shot_IncendiaryLauncher</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>14</muzzleFlashScale>
+					<drawHighlightWithLineOfSight>true</drawHighlightWithLineOfSight>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+					<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
+					<defaultProjectile>Bullet_30x64mmFuel_Incendiary</defaultProjectile>
+					<rangedFireRulepack>Combat_RangedFire_Thrown</rangedFireRulepack>
+				</li>
+			</verbs>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorPhoenixPrestige"]/comps/li[@Class="CompProperties_ApparelReloadable"]/ammoDef</xpath>
+		<value>
+			<ammoDef>Ammo_30x64mmFuel_Incendiary</ammoDef>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorPhoenixPrestige"]/comps/li[@Class="CompProperties_ApparelReloadable"]/ammoCountPerCharge</xpath>
+		<value>
+			<ammoCountPerCharge>1</ammoCountPerCharge>
+		</value>
+	</Operation>
+
+	<!-- ========== Locust Armor ========== -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorLocustPrestige"]/statBases</xpath>
+		<value>
+			<Bulk>85</Bulk>
+			<WornBulk>15</WornBulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorLocustPrestige"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>15</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorLocustPrestige"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>38</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorLocustPrestige"]/costList</xpath>
+		<value>
+			<DevilstrandCloth>40</DevilstrandCloth>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorLocustPrestige"]/statBases/JumpRange</xpath>
+		<value>
+			<JumpRange>30</JumpRange>
+		</value>
+	</Operation>
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -574,6 +574,7 @@ Vanilla Ideology Expanded - Hats and Rags |
 Vanilla Ideology Expanded - Memes and Structures    |
 Vanilla Persona Weapons Expanded   |
 Vanilla Plants Expanded - Mushrooms  |
+Vanilla Prestige Specialist Armours Reworked    |
 Vanilla Psycasts Expanded   |
 Vanilla Psycasts Expanded - Hemosage  |
 Vanilla Psycasts Expanded - Runesmith   |


### PR DESCRIPTION
[Vanilla Prestige Specialist Armours Reworked](https://steamcommunity.com/sharedfiles/filedetails/?id=3246196440)

## Additions

Recycled the patch for [Prestige Specialist Armor](https://github.com/CombatExtended-Continued/CombatExtended/blob/Development/ModPatches/Prestige%20Specialist%20Armor/Patches/Prestige%20Specialist%20Armor/Apparel_Armor.xml) because they're both forks of the same mod and share the same defNames. This patch is nearly identical to the original, with only a few updated xpath arguments to get it working.

## Changes

- Add mod to LoadFolders.xml
- Add patch to ModPatches/ModName/Patches/ModName as outlined in wiki
- Change to recycled patch: replaced xpath `@Class="CompProperties_Reloadable"` with `@Class="CompProperties_ApparelReloadable"`.

## Testing

Check tests you have performed:
- [x] ~~Compiles without warnings~~ N/A, XML only
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony long enough to equip the apparel and fight off a few raids without issue