### PR TITLE
Forced Shield Material/Color

### DIFF
--- a/Royalty/Patches/PawnKindDefs_Royalty/PawnKinds_Royalty.xml
+++ b/Royalty/Patches/PawnKindDefs_Royalty/PawnKinds_Royalty.xml
@@ -157,11 +157,12 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<shieldMoney>
-					<min>400</min>
+					<min>620</min>
 					<max>1200</max>
 				</shieldMoney>
 				<shieldTags>
 					<li>OutlanderShield</li>
+					<li>TribalShield</li>
 				</shieldTags>
 				<forceShieldMaterial>true</forceShieldMaterial> 
 				<shieldMaterialFilter>

--- a/Royalty/Patches/PawnKindDefs_Royalty/PawnKinds_Royalty.xml
+++ b/Royalty/Patches/PawnKindDefs_Royalty/PawnKinds_Royalty.xml
@@ -158,12 +158,11 @@
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<shieldMoney>
 					<min>400</min>
-					<max>1000</max>
+					<max>1200</max>
 				</shieldMoney>
 				<shieldTags>
 					<li>OutlanderShield</li>
 				</shieldTags>
-				<!--
 				<forceShieldMaterial>true</forceShieldMaterial> 
 				<shieldMaterialFilter>
 					<thingDefs>
@@ -171,7 +170,6 @@
 					</thingDefs>
 				</shieldMaterialFilter>				
 				<shieldChance>0.75</shieldChance>
-				-->
 			</li>
 		</value>
 	</Operation>
@@ -388,20 +386,18 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<shieldMoney>
-					<min>400</min>
-					<max>1000</max>
+					<min>600</min>
+					<max>1600</max>
 				</shieldMoney>
 				<shieldTags>
 					<li>OutlanderShield</li>
 				</shieldTags>
-				<!--
 				<forceShieldMaterial>true</forceShieldMaterial> 
 				<shieldMaterialFilter>
 					<thingDefs>
 						<li>Plasteel</li>
 					</thingDefs>
 				</shieldMaterialFilter>
-				-->					
 				<shieldChance>0.5</shieldChance>
 			</li>
 		</value>

--- a/Royalty/Patches/PawnKindDefs_Royalty/PawnKinds_Royalty.xml
+++ b/Royalty/Patches/PawnKindDefs_Royalty/PawnKinds_Royalty.xml
@@ -387,7 +387,7 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<shieldMoney>
-					<min>600</min>
+					<min>1000</min>
 					<max>1600</max>
 				</shieldMoney>
 				<shieldTags>

--- a/Royalty/Patches/PawnKindDefs_Royalty/PawnKinds_Royalty.xml
+++ b/Royalty/Patches/PawnKindDefs_Royalty/PawnKinds_Royalty.xml
@@ -163,7 +163,15 @@
 				<shieldTags>
 					<li>OutlanderShield</li>
 				</shieldTags>
+				<!--
+				<forceShieldMaterial>true</forceShieldMaterial> 
+				<shieldMaterialFilter>
+					<thingDefs>
+						<li>Plasteel</li>
+					</thingDefs>
+				</shieldMaterialFilter>				
 				<shieldChance>0.75</shieldChance>
+				-->
 			</li>
 		</value>
 	</Operation>
@@ -386,6 +394,14 @@
 				<shieldTags>
 					<li>OutlanderShield</li>
 				</shieldTags>
+				<!--
+				<forceShieldMaterial>true</forceShieldMaterial> 
+				<shieldMaterialFilter>
+					<thingDefs>
+						<li>Plasteel</li>
+					</thingDefs>
+				</shieldMaterialFilter>
+				-->					
 				<shieldChance>0.5</shieldChance>
 			</li>
 		</value>

--- a/Source/CombatExtended/CombatExtended/DefUtility.cs
+++ b/Source/CombatExtended/CombatExtended/DefUtility.cs
@@ -81,6 +81,12 @@ namespace CombatExtended
             {
                 def.PrepareStats();
             }
