### PR TITLE
Update mech ammo reclaim recipes

### DIFF
--- a/Defs/RecipeDefs/Recipes_Production.xml
+++ b/Defs/RecipeDefs/Recipes_Production.xml
@@ -151,7 +151,7 @@
 		</fixedIngredientFilter>
 		<products>
 			<Plasteel>5</Plasteel>
-			<Steel>20</Steel>
+			<Steel>10</Steel>
 		</products>
 		<recipeUsers Inherit="False">
 			<li>FabricationBench</li>

--- a/Defs/RecipeDefs/Recipes_Production.xml
+++ b/Defs/RecipeDefs/Recipes_Production.xml
@@ -84,8 +84,10 @@
 			<li>
 				<filter>
 					<thingDefs>
+						<li>Ammo_5x16mmCharged</li>
 						<li>Ammo_5x35mmCharged</li>
 						<li>Ammo_6x22mmCharged</li>
+						<li>Ammo_8x40mmCharged</li>
 						<li>Ammo_12x64mmCharged</li>
 						<li>Ammo_Mech_Charged</li>
 					</thingDefs>
@@ -95,8 +97,10 @@
 		</ingredients>
 		<fixedIngredientFilter>
 			<thingDefs>
+				<li>Ammo_5x16mmCharged</li>
 				<li>Ammo_5x35mmCharged</li>
 				<li>Ammo_6x22mmCharged</li>
+				<li>Ammo_8x40mmCharged</li>
 				<li>Ammo_12x64mmCharged</li>
 				<li>Ammo_Mech_Charged</li>
 			</thingDefs>
@@ -124,8 +128,10 @@
 			<li>
 				<filter>
 					<thingDefs>
+						<li>Ammo_5x16mmCharged</li>
 						<li>Ammo_5x35mmCharged</li>
 						<li>Ammo_6x22mmCharged</li>
+						<li>Ammo_8x40mmCharged</li>
 						<li>Ammo_12x64mmCharged</li>
 						<li>Ammo_Mech_Charged</li>
 					</thingDefs>
@@ -135,8 +141,10 @@
 		</ingredients>
 		<fixedIngredientFilter>
 			<thingDefs>
+				<li>Ammo_5x16mmCharged</li>
 				<li>Ammo_5x35mmCharged</li>
 				<li>Ammo_6x22mmCharged</li>
+				<li>Ammo_8x40mmCharged</li>
 				<li>Ammo_12x64mmCharged</li>
 				<li>Ammo_Mech_Charged</li>
 			</thingDefs>


### PR DESCRIPTION
## Changes

- What it says on the tin, added 5x16mm and 8x40mm mech ammo types to reclaim and recycle recipes.

## Reasoning

- None shall go to waste, those ammo types can potentially drop from modded mechs.

## Alternatives

- 5x50mm caseless too, but that doesn't have plasteel in it and would be a bit exploity?

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Works)
