### PR TITLE
Ammo housekeeping and additions

### DIFF
--- a/Defs/Ammo/HighCaliber/23x115mm.xml
+++ b/Defs/Ammo/HighCaliber/23x115mm.xml
@@ -146,7 +146,7 @@
 	</ThingDef>
 
 	<ThingDef ParentName="Base23x115mmBullet">
-		<defName>Bullet23x115mm_Sabot</defName>
+		<defName>Bullet_23x115mm_Sabot</defName>
 		<label>23x115mm bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>42</damageAmountBase>

--- a/Defs/Ammo/HighCaliber/23x115mm.xml
+++ b/Defs/Ammo/HighCaliber/23x115mm.xml
@@ -1,0 +1,301 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+	<ThingCategoryDef>
+		<defName>Ammo23x115mm</defName>
+		<label>23x115mm</label>
+		<parent>AmmoHighCaliber</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberHighCaliber</iconPath>
+	</ThingCategoryDef>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_23x115mm</defName>
+		<label>23x115mm</label>
+		<ammoTypes>
+			<Ammo_23x115mm_AP>Bullet_23x115mm_AP</Ammo_23x115mm_AP>
+			<Ammo_23x115mm_HE>Bullet_23x115mm_HE</Ammo_23x115mm_HE>
+			<Ammo_23x115mm_Incendiary>Bullet_23x115mm_Incendiary</Ammo_23x115mm_Incendiary>
+			<Ammo_23x115mm_Sabot>Bullet_23x115mm_Sabot</Ammo_23x115mm_Sabot>
+		</ammoTypes>
+		<similarTo>AmmoSet_Autocannon</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo23x115mmBase" ParentName="MediumAmmoBase" Abstract="True">
+		<description>Large caliber cartridge used by autocannons.</description>
+		<statBases>
+			<Mass>0.35</Mass>
+			<Bulk>0.332</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
+		<thingCategories>
+			<li>Ammo23x115mm</li>
+		</thingCategories>
+		<stackLimit>1000</stackLimit>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo23x115mmBase">
+		<defName>Ammo_23x115mm_AP</defName>
+		<label>23x115mm cartridge (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_23x115mm_AP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo23x115mmBase">
+		<defName>Ammo_23x115mm_Incendiary</defName>
+		<label>23x115mm cartridge (AP-I)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<ammoClass>IncendiaryAP</ammoClass>
+		<cookOffProjectile>Bullet_23x115mm_Incendiary</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo23x115mmBase">
+		<defName>Ammo_23x115mm_HE</defName>
+		<label>23x115mm cartridge (AP-HE)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<ammoClass>ExplosiveAP</ammoClass>
+		<cookOffProjectile>Bullet_23x115mm_HE</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo23x115mmBase">
+		<defName>Ammo_23x115mm_Sabot</defName>
+		<label>23x115mm cartridge (Sabot)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<Mass>0.257</Mass>
+		</statBases>
+		<ammoClass>Sabot</ammoClass>
+		<cookOffProjectile>Bullet_23x115mm_Sabot</cookOffProjectile>
+	</ThingDef>
+
+	<!-- ================== Projectile ================== -->
+
+	<ThingDef Name="Base23x115mmBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_Big</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>141</speed>
+			<dropsCasings>true</dropsCasings>
+			<casingMoteDefname>Fleck_RifleAmmoCasings_HighCal</casingMoteDefname>
+			<casingFilthDefname>Filth_RifleAmmoCasings_HighCal</casingFilthDefname>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base23x115mmBullet">
+		<defName>Bullet_23x115mm_AP</defName>
+		<label>23x115mm bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>44</damageAmountBase>
+			<armorPenetrationSharp>29</armorPenetrationSharp>
+			<armorPenetrationBlunt>932.58</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base23x115mmBullet">
+		<defName>Bullet_23x115mm_Incendiary</defName>
+		<label>23x115mm bullet (AP-I)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>44</damageAmountBase>
+			<armorPenetrationSharp>29</armorPenetrationSharp>
+			<armorPenetrationBlunt>932.58</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+					<def>Flame_Secondary</def>
+					<amount>32</amount>
+				</li>
+			</secondaryDamage>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base23x115mmBullet">
+		<defName>Bullet_23x115mm_HE</defName>
+		<label>23x115mm bullet (AP-HE)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>71</damageAmountBase>
+			<armorPenetrationSharp>14.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>932.58</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+					<def>Bomb_Secondary</def>
+					<amount>44</amount>
+				</li>
+			</secondaryDamage>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base23x115mmBullet">
+		<defName>Bullet23x115mm_Sabot</defName>
+		<label>23x115mm bullet (Sabot)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>42</damageAmountBase>
+			<armorPenetrationSharp>50.75</armorPenetrationSharp>
+			<armorPenetrationBlunt>1199.02</armorPenetrationBlunt>
+			<speed>191</speed>
+		</projectile>
+	</ThingDef>
+
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_23x115mm_AP</defName>
+		<label>make 23x115mm (AP) cartridge x200</label>
+		<description>Craft 200 23x115mm (AP) cartridges.</description>
+		<jobString>Making 23x115mm (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>134</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_23x115mm_AP>200</Ammo_23x115mm_AP>
+		</products>
+		<workAmount>16080</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_23x115mm_Incendiary</defName>
+		<label>make 23x115mm (AP-I) cartridge x200</label>
+		<description>Craft 200 23x115mm (AP-I) cartridges.</description>
+		<jobString>Making 23x115mm (AP-I) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>134</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Prometheum</li>
+					</thingDefs>
+				</filter>
+				<count>17</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Prometheum</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_23x115mm_Incendiary>200</Ammo_23x115mm_Incendiary>
+		</products>
+		<workAmount>20200</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_23x115mm_HE</defName>
+		<label>make 23x115mm (AP-HE) cartridge x200</label>
+		<description>Craft 200 23x115mm (AP-HE) cartridges.</description>
+		<jobString>Making 23x115mm (AP-HE) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>134</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>FSX</li>
+					</thingDefs>
+				</filter>
+				<count>32</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>FSX</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_23x115mm_HE>200</Ammo_23x115mm_HE>
+		</products>
+		<workAmount>26200</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_23x115mm_Sabot</defName>
+		<label>make 23x115mm (Sabot) cartridge x200</label>
+		<description>Craft 200 23x115mm (Sabot) cartridges.</description>
+		<jobString>Making 23x115mm (Sabot) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>64</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Uranium</li>
+					</thingDefs>
+				</filter>
+				<count>20</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Chemfuel</li>
+					</thingDefs>
+				</filter>
+				<count>20</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Uranium</li>
+				<li>Chemfuel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_23x115mm_Sabot>200</Ammo_23x115mm_Sabot>
+		</products>
+		<workAmount>18400</workAmount>
+	</RecipeDef>
+
+</Defs>

--- a/Defs/Ammo/HighCaliber/23x115mm.xml
+++ b/Defs/Ammo/HighCaliber/23x115mm.xml
@@ -96,7 +96,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>141</speed>
+			<speed>139</speed>
 			<dropsCasings>true</dropsCasings>
 			<casingMoteDefname>Fleck_RifleAmmoCasings_HighCal</casingMoteDefname>
 			<casingFilthDefname>Filth_RifleAmmoCasings_HighCal</casingFilthDefname>
@@ -109,7 +109,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>44</damageAmountBase>
 			<armorPenetrationSharp>29</armorPenetrationSharp>
-			<armorPenetrationBlunt>932.58</armorPenetrationBlunt>
+			<armorPenetrationBlunt>907.2</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -119,7 +119,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>44</damageAmountBase>
 			<armorPenetrationSharp>29</armorPenetrationSharp>
-			<armorPenetrationBlunt>932.58</armorPenetrationBlunt>
+			<armorPenetrationBlunt>907.2</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
@@ -135,7 +135,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>71</damageAmountBase>
 			<armorPenetrationSharp>14.5</armorPenetrationSharp>
-			<armorPenetrationBlunt>932.58</armorPenetrationBlunt>
+			<armorPenetrationBlunt>907.2</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
@@ -151,8 +151,8 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>42</damageAmountBase>
 			<armorPenetrationSharp>50.75</armorPenetrationSharp>
-			<armorPenetrationBlunt>1199.02</armorPenetrationBlunt>
-			<speed>191</speed>
+			<armorPenetrationBlunt>1166.4</armorPenetrationBlunt>
+			<speed>189</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/23x115mm.xml
+++ b/Defs/Ammo/HighCaliber/23x115mm.xml
@@ -109,7 +109,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>44</damageAmountBase>
 			<armorPenetrationSharp>29</armorPenetrationSharp>
-			<armorPenetrationBlunt>907.2</armorPenetrationBlunt>
+			<armorPenetrationBlunt>894.64</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -119,7 +119,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>44</damageAmountBase>
 			<armorPenetrationSharp>29</armorPenetrationSharp>
-			<armorPenetrationBlunt>907.2</armorPenetrationBlunt>
+			<armorPenetrationBlunt>894.64</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
@@ -133,9 +133,9 @@
 		<defName>Bullet_23x115mm_HE</defName>
 		<label>23x115mm bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>71</damageAmountBase>
+			<damageAmountBase>70</damageAmountBase>
 			<armorPenetrationSharp>14.5</armorPenetrationSharp>
-			<armorPenetrationBlunt>907.2</armorPenetrationBlunt>
+			<armorPenetrationBlunt>894.64</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
@@ -151,8 +151,8 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>42</damageAmountBase>
 			<armorPenetrationSharp>50.75</armorPenetrationSharp>
-			<armorPenetrationBlunt>1166.4</armorPenetrationBlunt>
-			<speed>189</speed>
+			<armorPenetrationBlunt>1151.32</armorPenetrationBlunt>
+			<speed>188</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/27x145mmMauser.xml
+++ b/Defs/Ammo/HighCaliber/27x145mmMauser.xml
@@ -27,7 +27,7 @@
 	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo27x145mmMauserBase" ParentName="MediumAmmoBase" Abstract="True">
 		<description>Large caliber cartridge used by autocannons.</description>
 		<statBases>
-			<Mass>0.6</Mass>
+			<Mass>0.516</Mass>
 			<Bulk>0.67</Bulk>
 		</statBases>
 		<tradeTags>
@@ -81,7 +81,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<Mass>0.516</Mass>
+			<Mass>0.403</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
 		<cookOffProjectile>Bullet_27x145mmMauser_Sabot</cookOffProjectile>
@@ -90,7 +90,7 @@
 	<!-- ================== Projectile ================== -->
 
 	<ThingDef Name="Base27x145mmMauserBullet" ParentName="BaseBulletCE" Abstract="true">
-	    <graphicData>
+		<graphicData>
 			<texPath>Things/Projectile/Bullet_Big</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
@@ -107,9 +107,9 @@
 		<defName>Bullet_27x145mmMauser_AP</defName>
 		<label>27x145mm Mauser bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>79</damageAmountBase>
+			<damageAmountBase>72</damageAmountBase>
 			<armorPenetrationSharp>60</armorPenetrationSharp>
-			<armorPenetrationBlunt>4162.4</armorPenetrationBlunt>
+			<armorPenetrationBlunt>3146</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -117,15 +117,15 @@
 		<defName>Bullet_27x145mmMauser_Incendiary</defName>
 		<label>27x145mm Mauser bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>79</damageAmountBase>
+			<damageAmountBase>72</damageAmountBase>
 			<armorPenetrationSharp>30</armorPenetrationSharp>
-			<armorPenetrationBlunt>4162.4</armorPenetrationBlunt>
-		    <secondaryDamage>
-                <li>
-                  <def>Flame_Secondary</def>
-                   <amount>48</amount>
-                </li>
-	        </secondaryDamage>
+			<armorPenetrationBlunt>3146</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+					<def>Flame_Secondary</def>
+					<amount>41</amount>
+				</li>
+			</secondaryDamage>
 		</projectile>
 	</ThingDef>
 
@@ -133,15 +133,15 @@
 		<defName>Bullet_27x145mmMauser_HE</defName>
 		<label>27x145mm Mauser bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>125</damageAmountBase>
+			<damageAmountBase>114</damageAmountBase>
 			<armorPenetrationSharp>30</armorPenetrationSharp>
-			<armorPenetrationBlunt>4162.4</armorPenetrationBlunt>
-		    <secondaryDamage>
+			<armorPenetrationBlunt>3146</armorPenetrationBlunt>
+			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>68</amount>
+					<amount>56</amount>
 				</li>
-		    </secondaryDamage>
+			</secondaryDamage>
 		</projectile>
 	</ThingDef>
 
@@ -149,9 +149,9 @@
 		<defName>Bullet_27x145mmMauser_Sabot</defName>
 		<label>27x145mm Mauser bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>72</damageAmountBase>
+			<damageAmountBase>59</damageAmountBase>
 			<armorPenetrationSharp>101</armorPenetrationSharp>
-			<armorPenetrationBlunt>7078.5</armorPenetrationBlunt>
+			<armorPenetrationBlunt>4002.08</armorPenetrationBlunt>
 			<speed>259</speed>
 		</projectile>
 	</ThingDef>
@@ -170,7 +170,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>182</count>
+				<count>156</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -181,7 +181,7 @@
 		<products>
 			<Ammo_27x145mmMauser_AP>150</Ammo_27x145mmMauser_AP>
 		</products>
-		<workAmount>21840</workAmount>
+		<workAmount>18720</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
@@ -196,7 +196,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>182</count>
+				<count>156</count>
 			</li>
 			<li>
 				<filter>
@@ -204,7 +204,7 @@
 						<li>Prometheum</li>
 					</thingDefs>
 				</filter>
-				<count>25</count>
+				<count>19</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -216,7 +216,7 @@
 		<products>
 			<Ammo_27x145mmMauser_Incendiary>150</Ammo_27x145mmMauser_Incendiary>
 		</products>
-		<workAmount>28200</workAmount>
+		<workAmount>23200</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
@@ -231,7 +231,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>182</count>
+				<count>156</count>
 			</li>
 			<li>
 				<filter>
@@ -239,7 +239,7 @@
 						<li>FSX</li>
 					</thingDefs>
 				</filter>
-				<count>47</count>
+				<count>37</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -251,7 +251,7 @@
 		<products>
 			<Ammo_27x145mmMauser_HE>150</Ammo_27x145mmMauser_HE>
 		</products>
-		<workAmount>37000</workAmount>
+		<workAmount>30400</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
@@ -274,7 +274,7 @@
 						<li>Uranium</li>
 					</thingDefs>
 				</filter>
-				<count>39</count>
+				<count>23</count>
 			</li>
 			<li>
 				<filter>
@@ -282,7 +282,7 @@
 						<li>Chemfuel</li>
 					</thingDefs>
 				</filter>
-				<count>39</count>
+				<count>23</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -295,7 +295,7 @@
 		<products>
 			<Ammo_27x145mmMauser_Sabot>150</Ammo_27x145mmMauser_Sabot>
 		</products>
-		<workAmount>31200</workAmount>
+		<workAmount>21600</workAmount>
 	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/HighCaliber/30x170mm.xml
+++ b/Defs/Ammo/HighCaliber/30x170mm.xml
@@ -27,7 +27,7 @@
 	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo30x170mmBase" ParentName="MediumAmmoBase" Abstract="True">
 		<description>Large caliber cartridge used by autocannons.</description>
 		<statBases>
-			<Mass>0.71</Mass>
+			<Mass>0.81</Mass>
 			<Bulk>1.25</Bulk>
 		</statBases>
 		<tradeTags>
@@ -81,7 +81,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<Mass>0.556</Mass>
+			<Mass>0.656</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
 		<cookOffProjectile>Bullet_30x170mm_Sabot</cookOffProjectile>
@@ -170,7 +170,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>142</count>
+				<count>162</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -181,7 +181,7 @@
 		<products>
 			<Ammo_30x170mm_AP>100</Ammo_30x170mm_AP>
 		</products>
-		<workAmount>17040</workAmount>
+		<workAmount>19440</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
@@ -196,7 +196,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>142</count>
+				<count>162</count>
 			</li>
 			<li>
 				<filter>
@@ -216,7 +216,7 @@
 		<products>
 			<Ammo_30x170mm_Incendiary>100</Ammo_30x170mm_Incendiary>
 		</products>
-		<workAmount>21400</workAmount>
+		<workAmount>23400</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
@@ -231,7 +231,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>142</count>
+				<count>162</count>
 			</li>
 			<li>
 				<filter>
@@ -251,7 +251,7 @@
 		<products>
 			<Ammo_30x170mm_HE>100</Ammo_30x170mm_HE>
 		</products>
-		<workAmount>27800</workAmount>
+		<workAmount>29800</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
@@ -266,7 +266,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>70</count>
+				<count>90</count>
 			</li>
 			<li>
 				<filter>
@@ -295,7 +295,7 @@
 		<products>
 			<Ammo_30x170mm_Sabot>100</Ammo_30x170mm_Sabot>
 		</products>
-		<workAmount>19600</workAmount>
+		<workAmount>21600</workAmount>
 	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/HighCaliber/30x170mm.xml
+++ b/Defs/Ammo/HighCaliber/30x170mm.xml
@@ -1,0 +1,301 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+	<ThingCategoryDef>
+		<defName>Ammo30x170mm</defName>
+		<label>30x170mm</label>
+		<parent>AmmoHighCaliber</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberHighCaliber</iconPath>
+	</ThingCategoryDef>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_30x170mm</defName>
+		<label>30x170mm</label>
+		<ammoTypes>
+			<Ammo_30x170mm_AP>Bullet_30x170mm_AP</Ammo_30x170mm_AP>
+			<Ammo_30x170mm_Incendiary>Bullet_30x170mm_Incendiary</Ammo_30x170mm_Incendiary>
+			<Ammo_30x170mm_HE>Bullet_30x170mm_HE</Ammo_30x170mm_HE>
+			<Ammo_30x170mm_Sabot>Bullet_30x170mm_Sabot</Ammo_30x170mm_Sabot>
+		</ammoTypes>
+		<similarTo>AmmoSet_Autocannon</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo30x170mmBase" ParentName="MediumAmmoBase" Abstract="True">
+		<description>Large caliber cartridge used by autocannons.</description>
+		<statBases>
+			<Mass>0.71</Mass>
+			<Bulk>1.25</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
+		<thingCategories>
+			<li>Ammo30x170mm</li>
+		</thingCategories>
+		<stackLimit>150</stackLimit>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo30x170mmBase">
+		<defName>Ammo_30x170mm_AP</defName>
+		<label>30x170mm cartridge (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_30x170mm_AP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo30x170mmBase">
+		<defName>Ammo_30x170mm_Incendiary</defName>
+		<label>30x170mm cartridge (AP-I)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<ammoClass>IncendiaryAP</ammoClass>
+		<cookOffProjectile>Bullet_30x170mm_Incendiary</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo30x170mmBase">
+		<defName>Ammo_30x170mm_HE</defName>
+		<label>30x170mm cartridge (AP-HE)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<ammoClass>ExplosiveAP</ammoClass>
+		<cookOffProjectile>Bullet_30x170mm_HE</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo30x170mmBase">
+		<defName>Ammo_30x170mm_Sabot</defName>
+		<label>30x170mm cartridge (Sabot)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<Mass>0.556</Mass>
+		</statBases>
+		<ammoClass>Sabot</ammoClass>
+		<cookOffProjectile>Bullet_30x170mm_Sabot</cookOffProjectile>
+	</ThingDef>
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef Name="Base30x170mmBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_Big</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>189</speed>
+			<dropsCasings>true</dropsCasings>
+			<casingMoteDefname>Fleck_RifleAmmoCasings_HighCal</casingMoteDefname>
+			<casingFilthDefname>Filth_RifleAmmoCasings_HighCal</casingFilthDefname>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base30x170mmBullet">
+		<defName>Bullet_30x170mm_AP</defName>
+		<label>30x170mm bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>82</damageAmountBase>
+			<armorPenetrationSharp>72</armorPenetrationSharp>
+			<armorPenetrationBlunt>4199.04</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base30x170mmBullet">
+		<defName>Bullet_30x170mm_Incendiary</defName>
+		<label>30x170mm bullet (AP-I)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>82</damageAmountBase>
+			<armorPenetrationSharp>72</armorPenetrationSharp>
+			<armorPenetrationBlunt>4199.04</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+					<def>Flame_Secondary</def>
+					<amount>49</amount>
+				</li>
+			</secondaryDamage>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base30x170mmBullet">
+		<defName>Bullet_30x170mm_HE</defName>
+		<label>30x170mm bullet (AP-HE)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>130</damageAmountBase>
+			<armorPenetrationSharp>36</armorPenetrationSharp>
+			<armorPenetrationBlunt>4199.04</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+					<def>Bomb_Secondary</def>
+					<amount>68</amount>
+				</li>
+			</secondaryDamage>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base30x170mmBullet">
+		<defName>Bullet_30x170mm_Sabot</defName>
+		<label>30x170mm bullet (Sabot)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>60</damageAmountBase>
+			<armorPenetrationSharp>126</armorPenetrationSharp>
+			<armorPenetrationBlunt>5385.26</armorPenetrationBlunt>
+			<speed>256</speed>
+		</projectile>
+	</ThingDef>
+
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_30x170mm_AP</defName>
+		<label>make 30x170mm (AP) cartridge x100</label>
+		<description>Craft 100 30x170mm (AP) cartridges.</description>
+		<jobString>Making 30x170mm (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>142</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_30x170mm_AP>100</Ammo_30x170mm_AP>
+		</products>
+		<workAmount>17040</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_30x170mm_Incendiary</defName>
+		<label>make 30x170mm (AP-I) cartridge x100</label>
+		<description>Craft 100 30x170mm (AP-I) cartridges.</description>
+		<jobString>Making 30x170mm (AP-I) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>142</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Prometheum</li>
+					</thingDefs>
+				</filter>
+				<count>18</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Prometheum</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_30x170mm_Incendiary>100</Ammo_30x170mm_Incendiary>
+		</products>
+		<workAmount>21400</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_30x170mm_HE</defName>
+		<label>make 30x170mm (AP-HE) cartridge x200</label>
+		<description>Craft 200 30x170mm (AP-HE) cartridges.</description>
+		<jobString>Making 30x170mm (AP-HE) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>142</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>FSX</li>
+					</thingDefs>
+				</filter>
+				<count>34</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>FSX</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_30x170mm_HE>100</Ammo_30x170mm_HE>
+		</products>
+		<workAmount>27800</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_30x170mm_Sabot</defName>
+		<label>make 30x170mm (Sabot) cartridge x100</label>
+		<description>Craft 100 30x170mm (Sabot) cartridges.</description>
+		<jobString>Making 30x170mm (Sabot) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>70</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Uranium</li>
+					</thingDefs>
+				</filter>
+				<count>21</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Chemfuel</li>
+					</thingDefs>
+				</filter>
+				<count>21</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Uranium</li>
+				<li>Chemfuel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_30x170mm_Sabot>100</Ammo_30x170mm_Sabot>
+		</products>
+		<workAmount>19600</workAmount>
+	</RecipeDef>
+
+</Defs>

--- a/Defs/Ammo/HighCaliber/35x228mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/35x228mmNATO.xml
@@ -120,13 +120,13 @@
 			<damageAmountBase>106</damageAmountBase>
 			<armorPenetrationSharp>80</armorPenetrationSharp>
 			<armorPenetrationBlunt>7593.44</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+					<def>Flame_Secondary</def>
+					<amount>64</amount>
+				</li>
+			</secondaryDamage>
 		</projectile>
-		<secondaryDamage>
-			<li>
-				<def>Flame_Secondary</def>
-				<amount>64</amount>
-			</li>
-		</secondaryDamage>
 	</ThingDef>
 
 	<ThingDef ParentName="Base35x228mmNATOBullet">

--- a/Defs/Ammo/HighCaliber/35x228mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/35x228mmNATO.xml
@@ -1,0 +1,301 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+	<ThingCategoryDef>
+		<defName>Ammo35x228mmNATO</defName>
+		<label>35x228mm NATO</label>
+		<parent>AmmoHighCaliber</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberHighCaliber</iconPath>
+	</ThingCategoryDef>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_35x228mm</defName>
+		<label>35x228mm NATO</label>
+		<ammoTypes>
+			<Ammo_35x228mmNATO_AP>Bullet_35x228mmNATO_AP</Ammo_35x228mmNATO_AP>
+			<Ammo_35x228mmNATO_Incendiary>Bullet_35x228mmNATO_Incendiary</Ammo_35x228mmNATO_Incendiary>
+			<Ammo_35x228mmNATO_HE>Bullet_35x228mmNATO_HE</Ammo_35x228mmNATO_HE>
+			<Ammo_35x228mmNATO_Sabot>Bullet_35x228mmNATO_Sabot</Ammo_35x228mmNATO_Sabot>
+		</ammoTypes>
+		<similarTo>AmmoSet_Autocannon</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo35x228mmNATOBase" ParentName="MediumAmmoBase" Abstract="True">
+		<description>Large caliber cartridge used by autocannons.</description>
+		<statBases>
+			<Mass>1.572</Mass>
+			<Bulk>2.86</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
+		<thingCategories>
+			<li>Ammo35x228mmNATO</li>
+		</thingCategories>
+		<stackLimit>50</stackLimit>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo35x228mmNATOBase">
+		<defName>Ammo_35x228mmNATO_AP</defName>
+		<label>35x228mmNATO cartridge (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_35x228mmNATO_AP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo35x228mmNATOBase">
+		<defName>Ammo_35x228mmNATO_Incendiary</defName>
+		<label>35x228mmNATO cartridge (AP-I)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<ammoClass>IncendiaryAP</ammoClass>
+		<cookOffProjectile>Bullet_35x228mmNATO_Incendiary</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo35x228mmNATOBase">
+		<defName>Ammo_35x228mmNATO_HE</defName>
+		<label>35x228mmNATO cartridge (AP-HE)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<ammoClass>ExplosiveAP</ammoClass>
+		<cookOffProjectile>Bullet_35x228mmNATO_HE</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo35x228mmNATOBase">
+		<defName>Ammo_35x228mmNATO_Sabot</defName>
+		<label>35x228mmNATO cartridge (Sabot)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<Mass>1.336</Mass>
+		</statBases>
+		<ammoClass>Sabot</ammoClass>
+		<cookOffProjectile>Bullet_35x228mmNATO_Sabot</cookOffProjectile>
+	</ThingDef>
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef Name="Base35x228mmNATOBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_Big</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>201</speed>
+			<dropsCasings>true</dropsCasings>
+			<casingMoteDefname>Fleck_RifleAmmoCasings_HighCal</casingMoteDefname>
+			<casingFilthDefname>Filth_RifleAmmoCasings_HighCal</casingFilthDefname>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base35x228mmNATOBullet">
+		<defName>Bullet_35x228mmNATO_AP</defName>
+		<label>35x228mmNATO bullet (APHC)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>106</damageAmountBase>
+			<armorPenetrationSharp>80</armorPenetrationSharp>
+			<armorPenetrationBlunt>7593.44</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base35x228mmNATOBullet">
+		<defName>Bullet_35x228mmNATO_Incendiary</defName>
+		<label>35x228mmNATO bullet (AP-I)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>106</damageAmountBase>
+			<armorPenetrationSharp>80</armorPenetrationSharp>
+			<armorPenetrationBlunt>7593.44</armorPenetrationBlunt>
+		</projectile>
+		<secondaryDamage>
+			<li>
+				<def>Flame_Secondary</def>
+				<amount>64</amount>
+			</li>
+		</secondaryDamage>
+	</ThingDef>
+
+	<ThingDef ParentName="Base35x228mmNATOBullet">
+		<defName>Bullet_35x228mmNATO_HE</defName>
+		<label>35x228mmNATO bullet (AP-HE)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>169</damageAmountBase>
+			<armorPenetrationSharp>40</armorPenetrationSharp>
+			<armorPenetrationBlunt>7593.44</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+					<def>Bomb_Secondary</def>
+					<amount>87</amount>
+				</li>
+			</secondaryDamage>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base35x228mmNATOBullet">
+		<defName>Bullet_35x228mmNATO_Sabot</defName>
+		<label>35x228mmNATO bullet (Sabot)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>94</damageAmountBase>
+			<armorPenetrationSharp>140</armorPenetrationSharp>
+			<armorPenetrationBlunt>9744.1</armorPenetrationBlunt>
+			<speed>273</speed>
+		</projectile>
+	</ThingDef>
+
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_35x228mmNATO_AP</defName>
+		<label>make 35x228mmNATO (AP) cartridge x50</label>
+		<description>Craft 50 35x228mmNATO (AP) cartridges.</description>
+		<jobString>Making 35x228mmNATO (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>160</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_35x228mmNATO_AP>50</Ammo_35x228mmNATO_AP>
+		</products>
+		<workAmount>19200</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_35x228mmNATO_Incendiary</defName>
+		<label>make 35x228mmNATO (AP-I) cartridge x50</label>
+		<description>Craft 50 35x228mmNATO (AP-I) cartridges.</description>
+		<jobString>Making 35x228mmNATO (AP-I) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>160</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Prometheum</li>
+					</thingDefs>
+				</filter>
+				<count>14</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Prometheum</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_35x228mmNATO_Incendiary>50</Ammo_35x228mmNATO_Incendiary>
+		</products>
+		<workAmount>21600</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_35x228mmNATO_HE</defName>
+		<label>make 35x228mmNATO (AP-HE) cartridge x50</label>
+		<description>Craft 50 35x228mmNATO (AP-HE) cartridges.</description>
+		<jobString>Making 35x228mmNATO (AP-HE) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>160</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>FSX</li>
+					</thingDefs>
+				</filter>
+				<count>26</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>FSX</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_35x228mmNATO_HE>50</Ammo_35x228mmNATO_HE>
+		</products>
+		<workAmount>26400</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_35x228mmNATO_Sabot</defName>
+		<label>make 35x228mmNATO (Sabot) cartridge x50</label>
+		<description>Craft 50 35x228mmNATO (Sabot) cartridges.</description>
+		<jobString>Making 35x228mmNATO (Sabot) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>104</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Uranium</li>
+					</thingDefs>
+				</filter>
+				<count>16</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Chemfuel</li>
+					</thingDefs>
+				</filter>
+				<count>16</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Uranium</li>
+				<li>Chemfuel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_35x228mmNATO_Sabot>50</Ammo_35x228mmNATO_Sabot>
+		</products>
+		<workAmount>20000</workAmount>
+	</RecipeDef>
+
+</Defs>


### PR DESCRIPTION
## Additions

- New ammo types added in the now closed #3792.

## Changes

- Stat fixes and correction for the 27mm Mauser ammo.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit?gid=1393347070#gid=1393347070

## Reasoning

- Even though I dislike the main mod getting cluttered with new ammo types that are not going to get widely used, 27mm Mauser was added without resistance so ¯\_(ツ)_/¯. If it's getting done, then it has to be done properly.
- Both 27mm Mauser and the newly added ammo in the aforementioned PR needed adjustments and corrections based on proper citations.

## Alternatives

- Remove/revert 27mm Mauser.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