+
+            // Process all pawnKindDefs for shield filter
+            foreach (PawnKindDef def in DefDatabase<PawnKindDef>.AllDefs.Where(t => t.HasModExtension<LoadoutPropertiesExtension>()))
+            {
+               ProcessLoadoutPropertiesExenstionCE(def);
+            }
         }
 
         /// <summary>
@@ -247,7 +253,7 @@ namespace CombatExtended
         }
 
         /// <summary>
-        /// Perpare the ThingDefExtensionCE.
+        /// Prepare the ThingDefExtensionCE.
         /// </summary>
         /// <param name="def">ThingDef with </param>
         private static void ProcessThingDefExtensionCE(ThingDef def)
@@ -257,6 +263,20 @@ namespace CombatExtended
             if (ext != null)
             {
                 isMenuHiddenArray[def.index] = ext.MenuHidden;
+            }
+        }
+        
+        /// <summary>
+        /// Process pawnKindDefs loadout properties filters
+        /// </summary>
+        /// <param name="def">PawnKindDef</param>
+        private static void ProcessLoadoutPropertiesExenstionCE(PawnKindDef def)
+        {
+            LoadoutPropertiesExtension ext = def.GetModExtension<LoadoutPropertiesExtension>();
+
+            if (ext != null && ext.shieldMaterialFilter != null)
+            {
+                ext.shieldMaterialFilter.ResolveReferences();
             }
         }
 

--- a/Source/CombatExtended/CombatExtended/DefUtility.cs
+++ b/Source/CombatExtended/CombatExtended/DefUtility.cs
@@ -85,7 +85,7 @@ namespace CombatExtended
             // Process all pawnKindDefs for shield filter
             foreach (PawnKindDef def in DefDatabase<PawnKindDef>.AllDefs.Where(t => t.HasModExtension<LoadoutPropertiesExtension>()))
             {
-               ProcessLoadoutPropertiesExenstionCE(def);
+                ProcessLoadoutPropertiesExenstionCE(def);
             }
         }
 
@@ -265,7 +265,7 @@ namespace CombatExtended
                 isMenuHiddenArray[def.index] = ext.MenuHidden;
             }
         }
-        
+
         /// <summary>
         /// Process pawnKindDefs loadout properties filters
         /// </summary>

--- a/Source/CombatExtended/CombatExtended/Defs/LoadoutPropertiesExtension.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/LoadoutPropertiesExtension.cs
@@ -22,6 +22,7 @@ namespace CombatExtended
         public SidearmOption forcedSidearm;
         public List<SidearmOption> sidearms;
         public AmmoCategoryDef forcedAmmoCategory;
+        public List<ThingDef> forcedShieldMaterial;
 
         private static List<ThingStuffPair> allWeaponPairs;
         private static List<ThingStuffPair> allShieldPairs;
@@ -311,7 +312,8 @@ namespace CombatExtended
                         && shieldTags.Any(t => cur.thing.apparel.tags.Contains(t))
                         && (cur.thing.generateAllowChance >= 1f || Rand.ValueSeeded(pawn.thingIDNumber ^ 68715844) <= cur.thing.generateAllowChance)
                         && pawn.apparel.CanWearWithoutDroppingAnything(cur.thing)
-                        && ApparelUtility.HasPartsToWear(pawn, cur.thing))
+                        && ApparelUtility.HasPartsToWear(pawn, cur.thing)
+                        && (forcedShieldMaterial.NullOrEmpty() || forcedShieldMaterial.Contains(cur.stuff)))
                 {
                     workingShields.Add(cur);
                 }
@@ -320,12 +322,11 @@ namespace CombatExtended
             {
                 return;
             }
