### PR TITLE
VWENL gas damage fix

### DIFF
--- a/ModPatches/Vanilla Weapons Expanded - Non-Lethal/Defs/Vanilla Weapons Expanded - Non-Lethal/40mmLessLethal.xml
+++ b/ModPatches/Vanilla Weapons Expanded - Non-Lethal/Defs/Vanilla Weapons Expanded - Non-Lethal/40mmLessLethal.xml
@@ -33,7 +33,7 @@
 		<label>40x46mm grenade (CN)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<explosionRadius>3.9</explosionRadius>
-			<damageDef>VWENL_TearGas</damageDef>
+			<damageDef>Smoke</damageDef>
 			<postExplosionSpawnThingDef>VWENL_TearGasCloud</postExplosionSpawnThingDef>
 			<preExplosionSpawnChance>1</preExplosionSpawnChance>
 			<postExplosionSpawnThingCount>1</postExplosionSpawnThingCount>

--- a/ModPatches/Vanilla Weapons Expanded - Non-Lethal/Patches/Vanilla Weapons Expanded - Non-Lethal/NonLethal_Grenades.xml
+++ b/ModPatches/Vanilla Weapons Expanded - Non-Lethal/Patches/Vanilla Weapons Expanded - Non-Lethal/NonLethal_Grenades.xml
@@ -14,9 +14,8 @@
 		<xpath>Defs/ThingDef[defName="VWENL_Projectile_TearGasGrenade"]/projectile</xpath>
 		<value>
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
-				<damageDef>VWENL_TearGas</damageDef>
+				<damageDef>Smoke</damageDef>
 				<explosionRadius>3.9</explosionRadius>
-				<damageAmountBase>1</damageAmountBase>
 				<explosionDelay>100</explosionDelay>
 				<dropsCasings>true</dropsCasings>
 				<flyOverhead>false</flyOverhead>


### PR DESCRIPTION
## Additions
## Changes
change the damage from VWENL_TearGas to Smoke
## References
https://discord.com/channels/278818534069501953/630624305947869184/1356656090745671860
## Reasoning
the VWENL_TearGas damage one shot pawns and cause error
## Alternatives
make a CE damage and armor type of gas.
## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long) 5 mins
