### PR TITLE
Log version info on startup

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -8,7 +8,7 @@
 		<li>1.5</li>
 	</supportedVersions>
 	<packageId>CETeam.CombatExtended</packageId>
-        <modVersion>15.6.2.0</modVersion>
+	<modVersion>15.6.2.0</modVersion>
 	<description>Version: 15.6.2.0\n\nExtends combat mechanics to make them deeper and more tactical.</description>
 	<modIconPath IgnoreIfNoMatchingField="True">UI/Icons/CE_ModIcon_JustHat</modIconPath>
 	<modDependencies>

--- a/About/About.xml
+++ b/About/About.xml
@@ -8,6 +8,7 @@
 		<li>1.5</li>
 	</supportedVersions>
 	<packageId>CETeam.CombatExtended</packageId>
+        <modVersion>15.6.2.0</modVersion>
 	<description>Version: 15.6.2.0\n\nExtends combat mechanics to make them deeper and more tactical.</description>
 	<modIconPath IgnoreIfNoMatchingField="True">UI/Icons/CE_ModIcon_JustHat</modIconPath>
 	<modDependencies>

--- a/Source/CombatExtended/CombatExtended/Controller.cs
+++ b/Source/CombatExtended/CombatExtended/Controller.cs
@@ -48,6 +48,11 @@ namespace CombatExtended
 
         public Controller(ModContentPack content) : base(content)
         {
+            var author = content.ModMetaData.Authors.First();
+            var repo = content.ModMetaData.Url;
+            var version = content.ModMetaData.ModVersion;
+            var commit = VersionInfo.COMMIT;
+            Log.Message($"Loading Combat Extended {version} ({commit}):\nPlease report issues with CE to {author} at {repo}");
             patches = new Patches();
             Controller.instance = this;
             Controller.content = content;

--- a/Source/CombatExtended/Version.cs
+++ b/Source/CombatExtended/Version.cs
@@ -1,0 +1,7 @@
+namespace CombatExtended
+{
+    static class VersionInfo
+    {
+        public static string COMMIT = "UNKNOWN";
+    }
+}


### PR DESCRIPTION
## Additions

Logs version information, including partial commit hash, on startup.

## Reasoning

Mod versions aren't otherwise logged. Sometimes someone comes by with a local compiled version, or an *ancient* copy of CE, requesting help.  Logging the version info, including the ability to identify PR snapshot versions, will reduce the friction identifying old or broken installs.


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
