### PR TITLE
Archer loadout adjustment followup to #3839

### DIFF
--- a/Biotech/Patches/PawnKindDefs_Humanlike/PawnKinds_Impid.xml
+++ b/Biotech/Patches/PawnKindDefs_Humanlike/PawnKinds_Impid.xml
@@ -9,8 +9,8 @@
 			<modExtensions Inherit="False">
 				<li Class="CombatExtended.LoadoutPropertiesExtension">
 					<primaryMagazineCount>
-						<min>20</min>
-						<max>40</max>
+						<min>4</min>
+						<max>7</max>
 					</primaryMagazineCount>
 					<forcedAmmoCategory>FlameArrow</forcedAmmoCategory>
 					<sidearms>
@@ -45,8 +45,8 @@
 			<modExtensions Inherit="False">
 				<li Class="CombatExtended.LoadoutPropertiesExtension">
 					<primaryMagazineCount>
-						<min>25</min>
-						<max>50</max>
+						<min>4</min>
+						<max>7</max>
 					</primaryMagazineCount>
 					<forcedAmmoCategory>FlameArrow</forcedAmmoCategory>
 					<sidearms>

--- a/Defs/PawnKindDefs/PawnKinds_CE.xml
+++ b/Defs/PawnKindDefs/PawnKinds_CE.xml
@@ -98,7 +98,7 @@
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
 					<min>10</min>
-					<max>30</max>
+					<max>20</max>
 				</primaryMagazineCount>
 				<forcedSidearm>
 					<sidearmMoney>

--- a/Ideology/Patches/PawnKindDefs_Ideology/IdeologyPawnKinds.xml
+++ b/Ideology/Patches/PawnKindDefs_Ideology/IdeologyPawnKinds.xml
@@ -34,8 +34,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>14</min>
-					<max>28</max>
+					<min>3</min>
+					<max>5</max>
 				</primaryMagazineCount>
 				<sidearms>
 					<li>

--- a/ModPatches/Antinium/Patches/Antinium/PawnKindDefs_Ants/Ant_PawnKindsRaider.xml
+++ b/ModPatches/Antinium/Patches/Antinium/PawnKindDefs_Ants/Ant_PawnKindsRaider.xml
@@ -62,8 +62,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>15</min>
-					<max>30</max>
+					<min>4</min>
+					<max>6</max>
 				</primaryMagazineCount>
 				<shieldMoney>
 					<min>80</min>
@@ -101,8 +101,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>20</min>
-					<max>40</max>
+					<min>5</min>
+					<max>7</max>
 				</primaryMagazineCount>
 				<shieldMoney>
 					<min>100</min>
@@ -140,8 +140,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>10</min>
-					<max>40</max>
+					<min>4</min>
+					<max>7</max>
 				</primaryMagazineCount>
 				<shieldMoney>
 					<min>100</min>

--- a/ModPatches/Argonians of Blackmarsh/Patches/Argonians of Blackmarsh/PawnKinds_Argonian.xml
+++ b/ModPatches/Argonians of Blackmarsh/Patches/Argonians of Blackmarsh/PawnKinds_Argonian.xml
@@ -5,8 +5,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>12</min>
-					<max>20</max>
+					<min>3</min>
+					<max>6</max>
 				</primaryMagazineCount>
 			</li>
 		</value>
@@ -17,8 +17,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>12</min>
-					<max>20</max>
+					<min>3</min>
+					<max>6</max>
 				</primaryMagazineCount>
 			</li>
 		</value>
@@ -29,8 +29,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>12</min>
-					<max>20</max>
+					<min>3</min>
+					<max>6</max>
 				</primaryMagazineCount>
 			</li>
 		</value>
@@ -41,8 +41,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>12</min>
-					<max>20</max>
+					<min>3</min>
+					<max>6</max>
 				</primaryMagazineCount>
 			</li>
 		</value>
@@ -53,8 +53,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>12</min>
-					<max>20</max>
+					<min>3</min>
+					<max>6</max>
 				</primaryMagazineCount>
 			</li>
 		</value>
@@ -65,8 +65,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>12</min>
-					<max>20</max>
+					<min>3</min>
+					<max>6</max>
 				</primaryMagazineCount>
 			</li>
 		</value>
@@ -77,8 +77,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>12</min>
-					<max>20</max>
+					<min>3</min>
+					<max>6</max>
 				</primaryMagazineCount>
 			</li>
 		</value>
@@ -89,8 +89,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>12</min>
-					<max>20</max>
+					<min>3</min>
+					<max>6</max>
 				</primaryMagazineCount>
 			</li>
 		</value>
@@ -101,8 +101,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>12</min>
-					<max>20</max>
+					<min>3</min>
+					<max>6</max>
 				</primaryMagazineCount>
 			</li>
 		</value>

--- a/ModPatches/Beast Man Tribes/Patches/Beast Man Tribes/Patch_PawnKinds_Beasts.xml
+++ b/ModPatches/Beast Man Tribes/Patches/Beast Man Tribes/Patch_PawnKinds_Beasts.xml
@@ -105,8 +105,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>20</min>
-					<max>40</max>
+					<min>4</min>
+					<max>8</max>
 				</primaryMagazineCount>
 				<shieldMoney>
 					<min>100</min>
@@ -161,8 +161,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>25</min>
-					<max>50</max>
+					<min>4</min>
+					<max>6</max>
 				</primaryMagazineCount>
 				<shieldMoney>
 					<min>100</min>
@@ -217,8 +217,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>20</min>
-					<max>40</max>
+					<min>4</min>
+					<max>8</max>
 				</primaryMagazineCount>
 				<shieldMoney>
 					<min>100</min>

