### PR TITLE
Fix arrow pickup

### DIFF
--- a/ModPatches/A Rimworld of Magic/Patches/A Rimworld of Magic/Patch_Ranged.xml
+++ b/ModPatches/A Rimworld of Magic/Patches/A Rimworld of Magic/Patch_Ranged.xml
@@ -309,6 +309,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_StreamlinedArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes>
 			<aiAimMode>AimedShot</aiAimMode>
@@ -354,6 +355,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_GreatArrowRoMThrumbo</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes>
 			<aiAimMode>AimedShot</aiAimMode>

--- a/ModPatches/Alpha Genes/Patches/Alpha Genes/ThingDefs_Misc/WeaponsRanged_Forsaken.xml
+++ b/ModPatches/Alpha Genes/Patches/Alpha Genes/ThingDefs_Misc/WeaponsRanged_Forsaken.xml
@@ -247,6 +247,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_ForsakensArrows</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes />
 		<researchPrerequisite>RecurveBow</researchPrerequisite>

--- a/ModPatches/Black Widows/Patches/Black Widows/ThingDefs_Weapons/Patch_Weapons.xml
+++ b/ModPatches/Black Widows/Patches/Black Widows/ThingDefs_Weapons/Patch_Weapons.xml
@@ -267,6 +267,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_BlackWidowArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<weaponTags>
 			<li>BWBow</li>

--- a/ModPatches/DD Elves/Patches/DD Elves/ThingDefs_RangedWeapon.xml
+++ b/ModPatches/DD Elves/Patches/DD Elves/ThingDefs_RangedWeapon.xml
@@ -88,6 +88,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_StreamlinedArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes/>
 		<AllowWithRunAndGun>false</AllowWithRunAndGun>
@@ -116,6 +117,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_GreatArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes/>
 		<AllowWithRunAndGun>false</AllowWithRunAndGun>
@@ -144,6 +146,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_StreamlinedArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes/>
 		<AllowWithRunAndGun>false</AllowWithRunAndGun>
@@ -172,6 +175,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_GreatArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes/>
 		<AllowWithRunAndGun>false</AllowWithRunAndGun>

--- a/ModPatches/EdoThemedExpansion/Patches/EdoThemedExpansion/EdoTheme_Weapons_Ranged.xml
+++ b/ModPatches/EdoThemedExpansion/Patches/EdoThemedExpansion/EdoTheme_Weapons_Ranged.xml
@@ -159,6 +159,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_GreatArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes />
 		<weaponTags>

--- a/ModPatches/Infinity Rim Ariadna/Patches/Infinity Rim Ariadna/Weapons/AntipodeWeapon.xml
+++ b/ModPatches/Infinity Rim Ariadna/Patches/Infinity Rim Ariadna/Weapons/AntipodeWeapon.xml
@@ -20,6 +20,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_GreatArrowAntipode</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes/>
 		<AllowWithRunAndGun>false</AllowWithRunAndGun>

--- a/ModPatches/JDS Castle Walls/Patches/JDS Castle Walls/ThingDefs_Tower.xml
+++ b/ModPatches/JDS Castle Walls/Patches/JDS Castle Walls/ThingDefs_Tower.xml
@@ -51,6 +51,7 @@
 			<magazineSize>25</magazineSize>
 			<reloadTime>10</reloadTime>
 			<ammoSet>AmmoSet_GreatArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<weaponTags Inherit="False">
 			<li>TurretGun</li>

--- a/ModPatches/Kijin 3.0/Patches/Kijin 3.0/ThingDef_Misc/Kijin_Weapons_Ranged.xml
+++ b/ModPatches/Kijin 3.0/Patches/Kijin 3.0/ThingDef_Misc/Kijin_Weapons_Ranged.xml
@@ -79,6 +79,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_ArrowKijinFlame</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes />
 	</Operation>
@@ -133,6 +134,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_ArrowKijinVenom</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes />
 	</Operation>

