### PR TITLE
Draw CIWS Projectiles using standard camera perspective. 

### DIFF
--- a/Defs/Ammo/Advanced/8x35mmCharged.xml
+++ b/Defs/Ammo/Advanced/8x35mmCharged.xml
@@ -148,7 +148,7 @@
       </secondaryDamage>
       <armorPenetrationSharp>16</armorPenetrationSharp>
       <armorPenetrationBlunt>57.6</armorPenetrationBlunt>
-      <trajectoryWorker>CombatExtended.LerpedTrajectoryWorker_ExactPosDrawing</trajectoryWorker>
+      <trajectoryWorker>CombatExtended.LerpedTrajectoryWorker</trajectoryWorker>
     </projectile>
   </ThingDef>
 

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -248,10 +248,15 @@ namespace CombatExtended
         /// <summary>
         /// Based on equations of motion
         /// </summary>
+        private Quaternion? _drawRotation = null;
         public virtual Quaternion DrawRotation
         {
             get
             {
+                if (_drawRotation != null)
+                {
+                    return (Quaternion)_drawRotation;
+                }
                 Vector2 w = (Destination - origin);
 
                 var vx = w.x / startingTicksToImpact;
@@ -1199,6 +1204,7 @@ namespace CombatExtended
             ticksToImpact--;
             FlightTicks++;
             Vector3 nextPosition = MoveForward();
+            _drawRotation = Quaternion.LookRotation(nextPosition - ExactPosition);
 
             if (!nextPosition.InBounds(Map))
             {

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_CIWS.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_CIWS.cs
@@ -53,13 +53,6 @@ namespace CombatExtended
         public virtual float ImpactChance => (def.projectile as ProjectilePropertiesCE)?.impactChance ?? 1f;
         protected override bool ShouldCollideWithSomething => ExactPosition.y <= 0f;
 
-        public override Quaternion DrawRotation
-        {
-            get
-            {
-                return Quaternion.LookRotation((PredictedPositions.FirstOrDefault() - ExactPosition).Yto0());
-            }
-        }
         public override Quaternion ExactRotation => DrawRotation;
         public override void Tick()
         {

--- a/Source/CombatExtended/CombatExtended/Verbs/VerbCIWS.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/VerbCIWS.cs
@@ -102,7 +102,7 @@ namespace CombatExtended
             projectile.isCIWS = true;
             return projectile;
         }
-        static BaseTrajectoryWorker lerpedTrajectoryWorker = new LerpedTrajectoryWorker_ExactPosDrawing();
+        static BaseTrajectoryWorker lerpedTrajectoryWorker = new LerpedTrajectoryWorker();
         protected BaseTrajectoryWorker TrajectoryWorker
         {
             get


### PR DESCRIPTION
## Changes

CIWS projectiles are drawn with the same 57 degree camera projection.
Draw all projectiles' rotation based on its actual movement, once we have it. Falling back to a reasonable estimate before the projectile first moves.

## Reasoning

Currently, CIWS projectiles are drawn using a top-down perspective, without distance scaling.  This makes it impossible to judge their height visually, hides their shadows, and makes them *look* like they are skimming across the ground.  Since we want them to visually intercept projectiles at the same time as they mechanically intercept them, they need to be drawn with the same camera properties as their target.

## Alternatives

Change the camera perspective for all projectiles.
Let them look odd.

## Future Work

Once we are satisfied with how skyfallers are drawn, CIWS projectiles targeting skyfallers should adjust their virtual camera to match the camera properties of their target.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
