### PR TITLE
Rework effects of venom

### DIFF
--- a/Defs/HediffDefs/Hediffs_CE.xml
+++ b/Defs/HediffDefs/Hediffs_CE.xml
@@ -155,6 +155,11 @@
 			<li Class="HediffCompProperties_Immunizable">
 				<severityPerDayNotImmune>-0.08</severityPerDayNotImmune>
 			</li>
+			<li Class="HediffCompProperties_MessageAfterTicks">
+				<ticks>100</ticks>
+				<message>{0} is poisoned!</message>
+				<messageType>NegativeHealthEvent</messageType>
+			  </li>
 		</comps>
 		<stages>
 			<li>

--- a/Defs/HediffDefs/Hediffs_CE.xml
+++ b/Defs/HediffDefs/Hediffs_CE.xml
@@ -147,7 +147,7 @@
 		<hediffClass>HediffWithComps</hediffClass>
 		<defaultLabelColor>(0.7, 1.0, 0.7)</defaultLabelColor>
 		<label>venom buildup</label>
-		<description>Venom building up</description>
+		<description>Venom building up. Severity will continue to progress until all venomous wounds are treated.</description>
 		<lethalSeverity>1</lethalSeverity>
 		<makesSickThought>true</makesSickThought>
 		<scenarioCanAdd>true</scenarioCanAdd>
@@ -156,7 +156,7 @@
 				<severityPerDayNotImmune>-0.08</severityPerDayNotImmune>
 			</li>
 			<li Class="HediffCompProperties_MessageAfterTicks">
-				<ticks>100</ticks>
+				<ticks>200</ticks>
 				<message>{0} is poisoned!</message>
 				<messageType>NegativeHealthEvent</messageType>
 			  </li>
@@ -171,16 +171,20 @@
 				<minSeverity>0.05</minSeverity>
 				<capMods>
 					<li>
+						<capacity>Sight</capacity>
+						<offset>-0.35</offset>
+					</li>
+					<li>
 						<capacity>Consciousness</capacity>
 						<offset>-0.05</offset>
 					</li>
 					<li>
 						<capacity>Breathing</capacity>
-						<offset>-0.05</offset>
+						<offset>-0.1</offset>
 					</li>
 					<li>
 						<capacity>BloodPumping</capacity>
-						<offset>-0.05</offset>
+						<offset>-0.1</offset>
 					</li>
 				</capMods>
 			</li>
@@ -189,16 +193,20 @@
 				<minSeverity>0.2</minSeverity>
 				<capMods>
 					<li>
+						<capacity>Sight</capacity>
+						<offset>-0.65</offset>
+					</li>
+					<li>
 						<capacity>Consciousness</capacity>
 						<offset>-0.05</offset>
 					</li>
 					<li>
 						<capacity>Breathing</capacity>
-						<offset>-0.15</offset>
+						<offset>-0.3</offset>
 					</li>
 					<li>
 						<capacity>BloodPumping</capacity>
-						<offset>-0.15</offset>
+						<offset>-0.3</offset>
 					</li>
 				</capMods>
 			</li>
@@ -208,16 +216,24 @@
 				<vomitMtbDays>2</vomitMtbDays>
 				<capMods>
 					<li>
+						<capacity>Sight</capacity>
+						<offset>-0.8</offset>
+					</li>
+					<li>
 						<capacity>Consciousness</capacity>
-						<offset>-0.05</offset>
+						<setMax>0.7</setMax>
+					</li>
+					<li>
+						<capacity>Moving</capacity>
+						<offset>-0.25</offset>
 					</li>
 					<li>
 						<capacity>Breathing</capacity>
-						<offset>-0.3</offset>
+						<offset>-0.6</offset>
 					</li>
 					<li>
 						<capacity>BloodPumping</capacity>
-						<offset>-0.3</offset>
+						<offset>-0.6</offset>
 					</li>
 				</capMods>
 			</li>
@@ -227,16 +243,24 @@
 				<vomitMtbDays>1</vomitMtbDays>
 				<capMods>
 					<li>
+						<capacity>Sight</capacity>
+						<offset>-0.95</offset>
+					</li>
+					<li>
+						<capacity>Moving</capacity>
+						<offset>-0.45</offset>
+					</li>
+					<li>
 						<capacity>Consciousness</capacity>
