### PR TITLE
Add starting delay to projectile fleck emitter

### DIFF
--- a/Defs/Ammo/Other/Flamethrower.xml
+++ b/Defs/Ammo/Other/Flamethrower.xml
@@ -121,14 +121,14 @@
 						<emissionsPerTick>2</emissionsPerTick>
 						<flecksPerEmission>2</flecksPerEmission>
 						<scale>1</scale>
-						<startDelayTick>1</startDelayTick>
+						<startDelayTick>2</startDelayTick>
 					</li>
 					<li>
 						<fleck>Fleck_CEFlamethrowerSmokeTrail</fleck>
 						<emissionsPerTick>2</emissionsPerTick>
 						<flecksPerEmission>1</flecksPerEmission>
 						<scale>1</scale>
-						<startDelayTick>1</startDelayTick>
+						<startDelayTick>2</startDelayTick>
 					</li>
 				</FleckDatas>
 			</li>

--- a/Defs/Ammo/Other/Flamethrower.xml
+++ b/Defs/Ammo/Other/Flamethrower.xml
@@ -121,12 +121,14 @@
 						<emissionsPerTick>2</emissionsPerTick>
 						<flecksPerEmission>2</flecksPerEmission>
 						<scale>1</scale>
+						<startDelayTick>1</startDelayTick>
 					</li>
 					<li>
 						<fleck>Fleck_CEFlamethrowerSmokeTrail</fleck>
 						<emissionsPerTick>2</emissionsPerTick>
 						<flecksPerEmission>1</flecksPerEmission>
 						<scale>1</scale>
+						<startDelayTick>1</startDelayTick>
 					</li>
 				</FleckDatas>
 			</li>

--- a/Defs/Ammo/Rocket/RPG7.xml
+++ b/Defs/Ammo/Rocket/RPG7.xml
@@ -105,6 +105,7 @@
 						<scale>1</scale>
 						<cutoffTickRange>25~30</cutoffTickRange>
 						<originOffset>0.4</originOffset>
+						<startDelayTick>2</startDelayTick>
 					</li>
 					<li>
 						<fleck>Fleck_CERocketSmokeTrail</fleck>
@@ -112,6 +113,7 @@
 						<rotation>0~360</rotation>
 						<scale>0.5</scale>
 						<flecksPerEmission>1</flecksPerEmission>
+						<startDelayTick>2</startDelayTick>						
 					</li>
 					<li>
 						<fleck>Fleck_CERocketSmoke</fleck>

--- a/Source/CombatExtended/CombatExtended/Comps/CompThrownFleckEmitterSmooth.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompThrownFleckEmitterSmooth.cs
@@ -58,7 +58,9 @@ namespace CombatExtended
             Vector3 delta = lastPos - parent.DrawPos;
             foreach (ProjectileFleckDataCE data in Props.FleckDatas)
             {
-                if ((data.cutoffTickRange.max < 0 || age < data.cutoffTickRange.max) && data.shouldEmit(age))
+                if ((data.cutoffTickRange.max < 0 || age < data.cutoffTickRange.max) 
+                    && (data.startDelayTick < 0 || age > data.startDelayTick)
+                    && data.shouldEmit(age))
                 {
                     float scaleoffset = 0;
                     Vector3 diff = Vector3.zero;
@@ -111,6 +113,8 @@ namespace CombatExtended
         public FloatRange scale = new FloatRange(1, 1);
 
         public IntRange cutoffTickRange = new IntRange(-1, -1);
+
+        public int startDelayTick = 1;
 
         public float originOffset = 0.7f;
 

--- a/Source/CombatExtended/CombatExtended/Comps/CompThrownFleckEmitterSmooth.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompThrownFleckEmitterSmooth.cs
@@ -63,6 +63,7 @@ namespace CombatExtended
                     && data.shouldEmit(age))
                 {
                     float scaleoffset = 0;
+
                     Vector3 diff = Vector3.zero;
                     for (int i = 0; i < data.emissionAmount; i++)
                     {

--- a/Source/CombatExtended/CombatExtended/Comps/CompThrownFleckEmitterSmooth.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompThrownFleckEmitterSmooth.cs
@@ -58,12 +58,11 @@ namespace CombatExtended
             Vector3 delta = lastPos - parent.DrawPos;
             foreach (ProjectileFleckDataCE data in Props.FleckDatas)
             {
-                if ((data.cutoffTickRange.max < 0 || age < data.cutoffTickRange.max) 
+                if ((data.cutoffTickRange.max < 0 || age < data.cutoffTickRange.max)
                     && (data.startDelayTick < 0 || age > data.startDelayTick)
                     && data.shouldEmit(age))
                 {
                     float scaleoffset = 0;
-
                     Vector3 diff = Vector3.zero;
                     for (int i = 0; i < data.emissionAmount; i++)
                     {


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Adds a `<startDelayTick>1</startDelayTick>` field to skip creating certain flecks before a certain tick
- Sets this field to skip the first tick by default

## Reasoning

Why did you choose to implement things this way, e.g.
- Projectiles like flamethrower fuel and RPG-7 rockets use this and look weird, because projectiles are launched from the center of the pawn, and firey flecks are left on the pawn itself. Since making projectiles spawn at gun's end is problematic, this is a quick fix that will be also useful for doing different visual effects. 
- Serina wanted to use this to make blackpowder guns emit smoke flecks

- Before and after:
![Image](https://i.imgur.com/RTi5Omd.png)

## Alternatives

Describe alternative implementations you have considered, e.g.
- Make projectiles appear at gun barrel position

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
