### PR TITLE
Gun Statsheet Rebalances (Part: 1 - General Crafting Tweaks)

### DIFF
--- a/Biotech/Patches/ThingDefs_Misc/Weapons/RangedMechanoid_Light.xml
+++ b/Biotech/Patches/ThingDefs_Misc/Weapons/RangedMechanoid_Light.xml
@@ -128,7 +128,7 @@
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_5x16mmCharged</defaultProjectile>
 			<warmupTime>1.1</warmupTime><!-- Intentionally increased from 0.8 due to balance reasons-->
-			<range>15</range>
+			<range>20</range>
 			<soundCast>Shot_Spiner</soundCast>
 			<soundCastTail>GunTail_Light</soundCastTail>
 			<muzzleFlashScale>9</muzzleFlashScale>

--- a/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
@@ -116,7 +116,7 @@
 		</graphicData>
 		<uiIconPath>UI/Icons/Turrets/ChargeBlaster_uiIcon</uiIconPath>
 		<statBases>
-			<WorkToBuild>66000</WorkToBuild>
+			<WorkToBuild>67000</WorkToBuild>
 			<MaxHitPoints>150</MaxHitPoints>
 			<Mass>20</Mass>
 			<Bulk>25</Bulk>
@@ -133,7 +133,7 @@
 		</comps>
 		<description>Automatic turret equipped with a charge blaster.</description>
 		<costList>
-			<Steel>115</Steel>
+			<Steel>125</Steel>
 			<Plasteel>35</Plasteel>
 			<ComponentIndustrial>10</ComponentIndustrial>
 			<ComponentSpacer>1</ComponentSpacer>
@@ -168,7 +168,7 @@
 		</graphicData>
 		<uiIconPath>UI/Icons/Turrets/HeavyAutoTurret_uiIcon</uiIconPath>
 		<statBases>
-			<WorkToBuild>61500</WorkToBuild>
+			<WorkToBuild>66000</WorkToBuild>
 			<MaxHitPoints>350</MaxHitPoints>
 			<Flammability>0.5</Flammability>
 			<Mass>60</Mass>
@@ -178,7 +178,7 @@
 		</statBases>
 		<description>Plated automatic turret equiped with a high caliber machine gun. Very resistant to damage.</description>
 		<costList>
-			<Steel>205</Steel>
+			<Steel>240</Steel>
 			<ComponentIndustrial>12</ComponentIndustrial>
 		</costList>
 		<building>
@@ -218,7 +218,7 @@
 		</graphicData>
 		<uiIconPath>UI/Icons/Turrets/MediumAutoTurret_uiIcon</uiIconPath>
 		<statBases>
-			<WorkToBuild>50000</WorkToBuild>
+			<WorkToBuild>51500</WorkToBuild>
 			<MaxHitPoints>200</MaxHitPoints>
 			<Flammability>0.6</Flammability>
 			<Mass>30</Mass>
@@ -228,7 +228,7 @@
 		</statBases>
 		<description>Automatic turret equiped with a full powered cartridge machine gun. Fairly resistant to damage.</description>
 		<costList>
-			<Steel>110</Steel>
+			<Steel>125</Steel>
 			<ComponentIndustrial>12</ComponentIndustrial>
 		</costList>
 		<building>
@@ -271,13 +271,13 @@
 		<uiIconPath>UI/Icons/Turrets/KPV_uiIcon</uiIconPath>
 		<statBases>
 			<MaxHitPoints>150</MaxHitPoints>
-			<WorkToBuild>58500</WorkToBuild>
+			<WorkToBuild>63500</WorkToBuild>
 			<Mass>88</Mass>
 			<Bulk>100</Bulk>
 		</statBases>
 		<description>KPV heavy machine gun mounted on a tripod.</description>
 		<costList>
-			<Steel>235</Steel>
+			<Steel>275</Steel>
 			<ComponentIndustrial>8</ComponentIndustrial>
 		</costList>
 		<building>
