### PR TITLE
CompAmmoUser Remove Whitespace

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
@@ -943,7 +943,7 @@ namespace CombatExtended
 
         public override string TransformLabel(string label)
         {
-            string ammoSet = UseAmmo && Controller.settings.ShowCaliberOnGuns ? " (" + (string)Props.ammoSet.LabelCap + ") " : "";
+            string ammoSet = UseAmmo && Controller.settings.ShowCaliberOnGuns ? " (" + (string)Props.ammoSet.LabelCap + ")" : "";
             return label + ammoSet;
         }
 


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Removes white space at end of CompAmmoUser.TransformLabel

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #2726

## Reasoning

Why did you choose to implement things this way, e.g.
- Fixes issue of picking up warcasket guns. Extra white space was preventing a Contains check that VE team was doing on the float option menu from properly matching.

## Alternatives

Describe alternative implementations you have considered, e.g.
- Transpile VE HeavyWEapon harmony patch to Trim the label
- Open PR on VE team to see if they will fix it on their end

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Quicktest)
