### PR TITLE
New Ammo 23x115mm, 30x170mm and 35x228mmNATO

### DIFF
--- a/Defs/Ammo/HighCaliber/23x115mm.xml
+++ b/Defs/Ammo/HighCaliber/23x115mm.xml
@@ -1,0 +1,369 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+	<ThingCategoryDef>
+		<defName>Ammo23x115mm</defName>
+		<label>23x115mm</label>
+		<parent>AmmoHighCaliber</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberHighCaliber</iconPath>
+	</ThingCategoryDef>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_23x115mm</defName>
+		<label>23x115mm</label>
+		<ammoTypes>
+			<Ammo_23x115mm_AP>Bullet_23x115mm_AP</Ammo_23x115mm_AP>
+			<Ammo_23x115mm_HE>Bullet_23x115mm_HE</Ammo_23x115mm_HE>
+			<Ammo_23x115mm_Incendiary>Bullet_23x115mm_Incendiary</Ammo_23x115mm_Incendiary>
+			<Ammo_23x115mm_Sabot>Bullet_23x115mm_Sabot</Ammo_23x115mm_Sabot>
+		</ammoTypes>
+		<similarTo>AmmoSet_Autocannon</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_23x115mm_HV</defName>
+		<label>23x115mm</label>
+		<ammoTypes>
+			<Ammo_23x115mm_AP>Bullet_23x115mm_AP_HV</Ammo_23x115mm_AP>
+			<Ammo_23x115mm_HE>Bullet_23x115mm_HE_HV</Ammo_23x115mm_HE>
+			<Ammo_23x115mm_Incendiary>Bullet_23x115mm_Incendiary_HV</Ammo_23x115mm_Incendiary>
+			<Ammo_23x115mm_Sabot>Bullet_23x115mm_Sabot_HV</Ammo_23x115mm_Sabot>
+		</ammoTypes>
+		<similarTo>AmmoSet_Autocannon</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo23x115mmBase" ParentName="MediumAmmoBase" Abstract="True">
+		<description>Large caliber cartridge used by autocannons.</description>
+		<statBases>
+			<Mass>0.35</Mass>
+			<Bulk>0.331</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
+		<thingCategories>
+			<li>Ammo23x115mm</li>
+		</thingCategories>
+		<stackLimit>1000</stackLimit>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo23x115mmBase">
+		<defName>Ammo_23x115mm_AP</defName>
+		<label>23x115mm cartridge (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_23x115mm_AP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo23x115mmBase">
+		<defName>Ammo_23x115mm_Incendiary</defName>
+		<label>23x115mm cartridge (AP-I)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<ammoClass>IncendiaryAP</ammoClass>
+		<cookOffProjectile>Bullet_23x115mm_Incendiary</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo23x115mmBase">
+		<defName>Ammo_23x115mm_HE</defName>
+		<label>23x115mm cartridge (AP-HE)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<ammoClass>ExplosiveAP</ammoClass>
+		<cookOffProjectile>Bullet_23x115mm_HE</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo23x115mmBase">
+		<defName>Ammo_23x115mm_Sabot</defName>
+		<label>23x115mm cartridge (Sabot)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<Mass>0.257</Mass>
+		</statBases>
+		<ammoClass>Sabot</ammoClass>
+		<cookOffProjectile>Bullet_23x115mm_Sabot</cookOffProjectile>
+	</ThingDef>
+
+	<!-- ================== Projectile ================== -->
+
+	<ThingDef Name="Base23x115mmBullet" ParentName="BaseBulletCE" Abstract="true">
+	    <graphicData>
+			<texPath>Things/Projectile/Bullet_Big</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>139</speed>
+			<dropsCasings>true</dropsCasings>
+			<casingMoteDefname>Fleck_RifleAmmoCasings_HighCal</casingMoteDefname>
+			<casingFilthDefname>Filth_RifleAmmoCasings_HighCal</casingFilthDefname>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base23x115mmBullet">
+		<defName>Bullet_23x115mm_AP</defName>
+		<label>23x115mm bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>44</damageAmountBase>
+			<armorPenetrationSharp>29</armorPenetrationSharp>
+			<armorPenetrationBlunt>889.54</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base23x115mmBullet">
+		<defName>Bullet_23x115mm_Incendiary</defName>
+		<label>23x115mm bullet (AP-I)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>44</damageAmountBase>
+			<armorPenetrationSharp>29</armorPenetrationSharp>
+			<armorPenetrationBlunt>889.54</armorPenetrationBlunt>
+		    <secondaryDamage>
+                <li>
+                  <def>Flame_Secondary</def>
+                   <amount>32</amount>
+                </li>
+	        </secondaryDamage>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base23x115mmBullet">
+		<defName>Bullet_23x115mm_HE</defName>
+		<label>23x115mm bullet (AP-HE)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>70</damageAmountBase>
+			<armorPenetrationSharp>14.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>889.54</armorPenetrationBlunt>
+		    <secondaryDamage>
+				<li>
+					<def>Bomb_Secondary</def>
+					<amount>44</amount>
+				</li>
+		    </secondaryDamage>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base23x115mmBullet">
+		<defName>Bullet23x115mm_Sabot</defName>
+		<label>23x115mm bullet (Sabot)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>42</damageAmountBase>
+			<armorPenetrationSharp>49.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>1142.64</armorPenetrationBlunt>
+			<speed>188</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base23x115mmBullet">
+		<defName>Bullet_23x115mm_AP_HV</defName>
+		<label>23x115mm bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>48</damageAmountBase>
+			<armorPenetrationSharp>40</armorPenetrationSharp>
+			<armorPenetrationBlunt>1155.76</armorPenetrationBlunt>
+			<speed>153</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base23x115mmBullet">
+		<defName>Bullet_23x115mm_Incendiary_HV</defName>
+		<label>23x115mm bullet (AP-I)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>48</damageAmountBase>
+			<armorPenetrationSharp>40</armorPenetrationSharp>
+			<armorPenetrationBlunt>1155.76</armorPenetrationBlunt>
+			<speed>153</speed>
+		    <secondaryDamage>
+                <li>
+                  <def>Flame_Secondary</def>
+                   <amount>32</amount>
+                </li>
+	        </secondaryDamage>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base23x115mmBullet">
+		<defName>Bullet_23x115mm_HE_HV</defName>
+		<label>23x115mm bullet (AP-HE)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>76</damageAmountBase>
+			<armorPenetrationSharp>20</armorPenetrationSharp>
+			<armorPenetrationBlunt>1155.76</armorPenetrationBlunt>
+			<speed>153</speed>
+		    <secondaryDamage>
+				<li>
+					<def>Bomb_Secondary</def>
+					<amount>44</amount>
+				</li>
+		    </secondaryDamage>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base23x115mmBullet">
+		<defName>Bullet23x115mm_Sabot_HV</defName>
+		<label>23x115mm bullet (Sabot)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>46</damageAmountBase>
+			<armorPenetrationSharp>49.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>1484.78</armorPenetrationBlunt>
+			<speed>207</speed>
+		</projectile>
+	</ThingDef>
+
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_23x115mm_AP</defName>
+		<label>make 23x115mm (AP) cartridge x200</label>
+		<description>Craft 200 23x115mm (AP) cartridges.</description>
+		<jobString>Making 23x115mm (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>107</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_23x115mm_AP>200</Ammo_23x115mm_AP>
+		</products>
+		<workAmount>12480</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_23x115mm_Incendiary</defName>
+		<label>make 23x115mm (AP-I) cartridge x200</label>
+		<description>Craft 200 23x115mm (AP-I) cartridges.</description>
+		<jobString>Making 23x115mm (AP-I) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>107</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Prometheum</li>
+					</thingDefs>
+				</filter>
+				<count>11</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Prometheum</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_23x115mm_Incendiary>200</Ammo_23x115mm_Incendiary>
+		</products>
+		<workAmount>14880</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_23x115mm_HE</defName>
+		<label>make 23x115mm (AP-HE) cartridge x200</label>
+		<description>Craft 200 23x115mm (AP-HE) cartridges.</description>
+		<jobString>Making 23x115mm (AP-HE) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>107</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>FSX</li>
+					</thingDefs>
+				</filter>
+				<count>20</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>FSX</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_23x115mm_HE>200</Ammo_23x115mm_HE>
+		</products>
+		<workAmount>18600</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_23x115mm_Sabot</defName>
+		<label>make 23x115mm (Sabot) cartridge x200</label>
+		<description>Craft 200 23x115mm (Sabot) cartridges.</description>
+		<jobString>Making 23x115mm (Sabot) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>66</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Uranium</li>
+					</thingDefs>
+				</filter>
+				<count>13</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Chemfuel</li>
+					</thingDefs>
+				</filter>
+				<count>13</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Uranium</li>
+				<li>Chemfuel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_23x115mm_Sabot>200</Ammo_23x115mm_Sabot>
+		</products>
+		<workAmount>14000</workAmount>
+	</RecipeDef>
+
+</Defs>

--- a/Defs/Ammo/HighCaliber/30x170mm.xml
+++ b/Defs/Ammo/HighCaliber/30x170mm.xml
@@ -1,0 +1,301 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+	<ThingCategoryDef>
+		<defName>Ammo30x170mm</defName>
+		<label>30x170mm</label>
+		<parent>AmmoHighCaliber</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberHighCaliber</iconPath>
+	</ThingCategoryDef>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_30x170mm</defName>
+		<label>30x170mm</label>
+		<ammoTypes>
+			<Ammo_30x170mm_AP>Bullet_30x170mm_AP</Ammo_30x170mm_AP>
+			<Ammo_30x170mm_Incendiary>Bullet_30x170mm_Incendiary</Ammo_30x170mm_Incendiary>
+			<Ammo_30x170mm_HE>Bullet_30x170mm_HE</Ammo_30x170mm_HE>
+			<Ammo_30x170mm_Sabot>Bullet_30x170mm_Sabot</Ammo_30x170mm_Sabot>
+		</ammoTypes>
+		<similarTo>AmmoSet_Autocannon</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo30x170mmBase" ParentName="MediumAmmoBase" Abstract="True">
+		<description>Large caliber cartridge used by autocannons.</description>
+		<statBases>
+			<Mass>0.810</Mass>
+			<Bulk>1.25</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
+		<thingCategories>
+			<li>Ammo30x170mm</li>
+		</thingCategories>
+		<stackLimit>150</stackLimit>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo30x170mmBase">
+		<defName>Ammo_30x170mm_AP</defName>
+		<label>30x170mm cartridge (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_30x170mm_AP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo30x170mmBase">
+		<defName>Ammo_30x170mm_Incendiary</defName>
+		<label>30x170mm cartridge (AP-I)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<ammoClass>IncendiaryAP</ammoClass>
+		<cookOffProjectile>Bullet_30x170mm_Incendiary</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo30x170mmBase">
+		<defName>Ammo_30x170mm_HE</defName>
+		<label>30x170mm cartridge (AP-HE)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<ammoClass>ExplosiveAP</ammoClass>
+		<cookOffProjectile>Bullet_30x170mm_HE</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo30x170mmBase">
+		<defName>Ammo_30x170mm_Sabot</defName>
+		<label>30x170mm cartridge (Sabot)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<Mass>0.780</Mass>
+		</statBases>
+		<ammoClass>Sabot</ammoClass>
+		<cookOffProjectile>Bullet_30x170mm_Sabot</cookOffProjectile>
+	</ThingDef>
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef Name="Base30x170mmBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_Big</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>181</speed>
+			<dropsCasings>true</dropsCasings>
+			<casingMoteDefname>Fleck_RifleAmmoCasings_HighCal</casingMoteDefname>
+			<casingFilthDefname>Filth_RifleAmmoCasings_HighCal</casingFilthDefname>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base30x170mmBullet">
+		<defName>Bullet_30x170mm_AP</defName>
+		<label>30x170mm bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>82</damageAmountBase>
+			<armorPenetrationSharp>78</armorPenetrationSharp>
+			<armorPenetrationBlunt>4199.04</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base30x170mmBullet">
+		<defName>Bullet_30x170mm_Incendiary</defName>
+		<label>30x170mm bullet (AP-I)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>82</damageAmountBase>
+			<armorPenetrationSharp>78</armorPenetrationSharp>
+			<armorPenetrationBlunt>4199.04</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+					<def>Flame_Secondary</def>
+					<amount>49</amount>
+				</li>
+			</secondaryDamage>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base30x170mmBullet">
+		<defName>Bullet_30x170mm_HE</defName>
+		<label>30x170mm bullet (AP-HE)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>130</damageAmountBase>
+			<armorPenetrationSharp>39</armorPenetrationSharp>
+			<armorPenetrationBlunt>4199.04</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+					<def>Bomb_Secondary</def>
+					<amount>68</amount>
+				</li>
+			</secondaryDamage>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base30x170mmBullet">
+		<defName>Bullet_30x170mm_Sabot</defName>
+		<label>30x170mm bullet (Sabot)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>55</damageAmountBase>
+			<armorPenetrationSharp>123</armorPenetrationSharp>
+			<armorPenetrationBlunt>4936.96</armorPenetrationBlunt>
+			<speed>245</speed>
+		</projectile>
+	</ThingDef>
+
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_30x170mm_AP</defName>
+		<label>make 30x170mm (AP) cartridge x100</label>
+		<description>Craft 100 30x170mm (AP) cartridges.</description>
+		<jobString>Making 30x170mm (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>168</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_30x170mm_AP>100</Ammo_30x170mm_AP>
+		</products>
+		<workAmount>20160</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_30x170mm_Incendiary</defName>
+		<label>make 30x170mm (AP-I) cartridge x100</label>
+		<description>Craft 100 30x170mm (AP-I) cartridges.</description>
+		<jobString>Making 30x170mm (AP-I) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>168</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Prometheum</li>
+					</thingDefs>
+				</filter>
+				<count>19</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Prometheum</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_30x170mm_Incendiary>100</Ammo_30x170mm_Incendiary>
+		</products>
+		<workAmount>24400</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_30x170mm_HE</defName>
+		<label>make 30x170mm (AP-HE) cartridge x200</label>
+		<description>Craft 200 30x170mm (AP-HE) cartridges.</description>
+		<jobString>Making 30x170mm (AP-HE) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>168</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>FSX</li>
+					</thingDefs>
+				</filter>
+				<count>35</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>FSX</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_30x170mm_HE>100</Ammo_30x170mm_HE>
+		</products>
+		<workAmount>30800</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_30x170mm_Sabot</defName>
+		<label>make 30x170mm (Sabot) cartridge x100</label>
+		<description>Craft 100 30x170mm (Sabot) cartridges.</description>
+		<jobString>Making 30x170mm (Sabot) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>94</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Uranium</li>
+					</thingDefs>
+				</filter>
+				<count>22</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Chemfuel</li>
+					</thingDefs>
+				</filter>
+				<count>22</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Uranium</li>
+				<li>Chemfuel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_30x170mm_Sabot>100</Ammo_30x170mm_Sabot>
+		</products>
+		<workAmount>22600</workAmount>
+	</RecipeDef>
+
+</Defs>

--- a/Defs/Ammo/HighCaliber/35x228mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/35x228mmNATO.xml
@@ -1,0 +1,305 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+	<ThingCategoryDef>
+		<defName>Ammo35x228mmNATO</defName>
+		<label>35x228mm NATO</label>
+		<parent>AmmoHighCaliber</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberHighCaliber</iconPath>
+	</ThingCategoryDef>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_35x228mm</defName>
+		<label>35x228mm NATO</label>
+		<ammoTypes>
+			<Ammo_35x228mmNATO_AP>Bullet_35x228mmNATO_AP</Ammo_35x228mmNATO_AP>
+			<Ammo_35x228mmNATO_Incendiary>Bullet_35x228mmNATO_Incendiary</Ammo_35x228mmNATO_Incendiary>
+			<Ammo_35x228mmNATO_HE>Bullet_35x228mmNATO_HE</Ammo_35x228mmNATO_HE>
+			<Ammo_35x228mmNATO_Sabot>Bullet_35x228mmNATO_Sabot</Ammo_35x228mmNATO_Sabot>
+		</ammoTypes>
+		<similarTo>AmmoSet_Autocannon</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo35x228mmNATOBase" ParentName="MediumAmmoBase" Abstract="True">
+		<description>Large caliber cartridge used by autocannons.</description>
+		<statBases>
+			<Mass>1.572</Mass>
+			<Bulk>2.86</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
+		<thingCategories>
+			<li>Ammo35x228mmNATO</li>
+		</thingCategories>
+		<stackLimit>150</stackLimit>
+	</ThingDef>
+
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo35x228mmNATOBase">
+		<defName>Ammo_35x228mmNATO_AP</defName>
+		<label>35x228mmNATO cartridge (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_35x228mmNATO_AP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo35x228mmNATOBase">
+		<defName>Ammo_35x228mmNATO_Incendiary</defName>
+		<label>35x228mmNATO cartridge (AP-I)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<ammoClass>IncendiaryAP</ammoClass>
+		<cookOffProjectile>Bullet_35x228mmNATO_Incendiary</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo35x228mmNATOBase">
+		<defName>Ammo_35x228mmNATO_HE</defName>
+		<label>35x228mmNATO cartridge (AP-HE)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<ammoClass>ExplosiveAP</ammoClass>
+		<cookOffProjectile>Bullet_35x228mmNATO_HE</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo35x228mmNATOBase">
+		<defName>Ammo_35x228mmNATO_Sabot</defName>
+		<label>35x228mmNATO cartridge (Sabot)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<Mass>1.445</Mass>
+		</statBases>
+		<ammoClass>Sabot</ammoClass>
+		<cookOffProjectile>Bullet_35x228mmNATO_Sabot</cookOffProjectile>
+	</ThingDef>
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef Name="Base35x228mmNATOBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_Big</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>201</speed>
+			<dropsCasings>true</dropsCasings>
+			<casingMoteDefname>Fleck_RifleAmmoCasings_HighCal</casingMoteDefname>
+			<casingFilthDefname>Filth_RifleAmmoCasings_HighCal</casingFilthDefname>
+		</projectile>
+	</ThingDef>
+
+
+	<ThingDef ParentName="Base35x228mmNATOBullet">
+		<defName>Bullet_35x228mmNATO_AP</defName>
+		<label>35x228mmNATO bullet (APHC)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>106</damageAmountBase>
+			<armorPenetrationSharp>80</armorPenetrationSharp>
+			<armorPenetrationBlunt>7593.44</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base35x228mmNATOBullet">
+		<defName>Bullet_35x228mmNATO_Incendiary</defName>
+		<label>35x228mmNATO bullet (AP-I)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>106</damageAmountBase>
+			<armorPenetrationSharp>80</armorPenetrationSharp>
+			<armorPenetrationBlunt>7593.44</armorPenetrationBlunt>
+		</projectile>
+		<secondaryDamage>
+			<li>
+				<def>Flame_Secondary</def>
+				<amount>64</amount>
+			</li>
+		</secondaryDamage>
+	</ThingDef>
+
+	<ThingDef ParentName="Base35x228mmNATOBullet">
+		<defName>Bullet_35x228mmNATO_HE</defName>
+		<label>35x228mmNATO bullet (AP-HE)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>169</damageAmountBase>
+			<armorPenetrationSharp>40</armorPenetrationSharp>
+			<armorPenetrationBlunt>7593.44</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+					<def>Bomb_Secondary</def>
+					<amount>64</amount>
+				</li>
+			</secondaryDamage>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base35x228mmNATOBullet">
+		<defName>Bullet_35x228mmNATO_Sabot</defName>
+		<label>35x228mmNATO bullet (Sabot)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>85</damageAmountBase>
+			<armorPenetrationSharp>125</armorPenetrationSharp>
+			<armorPenetrationBlunt>7879.68</armorPenetrationBlunt>
+			<speed>229</speed>
+		</projectile>
+	</ThingDef>
+
+	<!-- ==================== Recipes ========================== -->
+
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_35x228mmNATO_AP</defName>
+		<label>make 35x228mmNATO (AP) cartridge x125</label>
+		<description>Craft 125 35x228mmNATO (AP) cartridges.</description>
+		<jobString>Making 35x228mmNATO (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>216</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_35x228mmNATO_AP>125</Ammo_35x228mmNATO_AP>
+		</products>
+		<workAmount>20160</workAmount>
+	</RecipeDef>
+
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_35x228mmNATO_Incendiary</defName>
+		<label>make 35x228mmNATO (AP-I) cartridge x125</label>
+		<description>Craft 125 35x228mmNATO (AP-I) cartridges.</description>
+		<jobString>Making 35x228mmNATO (AP-I) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>216</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Prometheum</li>
+					</thingDefs>
+				</filter>
+				<count>22</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Prometheum</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_35x228mmNATO_Incendiary>125</Ammo_35x228mmNATO_Incendiary>
+		</products>
+		<workAmount>22160</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_35x228mmNATO_HE</defName>
+		<label>make 35x228mmNATO (AP-HE) cartridge x125</label>
+		<description>Craft 125 35x228mmNATO (AP-HE) cartridges.</description>
+		<jobString>Making 35x228mmNATO (AP-HE) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>216</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>FSX</li>
+					</thingDefs>
+				</filter>
+				<count>41</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>FSX</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_35x228mmNATO_HE>125</Ammo_35x228mmNATO_HE>
+		</products>
+		<workAmount>32600</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_35x228mmNATO_Sabot</defName>
+		<label>make 35x228mmNATO (Sabot) cartridge x125</label>
+		<description>Craft 125 35x228mmNATO (Sabot) cartridges.</description>
+		<jobString>Making 35x228mmNATO (Sabot) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>126</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Uranium</li>
+					</thingDefs>
+				</filter>
+				<count>26</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Chemfuel</li>
+					</thingDefs>
+				</filter>
+				<count>26</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Uranium</li>
+				<li>Chemfuel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_35x228mmNATO_Sabot>125</Ammo_35x228mmNATO_Sabot>
+		</products>
+		<workAmount>22600</workAmount>
+	</RecipeDef>
+
+</Defs>


### PR DESCRIPTION
https://docs.google.com/spreadsheets/d/1D5MAdmT2a5rNoBwimvbh2cdgl13pkDuO/edit?usp=sharing&ouid=115134056028872608879&rtpof=true&sd=true

This is the ammo sheet with new ammo and information I founded.  I have marked the new ammunition in red. Please ignore the 152mm ammunition details—after some consideration, I've decided to postpone submitting the 152mm ammunition for now.

## Changes

Added three new real-world ammunition types:

23x115mm (Used by GSh-23L and GSh-6-23 autocannons)

30x170mm (Used by Oerlikon KCB, Oerlikon KCC, L21A1 Rarden and Hispano-Suiza HS831 autocannons)

35x228mm NATO (Used by 35mm Bushmaster and Oerlikon 35mm series autocannons)

## Reasoning

These widely adopted ammunition types were added to standardize player defnames for convenience and to further enhance CE's real-world ammunition system.
