### PR TITLE
Remove Armor Overheal

### DIFF
--- a/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Heavy.xml
+++ b/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Heavy.xml
@@ -116,8 +116,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>250</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>

--- a/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Light.xml
+++ b/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Light.xml
@@ -141,8 +141,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>70</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -313,8 +311,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>50</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -369,8 +365,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>100</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>

--- a/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Medium.xml
+++ b/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Medium.xml
@@ -200,8 +200,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>100</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>

--- a/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_SuperHeavy.xml
+++ b/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_SuperHeavy.xml
@@ -157,8 +157,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>310</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -255,8 +253,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>330</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -347,8 +343,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>460</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -424,8 +418,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>425</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>

--- a/ModPatches/AV Mechtech/Patches/AV Mechtech/CompanionSphere.xml
+++ b/ModPatches/AV Mechtech/Patches/AV Mechtech/CompanionSphere.xml
@@ -37,8 +37,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>460</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>

--- a/ModPatches/AV Mechtech/Patches/AV Mechtech/Fluoid.xml
+++ b/ModPatches/AV Mechtech/Patches/AV Mechtech/Fluoid.xml
@@ -89,8 +89,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>460</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>

--- a/ModPatches/AV Mechtech/Patches/AV Mechtech/RoyalLancer.xml
+++ b/ModPatches/AV Mechtech/Patches/AV Mechtech/RoyalLancer.xml
@@ -74,8 +74,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>460</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 				<MinArmorValueSharp>6.5</MinArmorValueSharp>
 				<MinArmorValueBlunt>5.4</MinArmorValueBlunt>

--- a/ModPatches/AV Mechtech/Patches/AV Mechtech/Scrapper.xml
+++ b/ModPatches/AV Mechtech/Patches/AV Mechtech/Scrapper.xml
@@ -58,8 +58,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>90</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>

--- a/ModPatches/AV Work Queen/Patches/AV Work Queen/WorkQueen.xml
+++ b/ModPatches/AV Work Queen/Patches/AV Work Queen/WorkQueen.xml
@@ -74,8 +74,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>460</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>

--- a/ModPatches/AV Work Queen/Patches/AV Work Queen/WorkUrchins.xml
+++ b/ModPatches/AV Work Queen/Patches/AV Work Queen/WorkUrchins.xml
@@ -48,8 +48,6 @@
 				</RepairIngredients>
 				<RepairTime>200</RepairTime>
 				<RepairValue>100</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>100</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Slurrypede.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Slurrypede.xml
