### PR TITLE
Bugfix - Advanced Bionics Expansion -  Advanced Power leg

### DIFF
--- a/ModPatches/FSF Advanced Bionics Expansion/Patches/FSF Advanced Bionics Expansion/HediffDefs/FSFAdvancedBionics_AddedParts.xml
+++ b/ModPatches/FSF Advanced Bionics Expansion/Patches/FSF Advanced Bionics Expansion/HediffDefs/FSFAdvancedBionics_AddedParts.xml
@@ -49,6 +49,53 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/HediffDef[defName="FSFAdvBionicPowerLeg"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>foot</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>15</power>
+					<cooldownTime>1.21</cooldownTime>
+					<armorPenetrationSharp>0</armorPenetrationSharp>
+					<armorPenetrationBlunt>30</armorPenetrationBlunt>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+					<soundMeleeHit>MeleeHit_BionicPunch</soundMeleeHit>
+					<soundMeleeMiss>MeleeMiss_BionicPunch</soundMeleeMiss>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>edge</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>25</power>
+					<cooldownTime>1.21</cooldownTime>
+					<armorPenetrationSharp>9</armorPenetrationSharp>
+					<armorPenetrationBlunt>6.25</armorPenetrationBlunt>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+					<soundMeleeHit>MeleeHit_BionicPunch</soundMeleeHit>
+					<soundMeleeMiss>MeleeMiss_BionicPunch</soundMeleeMiss>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>point</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>10</power>
+					<cooldownTime>1.21</cooldownTime>
+					<armorPenetrationSharp>18</armorPenetrationSharp>
+					<armorPenetrationBlunt>4.75</armorPenetrationBlunt>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+					<soundMeleeHit>MeleeHit_BionicPunch</soundMeleeHit>
+					<soundMeleeMiss>MeleeMiss_BionicPunch</soundMeleeMiss>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="FSFArchotechPowerArm"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
 		<value>
 			<tools>


### PR DESCRIPTION
## Changes

Copies the Advanced Power Arm's melee attack definitions and assigns them to the Advanced Power Leg, so that it doesn't produce a Null Reference Exception and dissapear during regular play.

## Reasoning

Since in the mod, the Advanced Power Arm and Advanced Power Leg have the exact same stats, I just copied over the existing patched melee attacks to the leg bionic.

## Testing

Check tests you have performed:
- [] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)


Tested by modifying the XML locally and seeing the leg attack properly and not dissapear.
This is my first time attempting a CE patch so I am not sure if a pure XML change like this needs another kind of test? Do I need to compile it somehow? Please let me know if anything is lacking or wrong, thank you.