--- a/ModPatches/Medieval Overhaul/Patches/Medieval Overhaul/ThingDefs_Misc/Weapons/MO_Weapons_Ranged.xml
+++ b/ModPatches/Medieval Overhaul/Patches/Medieval Overhaul/ThingDefs_Misc/Weapons/MO_Weapons_Ranged.xml
@@ -168,6 +168,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_HuntingArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes/>
 		<weaponTags>
@@ -200,6 +201,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_WarArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes/>
 		<weaponTags>

--- a/ModPatches/MorrowRim - Bloodmoon/Patches/MorrowRim - Bloodmoon/Hunter_Weapons.xml
+++ b/ModPatches/MorrowRim - Bloodmoon/Patches/MorrowRim - Bloodmoon/Hunter_Weapons.xml
@@ -74,6 +74,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_HuntardArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes/>
 		<AllowWithRunAndGun>true</AllowWithRunAndGun>

--- a/ModPatches/Nyaron/Patches/Nyaron/ThingDefs_Misc/Weapons.xml
+++ b/ModPatches/Nyaron/Patches/Nyaron/ThingDefs_Misc/Weapons.xml
@@ -453,6 +453,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_GreatArrowNyaron</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes/>
 		<AllowWithRunAndGun>false</AllowWithRunAndGun>

--- a/ModPatches/Outland - Eastborn/Patches/Outland - Eastborn/Eastborn_WeaponsRanged.xml
+++ b/ModPatches/Outland - Eastborn/Patches/Outland - Eastborn/Eastborn_WeaponsRanged.xml
@@ -23,6 +23,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_StreamlinedArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes/>
 		<weaponTags>

--- a/ModPatches/Possessed Weapons/Patches/PossessedWeapons_RangedPatch.xml
+++ b/ModPatches/Possessed Weapons/Patches/PossessedWeapons_RangedPatch.xml
@@ -34,6 +34,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_DragonFireArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes />
 		<weaponTags>
@@ -290,6 +291,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_VerdantArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes />
 		<weaponTags>
@@ -309,6 +311,7 @@
 				<comps>
 					<li Class="CombatExtended.CompProperties_AmmoUser">
 						<ammoSet>AmmoSet_VerdantMOArrow</ammoSet>
+						<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 					</li>
 				</comps>
 			</value>

--- a/ModPatches/Profaned/Patches/Profaned/ThingDefs_Misc/Weapons/Profaned_Weapons_Ranged.xml
+++ b/ModPatches/Profaned/Patches/Profaned/ThingDefs_Misc/Weapons/Profaned_Weapons_Ranged.xml
@@ -25,6 +25,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_Arrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes />
 		<weaponTags>
@@ -69,6 +70,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_ProfanedGreatbowArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes/>
 		<weaponTags>

--- a/ModPatches/Rim-Elves/Patches/Rim-Elves/Weapons_Elves.xml
+++ b/ModPatches/Rim-Elves/Patches/Rim-Elves/Weapons_Elves.xml
@@ -21,6 +21,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_GreatArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes/>
 	</Operation>
@@ -132,6 +133,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_ChargedGreatArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes/>
 	</Operation>

--- a/ModPatches/RimFantasy - House Doyle/Patches/RimFantasy - House Doyle/Patch_RFDoyle_Ranged.xml
+++ b/ModPatches/RimFantasy - House Doyle/Patches/RimFantasy - House Doyle/Patch_RFDoyle_Ranged.xml
@@ -46,6 +46,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_GreatArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes/>
 		<weaponTags>
@@ -79,6 +80,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_WarArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes/>
 		<weaponTags>

--- a/ModPatches/Rimcraft Weaponry/Patches/Rimcraft Weaponry/Patch_WOW_Ranged.xml
+++ b/ModPatches/Rimcraft Weaponry/Patches/Rimcraft Weaponry/Patch_WOW_Ranged.xml
@@ -59,6 +59,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_GreatArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes/>
 		<weaponTags>
@@ -86,6 +87,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_StreamlinedArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes/>
 		<weaponTags>
@@ -113,6 +115,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_StreamlinedArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes/>
 		<weaponTags>
