### PR TITLE
Fix CIWS turret shoot line

### DIFF
--- a/Source/CombatExtended/CombatExtended/Verbs/VerbCIWS.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/VerbCIWS.cs
@@ -263,7 +263,7 @@ namespace CombatExtended
                 {
                     Log.Message("Found shot line at the right delay");
                 }
-                resultingLine = new ShootLine(Shooter.Position, new IntVec3((int)pos.x, (int)pos.y, (int)pos.z));
+                resultingLine = new ShootLine(Shooter.Position, new IntVec3((int)pos.x, 0, (int)pos.z));
                 targetPos = pos;
                 return true;
             }


### PR DESCRIPTION


## Changes

Aims the turret Top in 2d space for visual continuity

## Reasoning

Turret tops cannot aim up visually, and them trying to do so can look odd

## Alternatives

enable proper 3d aiming

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
