### PR TITLE
Cursed Guns Loadfolder fix

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -118,7 +118,7 @@
 		<li IfModActive="Jewsader.Cossacks.Rimworld_copy">ModPatches/Cossacks of the Rim</li>
 		<li IfModActive="Canon.CrownsandRegalia">ModPatches/Crowns and Regalia</li>
 		<li IfModActive="Mlie.CuprosAlloys">ModPatches/CuprosAlloys</li>
-		<li IfModActive="DanDMan.CursedGuns">ModPatches/Cursed Guns</li>
+		<li IfModActive="MyLegsAreOkay.CursedGunsReUp">ModPatches/Cursed Guns</li>
 		<li IfModActive="K.CyberNet">ModPatches/Cybernet</li>
 		<li IfModActive="kikohi.cybernetic">ModPatches/Cybernetic Organism and Neural Network</li>
 		<li IfModActive="Mlie.CyberneticWarfare">ModPatches/Cybernetic Warfare and Special Weapons</li>

--- a/ModPatches/Cursed Guns/Patches/Cursed Guns/CursedGuns.xml
+++ b/ModPatches/Cursed Guns/Patches/Cursed Guns/CursedGuns.xml
@@ -891,14 +891,20 @@
 		<value>
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
 				<damageDef>Blunt</damageDef>
-				<damageAmountBase>20</damageAmountBase>
+				<damageAmountBase>14</damageAmountBase>
 				<flyOverhead>false</flyOverhead>
-				<speed>35</speed>
+				<speed>24</speed>
 				<armorPenetrationBlunt>2.25</armorPenetrationBlunt>
-				<armorPenetrationSharp>0</armorPenetrationSharp>
-				<preExplosionSpawnChance>1</preExplosionSpawnChance>
+				<preExplosionSpawnChance>0.9</preExplosionSpawnChance>
 				<preExplosionSpawnThingDef>CursedGun_ZipTwoTwoThrown</preExplosionSpawnThingDef>
 			</projectile>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Bullet_ZipTwoTwoThrown"]</xpath>
+		<value>
+			<thingClass>CombatExtended.BulletCE</thingClass>
 		</value>
 	</Operation>
 


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.

- Fixed the Cursed Guns CE loadfolders patch only activating on the outdated version from 1.3 and not the unofficial 1.5 version

## Changes

Describe adjustments to existing features made in this merge, e.g.

- Cursed guns go brrr

## Reasoning

Why did you choose to implement things this way, e.g.

- I want cursed guns in CE

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [X] (For compatibility patches) ...with and without patched mod loaded
- [X] Playtested a colony (A few ingame hours)
