### PR TITLE
Fix IED shootability

### DIFF
--- a/ModPatches/Gas Traps and Shells/Patches/Gas Traps and Shells/Patch_Buildings_GasTrap.xml
+++ b/ModPatches/Gas Traps and Shells/Patches/Gas Traps and Shells/Patch_Buildings_GasTrap.xml
@@ -6,6 +6,7 @@
 		<xpath>Defs/ThingDef[defName="GasTrap"]/label</xpath>
 		<value>
 			<label>IED toxic gas trap</label>
+			<fillPercent>0.01</fillPercent>
 		</value>
 	</Operation>
 
@@ -13,6 +14,7 @@
 		<xpath>Defs/ThingDef[defName="GasTrapRage"]/label</xpath>
 		<value>
 			<label>IED rage gas trap</label>
+			<fillPercent>0.01</fillPercent>
 		</value>
 	</Operation>
 
@@ -20,6 +22,7 @@
 		<xpath>Defs/ThingDef[defName="GasTrapSleepGas"]/label</xpath>
 		<value>
 			<label>IED sleep gas trap</label>
+			<fillPercent>0.01</fillPercent>
 		</value>
 	</Operation>
 
@@ -27,6 +30,7 @@
 		<xpath>Defs/ThingDef[defName="GasTrapFearGas"]/label</xpath>
 		<value>
 			<label>IED fear gas trap</label>
+			<fillPercent>0.01</fillPercent>
 		</value>
 	</Operation>
 
@@ -34,6 +38,7 @@
 		<xpath>Defs/ThingDef[defName="GasTrapAcid"]/label</xpath>
 		<value>
 			<label>IED corrosive gas trap</label>
+			<fillPercent>0.01</fillPercent>
 		</value>
 	</Operation>
 
@@ -41,6 +46,7 @@
 		<xpath>Defs/ThingDef[defName="GasTrapMechanoidVirus"]/label</xpath>
 		<value>
 			<label>IED nanomachine trap</label>
+			<fillPercent>0.01</fillPercent>
 		</value>
 	</Operation>
 
@@ -48,6 +54,7 @@
 		<xpath>Defs/ThingDef[defName="GasTrapAntiBugGas"]/label</xpath>
 		<value>
 			<label>IED insecticide gas trap</label>
+			<fillPercent>0.01</fillPercent>
 		</value>
 	</Operation>
 

--- a/ModPatches/Nukes/Patches/Nukes/IEDs_Nuclear.xml
+++ b/ModPatches/Nukes/Patches/Nukes/IEDs_Nuclear.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[@Name="FusionIEDBase" or @Name="LargeNuclearIEDBase" or @Name="SmallNuclearIEDBase"]</xpath>
+		<value>
+			<fillPercent>0.01</fillPercent>
+		</value>
+	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="TrapIED_Fusion"]/costList</xpath>
 		<value>

--- a/ModPatches/Outer Rim - Core/Patches/Outer Rim - Core/Outer_Rim_Core_Mines.xml
+++ b/ModPatches/Outer Rim - Core/Patches/Outer Rim - Core/Outer_Rim_Core_Mines.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[@Name="OuterRimIEDBase"]</xpath>
+		<value>
+			<fillPercent>0.01</fillPercent>
+		</value>
+	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="OuterRim_Mine_Frag"]/comps/li[@Class="CompProperties_Explosive"]</xpath>
 		<value>

--- a/ModPatches/Remote Detonator/Patches/Remote Detonator/Remote_Detonator_CEpatch.xml
+++ b/ModPatches/Remote Detonator/Patches/Remote Detonator/Remote_Detonator_CEpatch.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[@Name="RD_IEDBase"]</xpath>
+		<value>
+			<fillPercent>0.01</fillPercent>
+		</value>
+	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RD_IED_HighExplosive"]/costList</xpath>
 		<value>