@@ -102,8 +102,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>350</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/VFE_Mechs/VFESlurrymaster.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/VFE_Mechs/VFESlurrymaster.xml
@@ -84,8 +84,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>450</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/AlphaBees/Apiarist.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/AlphaBees/Apiarist.xml
@@ -62,8 +62,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>70</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Apoptosis.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Apoptosis.xml
@@ -127,8 +127,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>525</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Bellicor.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Bellicor.xml
@@ -90,8 +90,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>100</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Bellicor_Mortar.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Bellicor_Mortar.xml
@@ -90,8 +90,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>525</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Blitzkrieg.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Blitzkrieg.xml
@@ -61,8 +61,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>70</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Guttersnipe.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Guttersnipe.xml
@@ -99,8 +99,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>160</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Infernus.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Infernus.xml
@@ -77,8 +77,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>425</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Legate.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Legate.xml
@@ -98,8 +98,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>380</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Lux.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Lux.xml
@@ -84,8 +84,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>100</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_MasterChef.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_MasterChef.xml
@@ -43,8 +43,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>70</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Munifex.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Munifex.xml
@@ -84,8 +84,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>100</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Optio.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Optio.xml
@@ -78,8 +78,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>86</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Polychoron.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Polychoron.xml
@@ -58,8 +58,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>135</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_PristineAssembler.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_PristineAssembler.xml
@@ -91,8 +91,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>350</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_PristineSlurrypede.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_PristineSlurrypede.xml
@@ -83,8 +83,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>350</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_PristineStrider.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_PristineStrider.xml
@@ -75,8 +75,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>100</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Sagittarius.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Sagittarius.xml
@@ -91,8 +91,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>100</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Siegemelter.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Siegemelter.xml
@@ -90,8 +90,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>425</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Starfire.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Starfire.xml
@@ -90,8 +90,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>450</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_TurboCleaner.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_TurboCleaner.xml
@@ -61,8 +61,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>60</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_WarEmpress.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_WarEmpress.xml
@@ -114,8 +114,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>575</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Rimatomics/Nucleotron.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Rimatomics/Nucleotron.xml
@@ -43,8 +43,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>70</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VE_Books/Librarian.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VE_Books/Librarian.xml
@@ -43,8 +43,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>70</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VE_Fishing/Angler.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VE_Fishing/Angler.xml
@@ -61,8 +61,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>70</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VE_Genetics/Geneticor.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VE_Genetics/Geneticor.xml
@@ -43,8 +43,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>70</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvAura.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvAura.xml
@@ -101,8 +101,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>142</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvDaggersnout.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvDaggersnout.xml
@@ -110,8 +110,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>100</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvFireworm.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvFireworm.xml
@@ -89,8 +89,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>340</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvGoliath.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvGoliath.xml
@@ -91,8 +91,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>365</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvPhalanx.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvPhalanx.xml
@@ -89,8 +89,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>310</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvSiegebreaker.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvSiegebreaker.xml
@@ -91,8 +91,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>425</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEAura.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEAura.xml
@@ -99,8 +99,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>142</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEDaggersnout.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEDaggersnout.xml
@@ -110,8 +110,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>90</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEFireworm.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEFireworm.xml
@@ -89,8 +89,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>290</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEGoliath.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEGoliath.xml
@@ -91,8 +91,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>320</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEPhalanx.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEPhalanx.xml
@@ -88,8 +88,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>272</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFESiegebreaker.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFESiegebreaker.xml
@@ -91,8 +91,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>350</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Aura.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Aura.xml
@@ -105,8 +105,6 @@
 								</RepairIngredients>
 								<RepairTime>300</RepairTime>
 								<RepairValue>200</RepairValue>
-								<CanOverHeal>true</CanOverHeal>
-								<MaxOverHeal>142</MaxOverHeal>
 								<MinArmorPct>0.5</MinArmorPct>
 							</li>
 						</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Daggersnout.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Daggersnout.xml
@@ -116,8 +116,6 @@
 								</RepairIngredients>
 								<RepairTime>300</RepairTime>
 								<RepairValue>200</RepairValue>
-								<CanOverHeal>true</CanOverHeal>
-								<MaxOverHeal>100</MaxOverHeal>
 								<MinArmorPct>0.5</MinArmorPct>
 							</li>
 						</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Fireworm.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Fireworm.xml
@@ -94,8 +94,6 @@
 								</RepairIngredients>
 								<RepairTime>300</RepairTime>
 								<RepairValue>200</RepairValue>
-								<CanOverHeal>true</CanOverHeal>
-								<MaxOverHeal>340</MaxOverHeal>
 								<MinArmorPct>0.5</MinArmorPct>
 							</li>
 						</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Goliath.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Goliath.xml
@@ -96,8 +96,6 @@
 								</RepairIngredients>
 								<RepairTime>300</RepairTime>
 								<RepairValue>200</RepairValue>
-								<CanOverHeal>true</CanOverHeal>
-								<MaxOverHeal>365</MaxOverHeal>
 								<MinArmorPct>0.5</MinArmorPct>
 							</li>
 						</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Phalanx.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Phalanx.xml
@@ -93,8 +93,6 @@
 								</RepairIngredients>
 								<RepairTime>300</RepairTime>
 								<RepairValue>200</RepairValue>
