### PR TITLE
Configurable explosions

### DIFF
--- a/Languages/English/Keyed/ModMenu.xml
+++ b/Languages/English/Keyed/ModMenu.xml
@@ -91,6 +91,12 @@
 	<CE_Settings_EnableExtraEffects_Title>Show additional projectile visual effects</CE_Settings_EnableExtraEffects_Title>
 	<CE_Settings_EnableExtraEffects_Desc>Bullets and other projectiles will display additional effects, such as bullets kicking up dust or incendiaries throwing sparks. Cosmetic only, does not affect gameplay.</CE_Settings_EnableExtraEffects_Desc>
 
+
+        <CE_Settings_ExplosionPenMultiplier_Title>Explosion Penetration Multiplier</CE_Settings_ExplosionPenMultiplier_Title>
+        <CE_Settings_ExplosionPenMultiplier_Desc>Scales all explosion penetration by this amount</CE_Settings_ExplosionPenMultiplier_Desc>
+        <CE_Settings_ExplosionDamageFalloffFactor_Title>Explosion Falloff Factor</CE_Settings_ExplosionDamageFalloffFactor_Title>
+        <CE_Settings_ExplosionDamageFalloffFactor_Desc>Scales explosion falloff rates. This is exponential, so small changes have a large effect</CE_Settings_ExplosionDamageFalloffFactor_Desc>
+
 	<!-- ========== Bipod settings ========== -->
 
 	<CE_Settings_BipodSettings>Bipod settings</CE_Settings_BipodSettings>

--- a/Languages/English/Keyed/ModMenu.xml
+++ b/Languages/English/Keyed/ModMenu.xml
@@ -92,10 +92,10 @@
 	<CE_Settings_EnableExtraEffects_Desc>Bullets and other projectiles will display additional effects, such as bullets kicking up dust or incendiaries throwing sparks. Cosmetic only, does not affect gameplay.</CE_Settings_EnableExtraEffects_Desc>
 
 
-        <CE_Settings_ExplosionPenMultiplier_Title>Explosion Penetration Multiplier</CE_Settings_ExplosionPenMultiplier_Title>
-        <CE_Settings_ExplosionPenMultiplier_Desc>Scales all explosion penetration by this amount</CE_Settings_ExplosionPenMultiplier_Desc>
-        <CE_Settings_ExplosionDamageFalloffFactor_Title>Explosion Falloff Factor</CE_Settings_ExplosionDamageFalloffFactor_Title>
-        <CE_Settings_ExplosionDamageFalloffFactor_Desc>Scales explosion falloff rates. This is exponential, so small changes have a large effect</CE_Settings_ExplosionDamageFalloffFactor_Desc>
+	<CE_Settings_ExplosionPenMultiplier_Title>Explosion Penetration Multiplier</CE_Settings_ExplosionPenMultiplier_Title>
+	<CE_Settings_ExplosionPenMultiplier_Desc>Scales all explosion penetration by this amount</CE_Settings_ExplosionPenMultiplier_Desc>
+	<CE_Settings_ExplosionDamageFalloffFactor_Title>Explosion Falloff Factor</CE_Settings_ExplosionDamageFalloffFactor_Title>
+	<CE_Settings_ExplosionDamageFalloffFactor_Desc>Scales explosion falloff rates. This is exponential, so small changes have a large effect</CE_Settings_ExplosionDamageFalloffFactor_Desc>
 
 	<!-- ========== Bipod settings ========== -->
 
@@ -117,7 +117,7 @@
 	<!-- ========== Autopatcher settings ========== -->
 
 	<CE_Settings_VerboseAutopatcher_Title>Enable autopatcher verbose logging</CE_Settings_VerboseAutopatcher_Title>
