### PR TITLE
High Velocity AmmoSets for .357 Magnum, .38 Special, and .44 Special

### DIFF
--- a/Defs/Ammo/Pistols/357Magnum.xml
+++ b/Defs/Ammo/Pistols/357Magnum.xml
@@ -22,12 +22,37 @@
 	</CombatExtended.AmmoSetDef>
 
 	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_357Magnum_HV</defName>
+		<label>.357 Magnum</label>
+		<ammoTypes>
+			<Ammo_357Magnum_FMJ>Bullet_357Magnum_HV_FMJ</Ammo_357Magnum_FMJ>
+			<Ammo_357Magnum_AP>Bullet_357Magnum_HV_AP</Ammo_357Magnum_AP>
+			<Ammo_357Magnum_HP>Bullet_357Magnum_HV_HP</Ammo_357Magnum_HP>
+		</ammoTypes>
+		<similarTo>AmmoSet_PistolMagnum</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<CombatExtended.AmmoSetDef>
 		<defName>AmmoSet_357Magnum_Revolver</defName>
 		<label>.357 Magnum</label>
 		<ammoTypes>
 			<Ammo_357Magnum_FMJ>Bullet_357Magnum_FMJ</Ammo_357Magnum_FMJ>
 			<Ammo_357Magnum_AP>Bullet_357Magnum_AP</Ammo_357Magnum_AP>
 			<Ammo_357Magnum_HP>Bullet_357Magnum_HP</Ammo_357Magnum_HP>
+			<Ammo_38Special_FMJ>Bullet_38Special_FMJ</Ammo_38Special_FMJ>
+			<Ammo_38Special_AP>Bullet_38Special_AP</Ammo_38Special_AP>
+			<Ammo_38Special_HP>Bullet_38Special_HP</Ammo_38Special_HP>
+		</ammoTypes>
+		<similarTo>AmmoSet_PistolMagnum</similarTo>
+	</CombatExtended.AmmoSetDef>
+	
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_357Magnum_Lever_HV</defName>
+		<label>.357 Magnum</label>
+		<ammoTypes>
+			<Ammo_357Magnum_FMJ>Bullet_357Magnum_HV_FMJ</Ammo_357Magnum_FMJ>
+			<Ammo_357Magnum_AP>Bullet_357Magnum_HV_AP</Ammo_357Magnum_AP>
+			<Ammo_357Magnum_HP>Bullet_357Magnum_HV_HP</Ammo_357Magnum_HP>
 			<Ammo_38Special_FMJ>Bullet_38Special_FMJ</Ammo_38Special_FMJ>
 			<Ammo_38Special_AP>Bullet_38Special_AP</Ammo_38Special_AP>
 			<Ammo_38Special_HP>Bullet_38Special_HP</Ammo_38Special_HP>
@@ -128,6 +153,41 @@
 			<damageAmountBase>17</damageAmountBase>
 			<armorPenetrationSharp>3</armorPenetrationSharp>
 			<armorPenetrationBlunt>18.6</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<!-- ========= High velocity ========= -->