-								<CanOverHeal>true</CanOverHeal>
-								<MaxOverHeal>310</MaxOverHeal>
 								<MinArmorPct>0.5</MinArmorPct>
 							</li>
 						</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Siegebreaker.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Siegebreaker.xml
@@ -96,8 +96,6 @@
 								</RepairIngredients>
 								<RepairTime>300</RepairTime>
 								<RepairValue>200</RepairValue>
-								<CanOverHeal>true</CanOverHeal>
-								<MaxOverHeal>425</MaxOverHeal>
 								<MinArmorPct>0.5</MinArmorPct>
 							</li>
 						</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Slurrymaster.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Slurrymaster.xml
@@ -89,8 +89,6 @@
 								</RepairIngredients>
 								<RepairTime>300</RepairTime>
 								<RepairValue>200</RepairValue>
-								<CanOverHeal>true</CanOverHeal>
-								<MaxOverHeal>400</MaxOverHeal>
 								<MinArmorPct>0.5</MinArmorPct>
 							</li>
 						</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VRE_Sanguophage/Sanguinarius.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VRE_Sanguophage/Sanguinarius.xml
@@ -103,8 +103,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>100</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Aura.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Aura.xml
@@ -89,8 +89,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>100</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Daggersnout.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Daggersnout.xml
@@ -102,8 +102,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>90</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Demolisher.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Demolisher.xml
@@ -85,8 +85,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>350</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Fireworm.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Fireworm.xml
@@ -81,8 +81,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>290</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Goliath.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Goliath.xml
@@ -83,8 +83,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>320</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Phalanx.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Phalanx.xml
@@ -81,8 +81,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>272</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Siegebreaker.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Siegebreaker.xml
@@ -83,8 +83,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>350</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>

--- a/ModPatches/Diverse Mechanoid War Procedure/Patches/Diverse Mechanoid War Procedure/ThingDefs_Races/Races_Mechanoids_Light.xml
+++ b/ModPatches/Diverse Mechanoid War Procedure/Patches/Diverse Mechanoid War Procedure/ThingDefs_Races/Races_Mechanoids_Light.xml
@@ -38,8 +38,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>70</MaxOverHeal>
 				<MinArmorPct>0.75</MinArmorPct>
 			</li>
 		</value>

--- a/ModPatches/Diverse Mechanoid War Procedure/Patches/Diverse Mechanoid War Procedure/ThingDefs_Races/Races_Mechanoids_Medium.xml
+++ b/ModPatches/Diverse Mechanoid War Procedure/Patches/Diverse Mechanoid War Procedure/ThingDefs_Races/Races_Mechanoids_Medium.xml
@@ -276,8 +276,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>100</MaxOverHeal>
 				<MinArmorPct>0.75</MinArmorPct>
 			</li>
 		</value>
@@ -336,8 +334,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>188</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 				<MinArmorValueSharp>10</MinArmorValueSharp>
 				<MinArmorValueBlunt>22</MinArmorValueBlunt>
@@ -372,8 +368,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>188</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 				<MinArmorValueSharp>10</MinArmorValueSharp>
 				<MinArmorValueBlunt>22</MinArmorValueBlunt>
@@ -408,8 +402,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>100</MaxOverHeal>
 				<MinArmorPct>0.75</MinArmorPct>
 				<MinArmorValueSharp>4</MinArmorValueSharp>
 				<MinArmorValueBlunt>8</MinArmorValueBlunt>
@@ -444,8 +436,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>100</MaxOverHeal>
 				<MinArmorPct>0.75</MinArmorPct>
 				<MinArmorValueSharp>4</MinArmorValueSharp>
 				<MinArmorValueBlunt>8</MinArmorValueBlunt>
@@ -470,8 +460,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>188</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 				<MinArmorValueSharp>3</MinArmorValueSharp>
 				<MinArmorValueBlunt>4.5</MinArmorValueBlunt>
@@ -506,8 +494,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>100</MaxOverHeal>
 				<MinArmorPct>0.75</MinArmorPct>
 			</li>
 		</value>

