### PR TITLE
Conditional PatchRemove ArmorRatingBase MaxValue

### DIFF
--- a/Patches/Core/Stats/Stats.xml
+++ b/Patches/Core/Stats/Stats.xml
@@ -29,8 +29,11 @@
 
 	<!-- Armor Cap -->
 
-	<Operation Class="PatchOperationRemove">
+	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/StatDef[@Name="ArmorRatingBase"]/maxValue</xpath>
+		<match Class="PatchOperationRemove">
+			<xpath>Defs/StatDef[@Name="ArmorRatingBase"]/maxValue</xpath>
+		</match>
 	</Operation>
 
 	<!-- Armor Rating -->


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Turns patch conditional to prevent patch errors

## Reasoning

Why did you choose to implement things this way, e.g.
- Some mods such as Pandora's Framework are also removing this node. Leading to patching errors in log.

## Alternatives

Describe alternative implementations you have considered, e.g.
- Harmless, but annoying error

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