@@ -317,13 +317,13 @@
 		</graphicData>
 		<uiIconPath>UI/Icons/Turrets/M240B_uiIcon</uiIconPath>
 		<statBases>
-			<WorkToBuild>45500</WorkToBuild>
+			<WorkToBuild>47000</WorkToBuild>
 			<Mass>16.5</Mass>
 			<Bulk>20</Bulk>
 		</statBases>
 		<description>M240B medium machine gun mounted on a tripod.</description>
 		<costList>
-			<Steel>130</Steel>
+			<Steel>145</Steel>
 			<ComponentIndustrial>8</ComponentIndustrial>
 		</costList>
 		<building>
@@ -358,13 +358,13 @@
 		</graphicData>
 		<uiIconPath>UI/Icons/Turrets/AGS30_uiIcon</uiIconPath>
 		<statBases>
-			<WorkToBuild>43500</WorkToBuild>
+			<WorkToBuild>45500</WorkToBuild>
 			<Mass>16</Mass>
 			<Bulk>20</Bulk>
 		</statBases>
 		<description>Lightweight automatic grenade launcher mounted on a tripod.</description>
 		<costList>
-			<Steel>120</Steel>
+			<Steel>135</Steel>
 			<ComponentIndustrial>7</ComponentIndustrial>
 		</costList>
 		<building>
@@ -403,19 +403,19 @@
 		<statBases>
 			<MaxHitPoints>500</MaxHitPoints>
 			<Flammability>0.4</Flammability>
-			<WorkToBuild>93000</WorkToBuild>
+			<WorkToBuild>97000</WorkToBuild>
 			<Mass>1000</Mass>
 			<Bulk>1000</Bulk>
 		</statBases>
 		<costList>
-			<Steel>475</Steel>
+			<Steel>505</Steel>
 			<ComponentIndustrial>7</ComponentIndustrial>
 		</costList>
 		<costListForDifficulty>
 			<difficultyVar>classicMortars</difficultyVar>
 			<invert>true</invert>
 			<costList>
-				<ComponentIndustrial>5</ComponentIndustrial>
+				<ComponentIndustrial>7</ComponentIndustrial>
 				<ReinforcedBarrel>1</ReinforcedBarrel>
 				<Steel>350</Steel>
 			</costList>

--- a/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
@@ -116,7 +116,7 @@
 		</graphicData>
 		<uiIconPath>UI/Icons/Turrets/ChargeBlaster_uiIcon</uiIconPath>
 		<statBases>
-			<WorkToBuild>23000</WorkToBuild>
+			<WorkToBuild>66000</WorkToBuild>
 			<MaxHitPoints>150</MaxHitPoints>
 			<Mass>20</Mass>
 			<Bulk>25</Bulk>
@@ -133,9 +133,9 @@
 		</comps>
 		<description>Automatic turret equipped with a charge blaster.</description>
 		<costList>
-			<Steel>125</Steel>
-			<Plasteel>40</Plasteel>
-			<ComponentIndustrial>6</ComponentIndustrial>
+			<Steel>115</Steel>
+			<Plasteel>35</Plasteel>
+			<ComponentIndustrial>10</ComponentIndustrial>
 			<ComponentSpacer>1</ComponentSpacer>
 		</costList>
 		<building>
@@ -168,7 +168,7 @@
 		</graphicData>
 		<uiIconPath>UI/Icons/Turrets/HeavyAutoTurret_uiIcon</uiIconPath>
 		<statBases>
-			<WorkToBuild>40000</WorkToBuild>
+			<WorkToBuild>61500</WorkToBuild>
 			<MaxHitPoints>350</MaxHitPoints>
 			<Flammability>0.5</Flammability>
 			<Mass>60</Mass>
@@ -178,8 +178,8 @@
 		</statBases>
 		<description>Plated automatic turret equiped with a high caliber machine gun. Very resistant to damage.</description>
 		<costList>
