### PR TITLE
Vanilla Genetics Expanded fix for damages ignore armor 

### DIFF
--- a/ModPatches/Vanilla Genetics Expanded/Patches/Vanilla Genetics Expanded/CE_Patch_DamageDef.xml
+++ b/ModPatches/Vanilla Genetics Expanded/Patches/Vanilla Genetics Expanded/CE_Patch_DamageDef.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/DamageDef[defName="GR_ToxicExplosion"]/armorCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>Defs/DamageDef[defName="GR_ToxicExplosion"]/armorCategory</xpath>
+			<value>
+				<armorCategory>Blunt</armorCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/DamageDef[defName="GR_ToxicExplosion"]</xpath>
+			<value>
+				<armorCategory>Blunt</armorCategory>
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/DamageDef[defName="GR_HairballExplosion"]/armorCategory</xpath>
+		<match Class="PatchOperationAdd">
+			<xpath>Defs/DamageDef[defName="GR_HairballExplosion"]/armorCategory</xpath>
+			<value>
+				<armorCategory>Blunt</armorCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/DamageDef[defName="GR_HairballExplosion"]</xpath>
+			<value>
+				<armorCategory>Blunt</armorCategory>
+			</value>
+		</nomatch>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Vanilla Genetics Expanded/Patches/Vanilla Genetics Expanded/CE_Patch_DamageDef.xml
+++ b/ModPatches/Vanilla Genetics Expanded/Patches/Vanilla Genetics Expanded/CE_Patch_DamageDef.xml
@@ -1,36 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
-
-	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/DamageDef[defName="GR_ToxicExplosion"]/armorCategory</xpath>
-		<match Class="PatchOperationReplace">
-			<xpath>Defs/DamageDef[defName="GR_ToxicExplosion"]/armorCategory</xpath>
-			<value>
-				<armorCategory>Blunt</armorCategory>
-			</value>
-		</match>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/DamageDef[defName="GR_ToxicExplosion"]</xpath>
-			<value>
-				<armorCategory>Blunt</armorCategory>
-			</value>
-		</nomatch>
+	<Operation Class="PatchOperationAttributeSet">
+		<xpath>Defs/DamageDef[defName="GR_ToxicExplosion" or 
+			defName="GR_HairballExplosion"]</xpath>
+		<attribute>ParentName</attribute>
+		<value>Bomb</value>
 	</Operation>
-
-	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/DamageDef[defName="GR_HairballExplosion"]/armorCategory</xpath>
-		<match Class="PatchOperationAdd">
-			<xpath>Defs/DamageDef[defName="GR_HairballExplosion"]/armorCategory</xpath>
-			<value>
-				<armorCategory>Blunt</armorCategory>
-			</value>
-		</match>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/DamageDef[defName="GR_HairballExplosion"]</xpath>
-			<value>
-				<armorCategory>Blunt</armorCategory>
-			</value>
-		</nomatch>
-	</Operation>
-
 </Patch>

--- a/ModPatches/Vanilla Genetics Expanded/Patches/Vanilla Genetics Expanded/CE_Patch_DamageDef.xml
+++ b/ModPatches/Vanilla Genetics Expanded/Patches/Vanilla Genetics Expanded/CE_Patch_DamageDef.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
+
 	<Operation Class="PatchOperationAttributeSet">
-		<xpath>Defs/DamageDef[defName="GR_ToxicExplosion" or 
-			defName="GR_HairballExplosion"]</xpath>
+		<xpath>Defs/DamageDef[defName="GR_ToxicExplosion" or defName="GR_HairballExplosion"]</xpath>
 		<attribute>ParentName</attribute>
 		<value>Bomb</value>
 	</Operation>
+
 </Patch>


### PR DESCRIPTION
## Additions ## Changes
a patch for two damages that ignore armor, gave them blunt armor category
Edit: that didn't work... switch to set their parent node to bomb
## References
discord Troubleshooting channel
## Reasoning
toxic explosion is still explosion 
## Alternatives

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