--- a/ModPatches/Big and Small - MO/Patches/Big and Small - MO/BS_MO_Pawnkind.xml
+++ b/ModPatches/Big and Small - MO/Patches/Big and Small - MO/BS_MO_Pawnkind.xml
@@ -7,8 +7,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>12</min>
-					<max>20</max>
+					<min>4</min>
+					<max>6</max>
 				</primaryMagazineCount>
 				<forcedSidearm>
 					<sidearmMoney>

--- a/ModPatches/Big and Small - Medieval Factions/Patches/Big and Small - Medieval Factions/BS_Medieval_Pawnkind.xml
+++ b/ModPatches/Big and Small - Medieval Factions/Patches/Big and Small - Medieval Factions/BS_Medieval_Pawnkind.xml
@@ -9,8 +9,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>12</min>
-					<max>20</max>
+					<min>4</min>
+					<max>6</max>
 				</primaryMagazineCount>
 				<forcedSidearm>
 					<sidearmMoney>

--- a/ModPatches/Big and Small Genes/Patches/Big and Small Genes/Pawnkind/BS_Genes_Pawnkind.xml
+++ b/ModPatches/Big and Small Genes/Patches/Big and Small Genes/Pawnkind/BS_Genes_Pawnkind.xml
@@ -35,8 +35,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>12</min>
-					<max>20</max>
+					<min>3</min>
+					<max>5</max>
 				</primaryMagazineCount>
 				<forcedSidearm>
 					<sidearmMoney>

--- a/ModPatches/Crossbows/Patches/Crossbows/Weapons_Ranged.xml
+++ b/ModPatches/Crossbows/Patches/Crossbows/Weapons_Ranged.xml
@@ -48,6 +48,7 @@
 			<magazineSize>1</magazineSize>
 			<reloadTime>7</reloadTime>
 			<ammoSet>AmmoSet_CrossbowBolt</ammoSet>
+			<AmmoGenPerMagOverride>4</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes>
 			<aiAimMode>AimedShot</aiAimMode>
@@ -121,6 +122,7 @@
 			<magazineSize>1</magazineSize>
 			<reloadTime>1</reloadTime>
 			<ammoSet>AmmoSet_SlingBullet</ammoSet>
+			<AmmoGenPerMagOverride>4</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes>
 			<aiAimMode>AimedShot</aiAimMode>

--- a/ModPatches/DD Elves/Patches/DD Elves/PawnKindDefs.xml
+++ b/ModPatches/DD Elves/Patches/DD Elves/PawnKindDefs.xml
@@ -85,8 +85,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>15</min>
-					<max>30</max>
+					<min>4</min>
+					<max>7</max>
 				</primaryMagazineCount>
 				<forcedSidearm>
 					<sidearmMoney>
@@ -108,8 +108,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>15</min>
-					<max>30</max>
+					<min>4</min>
+					<max>7</max>
 				</primaryMagazineCount>
 				<forcedSidearm>
 					<sidearmMoney>

--- a/ModPatches/Divine Order/Patches/Divine Order/PawnKindDefs/Divine_Order_CE_Pawnkinds.xml
+++ b/ModPatches/Divine Order/Patches/Divine Order/PawnKindDefs/Divine_Order_CE_Pawnkinds.xml
@@ -7,8 +7,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>12</min>
-					<max>20</max>
+					<min>4</min>
+					<max>6</max>
 				</primaryMagazineCount>
 				<forcedSidearm>
 					<sidearmMoney>
@@ -28,8 +28,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>12</min>
-					<max>20</max>
+					<min>4</min>
+					<max>6</max>
 				</primaryMagazineCount>
 				<forcedSidearm>
 					<sidearmMoney>
@@ -49,8 +49,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>10</min>
-					<max>30</max>
+					<min>5</min>
+					<max>7</max>
 				</primaryMagazineCount>
 				<forcedSidearm>
 					<sidearmMoney>
@@ -70,8 +70,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>30</min>
-					<max>40</max>
+					<min>5</min>
+					<max>7</max>
 				</primaryMagazineCount>
 			</li>
 		</value>

--- a/ModPatches/Divine Order/Patches/Divine Order/ThingDef_Misc/Weapons/Divine_Order_CE_Ranged.xml
+++ b/ModPatches/Divine Order/Patches/Divine Order/ThingDef_Misc/Weapons/Divine_Order_CE_Ranged.xml
@@ -117,6 +117,7 @@
 			<magazineSize>1</magazineSize>
 			<reloadTime>3.5</reloadTime>
 			<ammoSet>AmmoSet_CrossbowBolt</ammoSet>
+			<AmmoGenPerMagOverride>4</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes>
 			<aiAimMode>AimedShot</aiAimMode>
@@ -149,6 +150,7 @@
 			<magazineSize>1</magazineSize>
 			<reloadTime>3.5</reloadTime>
 			<ammoSet>AmmoSet_CrossbowBolt</ammoSet>
+			<AmmoGenPerMagOverride>3</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes>
 			<aiAimMode>AimedShot</aiAimMode>

--- a/ModPatches/Dragons Descent/Patches/Dragons Descent/ThingDefs_Misc/Weapons/RangedDD.xml
+++ b/ModPatches/Dragons Descent/Patches/Dragons Descent/ThingDefs_Misc/Weapons/RangedDD.xml
@@ -121,6 +121,7 @@
 			<magazineSize>2</magazineSize>
 			<reloadTime>6.5</reloadTime>
 			<ammoSet>AmmoSet_CrossbowBolt</ammoSet>