@@ -140,6 +143,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_StreamlinedArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes/>
 		<weaponTags>
@@ -167,6 +171,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_GreatArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes/>
 		<weaponTags>
@@ -194,6 +199,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_StreamlinedArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes/>
 		<weaponTags>
@@ -221,6 +227,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_StreamlinedArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes/>
 		<weaponTags>
@@ -276,6 +283,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_GreatArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes/>
 		<weaponTags>

--- a/ModPatches/Rimmu-Nation - Weapons/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_Ranged_Misc.xml
+++ b/ModPatches/Rimmu-Nation - Weapons/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_Ranged_Misc.xml
@@ -117,6 +117,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_StreamlinedArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes>
 			<aiAimMode>AimedShot</aiAimMode>

--- a/ModPatches/Rimsenal Enhanced Vanilla/Patches/Rimsenal Enhanced Vanilla/Weapons_Ranged_CE.xml
+++ b/ModPatches/Rimsenal Enhanced Vanilla/Patches/Rimsenal Enhanced Vanilla/Weapons_Ranged_CE.xml
@@ -37,6 +37,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_CompoundArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes>
 			<aiAimMode>AimedShot</aiAimMode>

--- a/ModPatches/Royal Arsenal/Patches/Royal Arsenal/Things/RoyalArsenal_Ranged.xml
+++ b/ModPatches/Royal Arsenal/Patches/Royal Arsenal/Things/RoyalArsenal_Ranged.xml
@@ -2,215 +2,216 @@
 <Patch>
 	<!-- Ranged Weapon Melee Attacks -->
 
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="RA_RoyalChargeRifle" or defName="RA_RoyalChargeLance"]/tools</xpath>
-	<value>
-		<tools>
-			<li Class="CombatExtended.ToolCE">
-				<label>stock</label>
-				<capacities>
-				<li>Blunt</li>
-				</capacities>
-				<power>8</power>
-				<cooldownTime>1.55</cooldownTime>
-				<chanceFactor>1.5</chanceFactor>
-				<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-				<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="RA_RoyalChargeRifle" or defName="RA_RoyalChargeLance"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>stock</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>8</power>
+					<cooldownTime>1.55</cooldownTime>
+					<chanceFactor>1.5</chanceFactor>
+					<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>barrel</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>5</power>
+					<cooldownTime>2.02</cooldownTime>
+					<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>muzzle</label>
+					<capacities>
+						<li>Poke</li>
+					</capacities>
+					<power>8</power>
+					<cooldownTime>1.55</cooldownTime>
+					<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="RA_MonoBow"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>8</power>
+					<cooldownTime>1.6</cooldownTime>
+					<armorPenetrationBlunt>0.65</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+
+	<!-- Mono Longbow -->
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>RA_MonoBow</defName>
+		<statBases>
+			<Mass>8</Mass>
+			<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+			<SightsEfficiency>2</SightsEfficiency>
+			<ShotSpread>0.01</ShotSpread>
+			<SwayFactor>1</SwayFactor>
+			<Bulk>13.0</Bulk>
+		</statBases>
+		<costList>
+			<Plasteel>60</Plasteel>
+			<Uranium>20</Uranium>
+			<ComponentSpacer>6</ComponentSpacer>
+		</costList>
+		<Properties>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Projectile_MonoArrow</defaultProjectile>
+			<warmupTime>1.8</warmupTime>
+			<range>80</range>
+			<soundCast>ChargeLance_Fire</soundCast>
+			<muzzleFlashScale>0</muzzleFlashScale>
+			<recoilAmount>1.0</recoilAmount>
+		</Properties>
+		<AmmoUser>
+			<ammoSet>AmmoSet_MonoArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
+		</AmmoUser>
+		<FireModes/>
+		<weaponTags/>
+		<researchPrerequisite>RA_MonoBowResearch</researchPrerequisite>
+		<AllowWithRunAndGun>false</AllowWithRunAndGun>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="RA_MonoBow"]</xpath>
+		<value>
+			<li Class="CombatExtended.GunDrawExtension">
+				<DrawSize>1,1</DrawSize>
+				<DrawOffset>0.15,-0.05</DrawOffset>
 			</li>