--- a/ModPatches/Eccentric Militor/Patches/Eccentric Militor/Eccentric_Militor_Races.xml
+++ b/ModPatches/Eccentric Militor/Patches/Eccentric Militor/Eccentric_Militor_Races.xml
@@ -87,8 +87,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>70</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -285,8 +283,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>70</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>

--- a/ModPatches/Machines of War/Patches/Machines of War/ThingDefs_Races/CicadaRaces.xml
+++ b/ModPatches/Machines of War/Patches/Machines of War/ThingDefs_Races/CicadaRaces.xml
@@ -102,8 +102,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>158</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>

--- a/ModPatches/Machines of War/Patches/Machines of War/ThingDefs_Races/DemolisherRaces.xml
+++ b/ModPatches/Machines of War/Patches/Machines of War/ThingDefs_Races/DemolisherRaces.xml
@@ -103,8 +103,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>395</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>

--- a/ModPatches/Machines of War/Patches/Machines of War/ThingDefs_Races/EnforcerBreachRaces .xml
+++ b/ModPatches/Machines of War/Patches/Machines of War/ThingDefs_Races/EnforcerBreachRaces .xml
@@ -102,8 +102,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>131</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>

--- a/ModPatches/Machines of War/Patches/Machines of War/ThingDefs_Races/EnforcerRaces.xml
+++ b/ModPatches/Machines of War/Patches/Machines of War/ThingDefs_Races/EnforcerRaces.xml
@@ -102,8 +102,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>131</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>

--- a/ModPatches/Medieval Overhaul/Patches/Medieval Overhaul/ThingDefs_Races/MO_CE_Patch_Golem.xml
+++ b/ModPatches/Medieval Overhaul/Patches/Medieval Overhaul/ThingDefs_Races/MO_CE_Patch_Golem.xml
@@ -26,8 +26,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>false</CanOverHeal>
-				<MaxOverHeal>100</MaxOverHeal>
 				<MinArmorPct>0.75</MinArmorPct>
 				<MinArmorValueSharp>3</MinArmorValueSharp>
 				<MinArmorValueBlunt>1</MinArmorValueBlunt>

--- a/ModPatches/Metal Gear Rimworld-Gekko/Patches/Metal Gear Rimworld-Gekko/ThingDefs_Races/Races_Mechanoid.xml
+++ b/ModPatches/Metal Gear Rimworld-Gekko/Patches/Metal Gear Rimworld-Gekko/ThingDefs_Races/Races_Mechanoid.xml
@@ -160,8 +160,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>300</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>

--- a/ModPatches/Miho Race/Patches/Miho Race/ThingDefs_Races/Race_MihoMech.xml
+++ b/ModPatches/Miho Race/Patches/Miho Race/ThingDefs_Races/Race_MihoMech.xml
@@ -16,8 +16,6 @@
 					</RepairIngredients>
 					<RepairTime>300</RepairTime>
 					<RepairValue>200</RepairValue>
-					<CanOverHeal>true</CanOverHeal>
-					<MaxOverHeal>100</MaxOverHeal>
 					<MinArmorPct>0.50</MinArmorPct>
 				</li>
 			</comps>
@@ -121,8 +119,6 @@
 					</RepairIngredients>
 					<RepairTime>300</RepairTime>
 					<RepairValue>200</RepairValue>
-					<CanOverHeal>true</CanOverHeal>
-					<MaxOverHeal>100</MaxOverHeal>
 					<MinArmorPct>0.50</MinArmorPct>
 				</li>
 			</comps>
@@ -189,8 +185,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>100</MaxOverHeal>
 				<MinArmorPct>0.50</MinArmorPct>
 			</li>
 		</value>
@@ -238,8 +232,6 @@
 					</RepairIngredients>
 					<RepairTime>300</RepairTime>
 					<RepairValue>200</RepairValue>
-					<CanOverHeal>true</CanOverHeal>
-					<MaxOverHeal>100</MaxOverHeal>
 					<MinArmorPct>0.50</MinArmorPct>
 				</li>
 			</comps>