+			<AmmoGenPerMagOverride>4</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes>
 			<aiUseBurstMode>FALSE</aiUseBurstMode>

--- a/ModPatches/Epona Race/Patches/Epona Race/PawnKindDefs/Epona_PawnKind.xml
+++ b/ModPatches/Epona Race/Patches/Epona Race/PawnKindDefs/Epona_PawnKind.xml
@@ -44,8 +44,8 @@
 		<value>
 			<li Inherit="False" Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>15</min>
-					<max>25</max>
+					<min>4</min>
+					<max>6</max>
 				</primaryMagazineCount>
 				<forcedSidearm>
 					<sidearmMoney>

--- a/ModPatches/Equium/Patches/Equium/PawnKinds_Equium_Tribal.xml
+++ b/ModPatches/Equium/Patches/Equium/PawnKinds_Equium_Tribal.xml
@@ -134,8 +134,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>30</min>
-					<max>50</max>
+					<min>5</min>
+					<max>8</max>
 				</primaryMagazineCount>
 				<shieldMoney>
 					<min>500</min>
@@ -166,8 +166,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>8</min>
-					<max>9</max>
+					<min>5</min>
+					<max>7</max>
 				</primaryMagazineCount>
 				<shieldMoney>
 					<min>500</min>
@@ -198,8 +198,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>30</min>
-					<max>50</max>
+					<min>5</min>
+					<max>8</max>
 				</primaryMagazineCount>
 				<shieldMoney>
 					<min>500</min>

--- a/ModPatches/Fell Tribes/Patches/Fell Tribes/PawnkindDefs/PawnKinds_Fell.xml
+++ b/ModPatches/Fell Tribes/Patches/Fell Tribes/PawnkindDefs/PawnKinds_Fell.xml
@@ -14,8 +14,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>12</min>
-					<max>20</max>
+					<min>4</min>
+					<max>6</max>
 				</primaryMagazineCount>
 			</li>
 		</value>

--- a/ModPatches/Forgotten Realms - Lizardfolk/Patches/Forgotten Realms - Lizardfolk/Patch_PawnKinds_Lizardfolk.xml
+++ b/ModPatches/Forgotten Realms - Lizardfolk/Patches/Forgotten Realms - Lizardfolk/Patch_PawnKinds_Lizardfolk.xml
@@ -42,8 +42,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>20</min>
-					<max>40</max>
+					<min>4</min>
+					<max>8</max>
 				</primaryMagazineCount>
 				<shieldMoney>
 					<min>100</min>

--- a/ModPatches/Forgotten Realms - Minotaur/Patches/Forgotten Realms - Minotaur/Patch_PawnKinds_Mino.xml
+++ b/ModPatches/Forgotten Realms - Minotaur/Patches/Forgotten Realms - Minotaur/Patch_PawnKinds_Mino.xml
@@ -42,8 +42,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>20</min>
-					<max>40</max>
+					<min>4</min>
+					<max>8</max>
 				</primaryMagazineCount>
 				<shieldMoney>
 					<min>100</min>

--- a/ModPatches/Infinity Rim Ariadna/Patches/Infinity Rim Ariadna/Antipode.xml
+++ b/ModPatches/Infinity Rim Ariadna/Patches/Infinity Rim Ariadna/Antipode.xml
@@ -146,8 +146,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>20</min>
-					<max>40</max>
+					<min>4</min>
+					<max>7</max>
 				</primaryMagazineCount>
 				<shieldMoney>
 					<min>100</min>

--- a/ModPatches/Jernalk's Skeletal Legion/Patches/Jernalk's Skeletal Legion/PawnKindDefs/Skeleton_PawnKind.xml
+++ b/ModPatches/Jernalk's Skeletal Legion/Patches/Jernalk's Skeletal Legion/PawnKindDefs/Skeleton_PawnKind.xml
@@ -33,8 +33,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>20</min>
-					<max>40</max>
+					<min>4</min>
+					<max>8</max>
 				</primaryMagazineCount>
 				<shieldMoney>
 					<min>100</min>

--- a/ModPatches/Kijin 3.0/Patches/Kijin 3.0/PawnKindDefs/PawnKind_Kijin.xml
+++ b/ModPatches/Kijin 3.0/Patches/Kijin 3.0/PawnKindDefs/PawnKind_Kijin.xml
@@ -6,8 +6,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>45</min>
-					<max>60</max>
+					<min>6</min>
+					<max>9</max>
 				</primaryMagazineCount>
 				<sidearms>
 					<li>

--- a/ModPatches/Kobold Factions/Patches/Kobold Factions/Medieval_Kobold_Pawnkind.xml
+++ b/ModPatches/Kobold Factions/Patches/Kobold Factions/Medieval_Kobold_Pawnkind.xml
@@ -12,8 +12,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>15</min>
-					<max>30</max>
+					<min>3</min>
+					<max>8</max>
 				</primaryMagazineCount>
 			</li>
 		</value>

--- a/ModPatches/Lemolim Race/Patches/Lemolim Race/Lemonim_Pawnkind.xml
+++ b/ModPatches/Lemolim Race/Patches/Lemolim Race/Lemonim_Pawnkind.xml
@@ -22,8 +22,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>15</min>
-					<max>30</max>
+					<min>4</min>
+					<max>6</max>
 				</primaryMagazineCount>
 				<forcedSidearm>
 					<sidearmMoney>

--- a/ModPatches/Medieval Bowyer/Patches/Medieval Bowyer/Weapons_Ranged.xml
+++ b/ModPatches/Medieval Bowyer/Patches/Medieval Bowyer/Weapons_Ranged.xml
@@ -50,6 +50,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_Arrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes/>
 		<weaponTags>
