### PR TITLE
Outer Rim Patch update

### DIFF
--- a/ModPatches/Outer Rim - Galactic Empire/Patches/Outer Rim - Galactic Empire/Outer_Rim_Galactic_Empire_Apparel.xml
+++ b/ModPatches/Outer Rim - Galactic Empire/Patches/Outer Rim - Galactic Empire/Outer_Rim_Galactic_Empire_Apparel.xml
@@ -99,4 +99,19 @@
 			</li>
 		</value>
 	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="OuterRim_StormtrooperKama"]/statBases</xpath>
+		<value>
+			<ArmorRating_Sharp>1</ArmorRating_Sharp>
+			<ArmorRating_Blunt>2</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="OuterRim_StormtrooperKama"]/statBases/StuffEffectMultiplierArmor</xpath>
+		<value>
+			<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+		</value>
+	</Operation>
 </Patch>

--- a/ModPatches/Outer Rim - Galactic Empire/Patches/Outer Rim - Galactic Empire/Outer_Rim_Galactic_Empire_Ranged_Weapons.xml
+++ b/ModPatches/Outer Rim - Galactic Empire/Patches/Outer Rim - Galactic Empire/Outer_Rim_Galactic_Empire_Ranged_Weapons.xml
@@ -191,6 +191,44 @@
 	</Operation>
 
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>OuterRim_E11DBlasterRifle</defName>
+		<statBases>
+			<SightsEfficiency>0.95</SightsEfficiency>
+			<ShotSpread>0.14</ShotSpread>
+			<SwayFactor>0.75</SwayFactor>
+			<Bulk>5.60</Bulk>
+			<Mass>3.20</Mass>
+			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+		</statBases>
+		<Properties>
+			<recoilAmount>1.1</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_BlasterRifle_Red</defaultProjectile>
+			<warmupTime>0.72</warmupTime>
+			<range>46</range>
+			<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+			<burstShotCount>7</burstShotCount>
+			<soundCast>OuterRim_Shot_E11BlasterBolt</soundCast>
+			<soundCastTail>GunTail_Medium</soundCastTail>
+			<muzzleFlashScale>12</muzzleFlashScale>
+			<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
+			<targetParams>
+				<canTargetLocations>true</canTargetLocations>
+			</targetParams>
+		</Properties>
+		<FireModes>
+			<aiAimMode>AimedShot</aiAimMode>
+			<aimedBurstShotCount>3</aimedBurstShotCount>
+		</FireModes>
+		<AmmoUser>
+			<magazineSize>70</magazineSize>
+			<reloadTime>3.7</reloadTime>
+			<ammoSet>AmmoSet_PlasmaGasCartridgeRed_Rifle</ammoSet>
+		</AmmoUser>
+	</Operation>
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>OuterRim_E22BlasterRifle</defName>
 		<statBases>
 			<SightsEfficiency>0.85</SightsEfficiency>


### PR DESCRIPTION
## Patches
Patches the new E11D rifle and Stormtrooper Kama in the `Outer Rim: Galactic Empire` module. No other added content required patching thanks to the use of abstracts. Need to doublecheck the new pawnkinds but this is otherwise good to go.

The E11D is basically the E11 but slightly better, at the cost of increased weight and bulk; longer barrel and extended stock makes it more accurate, more stable, and very slightly longer ranged, whilst its CQB focus means longer bursts and slightly better warmup/cooldown times.

## References
https://starwars.fandom.com/wiki/E-11D_blaster_carbine

## TODO
- [x] patch weapons (e11d)
- [x] patch apparel (kama)
- [x] patch new pawnkinds (?)

## Testing
Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)