### PR TITLE
Patch Fantasy Metals Reforged Fork

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -190,6 +190,7 @@
 		<li IfModActive="zal.fnveliteriotgear">ModPatches/Fallout New Vegas - Elite Riot Gear</li>
 		<li IfModActive="Phaneron.Vault111Startpack">ModPatches/Fallout Vault 111 Starter Pack</li>
 		<li IfModActive="mercurydoll.fantasymetals">ModPatches/Fantasy Metals Reforged</li>
+		<li IfModActive="zav.fantasymetalsforked">ModPatches/Fantasy Metals Reforged Forked</li>
 		<li IfModActive="Mlie.FarmingExpansion">ModPatches/Farming Expansion</li>
 		<li IfModActive="spoonshortage.fashionrimsta">ModPatches/FashionRIMsta</li>
 		<li IfModActive="RicoFox233.FGO.StylesApparelPack">ModPatches/Fate Grand Order Styles Pack</li>

--- a/ModPatches/Fantasy Metals Reforged Forked/Patches/Fantasy Metals Reforged Forked/CE_Patch_FantayMetalsReforged.xml
+++ b/ModPatches/Fantasy Metals Reforged Forked/Patches/Fantasy Metals Reforged Forked/CE_Patch_FantayMetalsReforged.xml
@@ -2,7 +2,6 @@
 <Patch>
 
 	<!-- Add Bulk and thingCategories -->
-
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="zavMithril" or defName="zavzavOrichalcum" or defName="zavAdamantine"]/statBases</xpath>
 		<value>
@@ -19,31 +18,37 @@
 	</Operation>
 
 	<!-- Mithril -->
-
 	<!-- From 'The Hobbit,' Mithril is described as triple the strength of steel. -->
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="zavMithril"]/statBases/StuffPower_Armor_Sharp</xpath>
 		<value>
-			<StuffPower_Armor_Sharp>3</StuffPower_Armor_Sharp>
+			<StuffPower_Armor_Sharp>2</StuffPower_Armor_Sharp>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="zavMithril"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
-			<StuffPower_Armor_Blunt>3.2</StuffPower_Armor_Blunt>
+			<StuffPower_Armor_Blunt>3</StuffPower_Armor_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="zavMithril"]/statBases/StuffPower_Armor_Heat</xpath>
+		<value>
+			<StuffPower_Armor_Heat>0</StuffPower_Armor_Heat>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="zavMithril"]/stuffProps/statFactors</xpath>
 		<value>
-			<Mass>0.7</Mass>
+			<Mass>0.8</Mass>
+			<MeleePenetrationFactor>1.25</MeleePenetrationFactor>
 		</value>
 	</Operation>
 
 	<!-- zavOrichalcum -->
-
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="zavOrichalcum"]/statBases/StuffPower_Armor_Sharp</xpath>
 		<value>
@@ -58,15 +63,22 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="zavOrichalcum"]/statBases/StuffPower_Armor_Heat</xpath>
+		<value>
+			<StuffPower_Armor_Heat>0.0</StuffPower_Armor_Heat>
+		</value>
+	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="zavOrichalcum"]/stuffProps/statFactors</xpath>
 		<value>
 			<Mass>1.4</Mass>
+			<MeleePenetrationFactor>1.25</MeleePenetrationFactor>
 		</value>
 	</Operation>
 
 	<!-- zavAdamantine -->
-
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="zavAdamantine"]/statBases/StuffPower_Armor_Sharp</xpath>
 		<value>
@@ -78,6 +90,13 @@
 		<xpath>Defs/ThingDef[defName="zavAdamantine"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>4.2</StuffPower_Armor_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="zavAdamantine"]/statBases/StuffPower_Armor_Heat</xpath>
+		<value>
+			<StuffPower_Armor_Heat>0.0</StuffPower_Armor_Heat>
 		</value>
 	</Operation>
 

--- a/ModPatches/Fantasy Metals Reforged Forked/Patches/Fantasy Metals Reforged Forked/CE_Patch_FantayMetalsReforged.xml
+++ b/ModPatches/Fantasy Metals Reforged Forked/Patches/Fantasy Metals Reforged Forked/CE_Patch_FantayMetalsReforged.xml
@@ -5,7 +5,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[
 			defName="zavMithril" or
-			defName="zavzavOrichalcum" or
+			defName="zavOrichalcum" or
 			defName="zavAdamantine"
 			]/statBases</xpath>
 		<value>
@@ -105,6 +105,13 @@
 		<xpath>Defs/ThingDef[defName="zavAdamantine"]/statBases/StuffPower_Armor_Heat</xpath>
 		<value>
 			<StuffPower_Armor_Heat>0.0</StuffPower_Armor_Heat>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="zavAdamantine"]/stuffProps/statFactors</xpath>
