### PR TITLE
Fix off-screen laser rendering

### DIFF
--- a/Source/CombatExtended/CombatExtended/Lasers/LaserBeamCE.cs
+++ b/Source/CombatExtended/CombatExtended/Lasers/LaserBeamCE.cs
@@ -56,7 +56,9 @@ namespace CombatExtended.Lasers
             graphic.ticksToDetonation = this.def.projectile.explosionDelay;
             graphic.projDef = laserBeamDef;
             graphic.Setup(launcher, equipment, a, b);
-            GenSpawn.Spawn(graphic, Origin.ToIntVec3(), Map, WipeMode.Vanish);
+
+            bool inView = Find.CameraDriver.CurrentViewRect.Contains(Origin.ToIntVec3());
+            GenSpawn.Spawn(graphic, inView ? Origin.ToIntVec3() : b.ToIntVec3(), Map, WipeMode.Vanish);
         }
 
         void SpawnBeamReflections(Vector3 a, Vector3 b, int count)


### PR DESCRIPTION
## Changes

- Beams with off-screen origin now use their destination cell as their in-map position

## References

- Would be good to have with https://github.com/CombatExtended-Continued/CombatExtendedArmory/pull/111

## Reasoning

- The game culls rendering for objects that aren't in view of the camera, and since the position of the beam was set to the origin it made lasers invisible when shot off-screen

## Alternatives

- Dynamically calculate the visible cell of the beam to account for situations where both the origin and the destination are off-screen

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
