### PR TITLE
Fix Duplicate Float Menu

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_FloatMenuMakerMap.cs
+++ b/Source/CombatExtended/Harmony/Harmony_FloatMenuMakerMap.cs
@@ -234,6 +234,7 @@ namespace CombatExtended.HarmonyCE
                     codes[i + 3].opcode = OpCodes.Ldc_I4_1;
                     codes[i + 3].operand = null;
                     foundCaravanInjection = true;
+                    break;
                 }
             }
             if (!foundCaravanInjection)


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Fixes duplicate float menu while on ambush map
![image](https://github.com/user-attachments/assets/917050af-57f2-4ed4-b865-f24c2943fa1b)

## Reasoning

Why did you choose to implement things this way, e.g.
- Forcing true bypasses vanilla float menu without removing it's code

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #938 
- Closes #1277

## Alternatives

Describe alternative implementations you have considered, e.g.
- Duplicate float menu

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Tested on home map and ambush)