@@ -81,6 +82,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_StreamlinedArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes/>
 		<weaponTags>
@@ -113,6 +115,7 @@
 		</Properties>
 		<AmmoUser>
 			<ammoSet>AmmoSet_GreatArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes/>
 		<weaponTags>
@@ -157,6 +160,7 @@
 			<magazineSize>1</magazineSize>
 			<reloadTime>7</reloadTime>
 			<ammoSet>AmmoSet_CrossbowBolt</ammoSet>
+			<AmmoGenPerMagOverride>4</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes>
 			<aiAimMode>AimedShot</aiAimMode>
@@ -194,6 +198,7 @@
 			<magazineSize>1</magazineSize>
 			<reloadTime>7</reloadTime>
 			<ammoSet>AmmoSet_CrossbowBolt</ammoSet>
+			<AmmoGenPerMagOverride>4</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes>
 			<aiAimMode>AimedShot</aiAimMode>
@@ -231,6 +236,7 @@
 			<magazineSize>1</magazineSize>
 			<reloadTime>7</reloadTime>
 			<ammoSet>AmmoSet_CrossbowBolt</ammoSet>
+			<AmmoGenPerMagOverride>4</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes>
 			<aiAimMode>AimedShot</aiAimMode>
@@ -268,6 +274,7 @@
 			<magazineSize>1</magazineSize>
 			<reloadTime>7</reloadTime>
 			<ammoSet>AmmoSet_CrossbowBolt</ammoSet>
+			<AmmoGenPerMagOverride>4</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes>
 			<aiAimMode>AimedShot</aiAimMode>
@@ -305,6 +312,7 @@
 			<magazineSize>1</magazineSize>
 			<reloadTime>8</reloadTime>
 			<ammoSet>AmmoSet_GarrisonCrossbowBolt</ammoSet>
+			<AmmoGenPerMagOverride>4</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes>
 			<aiAimMode>AimedShot</aiAimMode>

--- a/ModPatches/Medieval Overhaul Royalty/Patches/Medieval Overhaul Royalty/MOR_PawnKinds_Empire.xml
+++ b/ModPatches/Medieval Overhaul Royalty/Patches/Medieval Overhaul Royalty/MOR_PawnKinds_Empire.xml
@@ -47,7 +47,7 @@
 			defName="Empire_Fighter_StellicGuardRanged"]</xpath>
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
-				<primaryMagazineCount>12~20</primaryMagazineCount>
+				<primaryMagazineCount>4~6</primaryMagazineCount>
 				<forcedSidearm>
 					<sidearmMoney>100~200</sidearmMoney>
 					<weaponTags>

--- a/ModPatches/Medieval Overhaul Royalty/Patches/Medieval Overhaul Royalty/VFEE/MOR_VFEE_PawnKinds.xml
+++ b/ModPatches/Medieval Overhaul Royalty/Patches/Medieval Overhaul Royalty/VFEE/MOR_VFEE_PawnKinds.xml
@@ -100,7 +100,7 @@
 								<invFoodDef>DankPyon_MealBread</invFoodDef>
 								<modExtensions>
 									<li Class="CombatExtended.LoadoutPropertiesExtension">
-										<primaryMagazineCount>12~20</primaryMagazineCount>
+										<primaryMagazineCount>4~6</primaryMagazineCount>
 										<forcedSidearm>
 											<sidearmMoney>100~200</sidearmMoney>
 											<weaponTags>
@@ -192,7 +192,7 @@
 								<invFoodDef>DankPyon_MealBread</invFoodDef>
 								<modExtensions>
 									<li Class="CombatExtended.LoadoutPropertiesExtension">
-										<primaryMagazineCount>12~20</primaryMagazineCount>
+										<primaryMagazineCount>4~6</primaryMagazineCount>
 										<forcedSidearm>
 											<sidearmMoney>100~200</sidearmMoney>
 											<weaponTags>
@@ -288,7 +288,7 @@
 								<invFoodDef>DankPyon_MealBread</invFoodDef>
 								<modExtensions>
 									<li Class="CombatExtended.LoadoutPropertiesExtension">
-										<primaryMagazineCount>12~20</primaryMagazineCount>
+										<primaryMagazineCount>4~6</primaryMagazineCount>
 										<forcedSidearm>
 											<sidearmMoney>100~200</sidearmMoney>
 											<weaponTags>
@@ -380,7 +380,7 @@
 								<invFoodDef>DankPyon_MealBread</invFoodDef>
 								<modExtensions>
 									<li Class="CombatExtended.LoadoutPropertiesExtension">
-										<primaryMagazineCount>12~20</primaryMagazineCount>
+										<primaryMagazineCount>4~7</primaryMagazineCount>
 										<forcedSidearm>
 											<sidearmMoney>100~200</sidearmMoney>
 											<weaponTags>

--- a/ModPatches/Medieval Overhaul/Patches/Medieval Overhaul/PawnKindDefs_Humanlikes/MO_Pawns_Medieval.xml
+++ b/ModPatches/Medieval Overhaul/Patches/Medieval Overhaul/PawnKindDefs_Humanlikes/MO_Pawns_Medieval.xml
@@ -70,7 +70,7 @@
 		<xpath>Defs/PawnKindDef[defName="DankPyon_Medieval_Bowman"]</xpath>
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
-				<primaryMagazineCount>15~30</primaryMagazineCount>
+				<primaryMagazineCount>4~7</primaryMagazineCount>
 				<forcedSidearm>
 					<sidearmMoney>50~150</sidearmMoney>
 					<weaponTags>

