### PR TITLE
Log the missing defName when our patch operation fails

### DIFF
--- a/Source/CombatExtended/CombatExtended/PatchOperationMakeGunCECompatible.cs
+++ b/Source/CombatExtended/CombatExtended/PatchOperationMakeGunCECompatible.cs
@@ -86,6 +86,10 @@ namespace CombatExtended
                     AddRunAndGunExtension(xml, xmlNode);
                 }
             }
+            if (!result)
+            {
+                Log.Warning($"PatchOperationMakeGunCECompatible tried to find def {defName} by defName, but it doesn't exist");
+            }
             return result;
         }
 


### PR DESCRIPTION
## Additions

Log which defName is missing when a `PatchOperationMakeGunCECompatible` fails

## Reasoning

The native logging only reports the file. In large patch files, it can take a bit to find the offending defName.


## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