--- a/ModPatches/Vanilla Factions Expanded - Deserters/Patches/Vanilla Factions Expanded - Deserters/Things_Security.xml
+++ b/ModPatches/Vanilla Factions Expanded - Deserters/Patches/Vanilla Factions Expanded - Deserters/Things_Security.xml
@@ -16,6 +16,13 @@
 		</match>
 	</Operation>
 
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[@Name="VFED_RemoteChargeBase"]</xpath>
+		<value>
+			<fillPercent>0.01</fillPercent>
+		</value>
+	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="VFED_RemoteTrapIED_HighExplosive"]/comps/li[@Class="CompProperties_Explosive"]</xpath>
 		<value>

--- a/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
@@ -592,7 +592,7 @@
 	<!-- ========== Traps ========== -->
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[@Nam="TrapIEDBase"]</xpath>
+		<xpath>Defs/ThingDef[@Name="TrapIEDBase"]</xpath>
 		<value>
 			<fillPercent>0.01</fillPercent>
 		</value>

--- a/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
@@ -591,6 +591,13 @@
 
 	<!-- ========== Traps ========== -->
 
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[@Nam="TrapIEDBase"]</xpath>
+		<value>
+			<fillPercent>0.01</fillPercent>
+		</value>
+	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="TrapIED_HighExplosive"]/costList</xpath>
 		<value>

--- a/Source/CombatExtended/CombatExtended/SuppressionUtility.cs
+++ b/Source/CombatExtended/CombatExtended/SuppressionUtility.cs
@@ -173,11 +173,19 @@ namespace CombatExtended
                     cover = coverCell.GetCover(pawn.Map);
                 }
                 // Only account for solid cover;
-                if (cover != null && !(cover is Plant || cover is Gas))
+                if (cover != null)
                 {
-                    pawnCrouchFillPercent = Mathf.Clamp(cover.def.fillPercent + pawnVisibleOverCoverFillPercent, pawnLowestCrouchFillPercent, pawnHeightFactor);
-                    var coverRating = 1f - ((pawnCrouchFillPercent - cover.def.fillPercent) / pawnHeightFactor);
-                    cellRating = Mathf.Min(coverRating, 1f) * 10f;
+                    // Landmines would never be used for cover
+                    if (cover is Building_TrapExplosive)
+                    {
+                        return -1000f;
+                    }
+                    if (!(cover is Plant || cover is Gas))
+                    {
+                        pawnCrouchFillPercent = Mathf.Clamp(cover.def.fillPercent + pawnVisibleOverCoverFillPercent, pawnLowestCrouchFillPercent, pawnHeightFactor);
+                        var coverRating = 1f - ((pawnCrouchFillPercent - cover.def.fillPercent) / pawnHeightFactor);
+                        cellRating = Mathf.Min(coverRating, 1f) * 10f;
+                    }
                 }
             }
 

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -809,7 +809,8 @@ namespace CombatExtended
                     if (newCover != null
                             && (targetThing == null || !newCover.Equals(targetThing))
                             && newCover.def.Fillage == FillCategory.Partial
-                            && !newCover.IsPlant())
+                            && !newCover.IsPlant()
+                            && newCover is not Building_TrapExplosive)
                     {
                         float newCoverHeight = new CollisionVertical(newCover).Max;
 


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Allows them to be shot and remotely triggered by giving them a fillPercent to interact with CE bullet system
- Add fillPercent of 0.01 to vanilla mine abstract. 
- Adds fillPercent to patched modded mines that do not use vanilla base class as parent.

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Changes cover code to prevent Building_TrapExplosive from being appropriate cover
- Changes shooting to prevent Building_TrapExplosive being calculated as cover

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #2887 

## Reasoning

Why did you choose to implement things this way, e.g.
- Building is meant to be able to be triggered via bullets.
- Only added fillPercent to patched mines that had triggers tied to damageDefs

## Alternatives

Describe alternative implementations you have considered, e.g.
- No remote trigger

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Dev quicktest)