-			<Steel>275</Steel>
-			<ComponentIndustrial>8</ComponentIndustrial>
+			<Steel>205</Steel>
+			<ComponentIndustrial>12</ComponentIndustrial>
 		</costList>
 		<building>
 			<ai_combatDangerous>true</ai_combatDangerous>
@@ -218,7 +218,7 @@
 		</graphicData>
 		<uiIconPath>UI/Icons/Turrets/MediumAutoTurret_uiIcon</uiIconPath>
 		<statBases>
-			<WorkToBuild>20000</WorkToBuild>
+			<WorkToBuild>50000</WorkToBuild>
 			<MaxHitPoints>200</MaxHitPoints>
 			<Flammability>0.6</Flammability>
 			<Mass>30</Mass>
@@ -228,8 +228,8 @@
 		</statBases>
 		<description>Automatic turret equiped with a full powered cartridge machine gun. Fairly resistant to damage.</description>
 		<costList>
-			<Steel>150</Steel>
-			<ComponentIndustrial>8</ComponentIndustrial>
+			<Steel>110</Steel>
+			<ComponentIndustrial>12</ComponentIndustrial>
 		</costList>
 		<building>
 			<ai_combatDangerous>true</ai_combatDangerous>
@@ -271,14 +271,14 @@
 		<uiIconPath>UI/Icons/Turrets/KPV_uiIcon</uiIconPath>
 		<statBases>
 			<MaxHitPoints>150</MaxHitPoints>
-			<WorkToBuild>25000</WorkToBuild>
+			<WorkToBuild>58500</WorkToBuild>
 			<Mass>88</Mass>
 			<Bulk>100</Bulk>
 		</statBases>
 		<description>KPV heavy machine gun mounted on a tripod.</description>
 		<costList>
-			<Steel>275</Steel>
-			<ComponentIndustrial>6</ComponentIndustrial>
+			<Steel>235</Steel>
+			<ComponentIndustrial>8</ComponentIndustrial>
 		</costList>
 		<building>
 			<turretGunDef>Gun_KPV</turretGunDef>
@@ -317,14 +317,14 @@
 		</graphicData>
 		<uiIconPath>UI/Icons/Turrets/M240B_uiIcon</uiIconPath>
 		<statBases>
-			<WorkToBuild>16000</WorkToBuild>
+			<WorkToBuild>45500</WorkToBuild>
 			<Mass>16.5</Mass>
 			<Bulk>20</Bulk>
 		</statBases>
 		<description>M240B medium machine gun mounted on a tripod.</description>
 		<costList>
-			<Steel>150</Steel>
-			<ComponentIndustrial>6</ComponentIndustrial>
+			<Steel>130</Steel>
+			<ComponentIndustrial>8</ComponentIndustrial>
 		</costList>
 		<building>
 			<turretGunDef>Gun_M240B</turretGunDef>
@@ -358,14 +358,14 @@
 		</graphicData>
 		<uiIconPath>UI/Icons/Turrets/AGS30_uiIcon</uiIconPath>
 		<statBases>
-			<WorkToBuild>17000</WorkToBuild>
+			<WorkToBuild>43500</WorkToBuild>
 			<Mass>16</Mass>
 			<Bulk>20</Bulk>
 		</statBases>
 		<description>Lightweight automatic grenade launcher mounted on a tripod.</description>
 		<costList>
-			<Steel>115</Steel>
-			<ComponentIndustrial>5</ComponentIndustrial>
+			<Steel>120</Steel>
+			<ComponentIndustrial>7</ComponentIndustrial>
 		</costList>
 		<building>
 			<turretGunDef>Gun_AGSThirty</turretGunDef>
@@ -403,13 +403,13 @@
 		<statBases>
 			<MaxHitPoints>500</MaxHitPoints>
 			<Flammability>0.4</Flammability>