-			<li Class="CombatExtended.ToolCE">
-				<label>barrel</label>
-				<capacities>
-				<li>Blunt</li>
-				</capacities>
-				<power>5</power>
-				<cooldownTime>2.02</cooldownTime>
-				<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-				<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+		</value>
+	</Operation>
+
+
+	<!-- Royal Charge Rifle -->
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>RA_RoyalChargeRifle</defName>
+		<statBases>
+			<Mass>5</Mass>
+			<RangedWeapon_Cooldown>0.3</RangedWeapon_Cooldown>
+			<SightsEfficiency>1.4</SightsEfficiency>
+			<ShotSpread>0.08</ShotSpread>
+			<SwayFactor>1</SwayFactor>
+			<Bulk>10.0</Bulk>
+		</statBases>
+		<costList>
+			<Plasteel>60</Plasteel>
+			<Gold>2</Gold>
+			<ComponentSpacer>6</ComponentSpacer>
+			<Chemfuel>10</Chemfuel>
+		</costList>
+		<Properties>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_6x24mmRoyal</defaultProjectile>
+			<warmupTime>1.0</warmupTime>
+			<range>55</range>
+			<burstShotCount>5</burstShotCount>
+			<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+			<soundCast>Shot_ChargeRifle</soundCast>
+			<soundCastTail>GunTail_Medium</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+			<recoilAmount>1.0</recoilAmount>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>40</magazineSize>
+			<reloadTime>4</reloadTime>
+			<ammoSet>AmmoSet_6x24mmRoyal</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aimedBurstShotCount>4</aimedBurstShotCount>
+			<aiUseBurstMode>TRUE</aiUseBurstMode>
+			<aiAimMode>AimedShot</aiAimMode>
+		</FireModes>
+		<weaponTags/>
+		<researchPrerequisite>RA_RoyalChargedShot</researchPrerequisite>
+		<AllowWithRunAndGun>false</AllowWithRunAndGun>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="RA_RoyalChargeRifle"]</xpath>
+		<value>
+			<li Class="CombatExtended.GunDrawExtension">
+				<DrawSize>1,1</DrawSize>
+				<DrawOffset>0.15,-0.05</DrawOffset>
 			</li>
-			<li Class="CombatExtended.ToolCE">
-				<label>muzzle</label>
-				<capacities>
-				<li>Poke</li>
-				</capacities>
-				<power>8</power>
-				<cooldownTime>1.55</cooldownTime>
-				<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-				<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+		</value>
+	</Operation>
+
+
+	<!-- Royal Charge Lance -->
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>RA_RoyalChargeLance</defName>
+		<statBases>
+			<Mass>5</Mass>
+			<RangedWeapon_Cooldown>0.3</RangedWeapon_Cooldown>
+			<SightsEfficiency>2.2</SightsEfficiency>
+			<ShotSpread>0.01</ShotSpread>
+			<SwayFactor>1</SwayFactor>
+			<Bulk>10.0</Bulk>
+		</statBases>
+		<costList>
+			<Plasteel>60</Plasteel>
+			<Gold>2</Gold>
+			<ComponentSpacer>6</ComponentSpacer>
+			<Chemfuel>10</Chemfuel>
+		</costList>
+		<Properties>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_5x35mmRoyal</defaultProjectile>
+			<warmupTime>1.0</warmupTime>
+			<range>75</range>
+			<soundCast>ChargeLance_Fire</soundCast>
+			<soundCastTail>GunTail_Medium</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+			<recoilAmount>1.0</recoilAmount>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>6</magazineSize>
+			<reloadTime>3</reloadTime>
+			<ammoSet>AmmoSet_5x35mmRoyal</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aiAimMode>AimedShot</aiAimMode>
+		</FireModes>
+		<weaponTags/>
+		<researchPrerequisite>RA_RoyalChargedShot</researchPrerequisite>
+		<AllowWithRunAndGun>false</AllowWithRunAndGun>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="RA_RoyalChargeLance"]</xpath>
+		<value>
+			<li Class="CombatExtended.GunDrawExtension">
+				<DrawSize>1,1</DrawSize>
+				<DrawOffset>0.15,-0.05</DrawOffset>
 			</li>