--- a/ModPatches/Medieval Overhaul/Patches/Medieval Overhaul/PawnKindDefs_Humanlikes/MO_Pawns_Settlement.xml
+++ b/ModPatches/Medieval Overhaul/Patches/Medieval Overhaul/PawnKindDefs_Humanlikes/MO_Pawns_Settlement.xml
@@ -146,7 +146,7 @@
 		<xpath>Defs/PawnKindDef[@Name="DankPyon_SettlementArcher"]</xpath>
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
-				<primaryMagazineCount>20~45</primaryMagazineCount>
+				<primaryMagazineCount>4~8</primaryMagazineCount>
 				<forcedSidearm>
 					<sidearmMoney>50~150</sidearmMoney>
 					<weaponTags>

--- a/ModPatches/Medieval Overhaul/Patches/Medieval Overhaul/ThingDefs_Misc/Weapons/MO_Weapons_Ranged.xml
+++ b/ModPatches/Medieval Overhaul/Patches/Medieval Overhaul/ThingDefs_Misc/Weapons/MO_Weapons_Ranged.xml
@@ -99,6 +99,7 @@
 			<magazineSize>1</magazineSize>
 			<reloadTime>3.5</reloadTime>
 			<ammoSet>AmmoSet_DankPyonCrossbowBolt</ammoSet>
+			<AmmoGenPerMagOverride>4</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes>
 			<aiAimMode>AimedShot</aiAimMode>
@@ -136,6 +137,7 @@
 			<magazineSize>1</magazineSize>
 			<reloadTime>5.5</reloadTime>
 			<ammoSet>AmmoSet_DankPyonArbalestBolt</ammoSet>
+			<AmmoGenPerMagOverride>4</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes>
 			<aiAimMode>AimedShot</aiAimMode>

--- a/ModPatches/O21 Forgotten Realms/Patches/O21 Forgotten Realms/ThingDefs_Races/PawnKinds_Misc.xml
+++ b/ModPatches/O21 Forgotten Realms/Patches/O21 Forgotten Realms/ThingDefs_Races/PawnKinds_Misc.xml
@@ -14,8 +14,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>12</min>
-					<max>20</max>
+					<min>4</min>
+					<max>6</max>
 				</primaryMagazineCount>
 				<sidearms>
 					<li>

--- a/ModPatches/Outland - Core/Patches/Outland - Core/Weapons_Ranged.xml
+++ b/ModPatches/Outland - Core/Patches/Outland - Core/Weapons_Ranged.xml
@@ -39,6 +39,7 @@
 			<magazineSize>1</magazineSize>
 			<reloadTime>7</reloadTime>
 			<ammoSet>AmmoSet_CrossbowBolt</ammoSet>
+			<AmmoGenPerMagOverride>4</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes>
 			<aiAimMode>AimedShot</aiAimMode>

--- a/ModPatches/Outland - Genetics/Patches/Outland - Genetics/Eastborn Empire/PawnKinds_Eastborn.xml
+++ b/ModPatches/Outland - Genetics/Patches/Outland - Genetics/Eastborn Empire/PawnKinds_Eastborn.xml
@@ -14,8 +14,8 @@
 					<value>
 						<li Class="CombatExtended.LoadoutPropertiesExtension">
 							<primaryMagazineCount>
-								<min>12</min>
-								<max>18</max>
+								<min>4</min>
+								<max>6</max>
 							</primaryMagazineCount>
 							<sidearms>
 								<li>
@@ -38,8 +38,8 @@
 					<value>
 						<li Class="CombatExtended.LoadoutPropertiesExtension">
 							<primaryMagazineCount>
-								<min>12</min>
-								<max>18</max>
+								<min>4</min>
+								<max>6</max>
 							</primaryMagazineCount>
 							<sidearms>
 								<li>

--- a/ModPatches/Outland - Genetics/Patches/Outland - Genetics/Motz Coalition/Motz_PawnkindPatch.xml
+++ b/ModPatches/Outland - Genetics/Patches/Outland - Genetics/Motz Coalition/Motz_PawnkindPatch.xml
@@ -13,8 +13,8 @@
 					<value>
 						<li Class="CombatExtended.LoadoutPropertiesExtension">
 							<primaryMagazineCount>
-								<min>7</min>
-								<max>10</max>
+								<min>3</min>
+								<max>6</max>
 							</primaryMagazineCount>
 							<forcedSidearm>
 								<sidearmMoney>

--- a/ModPatches/Outland - Genetics/Patches/Outland - Genetics/Redburn Pact/PawnKinds_Redburn.xml
+++ b/ModPatches/Outland - Genetics/Patches/Outland - Genetics/Redburn Pact/PawnKinds_Redburn.xml
@@ -17,8 +17,8 @@
 					<value>
 						<li Class="CombatExtended.LoadoutPropertiesExtension">
 							<primaryMagazineCount>
-								<min>12</min>
-								<max>18</max>
+								<min>3</min>
+								<max>5</max>
 							</primaryMagazineCount>
 							<sidearms>
 								<li>

--- a/ModPatches/Outland - Redburn Pact/Patches/Outland - Redburn Pact/Redburn_WeaponsRanged.xml
+++ b/ModPatches/Outland - Redburn Pact/Patches/Outland - Redburn Pact/Redburn_WeaponsRanged.xml
@@ -39,6 +39,7 @@
 			<magazineSize>1</magazineSize>
 			<reloadTime>3</reloadTime>
 			<ammoSet>AmmoSet_CrossbowBolt</ammoSet>
+			<AmmoGenPerMagOverride>4</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes>
 			<aiAimMode>AimedShot</aiAimMode>