-			<WorkToBuild>45000</WorkToBuild>
+			<WorkToBuild>93000</WorkToBuild>
 			<Mass>1000</Mass>
 			<Bulk>1000</Bulk>
 		</statBases>
 		<costList>
-			<Steel>500</Steel>
-			<ComponentIndustrial>5</ComponentIndustrial>
+			<Steel>475</Steel>
+			<ComponentIndustrial>7</ComponentIndustrial>
 		</costList>
 		<costListForDifficulty>
 			<difficultyVar>classicMortars</difficultyVar>

--- a/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -329,6 +329,16 @@
 			</li>
 		</value>
 	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/PawnKindDef[defName="Town_Guard"]/weaponMoney</xpath>
+		<value>
+			<weaponMoney>
+				<min>300</min>
+				<max>475</max>
+			</weaponMoney>
+		</value>
+	</Operation>
 
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="Town_Guard"]</xpath>
@@ -401,6 +411,16 @@
 					</li>
 				</sidearms>
 			</li>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/PawnKindDef[defName="Pirate"]/weaponMoney</xpath>
+		<value>
+			<weaponMoney>
+				<min>250</min>
+				<max>400</max>
+			</weaponMoney>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
@@ -40,7 +40,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_MiniTurret"]/statBases/WorkToBuild</xpath>
 		<value>
-			<WorkToBuild>6000</WorkToBuild>
+			<WorkToBuild>42500</WorkToBuild>
 		</value>
 	</Operation>
 
@@ -84,7 +84,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_MiniTurret"]/costList/ComponentIndustrial</xpath>
 		<value>
-			<ComponentIndustrial>5</ComponentIndustrial>
+			<ComponentIndustrial>9</ComponentIndustrial>
 		</value>
 	</Operation>
 
@@ -174,10 +174,10 @@
 		<xpath>Defs/ThingDef[defName="Turret_Sniper"]/costList</xpath>
 		<value>
 			<costList>
-				<Steel>465</Steel>
-				<Plasteel>30</Plasteel>
+				<Steel>370</Steel>
+				<Plasteel>45</Plasteel>
 				<Uranium>60</Uranium>
-				<ComponentIndustrial>10</ComponentIndustrial>
+				<ComponentIndustrial>12</ComponentIndustrial>
 			</costList>
 		</value>
 	</Operation>
@@ -244,7 +244,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="AutocannonTurret"]/statBases/WorkToBuild</xpath>
 		<value>
-			<WorkToBuild>35000</WorkToBuild>
+			<WorkToBuild>76000</WorkToBuild>
 		</value>
 	</Operation>
 
@@ -266,7 +266,7 @@
 		<xpath>Defs/ThingDef[defName="Turret_Autocannon"]/costList</xpath>
 		<value>
 			<costList>
-				<Steel>425</Steel>
+				<Steel>305</Steel>
 				<Plasteel>40</Plasteel>
 				<ComponentIndustrial>9</ComponentIndustrial>
 			</costList>
@@ -346,7 +346,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_RocketswarmLauncher"]/statBases/WorkToBuild</xpath>
 		<value>
-			<WorkToBuild>25000</WorkToBuild>
+			<WorkToBuild>75000</WorkToBuild>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -141,7 +141,7 @@
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_44Magnum_FMJ</defaultProjectile>
 			<warmupTime>0.6</warmupTime>
-			<range>12</range>
+			<range>20</range>
 			<soundCast>Shot_Revolver</soundCast>
 			<soundCastTail>GunTail_Light</soundCastTail>
 			<muzzleFlashScale>9</muzzleFlashScale>
@@ -205,7 +205,7 @@
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
 			<warmupTime>0.6</warmupTime>
-			<range>12</range>
+			<range>18</range>
 			<soundCast>Shot_Autopistol</soundCast>
 			<soundCastTail>GunTail_Light</soundCastTail>
 			<muzzleFlashScale>9</muzzleFlashScale>