-	<CE_Settings_VerboseAutopatcher_Desc>This will enable verbose logging of the autopatcher</CE_Settings_VerboseAutopatcher_Desc>			
+	<CE_Settings_VerboseAutopatcher_Desc>This will enable verbose logging of the autopatcher</CE_Settings_VerboseAutopatcher_Desc>
 
 	<CE_Settings_ApparelAutopatcher_Title>Enable apparel autopatcher</CE_Settings_ApparelAutopatcher_Title>
 	<CE_Settings_ApparelAutopatcher_Desc>Attempt to apply an appropriate apparel preset to the armor values of unpatched apparel.</CE_Settings_ApparelAutopatcher_Desc>
@@ -141,8 +141,8 @@
 	<CE_Settings_DeclineRestart>Continue</CE_Settings_DeclineRestart>
 	<CE_Settings_RestartTitle>Generic ammo setting has changed</CE_Settings_RestartTitle>
 
-  <!-- ========== CIWS ========== -->
-  <CE_Settings_EnableCIWS>Enable CIWS</CE_Settings_EnableCIWS>
-  <CE_Settings_EnableCIWS_Desc>Allows some turrets to function as Close-In Weapon Systems, capable of intercepting incoming hostile projectiles and/or drop pods.</CE_Settings_EnableCIWS_Desc>
+	<!-- ========== CIWS ========== -->
+	<CE_Settings_EnableCIWS>Enable CIWS</CE_Settings_EnableCIWS>
+	<CE_Settings_EnableCIWS_Desc>Allows some turrets to function as Close-In Weapon Systems, capable of intercepting incoming hostile projectiles and/or drop pods.</CE_Settings_EnableCIWS_Desc>
 
 </LanguageData>

--- a/Source/CombatExtended/CombatExtended/AmmoUtility.cs
+++ b/Source/CombatExtended/CombatExtended/AmmoUtility.cs
@@ -9,7 +9,7 @@ namespace CombatExtended
         /// <summary>
         /// Multiplier used to scale the armor penetration of a given projectile's explosion
         /// </summary>
-        private const float ExplosiveArmorPenetrationMultiplier = 0.4f;
+        private static float ExplosiveArmorPenetrationMultiplier => 0.4f * Controller.settings.ExplosionPenMultiplier;
 
         /// <summary>
         ///     Generates a readout text for a projectile with the damage amount, type, secondary explosion and other CE stats for

--- a/Source/CombatExtended/CombatExtended/ExplosionCE.cs
+++ b/Source/CombatExtended/CombatExtended/ExplosionCE.cs
@@ -16,8 +16,8 @@ namespace CombatExtended
         public bool radiusChange = false;
         public bool toBeMerged = false;
         private const int DamageAtEdge = 2;      // Synch these with spreadsheet
-        private const float PenAtEdge = 0.6f;
-        private const float PressurePerDamage = 0.3f;
+        private static float PenAtEdge => 0.6f * Controller.settings.ExplosionPenMultiplier;
+        private static float PressurePerDamage => 0.3f * Controller.settings.ExplosionPenMultiplier;
         private const float MaxMergeTicks = 3f;
         public const float MaxMergeRange = 3f;           //merge within 3 tiles
         public const bool MergeExplosions = false;
@@ -410,7 +410,7 @@ namespace CombatExtended
                 return damAmount;
             }
             var t = c.DistanceTo(Position) / radius;
-            t = Mathf.Pow(t, 0.333f);
+            t = Mathf.Pow(t, 0.333f * Controller.settings.ExplosionDamageFalloffFactor);
             return Mathf.Max(GenMath.RoundRandom(Mathf.Lerp((float)damAmount, DamageAtEdge, t)), 1);
         }
 
@@ -422,7 +422,7 @@ namespace CombatExtended
                 return basePen;
             }
             var t = c.DistanceTo(Position) / radius;
-            t = Mathf.Pow(t, 0.55f);
+            t = Mathf.Pow(t, 0.55f * Controller.settings.ExplosionDamageFalloffFactor);
             return Mathf.Lerp(basePen, PenAtEdge, t);
         }
     }