--- a/ModPatches/Pawnbold Race/Patches/Pawnbold Race/PawnKinds_Misc.xml
+++ b/ModPatches/Pawnbold Race/Patches/Pawnbold Race/PawnKinds_Misc.xml
@@ -7,8 +7,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>14</min>
-					<max>26</max>
+					<min>4</min>
+					<max>7</max>
 				</primaryMagazineCount>
 				<forcedSidearm>
 					<sidearmMoney>

--- a/ModPatches/Poleepkwa Race/Patches/Poleepkwa Race/Patch_PawnKinds_Prawn.xml
+++ b/ModPatches/Poleepkwa Race/Patches/Poleepkwa Race/Patch_PawnKinds_Prawn.xml
@@ -35,8 +35,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>20</min>
-					<max>40</max>
+					<min>4</min>
+					<max>8</max>
 				</primaryMagazineCount>
 				<shieldMoney>
 					<min>100</min>

--- a/ModPatches/Possessed Weapons/Patches/PossessedWeapons_RangedPatch.xml
+++ b/ModPatches/Possessed Weapons/Patches/PossessedWeapons_RangedPatch.xml
@@ -215,6 +215,7 @@
 			<magazineSize>3</magazineSize>
 			<reloadTime>5</reloadTime>
 			<ammoSet>AmmoSet_CrossbowBolt</ammoSet>
+			<AmmoGenPerMagOverride>4</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes>
 			<aiUseBurstMode>FALSE</aiUseBurstMode>

--- a/ModPatches/Profaned/Patches/Profaned/PawnKindDef/Profaned_PawnkindDef_Patch.xml
+++ b/ModPatches/Profaned/Patches/Profaned/PawnKindDef/Profaned_PawnkindDef_Patch.xml
@@ -6,8 +6,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>15</min>
-					<max>30</max>
+					<min>3</min>
+					<max>6</max>
 				</primaryMagazineCount>
 				<minAmmoCount>15</minAmmoCount>
 				<sidearms>
@@ -31,8 +31,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>20</min>
-					<max>40</max>
+					<min>4</min>
+					<max>7</max>
 				</primaryMagazineCount>
 				<minAmmoCount>20</minAmmoCount>
 				<sidearms>

--- a/ModPatches/RadWorld/Patches/RadWorld/PawnKinds_RadWorld.xml
+++ b/ModPatches/RadWorld/Patches/RadWorld/PawnKinds_RadWorld.xml
@@ -12,8 +12,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>14</min>
-					<max>26</max>
+					<min>3</min>
+					<max>6</max>
 				</primaryMagazineCount>
 				<forcedSidearm>
 					<sidearmMoney>

--- a/ModPatches/Rim Gnoblins/Patches/Rim Gnoblins/Gnoblins_Pawnkind.xml
+++ b/ModPatches/Rim Gnoblins/Patches/Rim Gnoblins/Gnoblins_Pawnkind.xml
@@ -28,8 +28,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>20</min>
-					<max>30</max>
+					<min>4</min>
+					<max>6</max>
 				</primaryMagazineCount>
 				<forcedSidearm>
 					<sidearmMoney>

--- a/ModPatches/Rim Gnoblins/Patches/Rim Gnoblins/Gnoblins_Pawnkind.xml
+++ b/ModPatches/Rim Gnoblins/Patches/Rim Gnoblins/Gnoblins_Pawnkind.xml
@@ -7,8 +7,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>20</min>
-					<max>30</max>
+					<min>4</min>
+					<max>8</max>
 				</primaryMagazineCount>
 				<forcedSidearm>
 					<sidearmMoney>
@@ -71,8 +71,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>30</min>
-					<max>40</max>
+					<min>8</min>
+					<max>12</max>
 				</primaryMagazineCount>
 				<forcedSidearm>
 					<sidearmMoney>

--- a/ModPatches/Rim-Elves/Patches/Rim-Elves/PawnKinds_Elves.xml
+++ b/ModPatches/Rim-Elves/Patches/Rim-Elves/PawnKinds_Elves.xml
@@ -7,8 +7,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>14</min>
-					<max>24</max>
+					<min>4</min>
+					<max>7</max>
 				</primaryMagazineCount>
 				<sidearms>
 					<li>

--- a/ModPatches/Rim-Elves/Patches/Rim-Elves/PawnKinds_Elves.xml
+++ b/ModPatches/Rim-Elves/Patches/Rim-Elves/PawnKinds_Elves.xml
@@ -62,8 +62,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>20</min>
-					<max>40</max>
+					<min>8</min>
+					<max>14</max>
 				</primaryMagazineCount>
 				<sidearms>
 					<li>
@@ -102,8 +102,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>20</min>
-					<max>40</max>
+					<min>6</min>
+					<max>14</max>
 				</primaryMagazineCount>
 				<sidearms>
 					<li>

--- a/ModPatches/Rim-Hivers!/Patches/Rim-Hivers!/Patch_PawnKinds_Hivers.xml
+++ b/ModPatches/Rim-Hivers!/Patches/Rim-Hivers!/Patch_PawnKinds_Hivers.xml
@@ -57,8 +57,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>14</min>
-					<max>40</max>
+					<min>4</min>
+					<max>7</max>
 				</primaryMagazineCount>
 				<shieldMoney>
 					<min>100</min>

--- a/ModPatches/Rimcraft Factions/Patches/Rimcraft Factions/Patch_PawnKinds_Wow.xml
+++ b/ModPatches/Rimcraft Factions/Patches/Rimcraft Factions/Patch_PawnKinds_Wow.xml
@@ -31,8 +31,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>20</min>
-					<max>40</max>
+					<min>4</min>
+					<max>7</max>
 				</primaryMagazineCount>
 				<sidearms>
 					<li>