+		<value>
+			<MeleePenetrationFactor>1.25</MeleePenetrationFactor>
 		</value>
 	</Operation>
 

--- a/ModPatches/Fantasy Metals Reforged Forked/Patches/Fantasy Metals Reforged Forked/CE_Patch_FantayMetalsReforged.xml
+++ b/ModPatches/Fantasy Metals Reforged Forked/Patches/Fantasy Metals Reforged Forked/CE_Patch_FantayMetalsReforged.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- Add Bulk and thingCategories -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="zavMithril" or defName="zavzavOrichalcum" or defName="zavAdamantine"]/statBases</xpath>
+		<value>
+			<Bulk>0.03</Bulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="zavMithril" or defName="zavzavOrichalcum" or defName="zavAdamantine"]/stuffProps/categories</xpath>
+		<value>
+			<li>Metallic_Weapon</li>
+			<li>Steeled</li>
+		</value>
+	</Operation>
+
+	<!-- Mithril -->
+
+	<!-- From 'The Hobbit,' Mithril is described as triple the strength of steel. -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="zavMithril"]/statBases/StuffPower_Armor_Sharp</xpath>
+		<value>
+			<StuffPower_Armor_Sharp>3</StuffPower_Armor_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="zavMithril"]/statBases/StuffPower_Armor_Blunt</xpath>
+		<value>
+			<StuffPower_Armor_Blunt>3.2</StuffPower_Armor_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="zavMithril"]/stuffProps/statFactors</xpath>
+		<value>
+			<Mass>0.7</Mass>
+		</value>
+	</Operation>
+
+	<!-- zavOrichalcum -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="zavOrichalcum"]/statBases/StuffPower_Armor_Sharp</xpath>
+		<value>
+			<StuffPower_Armor_Sharp>1.3</StuffPower_Armor_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="zavOrichalcum"]/statBases/StuffPower_Armor_Blunt</xpath>
+		<value>
+			<StuffPower_Armor_Blunt>1.5</StuffPower_Armor_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="zavOrichalcum"]/stuffProps/statFactors</xpath>
+		<value>
+			<Mass>1.4</Mass>
+		</value>
+	</Operation>
+
+	<!-- zavAdamantine -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="zavAdamantine"]/statBases/StuffPower_Armor_Sharp</xpath>
+		<value>
+			<StuffPower_Armor_Sharp>3.4</StuffPower_Armor_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="zavAdamantine"]/statBases/StuffPower_Armor_Blunt</xpath>
+		<value>
+			<StuffPower_Armor_Blunt>4.2</StuffPower_Armor_Blunt>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Fantasy Metals Reforged Forked/Patches/Fantasy Metals Reforged Forked/CE_Patch_FantayMetalsReforged.xml
+++ b/ModPatches/Fantasy Metals Reforged Forked/Patches/Fantasy Metals Reforged Forked/CE_Patch_FantayMetalsReforged.xml
@@ -3,14 +3,22 @@
 
 	<!-- Add Bulk and thingCategories -->
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="zavMithril" or defName="zavzavOrichalcum" or defName="zavAdamantine"]/statBases</xpath>
+		<xpath>Defs/ThingDef[
+			defName="zavMithril" or
+			defName="zavzavOrichalcum" or
+			defName="zavAdamantine"
+			]/statBases</xpath>
 		<value>
 			<Bulk>0.03</Bulk>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="zavMithril" or defName="zavzavOrichalcum" or defName="zavAdamantine"]/stuffProps/categories</xpath>
+		<xpath>Defs/ThingDef[
+			defName="zavMithril" or
+			defName="zavzavOrichalcum" or
+			defName="zavAdamantine"
+			]/stuffProps/categories</xpath>
 		<value>
 			<li>Metallic_Weapon</li>
 			<li>Steeled</li>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -232,6 +232,7 @@ Faction: Mafia  |
 Fallout New Vegas - Elite Riot Gear |
 Fallout: Vault 111 Starter Pack |
 Fantasy Metals Reforged |
+Fantasy Metals Reforged Forked |
 Farming Expansion   |
 FashionRIMsta	|
 Fate Grand Order - Styles Apparel Pack	|


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Patches metals partially based on the original mod

## Changes
- Mithril changed to match Plasteel as the modder specifically calls it out to being equal
- Heat Armor to 0 like other metals
- Add melee armor penetration like plasteel/uranium

## Reasoning

Why did you choose to implement things this way, e.g.
- Defnames changed in the forked version
-  Original mod will still technically work being a purely XML and relatively simple

## Alternatives

Describe alternative implementations you have considered, e.g.
- Completely overwrite the original

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (Quicktest)
