### PR TITLE
Remove deprecated FSFBionicJaw patch from [FSF] Vanilla Bionics Expansion

### DIFF
--- a/ModPatches/FSF Vanilla Bionics Expansion/Patches/FSF Vanilla Bionics Expansion/HediffDefs/FSFBionics_AddedParts.xml
+++ b/ModPatches/FSF Vanilla Bionics Expansion/Patches/FSF Vanilla Bionics Expansion/HediffDefs/FSFBionics_AddedParts.xml
@@ -40,24 +40,6 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/HediffDef[defName="FSFBionicJaw"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
-		<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-					<label>teeth</label>
-					<capacities>
-						<li>Bite</li>
-					</capacities>
-					<power>4</power>
-					<cooldownTime>1.5</cooldownTime>
-					<armorPenetrationSharp>0.2</armorPenetrationSharp>
-					<armorPenetrationBlunt>2.0</armorPenetrationBlunt>
-				</li>
-			</tools>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="FSFArchotechJaw"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
 		<value>
 			<tools>


### PR DESCRIPTION
## Changes

The FSFBionicJaw hediff was removed from [FSF] Vanilla Bionics Expansion in 1.5. All I've done is remove the patch that creates a harmless red error at startup.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings (N/A)
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (N/A)
