### PR TITLE
Init a default UBGL ammo def

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmosetSwitcher.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmosetSwitcher.cs
@@ -125,7 +125,7 @@ namespace CombatExtended
                 mainGunLoadedAmmo = CompAmmo.CurrentAmmo;
                 mainGunMagCount = CompAmmo.CurMagCount;
                 CompAmmo.CurMagCount = UnderBarrelMagCount;
-                CompAmmo.CurrentAmmo = UnderBarrelLoadedAmmo;
+                CompAmmo.CurrentAmmo = UnderBarrelLoadedAmmo ?? Props.propsUnderBarrel.ammoSet.ammoTypes[0].ammo; //same as AmmoUser's init
                 CompAmmo.SelectedAmmo = CompAmmo.CurrentAmmo;
             }
             CompAmmo.props = this.Props.propsUnderBarrel;


### PR DESCRIPTION
## Changes

- Switching to UBGL for the first time initializes the selected ammo type to the first option, imitating CompAmmoUser's initialization

## References

- Technically closes #3459 
	- The bug only happens if using the devmode option to fill the magazine. Loading it using ammo items doesn't cause it and using the devmode option after that also works as intended.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors