### PR TITLE
Medieval 2 map gen fix

### DIFF
--- a/Defs/ThingDefs_Items/Items_Turrets.xml
+++ b/Defs/ThingDefs_Items/Items_Turrets.xml
@@ -7,6 +7,7 @@
 		<thingCategories>
 			<li>WeaponsTurrets</li>
 		</thingCategories>
+		<techLevel>Industrial</techLevel>
 	</ThingDef>
 
 	<ThingDef ParentName="MinifiedTurretBase">

--- a/Defs/ThingDefs_Items/Items_Unfinished.xml
+++ b/Defs/ThingDefs_Items/Items_Unfinished.xml
@@ -90,6 +90,7 @@
 			<Mass>16</Mass>
 			<Bulk>20</Bulk>
 		</statBases>
+		<techLevel>Industrial</techLevel>
 	</ThingDef>
 
 </Defs>


### PR DESCRIPTION
## Additions
none
## Changes
added industrial tech level to minified turrets.
## References
discord bug channel
## Reasoning
Medieval 2 loot table look in trader inventory to spawn loot when it's a thing that can't be spawned on shelves map gen fails, add tech level is fastest to fix this issue on CE side.
## Alternatives
idk
## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