-						<offset>-0.05</offset>
+						<setMax>0.5</setMax>
 					</li>
 					<li>
 						<capacity>Breathing</capacity>
-						<offset>-0.6</offset>
+						<offset>-0.8</offset>
 					</li>
 					<li>
 						<capacity>BloodPumping</capacity>
-						<offset>-0.6</offset>
+						<offset>-0.8</offset>
 					</li>
 				</capMods>
 			</li>
@@ -246,8 +270,12 @@
 				<vomitMtbDays>0.5</vomitMtbDays>
 				<capMods>
 					<li>
+						<capacity>Sight</capacity>
+						<offset>-1</offset>
+					</li>
+					<li>
 						<capacity>Consciousness</capacity>
-						<offset>-0.05</offset>
+						<setMax>0.1</setMax>
 					</li>
 					<li>
 						<capacity>Breathing</capacity>


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Adds a notification when a colonist is poisoned
- Adds a tooltip text to venom build up hediff, explaining how to cure it.

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Changed the effects of venom buildup hediff, caused by venom arrows and snake bites. In particular:
- `Extreme` poisoning now caps conciousness to 10%. Instead of skipping away merrily, extremely poisoned raiders now always get downed.
- Changed conciousness debuff of -0.05 for all stages to be much more aggressive. It's starts being noticeable from `moderate` stage, capping conc at max 70%, then is max 40% at `severe` and max 10% at `extreme`. This is the biggest debuffs of the hediff, as blood pumping and breathing don't actually impact conciousness that much. Which leaves raiders perfectly able to fight back. All vanilla hediffs instead cap conciousness manually.
- Added a sight debuff to venom. This allows venom to be useful in the early stages of poisoning, by disabling ranged enemies. It starts off at a noticeable -35% at the first stage, and progresses to -80% at moderate and -95% at severe. This does not stop AI from dumping bullets at you, but at least they are likely to miss.
- Doubled the effects of breathing+bloodpumping debuffs. This way, they actually cause pawns to drop sometimes. Generally, most downs will be caused by decreased conciousness and movement, but sometimes, when a lung or liver is hit, or for sick pawns, these will cause them to get downed a little earlier, in moderate-severe stages.
- Added a movement debuff to `moderate` and `severe` stages. This is mostly to slow down melee enemies a bit, and also cause weaker pawns to start crawling at `severe` stage, taking them out of the fight and forcing to go to safety.

## References

Links to the associated issues or other related pull requests, e.g.
- Discord discussion and testing:
- [Part 1](https://discord.com/channels/278818534069501953/303988654492090370/1365774001506488370). [Part 2](https://discord.com/channels/278818534069501953/303988654492090370/1366146764608114718) 

## Reasoning

Why did you choose to implement things this way, e.g.
- Currently, venom arrows is a terrible ammo type. It costs 3 herbal medicine for 10 shots, and medicine is always very valuable. And even then, it kills raiders very slowly. It takes around 2.5 ingame hours for an average pawn to die from venom. Which is actually good if the victim is your colonist, but completely useless if you are trying to use it against raiders.
- The direct competitor of venom arrows are steel arrows. They have identical damage and penetration, but venom arrows are significantly more expensive. In close ranges, you will always kill enemies by shooting 5 arrows into them and causing lethal bleed out. By this time, venom build up will only get to a minor or moderate stage. So, crafting venom arrows is simply not worth it in this situation. 
- The only niche where venom arrows could dominate is medium-long range prolonged shootouts and capturing enemies alive. So, I didn't touch the speed at which venom accumulates. Instead, i've made the heavy stat debuffs appear sooner, so that you could use a venom arrow to disable an enemy that you cannot kill quick, or use them to capture and tend prisoners.

## Alternatives

Describe alternative implementations you have considered, e.g.
- Make venom kill faster. More unfair for player when 2% of tribal raiders have venom arrows, because it takes a long time to evac a colonist and heal them. Also doesn't solve the problem of bleedout via 5 steel arrows just being better. Makes any venom shot a death sentence.
- Make venom non-lethal, but with much accuracy debuffs right away. Kinda like xcom's thin man poison.
- Perhaps, add antivenom properties to some combat drug, allowing players to save fatally poisoned pawns.
- Instead of (or in addition to) toxic resistance, use immunity stat to counteract poison. Idea suggested by 3rdcrusade on discord.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