-            ThingStuffPair pair;
-            if (workingShields.TryRandomElementByWeight(p => p.Commonality * p.Price, out pair))
+            if (workingShields.TryRandomElementByWeight(p => p.Commonality * p.Price, out ThingStuffPair pair))
             {
                 var shield = (Apparel)ThingMaker.MakeThing(pair.thing, pair.stuff);
-                int count;
-                if (inventory.CanFitInInventory(shield, out count, false, true))
+                shield.SetColor(pawn.kindDef.apparelColor, reportFailure: false);
+                if (inventory.CanFitInInventory(shield, out int count, false, true))
                 {
                     pawn.apparel.Wear(shield);
                 }

--- a/Source/CombatExtended/CombatExtended/Defs/LoadoutPropertiesExtension.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/LoadoutPropertiesExtension.cs
@@ -314,7 +314,7 @@ namespace CombatExtended
                         && (cur.thing.generateAllowChance >= 1f || Rand.ValueSeeded(pawn.thingIDNumber ^ 68715844) <= cur.thing.generateAllowChance)
                         && pawn.apparel.CanWearWithoutDroppingAnything(cur.thing)
                         && ApparelUtility.HasPartsToWear(pawn, cur.thing)
-                        && (forceShieldMaterial && shieldMaterialFilter != null && shieldMaterialFilter.Allows(cur.thing)))
+                        && (!forceShieldMaterial || (forceShieldMaterial && shieldMaterialFilter != null && shieldMaterialFilter.Allows(cur.stuff))))
                 {
                     workingShields.Add(cur);
                 }

--- a/Source/CombatExtended/CombatExtended/Defs/LoadoutPropertiesExtension.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/LoadoutPropertiesExtension.cs
@@ -22,7 +22,8 @@ namespace CombatExtended
         public SidearmOption forcedSidearm;
         public List<SidearmOption> sidearms;
         public AmmoCategoryDef forcedAmmoCategory;
-        public List<ThingDef> forcedShieldMaterial;
+        public bool forceShieldMaterial;
+        public ThingFilter shieldMaterialFilter;
 
         private static List<ThingStuffPair> allWeaponPairs;
         private static List<ThingStuffPair> allShieldPairs;
@@ -313,7 +314,7 @@ namespace CombatExtended
                         && (cur.thing.generateAllowChance >= 1f || Rand.ValueSeeded(pawn.thingIDNumber ^ 68715844) <= cur.thing.generateAllowChance)
                         && pawn.apparel.CanWearWithoutDroppingAnything(cur.thing)
                         && ApparelUtility.HasPartsToWear(pawn, cur.thing)
-                        && (forcedShieldMaterial.NullOrEmpty() || forcedShieldMaterial.Contains(cur.stuff)))
+                        && (forceShieldMaterial && shieldMaterialFilter != null && shieldMaterialFilter.Allows(cur.thing)))
                 {
                     workingShields.Add(cur);
                 }


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Adds ability to force pawnKindDef shields to generate with select material
- Shield setColor according to their pawnKindDef apparelColor
- Filter resolved during startup so not to have any impact during play

Example:

```
<li Class="CombatExtended.LoadoutPropertiesExtension">
	<shieldMoney>100~350</shieldMoney>
	<shieldTags>
		<li>Shield</li>
		<li>BiggerShield</li>
		<li>BiggestShield</li>
	</shieldTags>
 	<forceShieldMaterial>true</forceShieldMaterial> 
	<shieldMaterialFilter>
		<thingDefs>
			<li>WoodLog</li>
		</thingDefs>
  		<categories>
			<li>Steeled</li>
		</categories>
	</shieldMaterialFilter>
	<shieldChance>0.35</shieldChance>
</li>
```

## Reasoning

Why did you choose to implement things this way, e.g.
- Ability to force material requirements bring shield generation inline with other apparel
- Shield being set to the pawnKindDef's apparelColor would bring shield generation inline with other apparel

## Alternatives

Describe alternative implementations you have considered, e.g.
- Wood shields on Ancient God Kings

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (Generated pawns with shields)
