### PR TITLE
CIWS projectile destroying changes

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -34,7 +34,6 @@ namespace CombatExtended
         public int fuelTicks;
         public Vector3 velocity;
         public float initialSpeed;
-        public bool isCIWS = false;
         #endregion
 
         #region Drawing
@@ -1184,14 +1183,6 @@ namespace CombatExtended
             {
                 Destroy(DestroyMode.Vanish);
                 return;
-            }
-            if (isCIWS && !(TrajectoryWorker is BallisticsTrajectoryWorker) && intendedTarget.ThingDestroyed)
-            {
-                if (shotAngle > 0.7853f) // 45 degrees
-                {
-                    Destroy(DestroyMode.Vanish);
-                    return;
-                }
             }
 
             TrajectoryWorker.NotifyTicked(this);

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_CIWS.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_CIWS.cs
@@ -63,6 +63,14 @@ namespace CombatExtended
         public override Quaternion ExactRotation => DrawRotation;
         public override void Tick()
         {
+            if (!(TrajectoryWorker is BallisticsTrajectoryWorker) && intendedTarget.ThingDestroyed)
+            {
+                if (shotAngle > 0.7853f) // 45 degrees
+                {
+                    Destroy(DestroyMode.Vanish);
+                    return;
+                }
+            }
             ticksToImpact++; //do not allow it hit zero
             base.Tick();
             TryCollideWith(intendedTargetThing);

--- a/Source/CombatExtended/CombatExtended/Verbs/VerbCIWS.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/VerbCIWS.cs
@@ -93,13 +93,11 @@ namespace CombatExtended
                 var thing = new ProjectileCE_CIWS();
                 thing.forcedTrajectoryWorker = TrajectoryWorker;
                 thing.def = def;
-                thing.isCIWS = true;
                 thing.PostMake();
                 thing.PostPostMake();
                 return thing;
             }
             var projectile = base.SpawnProjectile();
-            projectile.isCIWS = true;
             return projectile;
         }
         static BaseTrajectoryWorker lerpedTrajectoryWorker = new LerpedTrajectoryWorker_ExactPosDrawing();


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Removed isCIWS field
- Moved CIWS projectile destroying to ProjectileCE_CIWS

## Reasoning

Why did you choose to implement things this way, e.g.
- CIWS projectile must use ProjectileCE_CIWS (or subclass)
- Less checks for regular projectiles

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] Playtested a colony ()
