### PR TITLE
Use regions to spawn reusable ammo on existing stacks

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -1398,7 +1398,8 @@ namespace CombatExtended
                     var reusableAmmo = ThingMaker.MakeThing(thingDef);
                     reusableAmmo.stackCount = 1;
                     reusableAmmo.SetForbidden(true, false);
-                    GenPlace.TryPlaceThing(reusableAmmo, Position, Map, ThingPlaceMode.Near);
+                    Thing existingStack = Position.GetRegion(Map).listerThings.ThingsOfDef(thingDef).FirstOrFallback(thing => thing.stackCount < thing.def.stackLimit, null);
+                    GenPlace.TryPlaceThing(reusableAmmo, existingStack != null ? existingStack.positionInt : Position, Map, ThingPlaceMode.Near);
                     LessonAutoActivator.TeachOpportunity(CE_ConceptDefOf.CE_ReusableNeolithicProjectiles, reusableAmmo, OpportunityType.GoodToKnow);
                     ignoredThings.Add(reusableAmmo);
                 }


### PR DESCRIPTION
## Additions

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Severely reduces item clutter from tribal raids by checking the Region where reusable projectile impacted for existing stacks of that ammo

Demo:
https://discord.com/channels/278818534069501953/356498503847116801/1363145502723407902

## Reasoning

Why did you choose to implement things this way, e.g.
- Cluttered fields with items look ugly and obsturct vision. If cinematic effect is needed, I'd much rather redo it via flecks.

## Alternatives

Describe alternative implementations you have considered, e.g.
- Check nearby cells manually instead of using regions
- perhaps, if an existing stack is found, could increment its stackcount without spawning a Thing?

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