@@ -318,8 +310,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>100</MaxOverHeal>
 				<MinArmorPct>0.50</MinArmorPct>
 			</li>
 		</value>
@@ -397,8 +387,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>100</MaxOverHeal>
 				<MinArmorPct>0.50</MinArmorPct>
 			</li>
 		</value>

--- a/ModPatches/MoreMechanoids/Patches/MoreMechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/ModPatches/MoreMechanoids/Patches/MoreMechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -96,8 +96,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>27</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -196,8 +194,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>85</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -287,8 +283,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>40</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -416,8 +410,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>550</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -527,8 +519,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>152</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>

--- a/ModPatches/Outer Rim - Droid Depot/Patches/Outer Rim - Droid Depot/Outer_Rim_Droid_Droids.xml
+++ b/ModPatches/Outer Rim - Droid Depot/Patches/Outer Rim - Droid Depot/Outer_Rim_Droid_Droids.xml
@@ -116,8 +116,6 @@
 				</RepairIngredients>
 				<RepairTime>240</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>500</MaxOverHeal> -->
 				<MinArmorPct>0.5</MinArmorPct><!-- The default minimal armor percentage for all armor kinds. Will be overriden by any below -->
 				<!-- <MinArmorValueSharp>14</MinArmorValueSharp>
 				<MinArmorValueBlunt>30</MinArmorValueBlunt>

--- a/ModPatches/Reinforced Mechanoid 2/Patches/Reinforced Mechanoid 2/ThingDefs_Races/RM_Races_Machines.xml
+++ b/ModPatches/Reinforced Mechanoid 2/Patches/Reinforced Mechanoid 2/ThingDefs_Races/RM_Races_Machines.xml
@@ -105,8 +105,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>150</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -152,8 +150,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>200</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>

--- a/ModPatches/Reinforced Mechanoid 2/Patches/Reinforced Mechanoid 2/ThingDefs_Races/RM_Races_Mechanoids.xml
+++ b/ModPatches/Reinforced Mechanoid 2/Patches/Reinforced Mechanoid 2/ThingDefs_Races/RM_Races_Mechanoids.xml
@@ -105,8 +105,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>80</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -194,8 +192,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>500</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -305,8 +301,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>80</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -413,8 +407,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>80</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -524,8 +516,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>80</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -635,8 +625,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>100</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -746,8 +734,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>100</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -896,8 +882,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>100</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -1020,8 +1004,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>200</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -1133,8 +1115,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>300</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -1222,8 +1202,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>420</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -1311,8 +1289,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>400</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -1422,8 +1398,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>100</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>

--- a/ModPatches/Rimsenal - Spacer Faction Pack/Patches/Rimsenal - Spacer Faction Pack/Mechs_Smart_CE.xml
+++ b/ModPatches/Rimsenal - Spacer Faction Pack/Patches/Rimsenal - Spacer Faction Pack/Mechs_Smart_CE.xml
@@ -81,8 +81,6 @@
 					</RepairIngredients>
 					<RepairTime>300</RepairTime>
 					<RepairValue>200</RepairValue>
-					<CanOverHeal>true</CanOverHeal>
-					<MaxOverHeal>110</MaxOverHeal>
 					<MinArmorPct>0.50</MinArmorPct>
 				</li>
 			</comps>
@@ -233,8 +231,6 @@
 					</RepairIngredients>
 					<RepairTime>300</RepairTime>
 					<RepairValue>200</RepairValue>
-					<CanOverHeal>true</CanOverHeal>
-					<MaxOverHeal>86</MaxOverHeal>
 					<MinArmorPct>0.5</MinArmorPct>
 				</li>
 			</comps>

--- a/ModPatches/Robotic Servitude/Patches/ThingDefs_Races/Races_Mechanoid.xml
+++ b/ModPatches/Robotic Servitude/Patches/ThingDefs_Races/Races_Mechanoid.xml
@@ -152,8 +152,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>70</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>

