### PR TITLE
Bump Harmony version

### DIFF
--- a/Source/BetterTurretsCompat/BetterTurretsCompat.csproj
+++ b/Source/BetterTurretsCompat/BetterTurretsCompat.csproj
@@ -49,6 +49,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Krafs.Rimworld.Ref" Version="1.5.4104" GeneratePathProperty="true" />
-		<PackageReference Include="Lib.Harmony" Version="2.3.3" ExcludeAssets="runtime" />
+		<PackageReference Include="Lib.Harmony" Version="2.3.6" ExcludeAssets="runtime" />
 	</ItemGroup>
 </Project>

--- a/Source/CombatExtended/CombatExtended.csproj
+++ b/Source/CombatExtended/CombatExtended.csproj
@@ -123,7 +123,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Krafs.Rimworld.Ref" Version="1.5.4104" GeneratePathProperty="true" />
-		<PackageReference Include="Lib.Harmony" Version="2.3.3" ExcludeAssets="runtime" />
+		<PackageReference Include="Lib.Harmony" Version="2.3.6" ExcludeAssets="runtime" />
 	</ItemGroup>
 	<ItemGroup>
 		<Publicize Include="Assembly-CSharp" />

--- a/Source/Loader/Loader.csproj
+++ b/Source/Loader/Loader.csproj
@@ -36,6 +36,6 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Krafs.Rimworld.Ref" Version="1.5.4061" GeneratePathProperty="true" />
-		<PackageReference Include="Lib.Harmony" Version="2.3.3" ExcludeAssets="runtime" />
+		<PackageReference Include="Lib.Harmony" Version="2.3.6" ExcludeAssets="runtime" />
 	</ItemGroup>
 </Project>

--- a/Source/MiscTurretsCompat/MiscTurretsCompat.csproj
+++ b/Source/MiscTurretsCompat/MiscTurretsCompat.csproj
@@ -49,6 +49,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Krafs.Rimworld.Ref" Version="1.5.4104" GeneratePathProperty="true" />
-		<PackageReference Include="Lib.Harmony" Version="2.3.3" ExcludeAssets="runtime" />
+		<PackageReference Include="Lib.Harmony" Version="2.3.6" ExcludeAssets="runtime" />
 	</ItemGroup>
 </Project>

--- a/Source/MultiplayerCompat/MultiplayerCompat.csproj
+++ b/Source/MultiplayerCompat/MultiplayerCompat.csproj
@@ -41,7 +41,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Krafs.Rimworld.Ref" Version="1.5.4104" GeneratePathProperty="true" />
-		<PackageReference Include="Lib.Harmony" Version="2.3.3" ExcludeAssets="runtime" />
+		<PackageReference Include="Lib.Harmony" Version="2.3.6" ExcludeAssets="runtime" />
 		<PackageReference Include="RimWorld.MultiplayerAPI" Version="0.4.0" />
 	</ItemGroup>
 </Project>

--- a/Source/PsyblastersCompat/PsyblastersCompat.csproj
+++ b/Source/PsyblastersCompat/PsyblastersCompat.csproj
@@ -48,7 +48,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Krafs.Rimworld.Ref" Version="1.5.4104" GeneratePathProperty="true" />
-        <PackageReference Include="Lib.Harmony" Version="2.3.3" ExcludeAssets="runtime" />
+        <PackageReference Include="Lib.Harmony" Version="2.3.6" ExcludeAssets="runtime" />
     </ItemGroup>
     <ItemGroup>
         <Publicize Include="Assembly-CSharp" />

--- a/Source/SOS2Compat/SOS2Compat.csproj
+++ b/Source/SOS2Compat/SOS2Compat.csproj
@@ -52,7 +52,7 @@
 			  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
           </PackageReference>
           <PackageReference Include="Krafs.Rimworld.Ref" Version="1.5.4104" GeneratePathProperty="true" />
-          <PackageReference Include="Lib.Harmony" Version="2.3.3" ExcludeAssets="runtime" />
+          <PackageReference Include="Lib.Harmony" Version="2.3.6" ExcludeAssets="runtime" />
 	</ItemGroup>
 	<ItemGroup>
 		<Publicize Include="Assembly-CSharp" />

--- a/Source/SRTSCompat/SRTSCompat.csproj
+++ b/Source/SRTSCompat/SRTSCompat.csproj
@@ -47,6 +47,6 @@
 	</ItemGroup>
 	<ItemGroup>
           <PackageReference Include="Krafs.Rimworld.Ref" Version="1.5.4104" GeneratePathProperty="true" />
-          <PackageReference Include="Lib.Harmony" Version="2.3.3" ExcludeAssets="runtime" />
+          <PackageReference Include="Lib.Harmony" Version="2.3.6" ExcludeAssets="runtime" />
 	</ItemGroup>
 </Project>

--- a/Source/VehiclesCompat/VehiclesCompat.csproj
+++ b/Source/VehiclesCompat/VehiclesCompat.csproj
@@ -56,7 +56,7 @@
 			  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
           </PackageReference>
           <PackageReference Include="Krafs.Rimworld.Ref" Version="1.5.4104" GeneratePathProperty="true" />
-          <PackageReference Include="Lib.Harmony" Version="2.3.3" ExcludeAssets="runtime" />
+          <PackageReference Include="Lib.Harmony" Version="2.3.6" ExcludeAssets="runtime" />
 	</ItemGroup>
 	<ItemGroup>
 		<Publicize Include="Assembly-CSharp" />


### PR DESCRIPTION
## Changes

- Bumped Harmony version to 2.3.6.

## Reasoning

- 2.3.6 entered release.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
