### PR TITLE
Nukes Patch Update

### DIFF
--- a/ModPatches/Nukes/Patches/Nukes/IEDs_Nuclear.xml
+++ b/ModPatches/Nukes/Patches/Nukes/IEDs_Nuclear.xml
@@ -27,4 +27,5 @@
 			</costList>
 		</value>
 	</Operation>
+
 </Patch>

--- a/ModPatches/Nukes/Patches/Nukes/Projectiles_Nuclear.xml
+++ b/ModPatches/Nukes/Patches/Nukes/Projectiles_Nuclear.xml
@@ -48,6 +48,9 @@
 		</xpath>
 		<value>
 			<speed>0</speed>
+			<shellingProps>
+				<damage>0.85</damage>
+			</shellingProps>
 		</value>
 	</Operation>
 
@@ -61,4 +64,5 @@
 			<Ammo_DirtyNuclearBomb>Bullet_DirtyNuclearWarhead</Ammo_DirtyNuclearBomb>
 		</value>
 	</Operation>
+
 </Patch>


### PR DESCRIPTION
## Additions
- Add shelling props to Nuke mortar shells. Gave them damage in line with the anti-grain shell.

## Changes
- White space housekeeping.

## References
- Closes #3747 

## Reasoning
- The most straightforward approach.

## Alternatives
- Could split up the operations a bit more to individualize shelling damage.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