--- a/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
+++ b/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
@@ -130,8 +130,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>366</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -320,8 +318,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>116</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -352,8 +348,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>100</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -455,8 +449,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>100</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -577,8 +569,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>100</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -693,8 +683,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>120</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -783,8 +771,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>356</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -877,8 +863,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>188</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>

--- a/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid_PlayerControlled.xml
+++ b/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid_PlayerControlled.xml
@@ -93,8 +93,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>366</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>
@@ -275,8 +273,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>116</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>
@@ -307,8 +303,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>100</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>
@@ -422,8 +416,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>100</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>
@@ -544,8 +536,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>100</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>
@@ -660,8 +650,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>120</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>
@@ -751,8 +739,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>188</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Machines.xml
+++ b/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Machines.xml
@@ -209,8 +209,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>100</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -412,8 +410,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>250</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -444,8 +440,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>275</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -532,8 +526,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>350</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -637,8 +629,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>250</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>

--- a/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -145,8 +145,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>366</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -335,8 +333,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>116</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -367,8 +363,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>100</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -470,8 +464,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>100</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -592,8 +584,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>100</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -708,8 +698,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>120</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -808,8 +796,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>356</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -900,8 +886,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>188</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>

--- a/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid_PlayerControlled.xml
+++ b/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid_PlayerControlled.xml
@@ -92,8 +92,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>188</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>
@@ -214,8 +212,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>100</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>
@@ -330,8 +326,6 @@
 							</RepairIngredients>
 							<RepairTime>300</RepairTime>
 							<RepairValue>200</RepairValue>
-							<CanOverHeal>true</CanOverHeal>
-							<MaxOverHeal>120</MaxOverHeal>
 							<MinArmorPct>0.5</MinArmorPct>
 						</li>
 					</value>

--- a/ModPatches/pphhyy Expanded Scythers/Patches/pphhyy Expanded Scythers/MechKind_CE.xml
+++ b/ModPatches/pphhyy Expanded Scythers/Patches/pphhyy Expanded Scythers/MechKind_CE.xml
@@ -153,8 +153,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>116</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -250,8 +248,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>140</MaxOverHeal>
 				<MinArmorPct>0.65</MinArmorPct>
 			</li>
 		</value>
@@ -428,8 +424,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>116</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -584,8 +578,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>116</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -713,8 +705,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>150</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>

--- a/Patches/Core/ThingDefs_Races/Races_Humanlike.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Humanlike.xml
@@ -100,7 +100,8 @@
 				</RepairIngredients>
 				<RepairTime>240</RepairTime>
 				<RepairValue>200</RepairValue>
-				<MinArmorPct>0.5</MinArmorPct><!-- The default minimal armor percentage for all armor kinds. Will be overriden by any below -->
+				<MinArmorPct>0.5</MinArmorPct> !-->
+				<!-- The default minimal armor percentage for all armor kinds. Will be overriden by any below -->
 				<!-- <MinArmorValueSharp>14</MinArmorValueSharp>
 				<MinArmorValueBlunt>30</MinArmorValueBlunt>
 				<MinArmorValueHeat>0.2</MinArmorValueHeat>

--- a/Patches/Core/ThingDefs_Races/Races_Humanlike.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Humanlike.xml
@@ -100,8 +100,6 @@
 				</RepairIngredients>
 				<RepairTime>240</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>500</MaxOverHeal> -->
 				<MinArmorPct>0.5</MinArmorPct><!-- The default minimal armor percentage for all armor kinds. Will be overriden by any below -->
 				<!-- <MinArmorValueSharp>14</MinArmorValueSharp>
 				<MinArmorValueBlunt>30</MinArmorValueBlunt>

--- a/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
@@ -195,8 +195,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>366</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 				<MinArmorValueSharp>12</MinArmorValueSharp>
 				<MinArmorValueBlunt>27</MinArmorValueBlunt>