-		</tools>
-	</value>
-</Operation>
-
-<Operation Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="RA_MonoBow"]/tools</xpath>
-	<value>
-		<tools>
-			<li Class="CombatExtended.ToolCE">
-				<capacities>
-					<li>Blunt</li>
-				</capacities>
-				<power>8</power>
-				<cooldownTime>1.6</cooldownTime>
-			<armorPenetrationBlunt>0.65</armorPenetrationBlunt>
-			</li>
-		</tools>
-	</value>
-</Operation>
-
-
-<!-- Mono Longbow -->
-
-<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-	<defName>RA_MonoBow</defName>
-	<statBases>
-		<Mass>8</Mass>
-		<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-		<SightsEfficiency>2</SightsEfficiency>
-		<ShotSpread>0.01</ShotSpread>
-		<SwayFactor>1</SwayFactor>
-		<Bulk>13.0</Bulk>
-	</statBases>
-	<costList>
-		<Plasteel>60</Plasteel>
-		<Uranium>20</Uranium>
-		<ComponentSpacer>6</ComponentSpacer>
-	</costList>
-	<Properties>
-		<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-		<hasStandardCommand>true</hasStandardCommand>
-		<defaultProjectile>Projectile_MonoArrow</defaultProjectile>
-		<warmupTime>1.8</warmupTime>
-		<range>80</range>
-		<soundCast>ChargeLance_Fire</soundCast>
-		<muzzleFlashScale>0</muzzleFlashScale>
-		<recoilAmount>1.0</recoilAmount>
-	</Properties>
-	<AmmoUser>
-		<ammoSet>AmmoSet_MonoArrow</ammoSet>
-	</AmmoUser>
-	<FireModes/>
-	<weaponTags/>
-	<researchPrerequisite>RA_MonoBowResearch</researchPrerequisite>
-	<AllowWithRunAndGun>false</AllowWithRunAndGun>
-</Operation>
-
-<Operation Class="PatchOperationAddModExtension">
-	<xpath>Defs/ThingDef[defName="RA_MonoBow"]</xpath>
-	<value>
-		<li Class="CombatExtended.GunDrawExtension">
-		<DrawSize>1,1</DrawSize>
-		<DrawOffset>0.15,-0.05</DrawOffset>
-		</li>
-	</value>
-</Operation>
-
-
-<!-- Royal Charge Rifle -->
-
-<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-	<defName>RA_RoyalChargeRifle</defName>
-	<statBases>
-		<Mass>5</Mass>
-		<RangedWeapon_Cooldown>0.3</RangedWeapon_Cooldown>
-		<SightsEfficiency>1.4</SightsEfficiency>
-		<ShotSpread>0.08</ShotSpread>
-		<SwayFactor>1</SwayFactor>
-		<Bulk>10.0</Bulk>
-	</statBases>
-	<costList>
-		<Plasteel>60</Plasteel>
-		<Gold>2</Gold>
-		<ComponentSpacer>6</ComponentSpacer>
-		<Chemfuel>10</Chemfuel>
-	</costList>
-	<Properties>
-		<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-		<hasStandardCommand>true</hasStandardCommand>
-		<defaultProjectile>Bullet_6x24mmRoyal</defaultProjectile>
-		<warmupTime>1.0</warmupTime>
-		<range>55</range>
-		<burstShotCount>5</burstShotCount>
-		<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
-		<soundCast>Shot_ChargeRifle</soundCast>
-		<soundCastTail>GunTail_Medium</soundCastTail>
-		<muzzleFlashScale>9</muzzleFlashScale>
-		<recoilAmount>1.0</recoilAmount>
-	</Properties>
-	<AmmoUser>
-		<magazineSize>40</magazineSize>
-		<reloadTime>4</reloadTime>
-		<ammoSet>AmmoSet_6x24mmRoyal</ammoSet>
-	</AmmoUser>
-	<FireModes>
-		<aimedBurstShotCount>4</aimedBurstShotCount>
-		<aiUseBurstMode>TRUE</aiUseBurstMode>
-		<aiAimMode>AimedShot</aiAimMode>
-	</FireModes>
-	<weaponTags/>
-	<researchPrerequisite>RA_RoyalChargedShot</researchPrerequisite>
-	<AllowWithRunAndGun>false</AllowWithRunAndGun>
-</Operation>
-
-<Operation Class="PatchOperationAddModExtension">
-	<xpath>Defs/ThingDef[defName="RA_RoyalChargeRifle"]</xpath>
-	<value>
-		<li Class="CombatExtended.GunDrawExtension">
-		<DrawSize>1,1</DrawSize>
-		<DrawOffset>0.15,-0.05</DrawOffset>
-		</li>
-	</value>
-</Operation>
-
-
-<!-- Royal Charge Lance -->
-
-<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-	<defName>RA_RoyalChargeLance</defName>
-	<statBases>
-		<Mass>5</Mass>
-		<RangedWeapon_Cooldown>0.3</RangedWeapon_Cooldown>
-		<SightsEfficiency>2.2</SightsEfficiency>
-		<ShotSpread>0.01</ShotSpread>
-		<SwayFactor>1</SwayFactor>
-		<Bulk>10.0</Bulk>
-	</statBases>
-	<costList>
-		<Plasteel>60</Plasteel>
-		<Gold>2</Gold>
-		<ComponentSpacer>6</ComponentSpacer>
-		<Chemfuel>10</Chemfuel>
-	</costList>
-	<Properties>
-		<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-		<hasStandardCommand>true</hasStandardCommand>
-		<defaultProjectile>Bullet_5x35mmRoyal</defaultProjectile>
-		<warmupTime>1.0</warmupTime>
-		<range>75</range>
-		<soundCast>ChargeLance_Fire</soundCast>
-		<soundCastTail>GunTail_Medium</soundCastTail>
-		<muzzleFlashScale>9</muzzleFlashScale>
-		<recoilAmount>1.0</recoilAmount>
-	</Properties>
-	<AmmoUser>
-		<magazineSize>6</magazineSize>
-		<reloadTime>3</reloadTime>
-		<ammoSet>AmmoSet_5x35mmRoyal</ammoSet>
-	</AmmoUser>
-	<FireModes>
-		<aiAimMode>AimedShot</aiAimMode>
-	</FireModes>
-	<weaponTags/>
-	<researchPrerequisite>RA_RoyalChargedShot</researchPrerequisite>
-	<AllowWithRunAndGun>false</AllowWithRunAndGun>
-</Operation>
-
-<Operation Class="PatchOperationAddModExtension">
-	<xpath>Defs/ThingDef[defName="RA_RoyalChargeLance"]</xpath>
-	<value>
-		<li Class="CombatExtended.GunDrawExtension">
-		<DrawSize>1,1</DrawSize>
-		<DrawOffset>0.15,-0.05</DrawOffset>
-		</li>
-	</value>
-</Operation>
+		</value>
+	</Operation>
 </Patch>

