### PR TITLE
Stop scars from applying venom buildup

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/HediffComp_Venom.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/HediffComp_Venom.cs
@@ -36,5 +36,12 @@ namespace CombatExtended
             base.CompTended(quality, maxQuality, batchPosition);
             _venomPerTick *= 1 - quality;
         }
+
+        public override void CompExposeData()
+        {
+            base.CompExposeData();
+            Scribe_Values.Look(ref _venomPerTick, "venomPerTick");
+            Scribe_Values.Look(ref _lifetime, "lifetime");
+        }
     }
 }

--- a/Source/CombatExtended/CombatExtended/Comps/HediffComp_Venom.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/HediffComp_Venom.cs
@@ -8,6 +8,7 @@ namespace CombatExtended
     {
         private float _venomPerTick;
         private int _lifetime;
+        private bool? _isPermanent;
 
         public HediffCompProperties_Venom Props => props as HediffCompProperties_Venom;
 
@@ -21,8 +22,10 @@ namespace CombatExtended
 
         public override void CompPostTick(ref float severityAdjustment)
         {
+            _isPermanent ??= parent.IsPermanent();
+            
             base.CompPostTick(ref severityAdjustment);
-            if (parent.ageTicks < _lifetime)
+            if (parent.ageTicks < _lifetime && !_isPermanent.Value)
             {
                 HealthUtility.AdjustSeverity(parent.pawn, CE_HediffDefOf.VenomBuildup, _venomPerTick);
             }

--- a/Source/CombatExtended/CombatExtended/Comps/HediffComp_Venom.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/HediffComp_Venom.cs
@@ -23,7 +23,7 @@ namespace CombatExtended
         public override void CompPostTick(ref float severityAdjustment)
         {
             _isPermanent ??= parent.IsPermanent();
-            
+
             base.CompPostTick(ref severityAdjustment);
             if (parent.ageTicks < _lifetime && !_isPermanent.Value)
             {


### PR DESCRIPTION
## Changes

- Scars no longer build up venom, as it was unable to be tended.
- Additionally changed the lifetime and venomPerTick values to be saved.

## Reasoning

- Permanent comp lookup is cached by Viral's suggestion

## References

- Related report: https://discord.com/channels/278818534069501953/303988654492090370/1366153391893385388

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] It works
