### PR TITLE
Add Medieval Overhaul check to House Sanguin/MO patch

### DIFF
--- a/ModPatches/DD House Sanguin/Patches/DD House Sanguin/Mods/Medieval Overhaul/PawnKinds_MO.xml
+++ b/ModPatches/DD House Sanguin/Patches/DD House Sanguin/Mods/Medieval Overhaul/PawnKinds_MO.xml
@@ -1,13 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
+	
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Medieval Overhaul</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
 
-	<!-- === Remove conflicting apparel layer === -->
-	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/PawnKindDef[defName="DevDesigner_KnightSanguin"]/apparelRequired/li[.="DankPyon_Footwear_BootsPlate"]</xpath>
-	</Operation>
+				<!-- === Remove conflicting apparel layer === -->
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/PawnKindDef[defName="DevDesigner_KnightSanguin"]/apparelRequired/li[.="DankPyon_Footwear_BootsPlate"]</xpath>
+				</li>
 
-	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/PawnKindDef[defName="DevDesigner_KnightSanguin"]/apparelRequired/li[.="DankPyon_Handwear_GlovesPlate"]</xpath>
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/PawnKindDef[defName="DevDesigner_KnightSanguin"]/apparelRequired/li[.="DankPyon_Handwear_GlovesPlate"]</xpath>
+				</li>
+
+			</operations>
+		</match>
 	</Operation>
 
 </Patch>


### PR DESCRIPTION
Apologies for the duplicate PR, I unintentionally closed the previous one while doing some housekeeping on my end.

## Changes

Adds a FindMod check to the Medieval Overhaul-specific patches in House Sanguin. The check is present in the [bloodwine patch](https://github.com/CombatExtended-Continued/CombatExtended/blob/Development/ModPatches/DD%20House%20Sanguin/Patches/DD%20House%20Sanguin/Mods/Medieval%20Overhaul/Bloodwine_MO.xml), but not this one. Without this check, users with House Sanguin but not Medieval Overhaul will get harmless red errors about a patch failure.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings (N/A)
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (N/A)