--- a/ModPatches/T's Samurai Faction/Patches/T's Samurai Faction/T_Samurai_Weapons_Ranged.xml
+++ b/ModPatches/T's Samurai Faction/Patches/T's Samurai Faction/T_Samurai_Weapons_Ranged.xml
@@ -180,6 +180,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_StreamlinedArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes/>
 		<weaponTags>

--- a/ModPatches/Tribal Warrior Set/Patches/Tribal Warrior Set/TribalWarrior_Apparel.xml
+++ b/ModPatches/Tribal Warrior Set/Patches/Tribal Warrior Set/TribalWarrior_Apparel.xml
@@ -126,6 +126,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_GreatArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes/>
 		<weaponTags>

--- a/ModPatches/Vanilla Factions Expanded - Medieval 2/Patches/Vanilla Factions Expanded - Medieval 2/ThingDefs_Misc/Weapons/VFEM2_Weapons_Ranged.xml
+++ b/ModPatches/Vanilla Factions Expanded - Medieval 2/Patches/Vanilla Factions Expanded - Medieval 2/ThingDefs_Misc/Weapons/VFEM2_Weapons_Ranged.xml
@@ -128,6 +128,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_VFEM2WarArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes />
 		<weaponTags>

--- a/ModPatches/Vanilla Weapons Expanded/Patches/Vanilla Weapons Expanded/Industrial_Ranged.xml
+++ b/ModPatches/Vanilla Weapons Expanded/Patches/Vanilla Weapons Expanded/Industrial_Ranged.xml
@@ -167,6 +167,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_StreamlinedArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes />
 		<weaponTags Inherit="False">