--- a/Source/CombatExtended/CombatExtended/SecondaryDamage.cs
+++ b/Source/CombatExtended/CombatExtended/SecondaryDamage.cs
@@ -10,7 +10,7 @@ namespace CombatExtended
 {
     public class SecondaryDamage
     {
-        private const float SecExplosionPenPerDmg = 0.8f; // 2x ExplosiveArmorPenetrationMultiplier
+        private static float SecExplosionPenPerDmg => 0.8f * Controller.settings.ExplosionPenMultiplier; // 2x ExplosiveArmorPenetrationMultiplier
 
         public DamageDef def;
         public int amount;

--- a/Source/CombatExtended/CombatExtended/Settings.cs
+++ b/Source/CombatExtended/CombatExtended/Settings.cs
@@ -40,6 +40,9 @@ namespace CombatExtended
 
         private bool fasterRepeatShots = true;
 
+        private float explosionPenMultiplier = 1.0f;
+        private float explosionDamageFalloffFactor = 1.0f;
+
         public bool ShowCasings => showCasings;
 
         public bool BipodMechanics => bipodMechanics;
@@ -133,6 +136,9 @@ namespace CombatExtended
 
         public bool FasterRepeatShots => fasterRepeatShots;
 
+        public float ExplosionPenMultiplier => explosionPenMultiplier;
+        public float ExplosionDamageFalloffFactor => explosionDamageFalloffFactor;
+
         public bool CreateCasingsFilth => createCasingsFilth;
 
         public bool RecoilAnim => recoilAnim;
@@ -208,6 +214,8 @@ namespace CombatExtended
 
             Scribe_Values.Look(ref fragmentsFromWalls, "fragmentsFromWalls", false);
             Scribe_Values.Look(ref fasterRepeatShots, "fasterRepeatShots", false);
+            Scribe_Values.Look(ref explosionPenMultiplier, "explosionPenMultiplier", 1.0f);
+            Scribe_Values.Look(ref explosionDamageFalloffFactor, "explosionDamageFalloffFactor", 1.0f);
 
             //CIWS
             Scribe_Values.Look(ref enableCIWS, nameof(enableCIWS), true);
@@ -237,6 +245,8 @@ namespace CombatExtended
             list.CheckboxLabeled("CE_Settings_EnableExtraEffects_Title".Translate(), ref enableExtraEffects, "CE_Settings_EnableExtraEffects_Desc".Translate());
             list.CheckboxLabeled("CE_Settings_EnableCIWS".Translate(), ref enableCIWS, "CE_Settings_EnableCIWS_Desc".Translate());
             list.CheckboxLabeled("CE_Settings_FragmentsFromWalls_Title".Translate(), ref fragmentsFromWalls, "CE_Settings_FragmentsFromWalls_Desc".Translate());
+            explosionPenMultiplier = list.SliderLabeled("CE_Settings_ExplosionPenMultiplier_Title".Translate(), explosionPenMultiplier, 0.1f, 10f, tooltip:"CE_Settings_ExplosionPenMultiplier_Desc".Translate());
+            explosionDamageFalloffFactor = list.SliderLabeled("CE_Settings_ExplosionDamageFalloffFactor_Title".Translate(), explosionDamageFalloffFactor, 0.1f, 10f, tooltip:"CE_Settings_ExplosionDamageFalloffFactor_Desc".Translate());
 
             list.GapLine(); Text.Font = GameFont.Medium;
             list.Label("CE_Settings_Rendering_Title".Translate(), tooltip: "CE_Settings_Rendering_Desc".Translate());


### PR DESCRIPTION
## Additions

Adds a pair of settings for dynamically adjusting global explosion parameters via sliders.

## Changes

Explosion related constants are now getter functions that are scaled via a slider setting.

## Reasoning

Explosion penetration and falloff rates are hard to get right. Different mod sets work better with different values, so it is impossible to configure generic explosions to make everyone happy.  This lets each player set it however they like.

## Alternatives

Get a better real-world model for explosions -- hard to do
Continually tweak the value based on different assumptions -- will always introduce new edge cases.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
