### PR TITLE
Patch Grimworld Heresy Addon

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -214,6 +214,7 @@
 		<li IfModActive="Grimworld.Autoguns">ModPatches/Grimworld Autoguns</li>		
 		<li IfModActive="Grimworld.Core">ModPatches/Grimworld Core Imperialis</li>	
 		<li IfModActive="Grimworld.AstraMilitarum">ModPatches/GrimWorld Hammer of the Imperium</li>
+		<li IfModActive="Grimworld.Iron">ModPatches/GrimWorld Heresy Addon</li>		
 		<li IfModActive="Grimworld.Vehicles">ModPatches/GrimWorld Imperial Vehicles</li>
 		<li IfModActive="Grimworld.Lasguns">ModPatches/Grimworld Lasguns</li>
 		<li IfModActive="Grimworld.Melee">ModPatches/Grimworld Melee</li>
@@ -315,7 +316,7 @@
 		<li IfModActive="Mlie.MedicalSupplements">ModPatches/Medicine Supplements (Continued)</li>
 		<li IfModActive="JoeDaly.MedMeds.MO">ModPatches/Medieval Medicines 1.4 Medieval Overhaul Edition</li>
 		<li IfModActive="DankPyon.Medieval.Overhaul">ModPatches/Medieval Overhaul</li>
-    <li IfModActive="Turkler.MedievalOverhaul.ArcaneArchaeologists">ModPatches/Medieval Overhaul Arcane Archaeologists</li>
+		<li IfModActive="Turkler.MedievalOverhaul.ArcaneArchaeologists">ModPatches/Medieval Overhaul Arcane Archaeologists</li>
 		<li IfModActive="pphhyy.BarbariansMOSubmod">ModPatches/Medieval Overhaul Barbarians</li>
 		<li IfModActive="DankPyon.Medieval.Overhaul.House.Roxmont">ModPatches/Medieval Overhaul House Roxmont</li>
 		<li IfModActive="Arisher.Medieval.Tailor">ModPatches/Medieval Tailor</li>

--- a/ModPatches/Grimworld Heresy Addon/Patches/Grimworld Heresy Addon/CE_Patch_Armors.xml
+++ b/ModPatches/Grimworld Heresy Addon/Patches/Grimworld Heresy Addon/CE_Patch_Armors.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<!-- ========== Mark II Crusader  ========== -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="GW_SM_CrusaderArmor"]/statBases</xpath>
+		<value>
+			<Bulk>225</Bulk>
+			<WornBulk>20</WornBulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GW_SM_CrusaderArmor"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>36</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GW_SM_CrusaderArmor"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>360</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<!-- ========== Mark III Iron  ========== -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="GW_SM_IronArmor"]/statBases</xpath>
+		<value>
+			<Bulk>200</Bulk>
+			<WornBulk>20</WornBulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GW_SM_IronArmor"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>40</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GW_SM_IronArmor"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>370</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<!-- ========== Mark III Heresy ========== -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="GW_SM_HeresyArmor"]/statBases</xpath>
+		<value>
+			<Bulk>300</Bulk>
+			<WornBulk>40</WornBulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GW_SM_HeresyArmor"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>46</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GW_SM_HeresyArmor"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>380</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Grimworld Heresy Addon/Patches/Grimworld Heresy Addon/CE_Patch_Armors_Backpacks.xml
+++ b/ModPatches/Grimworld Heresy Addon/Patches/Grimworld Heresy Addon/CE_Patch_Armors_Backpacks.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<!-- ============ Light ============ -->
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="GW_SM_IronBackpackA" or defName="GW_SM_IronBackpackB"]/statBases</xpath>
+		<value>
+			<Bulk>5</Bulk>
+			<WornBulk>3</WornBulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GW_SM_IronBackpackA" or defName="GW_SM_IronBackpackB"]/equippedStatOffsets/VEF_MassCarryCapacity</xpath>
+		<value>
+			<CarryWeight>40</CarryWeight>
+			<CarryBulk>60</CarryBulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GW_SM_IronBackpackA" or defName="GW_SM_IronBackpackB"]/statBases/Flammability</xpath>
+		<value>
+			<Flammability>0</Flammability>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GW_SM_IronBackpackA" or defName="GW_SM_IronBackpackB"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>5</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GW_SM_IronBackpackA" or defName="GW_SM_IronBackpackB"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>26</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Grimworld Heresy Addon/Patches/Grimworld Heresy Addon/CE_Patch_Armors_Backpacks.xml
+++ b/ModPatches/Grimworld Heresy Addon/Patches/Grimworld Heresy Addon/CE_Patch_Armors_Backpacks.xml
@@ -10,8 +10,8 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="GW_SM_IronBackpackA" or defName="GW_SM_IronBackpackB"]/equippedStatOffsets/VEF_MassCarryCapacity</xpath>
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="GW_SM_IronBackpackA" or defName="GW_SM_IronBackpackB"]/equippedStatOffsets</xpath>
 		<value>
 			<CarryWeight>40</CarryWeight>
 			<CarryBulk>60</CarryBulk>

