### PR TITLE
Bioferrite flare recipe output fix

### DIFF
--- a/Defs/Ammo/Other/Flare.xml
+++ b/Defs/Ammo/Other/Flare.xml
@@ -80,7 +80,7 @@
 		<cookOffProjectile>Bullet_Flare</cookOffProjectile>
 	</ThingDef>
 
-		<ThingDef Class="CombatExtended.AmmoDef" ParentName="FlareBase" MayRequire="Ludeon.RimWorld.Anomaly">
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="FlareBase" MayRequire="Ludeon.RimWorld.Anomaly">
 		<defName>Ammo_FlareBioferrite</defName>
 		<label>bioferrite flare round</label>
 		<graphicData>
@@ -141,7 +141,7 @@
 					</li>
 				</FleckDatas>
 			</li>
-    	</comps>
+		</comps>
 	</ThingDef>
 
 	<ThingDef MayRequire="Ludeon.RimWorld.Anomaly">
@@ -280,7 +280,7 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_Flare>200</Ammo_Flare>
+			<Ammo_FlareBioferrite>200</Ammo_FlareBioferrite>
 		</products>
 		<workAmount>2000</workAmount>
 	</RecipeDef>


### PR DESCRIPTION
## Changes

- What it says on the tin, the recipe output was incorrectly set to normal flares and not caught.

## Alternatives

- Suffer the goof.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
