### PR TITLE
re-add lerpPosition to ProjectileCE for legacy compatibility

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -34,6 +34,9 @@ namespace CombatExtended
         public int fuelTicks;
         public Vector3 velocity;
         public float initialSpeed;
+
+        // Deprecated: Remove in 1.6
+        public bool lerpPosition = true;
         #endregion
 
         #region Drawing
@@ -1188,6 +1191,10 @@ namespace CombatExtended
             {
                 return;
             }
+            if (lerpPosition != (TrajectoryWorker is LerpedTrajectoryWorker))
+            {
+                Log.Warning($"ProjectileCE.lerpPosition value changed in {this}. Setting or referencing this field is deprecated. Please report this.");
+            }
             if (TrajectoryWorker is BallisticsTrajectoryWorker && DamageAmount < 0.01f && mass < 1f) // We've stopped, and won't restart.
             {
                 Destroy(DestroyMode.Vanish);
@@ -1581,6 +1588,7 @@ namespace CombatExtended
                         Log.WarningOnce($"{this} properties is not ProjectilePropertiesCE, please contact CE team", this.def.GetHashCode());
                         forcedTrajectoryWorker = new LerpedTrajectoryWorker();
                     }
+                    lerpPosition = forcedTrajectoryWorker is LerpedTrajectoryWorker;
                 }
                 return forcedTrajectoryWorker;
             }

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -183,6 +183,12 @@ namespace CombatExtended
         #region Position
         private Vector3 exactPosition;
 
+        public virtual Vector2 Vec2Position()
+        {
+            Log.ErrorOnce($"{this}.Vec2Position() is deprecated and will be removed in 1.6", 50021 + def.projectile.GetHashCode());
+            return new Vector2(ExactPosition.x, ExactPosition.z);
+        }
+
         /// <summary>
         /// Exact x,y,z (x,height,y) position in terms of Vec2Position.x, .y (lerped origin to Destination) and Height.
         /// </summary>
@@ -1193,7 +1199,7 @@ namespace CombatExtended
             }
             if (lerpPosition != (TrajectoryWorker is LerpedTrajectoryWorker))
             {
-                Log.Warning($"ProjectileCE.lerpPosition value changed in {this}. Setting or referencing this field is deprecated. Please report this.");
+                Log.WarningOnce($"ProjectileCE.lerpPosition value changed in {this}. Setting or referencing this field is deprecated. Please report this.", 50004 + def.projectile.GetHashCode());
             }
             if (TrajectoryWorker is BallisticsTrajectoryWorker && DamageAmount < 0.01f && mass < 1f) // We've stopped, and won't restart.
             {

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -1575,7 +1575,12 @@ namespace CombatExtended
             {
                 if (forcedTrajectoryWorker == null)
                 {
-                    if (def.projectile is ProjectilePropertiesCE propertiesCE)
+                    if (!lerpPosition)
+                    {
+                        Log.ErrorOnce($"Setting lerpPosition in ProjectileCE directly for {this} is deprecated, set the trajectoryWorker instead", 50003 + def.projectile.GetHashCode());
+                        forcedTrajectoryWorker = ProjectilePropertiesCE.defaultBallisticTrajectoryWorker;
+                    }
+                    else if (def.projectile is ProjectilePropertiesCE propertiesCE)
                     {
                         if (propertiesCE.lerpPosition != "")
                         {
@@ -1586,7 +1591,7 @@ namespace CombatExtended
                     else
                     {
                         Log.WarningOnce($"{this} properties is not ProjectilePropertiesCE, please contact CE team", this.def.GetHashCode());
-                        forcedTrajectoryWorker = new LerpedTrajectoryWorker();
+                        forcedTrajectoryWorker = ProjectilePropertiesCE.defaultLerpedTrajectoryWorker;
                     }
                     lerpPosition = forcedTrajectoryWorker is LerpedTrajectoryWorker;
                 }

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectilePropertiesCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectilePropertiesCE.cs
@@ -73,7 +73,7 @@ namespace CombatExtended
         private BaseTrajectoryWorker trajectoryWorkerInt;
         public string lerpPosition = "";
 
-        private static LerpedTrajectoryWorker defaultLerpedTrajectoryWorker = new LerpedTrajectoryWorker();
+        public static LerpedTrajectoryWorker defaultLerpedTrajectoryWorker = new LerpedTrajectoryWorker();
         public static BallisticsTrajectoryWorker defaultBallisticTrajectoryWorker = new BallisticsTrajectoryWorker();
 
         public BaseTrajectoryWorker TrajectoryWorker


### PR DESCRIPTION
## Additions

The legacy `lerpPosition` flag is re-added to ProjectileCE for downstream mods referencing it. It will be expunged when 1.6 drops.

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #3862 

## Reasoning

Some mods, at least Bill's, reference the lerpPosition field to determine how some of their projectiles behave. So we need to make it a field they can reference until the last mod depending on it is updated.

## Alternatives

Break other mods.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