@@ -584,7 +584,7 @@
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
 			<warmupTime>0.6</warmupTime>
-			<range>12</range>
+			<range>20</range>
 			<burstShotCount>6</burstShotCount>
 			<ticksBetweenBurstShots>3</ticksBetweenBurstShots>
 			<soundCast>Shot_MachinePistol</soundCast>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -124,7 +124,7 @@
 			<RangedWeapon_Cooldown>0.49</RangedWeapon_Cooldown>
 			<SightsEfficiency>0.7</SightsEfficiency>
 			<ShotSpread>0.16</ShotSpread>
-			<SwayFactor>1.39</SwayFactor>
+			<SwayFactor>0.84</SwayFactor>
 			<Bulk>2.79</Bulk>
 			<!-- <ToughnessRating>2.5</ToughnessRating> -->
 			<!-- Base toughness rating of a weapon -->
@@ -191,7 +191,7 @@
 			<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
 			<SightsEfficiency>0.7</SightsEfficiency>
 			<ShotSpread>0.17</ShotSpread>
-			<SwayFactor>1.07</SwayFactor>
+			<SwayFactor>0.64</SwayFactor>
 			<Bulk>2.10</Bulk>
 			<WorkToMake>7000</WorkToMake>
 		</statBases>
@@ -322,11 +322,11 @@
 			<SwayFactor>1.26</SwayFactor>
 			<Bulk>6.7</Bulk>
 			<SightsEfficiency>1</SightsEfficiency>
-			<WorkToMake>22500</WorkToMake>
+			<WorkToMake>26000</WorkToMake>
 		</statBases>
 		<costList>
 			<Steel>40</Steel>
-			<ComponentIndustrial>3</ComponentIndustrial>
+			<ComponentIndustrial>5</ComponentIndustrial>
 			<Chemfuel>10</Chemfuel>
 		</costList>
 		<Properties>
@@ -446,11 +446,11 @@
 			<ShotSpread>0.07</ShotSpread>
 			<SwayFactor>1.33</SwayFactor>
 			<Bulk>10.03</Bulk>
-			<WorkToMake>30000</WorkToMake>
+			<WorkToMake>33500</WorkToMake>
 		</statBases>
 		<costList>
 			<Steel>50</Steel>
-			<ComponentIndustrial>5</ComponentIndustrial>
+			<ComponentIndustrial>7</ComponentIndustrial>
 			<Chemfuel>10</Chemfuel>
 		</costList>
 		<Properties>
@@ -510,7 +510,7 @@
 			<ShotSpread>0.05</ShotSpread>
 			<SwayFactor>1.35</SwayFactor>
 			<Bulk>11.92</Bulk>
-			<WorkToMake>30000</WorkToMake>
+			<WorkToMake>30500</WorkToMake>
 		</statBases>
 		<costList>
 			<Steel>60</Steel>
@@ -570,13 +570,13 @@
 			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 			<SightsEfficiency>0.7</SightsEfficiency>
 			<ShotSpread>0.16</ShotSpread>
-			<SwayFactor>1.93</SwayFactor>
+			<SwayFactor>1.16</SwayFactor>
 			<Bulk>2.95</Bulk>
-			<WorkToMake>24500</WorkToMake>
+			<WorkToMake>26500</WorkToMake>
 		</statBases>
 		<costList>
 			<Steel>35</Steel>
-			<ComponentIndustrial>3</ComponentIndustrial>
+			<ComponentIndustrial>4</ComponentIndustrial>
 		</costList>
 		<Properties>
 			<recoilAmount>1.71</recoilAmount>
@@ -771,12 +771,12 @@
 			<ShotSpread>0.05</ShotSpread>
 			<SwayFactor>1.37</SwayFactor>
 			<Bulk>12.9</Bulk>
-			<WorkToMake>31500</WorkToMake>
+			<WorkToMake>37500</WorkToMake>
 		</statBases>
 		<costList>
 			<Steel>80</Steel>
 			<WoodLog>10</WoodLog>
