### PR TITLE
Add tools to Rimsenal smart grenades

### DIFF
--- a/ModPatches/Rimsenal - Spacer Faction Pack/Patches/Rimsenal - Spacer Faction Pack/Explosives_Smart_CE.xml
+++ b/ModPatches/Rimsenal - Spacer Faction Pack/Patches/Rimsenal - Spacer Faction Pack/Explosives_Smart_CE.xml
@@ -172,7 +172,7 @@
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
-					<label>Body</label>
+					<label>body</label>
 					<capacities>
 						<li>Blunt</li>
 					</capacities>

--- a/ModPatches/Rimsenal - Spacer Faction Pack/Patches/Rimsenal - Spacer Faction Pack/Explosives_Smart_CE.xml
+++ b/ModPatches/Rimsenal - Spacer Faction Pack/Patches/Rimsenal - Spacer Faction Pack/Explosives_Smart_CE.xml
@@ -167,4 +167,22 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Weapon_GrenadeSmart"]</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>Body</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>2</power>
+					<cooldownTime>1.75</cooldownTime>
+					<armorPenetrationBlunt>1.0</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Base</linkedBodyPartsGroup>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
 </Patch>


### PR DESCRIPTION
## Changes

- Added tools to smart grenades from Rimsenal spacer

## References

- Fixes #3559 

## Reasoning

- We patch vanilla nades to have tools

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