+
+	<ThingDef ParentName="Base357MagnumBullet">
+		<defName>Bullet_357Magnum_HV_FMJ</defName>
+		<label>.357 Magnum bullet (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>17</damageAmountBase>
+			<armorPenetrationSharp>7</armorPenetrationSharp>
+			<armorPenetrationBlunt>37.96</armorPenetrationBlunt>
+			<speed>123</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base357MagnumBullet">
+		<defName>Bullet_357Magnum_HV_AP</defName>
+		<label>.357 Magnum bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>11</damageAmountBase>
+			<armorPenetrationSharp>14</armorPenetrationSharp>
+			<armorPenetrationBlunt>37.96</armorPenetrationBlunt>
+			<speed>123</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base357MagnumBullet">
+		<defName>Bullet_357Magnum_HV_HP</defName>
+		<label>.357 Magnum bullet (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>22</damageAmountBase>
+			<armorPenetrationSharp>3.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>37.96</armorPenetrationBlunt>
+			<speed>123</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/357Magnum.xml
+++ b/Defs/Ammo/Pistols/357Magnum.xml
@@ -34,7 +34,7 @@
 
 	<CombatExtended.AmmoSetDef>
 		<defName>AmmoSet_357Magnum_Revolver</defName>
-		<label>.357 Magnum</label>
+		<label>.357 Magnum/.38 Special</label>
 		<ammoTypes>
 			<Ammo_357Magnum_FMJ>Bullet_357Magnum_FMJ</Ammo_357Magnum_FMJ>
 			<Ammo_357Magnum_AP>Bullet_357Magnum_AP</Ammo_357Magnum_AP>
@@ -47,15 +47,15 @@
 	</CombatExtended.AmmoSetDef>
 	
 	<CombatExtended.AmmoSetDef>
-		<defName>AmmoSet_357Magnum_Lever_HV</defName>
-		<label>.357 Magnum</label>
+		<defName>AmmoSet_357Magnum_Lever</defName>
+		<label>.357 Magnum/.38 Special</label>
 		<ammoTypes>
 			<Ammo_357Magnum_FMJ>Bullet_357Magnum_HV_FMJ</Ammo_357Magnum_FMJ>
 			<Ammo_357Magnum_AP>Bullet_357Magnum_HV_AP</Ammo_357Magnum_AP>
 			<Ammo_357Magnum_HP>Bullet_357Magnum_HV_HP</Ammo_357Magnum_HP>
-			<Ammo_38Special_FMJ>Bullet_38Special_FMJ</Ammo_38Special_FMJ>
-			<Ammo_38Special_AP>Bullet_38Special_AP</Ammo_38Special_AP>
-			<Ammo_38Special_HP>Bullet_38Special_HP</Ammo_38Special_HP>
+			<Ammo_38Special_FMJ>Bullet_38Special_HV_FMJ</Ammo_38Special_FMJ>
+			<Ammo_38Special_AP>Bullet_38Special_HV_AP</Ammo_38Special_AP>
+			<Ammo_38Special_HP>Bullet_38Special_HV_HP</Ammo_38Special_HP>
 		</ammoTypes>
 		<similarTo>AmmoSet_PistolMagnum</similarTo>
 	</CombatExtended.AmmoSetDef>

--- a/Defs/Ammo/Pistols/357Magnum.xml
+++ b/Defs/Ammo/Pistols/357Magnum.xml
@@ -162,10 +162,10 @@
 		<defName>Bullet_357Magnum_HV_FMJ</defName>
 		<label>.357 Magnum bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>17</damageAmountBase>
-			<armorPenetrationSharp>7</armorPenetrationSharp>
-			<armorPenetrationBlunt>37.96</armorPenetrationBlunt>
-			<speed>123</speed>
+			<damageAmountBase>15</damageAmountBase>
+			<armorPenetrationSharp>7.3</armorPenetrationSharp>
+			<armorPenetrationBlunt>27.58</armorPenetrationBlunt>
+			<speed>109</speed>
 		</projectile>
 	</ThingDef>
 
@@ -173,10 +173,10 @@
 		<defName>Bullet_357Magnum_HV_AP</defName>
 		<label>.357 Magnum bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>11</damageAmountBase>
-			<armorPenetrationSharp>14</armorPenetrationSharp>
-			<armorPenetrationBlunt>37.96</armorPenetrationBlunt>
-			<speed>123</speed>
+			<damageAmountBase>10</damageAmountBase>
+			<armorPenetrationSharp>14.6</armorPenetrationSharp>
+			<armorPenetrationBlunt>27.58</armorPenetrationBlunt>
+			<speed>109</speed>
 		</projectile>
 	</ThingDef>
 
@@ -184,10 +184,10 @@
 		<defName>Bullet_357Magnum_HV_HP</defName>
 		<label>.357 Magnum bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>22</damageAmountBase>
-			<armorPenetrationSharp>3.5</armorPenetrationSharp>
-			<armorPenetrationBlunt>37.96</armorPenetrationBlunt>
-			<speed>123</speed>
+			<damageAmountBase>19</damageAmountBase>
+			<armorPenetrationSharp>3.6</armorPenetrationSharp>
+			<armorPenetrationBlunt>27.58</armorPenetrationBlunt>
+			<speed>109</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/38Special.xml
+++ b/Defs/Ammo/Pistols/38Special.xml
@@ -123,10 +123,10 @@
 		<defName>Bullet_38Special_HV_FMJ</defName>
 		<label>.38 Special bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>12</damageAmountBase>
+			<damageAmountBase>13</damageAmountBase>
 			<armorPenetrationSharp>4</armorPenetrationSharp>
-			<armorPenetrationBlunt>13.76</armorPenetrationBlunt>
-			<speed>87</speed>
+			<armorPenetrationBlunt>16.02</armorPenetrationBlunt>
+			<speed>92</speed>
 		</projectile>
 	</ThingDef>
 
@@ -136,8 +136,8 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>8</damageAmountBase>
 			<armorPenetrationSharp>8</armorPenetrationSharp>
-			<armorPenetrationBlunt>13.76</armorPenetrationBlunt>
-			<speed>87</speed>
+			<armorPenetrationBlunt>16.02</armorPenetrationBlunt>
+			<speed>92</speed>
 		</projectile>
 	</ThingDef>
 
@@ -145,10 +145,10 @@
 		<defName>Bullet_38Special_HV_HP</defName>
 		<label>.38 Special bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>15</damageAmountBase>
+			<damageAmountBase>16</damageAmountBase>
 			<armorPenetrationSharp>2</armorPenetrationSharp>
-			<armorPenetrationBlunt>13.76</armorPenetrationBlunt>
-			<speed>87</speed>
+			<armorPenetrationBlunt>16.02</armorPenetrationBlunt>
+			<speed>92</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/38Special.xml
+++ b/Defs/Ammo/Pistols/38Special.xml
@@ -124,7 +124,7 @@
 		<label>.38 Special bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>13</damageAmountBase>
-			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationSharp>6</armorPenetrationSharp>
 			<armorPenetrationBlunt>16.02</armorPenetrationBlunt>
 			<speed>92</speed>
 		</projectile>
@@ -135,7 +135,7 @@
 		<label>.38 Special bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>8</damageAmountBase>
-			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationSharp>12</armorPenetrationSharp>
 			<armorPenetrationBlunt>16.02</armorPenetrationBlunt>
 			<speed>92</speed>
 		</projectile>
@@ -146,7 +146,7 @@
 		<label>.38 Special bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>16</damageAmountBase>
-			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
 			<armorPenetrationBlunt>16.02</armorPenetrationBlunt>
 			<speed>92</speed>
 		</projectile>

--- a/Defs/Ammo/Pistols/38Special.xml
+++ b/Defs/Ammo/Pistols/38Special.xml
@@ -117,6 +117,41 @@
 		</projectile>
 	</ThingDef>
 
+	<!-- ========= High velocity ========= -->
+
+	<ThingDef ParentName="Base38SpecialBullet">
+		<defName>Bullet_38Special_HV_FMJ</defName>
+		<label>.38 Special bullet (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>12</damageAmountBase>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationBlunt>13.76</armorPenetrationBlunt>
+			<speed>87</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base38SpecialBullet">
+		<defName>Bullet_38Special_HV_AP</defName>
+		<label>.38 Special bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>8</damageAmountBase>
+			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationBlunt>13.76</armorPenetrationBlunt>
+			<speed>87</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base38SpecialBullet">
+		<defName>Bullet_38Special_HV_HP</defName>
+		<label>.38 Special bullet (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>15</damageAmountBase>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationBlunt>13.76</armorPenetrationBlunt>
+			<speed>87</speed>
+		</projectile>
+	</ThingDef>
+
 	<!-- ==================== Recipes ========================== -->
 
 	<!-- Standard manufacture -->

--- a/Defs/Ammo/Pistols/44Magnum.xml
+++ b/Defs/Ammo/Pistols/44Magnum.xml
@@ -45,6 +45,20 @@
 		</ammoTypes>
 		<similarTo>AmmoSet_PistolMagnum</similarTo>
 	</CombatExtended.AmmoSetDef>
+	
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_44Magnum_Lever</defName>
+		<label>.44 Magnum/.44 Special</label>
+		<ammoTypes>
+			<Ammo_44Magnum_AP>Bullet_44Magnum_HV_FMJ</Ammo_44Magnum_AP>
+			<Ammo_44Magnum_AP>Bullet_44Magnum_HV_AP</Ammo_44Magnum_AP>
+			<Ammo_44Magnum_HP>Bullet_44Magnum_HV_HP</Ammo_44Magnum_HP>
+			<Ammo_44SWSpecial_FMJ>Bullet_44SWSpecial_HV_FMJ</Ammo_44SWSpecial_FMJ>
+			<Ammo_44SWSpecial_AP>Bullet_44SWSpecial_HV_AP</Ammo_44SWSpecial_AP>
+			<Ammo_44SWSpecial_HP>Bullet_44SWSpecial_HV_HP</Ammo_44SWSpecial_HP>
+		</ammoTypes>
+		<similarTo>AmmoSet_PistolMagnum</similarTo>
+	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->
 

--- a/Defs/Ammo/Pistols/44Magnum.xml
+++ b/Defs/Ammo/Pistols/44Magnum.xml
@@ -34,7 +34,7 @@
 
 	<CombatExtended.AmmoSetDef>
 		<defName>AmmoSet_44Magnum_Revolver</defName>
-		<label>.44 Magnum</label>
+		<label>.44 Magnum/.44 Special</label>
 		<ammoTypes>
 			<Ammo_44Magnum_FMJ>Bullet_44Magnum_FMJ</Ammo_44Magnum_FMJ>
 			<Ammo_44Magnum_AP>Bullet_44Magnum_AP</Ammo_44Magnum_AP>

--- a/Defs/Ammo/Pistols/44Magnum.xml
+++ b/Defs/Ammo/Pistols/44Magnum.xml
@@ -50,7 +50,7 @@
 		<defName>AmmoSet_44Magnum_Lever</defName>
 		<label>.44 Magnum/.44 Special</label>
 		<ammoTypes>
-			<Ammo_44Magnum_AP>Bullet_44Magnum_HV_FMJ</Ammo_44Magnum_AP>
+			<Ammo_44Magnum_FMJ>Bullet_44Magnum_HV_FMJ</Ammo_44Magnum_FMJ>
 			<Ammo_44Magnum_AP>Bullet_44Magnum_HV_AP</Ammo_44Magnum_AP>
 			<Ammo_44Magnum_HP>Bullet_44Magnum_HV_HP</Ammo_44Magnum_HP>
 			<Ammo_44SWSpecial_FMJ>Bullet_44SWSpecial_HV_FMJ</Ammo_44SWSpecial_FMJ>

--- a/Defs/Ammo/Pistols/44SWSpecial.xml
+++ b/Defs/Ammo/Pistols/44SWSpecial.xml
@@ -117,6 +117,41 @@
 		</projectile>
 	</ThingDef>
 
+	<!-- ========= High velocity ========= -->
+
+	<ThingDef ParentName="Base44SWSpecialBullet">
+		<defName>Bullet_44SWSpecial_HV_FMJ</defName>
+		<label>.44 Special bullet (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>14</damageAmountBase>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationBlunt>18.78</armorPenetrationBlunt>
+			<speed>87</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base44SWSpecialBullet">
+		<defName>Bullet_44SWSpecial_HV_AP</defName>
+		<label>.44 Special bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>9</damageAmountBase>
+			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationBlunt>18.78</armorPenetrationBlunt>
+			<speed>87</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base44SWSpecialBullet">
+		<defName>Bullet_44SWSpecial_HV_HP</defName>
+		<label>.44 Special bullet (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>18</damageAmountBase>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationBlunt>18.78</armorPenetrationBlunt>
+			<speed>87</speed>
+		</projectile>
+	</ThingDef>
+
 	<!-- ==================== Recipes ========================== -->
 
 	<!-- Standard manufacture -->

--- a/Defs/Ammo/Pistols/44SWSpecial.xml
+++ b/Defs/Ammo/Pistols/44SWSpecial.xml
@@ -123,10 +123,10 @@
 		<defName>Bullet_44SWSpecial_HV_FMJ</defName>
 		<label>.44 Special bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>14</damageAmountBase>
-			<armorPenetrationSharp>4</armorPenetrationSharp>
-			<armorPenetrationBlunt>18.78</armorPenetrationBlunt>
-			<speed>87</speed>
+			<damageAmountBase>17</damageAmountBase>
+			<armorPenetrationSharp>5.4</armorPenetrationSharp>
+			<armorPenetrationBlunt>31.72</armorPenetrationBlunt>
+			<speed>105</speed>
 		</projectile>
 	</ThingDef>
 
@@ -134,10 +134,10 @@
 		<defName>Bullet_44SWSpecial_HV_AP</defName>
 		<label>.44 Special bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>9</damageAmountBase>
-			<armorPenetrationSharp>8</armorPenetrationSharp>
-			<armorPenetrationBlunt>18.78</armorPenetrationBlunt>
-			<speed>87</speed>
+			<damageAmountBase>11</damageAmountBase>
+			<armorPenetrationSharp>10.8</armorPenetrationSharp>
+			<armorPenetrationBlunt>31.72</armorPenetrationBlunt>
+			<speed>105</speed>
 		</projectile>
 	</ThingDef>
 
@@ -145,10 +145,10 @@
 		<defName>Bullet_44SWSpecial_HV_HP</defName>
 		<label>.44 Special bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>18</damageAmountBase>
-			<armorPenetrationSharp>2</armorPenetrationSharp>
-			<armorPenetrationBlunt>18.78</armorPenetrationBlunt>
-			<speed>87</speed>
+			<damageAmountBase>22</damageAmountBase>
+			<armorPenetrationSharp>2.7</armorPenetrationSharp>
+			<armorPenetrationBlunt>31.72</armorPenetrationBlunt>
+			<speed>105</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/44SWSpecial.xml
+++ b/Defs/Ammo/Pistols/44SWSpecial.xml
@@ -3,7 +3,7 @@
 
 	<ThingCategoryDef>
 		<defName>Ammo44SWSpecial</defName>
-		<label>.44 S&amp;W Special</label>
+		<label>.44 Special</label>
 		<parent>AmmoPistols</parent>
 		<iconPath>UI/Icons/ThingCategories/CaliberPistol</iconPath>
 	</ThingCategoryDef>
@@ -12,7 +12,7 @@
 
 	<CombatExtended.AmmoSetDef>
 		<defName>AmmoSet_44SWSpecial</defName>
-		<label>.44 S&amp;W Special</label>
+		<label>.44 Special</label>
 		<ammoTypes>
 			<Ammo_44SWSpecial_FMJ>Bullet_44SWSpecial_FMJ</Ammo_44SWSpecial_FMJ>
 			<Ammo_44SWSpecial_AP>Bullet_44SWSpecial_AP</Ammo_44SWSpecial_AP>
@@ -40,7 +40,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="44SWSpecialBase">
 		<defName>Ammo_44SWSpecial_FMJ</defName>
-		<label>.44 S&amp;W Special (FMJ)</label>
+		<label>.44 Special (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Revolver/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -51,7 +51,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="44SWSpecialBase">
 		<defName>Ammo_44SWSpecial_AP</defName>
-		<label>.44 S&amp;W Special (AP)</label>
+		<label>.44 Special (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Revolver/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -62,7 +62,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="44SWSpecialBase">
 		<defName>Ammo_44SWSpecial_HP</defName>
-		<label>.44 S&amp;W Special (HP)</label>
+		<label>.44 Special (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Revolver/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -89,7 +89,7 @@
 
 	<ThingDef ParentName="Base44SWSpecialBullet">
 		<defName>Bullet_44SWSpecial_FMJ</defName>
-		<label>.44 S&amp;W Special bullet (FMJ)</label>
+		<label>.44 Special bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>11</damageAmountBase>
 			<armorPenetrationSharp>3</armorPenetrationSharp>
@@ -99,7 +99,7 @@
 
 	<ThingDef ParentName="Base44SWSpecialBullet">
 		<defName>Bullet_44SWSpecial_AP</defName>
-		<label>.44 S&amp;W Special bullet (AP)</label>
+		<label>.44 Special bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>7</damageAmountBase>
 			<armorPenetrationSharp>6</armorPenetrationSharp>
@@ -109,7 +109,7 @@
 
 	<ThingDef ParentName="Base44SWSpecialBullet">
 		<defName>Bullet_44SWSpecial_HP</defName>
-		<label>.44 S&amp;W Special bullet (HP)</label>
+		<label>.44 Special bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>14</damageAmountBase>
 			<armorPenetrationSharp>2</armorPenetrationSharp>
@@ -122,9 +122,9 @@
 	<!-- Standard manufacture -->
 	<RecipeDef ParentName="AmmoRecipeBase">
 		<defName>MakeAmmo_44SWSpecial_FMJ</defName>
-		<label>make .44 S&amp;W Special (FMJ) cartridge x500</label>
-		<description>Craft 500 .44 S&amp;W Special (FMJ) cartridges.</description>
-		<jobString>Making .44 S&amp;W Special (FMJ) cartridges.</jobString>
+		<label>make .44 Special (FMJ) cartridge x500</label>
+		<description>Craft 500 .44 Special (FMJ) cartridges.</description>
+		<jobString>Making .44 Special (FMJ) cartridges.</jobString>
 		<ingredients>
 			<li>
 				<filter>
@@ -148,9 +148,9 @@
 
 	<RecipeDef ParentName="AmmoRecipeBase">
 		<defName>MakeAmmo_44SWSpecial_AP</defName>
-		<label>make .44 S&amp;W Special (AP) cartridge x500</label>
-		<description>Craft 500 .44 S&amp;W Special (AP) cartridges.</description>
-		<jobString>Making .44 S&amp;W Special (AP) cartridges.</jobString>
+		<label>make .44 Special (AP) cartridge x500</label>
+		<description>Craft 500 .44 Special (AP) cartridges.</description>
+		<jobString>Making .44 Special (AP) cartridges.</jobString>
 		<ingredients>
 			<li>
 				<filter>
@@ -174,9 +174,9 @@
 
 	<RecipeDef ParentName="AmmoRecipeBase">
 		<defName>MakeAmmo_44SWSpecial_HP</defName>
-		<label>make .44 S&amp;W Special (HP) cartridge x500</label>
-		<description>Craft 500 .44 S&amp;W Special (HP) cartridges.</description>
-		<jobString>Making .44 S&amp;W Special (HP) cartridges.</jobString>
+		<label>make .44 Special (HP) cartridge x500</label>
+		<description>Craft 500 .44 Special (HP) cartridges.</description>
+		<jobString>Making .44 Special (HP) cartridges.</jobString>
 		<ingredients>
 			<li>
 				<filter>

--- a/Defs/Ammo/Pistols/454Casull.xml
+++ b/Defs/Ammo/Pistols/454Casull.xml
@@ -12,7 +12,7 @@
 
 	<CombatExtended.AmmoSetDef>
 		<defName>AmmoSet_454Casull</defName>
-		<label>.454 Casull</label>
+		<label>.454 Casull/.45 Colt</label>
 		<ammoTypes>
 			<Ammo_454Casull_FMJ>Bullet_454Casull_FMJ</Ammo_454Casull_FMJ>
 			<Ammo_454Casull_AP>Bullet_454Casull_AP</Ammo_454Casull_AP>
@@ -26,7 +26,7 @@
 
 	<CombatExtended.AmmoSetDef>
 		<defName>AmmoSet_454Casull410Bore</defName>
-		<label>.454 Casull</label>
+		<label>.454 Casull/.45 Colt/.410 bore</label>
 		<ammoTypes>
 			<Ammo_454Casull_FMJ>Bullet_454Casull_FMJ</Ammo_454Casull_FMJ>
 			<Ammo_454Casull_AP>Bullet_454Casull_AP</Ammo_454Casull_AP>


### PR DESCRIPTION
## Additions
- Added high velocity projectiles for rifles chambered in the above calibers.

## Changes
- Renamed .44 S&W Special to simply .44 Special for consistency and length (We don't call .38 Special .38 S&W Special).
- Certain multicaliber AmmoSets renamed to include their other calibers.

## References
https://docs.google.com/spreadsheets/d/1zlzjPXKY7beHLDCz6aLD-oU9xroHybU1WpcJnrpV9qc/edit?gid=1393347070#gid=1393347070

## Reasoning
- We have high-velocity AmmoSets for .44 Magnum but none for the others.
- 357_HV is used by bolt-action rifles such as the Ruger 77, 357_Lever is obviously used by lever actions, which explains the need to distinguish them.
- I'm not aware of any .38 Special or .44 Special rifles that aren't also able to chamber their magnum counterparts, so their HV projectiles are only included by the bigger multicaliber AmmoSets.