--- a/ModPatches/Grimworld Heresy Addon/Patches/Grimworld Heresy Addon/CE_Patch_Armors_Helmets.xml
+++ b/ModPatches/Grimworld Heresy Addon/Patches/Grimworld Heresy Addon/CE_Patch_Armors_Helmets.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<!-- ============ Crusader & Iron ============ -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="GW_SM_CrusaderHelmet_Simple" or defName="GW_SM_IronHelmet_Simple"]/statBases</xpath>
+		<value>
+			<Bulk>15</Bulk>
+			<WornBulk>5</WornBulk>
+			<NightVisionEfficiency_Apparel>0.75</NightVisionEfficiency_Apparel>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="GW_SM_CrusaderHelmet_Simple"]/apparel/immuneToToxGasExposure</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="GW_SM_CrusaderHelmet_Simple"]/apparel</xpath>
+			<value>
+				<immuneToToxGasExposure>true</immuneToToxGasExposure>
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="GW_SM_IronHelmet_Simple"]/apparel/immuneToToxGasExposure</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="GW_SM_IronHelmet_Simple"]/apparel</xpath>
+			<value>
+				<immuneToToxGasExposure>true</immuneToToxGasExposure>
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GW_SM_CrusaderHelmet_Simple" or defName="GW_SM_IronHelmet_Simple"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>30</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GW_SM_CrusaderHelmet_Simple" or defName="GW_SM_IronHelmet_Simple"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>35</ArmorRating_Blunt>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GW_SM_CrusaderHelmet_Simple" or defName="GW_SM_IronHelmet_Simple"]/statBases/Flammability</xpath>
+		<value>
+			<Flammability>0</Flammability>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="GW_SM_CrusaderHelmet_Simple" or defName="GW_SM_IronHelmet_Simple"]/equippedStatOffsets</xpath>
+		<value>
+			<AimingAccuracy>0.28</AimingAccuracy>
+			<SmokeSensitivity>-1</SmokeSensitivity>
+		</value>
+	</Operation>
+
+	<!-- ============ Heresy ============ -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="GW_SM_HeresyHelmet_Simple"]/statBases</xpath>
+		<value>
+			<Bulk>15</Bulk>
+			<WornBulk>5</WornBulk>
+			<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="GW_SM_HeresyHelmet_Simple"]/apparel/immuneToToxGasExposure</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="GW_SM_HeresyHelmet_Simple"]/apparel</xpath>
+			<value>
+				<immuneToToxGasExposure>true</immuneToToxGasExposure>
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GW_SM_HeresyHelmet_Simple"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>30</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GW_SM_HeresyHelmet_Simple"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>35</ArmorRating_Blunt>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GW_SM_HeresyHelmet_Simple"]/statBases/Flammability</xpath>
+		<value>
+			<Flammability>0</Flammability>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="GW_SM_HeresyHelmet_Simple"]/equippedStatOffsets</xpath>
+		<value>
+			<AimingAccuracy>0.28</AimingAccuracy>
+			<SmokeSensitivity>-1</SmokeSensitivity>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Grimworld Heresy Addon/Patches/Grimworld Heresy Addon/CE_Patch_Armors_Helmets.xml
+++ b/ModPatches/Grimworld Heresy Addon/Patches/Grimworld Heresy Addon/CE_Patch_Armors_Helmets.xml
@@ -62,7 +62,7 @@
 	</Operation>
 
 	<!-- ============ Heresy ============ -->
-
+<!-- Helmet uses the Name="GW_SM_MKVIHelmet_Base". Uncomment this is the author ever fixes it.
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="GW_SM_HeresyHelmet_Simple"]/statBases</xpath>
 		<value>
@@ -71,7 +71,7 @@
 			<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
 		</value>
 	</Operation>
-
+-->
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="GW_SM_HeresyHelmet_Simple"]/apparel/immuneToToxGasExposure</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -102,7 +102,7 @@
 			<Flammability>0</Flammability>
 		</value>
 	</Operation>
-
+<!-- Helmet uses the Name="GW_SM_MKVIHelmet_Base". Uncomment this is the author ever fixes it.
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="GW_SM_HeresyHelmet_Simple"]/equippedStatOffsets</xpath>
 		<value>
@@ -110,5 +110,5 @@
 			<SmokeSensitivity>-1</SmokeSensitivity>
 		</value>
 	</Operation>
-
+-->
 </Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -266,6 +266,7 @@ Grimworld: Melee	|
 GrimWorld 40,000 - Angels of Death |
 GrimWorld 40,000 - Core Imperialis |
 GrimWorld 40,000 - Hammer of the Imperium |
+Grimworld 40,000 - Heresy Armor Addon   |
 GrimWorld 40,000 - Imperial Vehicles of Grimworld |
 GrimWorld 40,000 - Scattered Sons |
 GrimWorld 40,000 - Talons of the Emperor |


### PR DESCRIPTION
## Additions
- Patch for the Grimworld 40k Heresy Armor Addon
  - Patches for three sets of armors and helmets + two backpacks.

## References
- Close #3652 

## Reasoning
- Patched along similar lines to Angels of Death armor that have similar vanilla values, with slight changes to exact armor value and night vision capability. Otherwise, functionally the same.

## Alternatives
- Different balancing scheme.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