--- a/ModPatches/SYR Naga/Patches/SYR Naga/Patch_PawnKinds_Naga.xml
+++ b/ModPatches/SYR Naga/Patches/SYR Naga/Patch_PawnKinds_Naga.xml
@@ -260,8 +260,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>10</min>
-					<max>40</max>
+					<min>4</min>
+					<max>7</max>
 				</primaryMagazineCount>
 				<shieldMoney>
 					<min>100</min>
@@ -292,8 +292,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>10</min>
-					<max>60</max>
+					<min>4</min>
+					<max>7</max>
 				</primaryMagazineCount>
 				<shieldMoney>
 					<min>100</min>
@@ -324,8 +324,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>10</min>
-					<max>80</max>
+					<min>4</min>
+					<max>8</max>
 				</primaryMagazineCount>
 				<shieldMoney>
 					<min>100</min>

--- a/ModPatches/Sergal/Patches/Sergal/PawnKinds_Frog.xml
+++ b/ModPatches/Sergal/Patches/Sergal/PawnKinds_Frog.xml
@@ -53,8 +53,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>30</min>
-					<max>50</max>
+					<min>4</min>
+					<max>7</max>
 				</primaryMagazineCount>
 				<shieldMoney>
 					<min>120</min>

--- a/ModPatches/Sergal/Patches/Sergal/PawnKinds_Gnoll.xml
+++ b/ModPatches/Sergal/Patches/Sergal/PawnKinds_Gnoll.xml
@@ -53,8 +53,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>30</min>
-					<max>50</max>
+					<min>4</min>
+					<max>7</max>
 				</primaryMagazineCount>
 				<shieldMoney>
 					<min>120</min>

--- a/ModPatches/Sergal/Patches/Sergal/PawnKinds_GnollTribe.xml
+++ b/ModPatches/Sergal/Patches/Sergal/PawnKinds_GnollTribe.xml
@@ -19,8 +19,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>20</min>
-					<max>40</max>
+					<min>4</min>
+					<max>7</max>
 				</primaryMagazineCount>
 				<sidearms>
 					<li>

--- a/ModPatches/Sergal/Patches/Sergal/PawnKinds_SergalTribe.xml
+++ b/ModPatches/Sergal/Patches/Sergal/PawnKinds_SergalTribe.xml
@@ -19,8 +19,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>20</min>
-					<max>40</max>
+					<min>4</min>
+					<max>7</max>
 				</primaryMagazineCount>
 				<sidearms>
 					<li>

--- a/ModPatches/Sergal/Patches/Sergal/PawnKinds_StripedGnollTribe.xml
+++ b/ModPatches/Sergal/Patches/Sergal/PawnKinds_StripedGnollTribe.xml
@@ -19,8 +19,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>20</min>
-					<max>40</max>
+					<min>4</min>
+					<max>7</max>
 				</primaryMagazineCount>
 				<sidearms>
 					<li>

--- a/ModPatches/Thrumkin/Patches/Thrumkin/Patch_PawnKinds_Thrumkin.xml
+++ b/ModPatches/Thrumkin/Patches/Thrumkin/Patch_PawnKinds_Thrumkin.xml
@@ -23,8 +23,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>10</min>
-					<max>40</max>
+					<min>4</min>
+					<max>7</max>
 				</primaryMagazineCount>
 				<shieldMoney>
 					<min>100</min>
@@ -86,8 +86,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>10</min>
-					<max>60</max>
+					<min>4</min>
+					<max>7</max>
 				</primaryMagazineCount>
 				<shieldMoney>
 					<min>100</min>
@@ -149,8 +149,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>10</min>
-					<max>80</max>
+					<min>4</min>
+					<max>7</max>
 				</primaryMagazineCount>
 				<shieldMoney>
 					<min>100</min>
@@ -205,8 +205,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>10</min>
-					<max>80</max>
+					<min>4</min>
+					<max>7</max>
 				</primaryMagazineCount>
 				<shieldMoney>
 					<min>100</min>
@@ -237,8 +237,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>10</min>
-					<max>40</max>
+					<min>4</min>
+					<max>7</max>
 				</primaryMagazineCount>
 				<shieldMoney>
 					<min>300</min>

--- a/ModPatches/Vanilla Factions Expanded - Classical/Patches/Vanilla Factions Expanded - Classical/PawnKinds_Misc.xml
+++ b/ModPatches/Vanilla Factions Expanded - Classical/Patches/Vanilla Factions Expanded - Classical/PawnKinds_Misc.xml
@@ -40,8 +40,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>12</min>
-					<max>20</max>
+					<min>4</min>
+					<max>6</max>
 				</primaryMagazineCount>
 				<sidearms>
 					<li>

--- a/ModPatches/Vanilla Factions Expanded - Medieval 2/Patches/Vanilla Factions Expanded - Medieval 2/PawnKindDefs_Humanlikes/VFEM2_PawnsKinds_Clan.xml
+++ b/ModPatches/Vanilla Factions Expanded - Medieval 2/Patches/Vanilla Factions Expanded - Medieval 2/PawnKindDefs_Humanlikes/VFEM2_PawnsKinds_Clan.xml
@@ -56,7 +56,7 @@
 		<xpath>Defs/PawnKindDef[defName="VFEM2_Bowman"]</xpath>
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
-				<primaryMagazineCount>15~30</primaryMagazineCount>
+				<primaryMagazineCount>4~6</primaryMagazineCount>
 				<forcedSidearm>
 					<sidearmMoney>50~150</sidearmMoney>
 					<weaponTags>