@@ -400,8 +398,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>116</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -432,8 +428,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>100</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -535,8 +529,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>100</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
@@ -641,8 +633,6 @@
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
-				<CanOverHeal>true</CanOverHeal>
-				<MaxOverHeal>188</MaxOverHeal>
 				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>

--- a/Source/CombatExtended/CombatExtended/Comps/CompArmorDurability.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompArmorDurability.cs
@@ -277,9 +277,11 @@ namespace CombatExtended
 
         public float RepairValue;
 
+        //TO-DO: To be removed in RimWorld 1.6
         [Obsolete("This field is deprecated and no longer functions. Will be removed in future versions.")]
         public bool CanOverHeal;
 
+        //TO-DO: To be removed in RimWorld 1.6
         [Obsolete("This field is deprecated and no longer functions. Will be removed in future versions.")]
         public float MaxOverHeal;
 

--- a/Source/CombatExtended/CombatExtended/Comps/CompArmorDurability.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompArmorDurability.cs
@@ -181,7 +181,7 @@ namespace CombatExtended
                 yield break;
             }
 
-            if (this.curDurability >= maxDurability + durabilityProps.MaxOverHeal)
+            if (this.curDurability >= maxDurability)
             {
                 yield return new FloatMenuOption("CE_ArmorDurability_CannotRepairUndamaged".Translate(), null);
                 yield break;
@@ -421,28 +421,13 @@ namespace CombatExtended
                     second?.SplitOff(countC).Destroy();
 
                     natArmor.curDurability += natArmor.durabilityProps.RepairValue;
-                    if (natArmor.durabilityProps.CanOverHeal)
+                    if (natArmor.curDurability > natArmor.maxDurability)
                     {
-                        if (natArmor.curDurability > natArmor.durabilityProps.MaxOverHeal + natArmor.maxDurability)
-                        {
-                            natArmor.curDurability = natArmor.maxDurability + natArmor.durabilityProps.MaxOverHeal;
-                        }
-                        else
-                        {
-                            natArmor.curDurability += natArmor.durabilityProps.RepairValue;
-                        }
-
+                        natArmor.curDurability = natArmor.maxDurability;
                     }
                     else
                     {
-                        if (natArmor.curDurability > natArmor.maxDurability)
-                        {
-                            natArmor.curDurability = natArmor.maxDurability;
-                        }
-                        else
-                        {
-                            natArmor.curDurability += natArmor.durabilityProps.RepairValue;
-                        }
+                        natArmor.curDurability += natArmor.durabilityProps.RepairValue;
                     }
                 }
 

--- a/Source/CombatExtended/CombatExtended/Comps/CompArmorDurability.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompArmorDurability.cs
@@ -277,8 +277,10 @@ namespace CombatExtended
 
         public float RepairValue;
 
+        [Obsolete("This field is deprecated and no longer functions. Will be removed in future versions.")]
         public bool CanOverHeal;
 
+        [Obsolete("This field is deprecated and no longer functions. Will be removed in future versions.")]
         public float MaxOverHeal;
 
         public float MinArmorValueSharp = -1;

--- a/Source/CombatExtended/CombatExtended/Comps/CompArmorDurability.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompArmorDurability.cs
@@ -427,10 +427,6 @@ namespace CombatExtended
                     {
                         natArmor.curDurability = natArmor.maxDurability;
                     }
-                    else
-                    {
-                        natArmor.curDurability += natArmor.durabilityProps.RepairValue;
-                    }
                 }
 
             });


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Removes natural armor overheal code.
- Marks MaxOverheal and CanOverheal fields as obsolete to prevent errors. Pending removal in 1.6
- Removes overheal from XML patches

## Reasoning

Why did you choose to implement things this way, e.g.
- Un-intuitive
- Dev Channel Convo
- Fixes occasional bugs from overhealing

## Alternatives

Describe alternative implementations you have considered, e.g.
- Leave it be

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (tested with save including already overhealed mechs.)
