### PR TITLE
Generic light HE-TF cannon shell ammoClass fix

### DIFF
--- a/Defs/Ammo/Generic/Shell_Cannon.xml
+++ b/Defs/Ammo/Generic/Shell_Cannon.xml
@@ -96,7 +96,7 @@
 			<texPath>Things/Ammo/HighCaliber/Bofors/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
-		<ammoClass>GrenadeHE</ammoClass>
+		<ammoClass>GrenadeHETF</ammoClass>
 		<cookOffProjectile>Bullet_40x365mmBofors_HE</cookOffProjectile>
 	</ThingDef>
 


### PR DESCRIPTION
## Changes

- What it says on the tin.

## Reasoning

-  Tt was set to normal HE by mistake making the HE-TF shells not convert to generic types properly.

## Alternatives

- Suffer.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