@@ -73,7 +73,7 @@
 		<xpath>Defs/PawnKindDef[defName="VFEM2_Skirmisher" or defName="VFEM2_HeavyBowman"]</xpath>
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
-				<primaryMagazineCount>12~20</primaryMagazineCount>
+				<primaryMagazineCount>4~6</primaryMagazineCount>
 				<forcedSidearm>
 					<sidearmMoney>50~150</sidearmMoney>
 					<weaponTags>

--- a/ModPatches/Vanilla Factions Expanded - Medieval 2/Patches/Vanilla Factions Expanded - Medieval 2/PawnKindDefs_Humanlikes/VFEM2_PawnsKinds_Kingdom.xml
+++ b/ModPatches/Vanilla Factions Expanded - Medieval 2/Patches/Vanilla Factions Expanded - Medieval 2/PawnKindDefs_Humanlikes/VFEM2_PawnsKinds_Kingdom.xml
@@ -38,7 +38,7 @@
 		<xpath>Defs/PawnKindDef[defName="VFEM2_Crossbowman"]</xpath>
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
-				<primaryMagazineCount>12~20</primaryMagazineCount>
+				<primaryMagazineCount>4~6</primaryMagazineCount>
 				<forcedSidearm>
 					<sidearmMoney>100~200</sidearmMoney>
 					<weaponTags>
@@ -72,7 +72,7 @@
 		<xpath>Defs/PawnKindDef[defName="VFEM2_Archer" or defName="VFEM2_Hunter"]</xpath>
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
-				<primaryMagazineCount>15~30</primaryMagazineCount>
+				<primaryMagazineCount>4~7</primaryMagazineCount>
 				<forcedSidearm>
 					<sidearmMoney>50~150</sidearmMoney>
 					<weaponTags>
@@ -89,7 +89,7 @@
 		<xpath>Defs/PawnKindDef[defName="VFEM2_Guildmaster" or defName="VFEM2_HeavyArcher"]</xpath>
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
-				<primaryMagazineCount>12~20</primaryMagazineCount>
+				<primaryMagazineCount>4~7</primaryMagazineCount>
 				<forcedSidearm>
 					<sidearmMoney>50~150</sidearmMoney>
 					<weaponTags>

--- a/ModPatches/Vanilla Factions Expanded - Medieval 2/Patches/Vanilla Factions Expanded - Medieval 2/ThingDefs_Misc/Weapons/VFEM2_Weapons_Ranged.xml
+++ b/ModPatches/Vanilla Factions Expanded - Medieval 2/Patches/Vanilla Factions Expanded - Medieval 2/ThingDefs_Misc/Weapons/VFEM2_Weapons_Ranged.xml
@@ -95,6 +95,7 @@
 			<magazineSize>1</magazineSize>
 			<reloadTime>5.5</reloadTime>
 			<ammoSet>AmmoSet_VFEM2ArbalestBolt</ammoSet>
+			<AmmoGenPerMagOverride>4</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes>
 			<aiAimMode>AimedShot</aiAimMode>

--- a/ModPatches/Vanilla Weapons Expanded/Patches/Vanilla Weapons Expanded/Medieval_Ranged.xml
+++ b/ModPatches/Vanilla Weapons Expanded/Patches/Vanilla Weapons Expanded/Medieval_Ranged.xml
@@ -112,6 +112,7 @@
 			<magazineSize>1</magazineSize>
 			<reloadTime>7</reloadTime>
 			<ammoSet>AmmoSet_CrossbowBolt</ammoSet>
+			<AmmoGenPerMagOverride>4</AmmoGenPerMagOverride>
 		</AmmoUser>
 		<FireModes>
 			<aiAimMode>AimedShot</aiAimMode>

--- a/ModPatches/Xenohumans Expanded/Patches/Xenohumans Expanded/Xenos_Pawns.xml
+++ b/ModPatches/Xenohumans Expanded/Patches/Xenohumans Expanded/Xenos_Pawns.xml
@@ -240,8 +240,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>20</min>
-					<max>40</max>
+					<min>4</min>
+					<max>7</max>
 				</primaryMagazineCount>
 				<shieldMoney>
 					<min>100</min>
@@ -271,8 +271,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>20</min>
-					<max>40</max>
+					<min>4</min>
+					<max>7</max>
 				</primaryMagazineCount>
 				<shieldMoney>
 					<min>100</min>

--- a/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -560,8 +560,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>20</min>
-					<max>40</max>
+					<min>4</min>
+					<max>6</max>
 				</primaryMagazineCount>
 				<shieldMoney>
 					<min>100</min>
@@ -598,8 +598,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>25</min>
-					<max>50</max>
+					<min>5</min>
+					<max>7</max>
 				</primaryMagazineCount>
 				<shieldMoney>
 					<min>100</min>
@@ -636,8 +636,8 @@
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-					<min>20</min>
-					<max>40</max>
+					<min>4</min>
+					<max>7</max>
 				</primaryMagazineCount>
 				<shieldMoney>
 					<min>100</min>


### PR DESCRIPTION
Bows getting `AmmoGenPerMagOverride` neccesiatates updating archer loadouts, also just generally good idea to have pawn loadouts flexible to weapon type variation if we can.

Checked all pawntypes with names containig `archer`, `bowman`, `hunter`, added `<AmmoGenPerMagOverride>4</...>` to crossbows I've found left out of the bow ammo override PR


Did I boot it up? No I did not boot it up, I've only replaced numbers, did check through git diff for typos/ spare whitespaces.