--- a/ModPatches/Vanilla Weapons Expanded/Patches/Vanilla Weapons Expanded/Neolithic_Ranged.xml
+++ b/ModPatches/Vanilla Weapons Expanded/Patches/Vanilla Weapons Expanded/Neolithic_Ranged.xml
@@ -25,6 +25,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_GreatArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes />
 		<weaponTags>

--- a/Patches/Core/ThingDefs_Misc/Weapons_RangedNeolithic.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_RangedNeolithic.xml
@@ -41,6 +41,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_Arrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes />
 		<weaponTags>
@@ -89,6 +90,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_StreamlinedArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes />
 		<weaponTags>
@@ -154,6 +156,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_GreatArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes />
 		<weaponTags>

--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_TakeAndEquip.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_TakeAndEquip.cs
@@ -109,7 +109,7 @@ namespace CombatExtended
                 if (viableAmmoBulk < potentialAmmoBulk)
                 {
                     // There's less ammo [nr] than fits a clip [nr]
-                    if (primaryAmmoUser.MagSize == 0 || viableAmmoCarried < magazineSize.min)
+                    if ((primaryAmmoUser.MagSize == 0 && viableAmmoCarried < primaryAmmoUser.MagSizeOverride) || viableAmmoCarried < magazineSize.min)
                     {
                         return Unload(pawn) ? WorkPriority.Unloading : WorkPriority.LowAmmo;
                     }
@@ -485,8 +485,7 @@ namespace CombatExtended
 
                                             if (closestThing != null)
                                             {
-                                                int numToCarry = 0;
-                                                if (inventory.CanFitInInventory(th, out numToCarry))
+                                                if (inventory.CanFitInInventory(th, out int numToCarry))
                                                 {
                                                     Job job = JobMaker.MakeJob(JobDefOf.TakeInventory, th);
                                                     int maxAmmoToPickup = (primaryAmmoUserWithInventoryCheck.MagSizeOverride > 0) ? primaryAmmoUserWithInventoryCheck.MagSizeOverride * 4 : primaryAmmoUserWithInventoryCheck.MagSize * 4;
@@ -497,8 +496,7 @@ namespace CombatExtended
                                         }
                                         else
                                         {
-                                            int numToCarry = 0;
-                                            if (inventory.CanFitInInventory(th, out numToCarry))
+                                            if (inventory.CanFitInInventory(th, out int numToCarry))
                                             {
                                                 Job job = JobMaker.MakeJob(JobDefOf.TakeInventory, th);
                                                 job.count = Mathf.RoundToInt(numToCarry * 0.8f);


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Adds magazine size override to all bows of 5. Pawns will pickup to max of 20 arrows (override size * 4)

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Adds magazine size override check to checking for low ammo when magazine size = 0. This allows pawns with bow to automatically find and pickup arrows similar to other ranged weapons. Also, stops constant searching for ammo that was happening under the hood.

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #2789 

## Reasoning

Why did you choose to implement things this way, e.g.
- Other ranged weapons pick up ammo automatically

## Alternatives

Describe alternative implementations you have considered, e.g.
- Sad archers

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (Dev quicktest)
