### PR TITLE
Add null-check to barrel offset extension

### DIFF
--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -66,7 +66,7 @@ namespace CombatExtended
 
         public VerbPropertiesCE VerbPropsCE => verbProps as VerbPropertiesCE;
         public ProjectilePropertiesCE projectilePropsCE => Projectile.projectile as ProjectilePropertiesCE;
-        public MultiBarrelExtension multiBarrelExt => EquipmentSource.def.GetModExtension<MultiBarrelExtension>();
+        public MultiBarrelExtension multiBarrelExt => EquipmentSource?.def.GetModExtension<MultiBarrelExtension>();
 
         // Returns either the pawn aiming the weapon or in case of turret guns the turret operator or null if neither exists        
         public Pawn ShooterPawn => CasterPawn ?? CE_Utility.TryGetTurretOperator(caster);


### PR DESCRIPTION
## Changes

- The barrel ext getter in LaunchProjectileCE now null-checks the equipment source, for attacks made without a weapon.

## References

- Closes #3814 

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (one dev entity raid)