-			<ComponentIndustrial>5</ComponentIndustrial>
+			<ComponentIndustrial>8</ComponentIndustrial>
 		</costList>
 		<Properties>
 			<recoilAmount>1.38</recoilAmount>
@@ -841,12 +841,12 @@
 			<ShotSpread>0.08</ShotSpread>
 			<SwayFactor>1.20</SwayFactor>
 			<Bulk>7.00</Bulk>
-			<WorkToMake>49000</WorkToMake>
+			<WorkToMake>52500</WorkToMake>
 		</statBases>
 		<costList>
 			<Steel>45</Steel>
 			<Plasteel>25</Plasteel>
-			<ComponentIndustrial>4</ComponentIndustrial>
+			<ComponentIndustrial>6</ComponentIndustrial>
 			<ComponentSpacer>1</ComponentSpacer>
 			<Chemfuel>10</Chemfuel>
 		</costList>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -124,7 +124,7 @@
 			<RangedWeapon_Cooldown>0.49</RangedWeapon_Cooldown>
 			<SightsEfficiency>0.7</SightsEfficiency>
 			<ShotSpread>0.16</ShotSpread>
-			<SwayFactor>0.84</SwayFactor>
+			<SwayFactor>1.39</SwayFactor>
 			<Bulk>2.79</Bulk>
 			<!-- <ToughnessRating>2.5</ToughnessRating> -->
 			<!-- Base toughness rating of a weapon -->
@@ -191,7 +191,7 @@
 			<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
 			<SightsEfficiency>0.7</SightsEfficiency>
 			<ShotSpread>0.17</ShotSpread>
-			<SwayFactor>0.64</SwayFactor>
+			<SwayFactor>1.07</SwayFactor>
 			<Bulk>2.10</Bulk>
 			<WorkToMake>7000</WorkToMake>
 		</statBases>
@@ -570,7 +570,7 @@
 			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 			<SightsEfficiency>0.7</SightsEfficiency>
 			<ShotSpread>0.16</ShotSpread>
-			<SwayFactor>1.16</SwayFactor>
+			<SwayFactor>1.93</SwayFactor>
 			<Bulk>2.95</Bulk>
 			<WorkToMake>26500</WorkToMake>
 		</statBases>


### PR DESCRIPTION
## Changes
Various tweaks to the stat spreadsheet intended to improve gameplay & progression.

- `Is Simple Blowback` component reduction changed from 2 to 1.
- Added an `Is Gas Operated` check which adds +2 components, intended to be used as a catch-all for any autoloading rifle/shotgun. Includes long-recoil and inertial operation.
- Increased max handgun range to around 100 meters.
- Added +1 component to drum mag cost and +1000 work.
- Changed minigun comp cost to match what we already wrote in the patches.
- Changed turret costs to match that of the values in the spreadsheet.

## References
Spreadsheet with new values:
https://docs.google.com/spreadsheets/d/15hS6kxv7X2Z8Wz1PJJf35pC2-uX6ceFbl60IPTOBg-Q/edit?usp=sharing

## Reasoning
Explained in detail here: https://discord.com/channels/278818534069501953/700236703180259358/1358330974475259964

Long-story short:
- The Mac-10 costs the same as an M1911, giving no reason to ever use the M1911.
- Rifles/Carbines/Autoshotties have the same component cost as typical SMGs, giving no reason to use SMGs.
- Drum mags are much more complex than box mags IRL, with the current way they're set up they're just free extra capacity.
- The minigun costs 11 comps in our patch for it, but the spreadsheet only had it at 7. Increased cost in spreadsheet to match.
- The changes to weapon costs brings our guns closer to that of vanilla's intended costs, good for consistency's sake.

## Alternatives
- Mac-10s that cost the same as M1911s, UMP-45s that cost the same as M16s, M1 Garands that are cheaper than a Sten Gun, etc.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (too many hours)
