### PR TITLE
Fix stray whitespace in readme image links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,13 @@
 </p>
 <p align="left">
   <a href="https://discord.gg/safyWuA">
-    <img src="https://img.shields.io/badge/join%20us-black?style=for-the-badge&logo=discord&logoColor=white">
-  </a>
+    <img src="https://img.shields.io/badge/join%20us-black?style=for-the-badge&logo=discord&logoColor=white"></a>
   <a href="https://steamcommunity.com/sharedfiles/filedetails/?id=2890901044">
-    <img src="https://img.shields.io/badge/subscribe-black?style=for-the-badge&logo=steam">
-  </a>
+    <img src="https://img.shields.io/badge/subscribe-black?style=for-the-badge&logo=steam"></a>
   <a href="https://github.com/CombatExtended-Continued/CombatExtended/releases">
-    <img src="https://img.shields.io/badge/-latest%20release-black?style=for-the-badge&logo=github">
-  </a>
+    <img src="https://img.shields.io/badge/-latest%20release-black?style=for-the-badge&logo=github"></a>
   <a href="https://combatextended.lp-programming.com/CombatExtended-latest.zip">
-    <img src="https://img.shields.io/badge/development%20snapshot-black?style=for-the-badge&logo=github">
-  </a>
+    <img src="https://img.shields.io/badge/development%20snapshot-black?style=for-the-badge&logo=github"></a>
 </p>
 
 Combat Extended completely overhauls combat. It adds completely new shooting and melee mechanics, an inventory system, and rebalances the health system.


### PR DESCRIPTION
## Changes

- Fixed stray underlined spaces from the image links in readme file.

## References

- These things between buttons:
![image](https://github.com/user-attachments/assets/49e5baf5-3d94-4e7b-971a-e52ddd28318b)


## Reasoning

- Whitespace collapsing turns any newlines between tags into single spaces, avoided by putting the closing tags inline.

## Testing

Check tests you have performed:
- [x] It's a readme
