### PR TITLE
Add LegacyTrajectoryWorker for projectiles that override Vec2Position

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -1588,7 +1588,7 @@ namespace CombatExtended
             try
             {
                 var vec2position_m = type.GetMethod("Vec2Position", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-                v2p = vec2position_m.GetBaseDefinition() != vec2position_m;
+                v2p = vec2position_m.GetBaseDefinition().DeclaringType != vec2position_m.DeclaringType;
             }
             catch (System.Reflection.AmbiguousMatchException) // Still using 1.3 era code
             {

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Linq;
 using RimWorld;
 using UnityEngine;
@@ -1575,13 +1576,52 @@ namespace CombatExtended
         #endregion
 
         #region Ballistics
+
+        private LegacyTrajectoryWorker CheckForLegacyProjectile()
+        {
+            Type type = this.GetType();
+            if (type == typeof(ProjectileCE) || type == typeof(BulletCE)) // early out for most common case
+            {
+                return null;
+            }
+            bool v2p;
+            try
+            {
+                var vec2position_m = type.GetMethod("Vec2Position", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                v2p = vec2position_m.GetBaseDefinition() != vec2position_m;
+            }
+            catch (System.Reflection.AmbiguousMatchException) // Still using 1.3 era code
+            {
+                v2p = true;
+            }
+            if (!v2p)
+            {
+                return null;
+            }
+
+            var exactPosition_m = type.GetProperty("ExactPosition", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            var exactPosition_gm = exactPosition_m.GetGetMethod();
+            var ep = exactPosition_gm.GetBaseDefinition() != exactPosition_gm;
+
+            if (v2p)
+            {
+                return new LegacyTrajectoryWorker(this, v2p, ep);
+            }
+            return null;
+        }
+
         public BaseTrajectoryWorker TrajectoryWorker
         {
             get
             {
                 if (forcedTrajectoryWorker == null)
                 {
-                    if (!lerpPosition)
+                    if (CheckForLegacyProjectile() is LegacyTrajectoryWorker worker)
+                    {
+                        Log.WarningOnce($"{this} uses legacy collision code. Falling back to legacy TrajectoryWorker", this.def.GetHashCode());
+                        forcedTrajectoryWorker = worker;
+                    }
+                    else if (!lerpPosition)
                     {
                         Log.ErrorOnce($"Setting lerpPosition in ProjectileCE directly for {this} is deprecated, set the trajectoryWorker instead", 50003 + def.projectile.GetHashCode());
                         forcedTrajectoryWorker = ProjectilePropertiesCE.defaultBallisticTrajectoryWorker;

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -1587,7 +1587,7 @@ namespace CombatExtended
             bool v2p;
             try
             {
-                var vec2position_m = type.GetMethod("Vec2Position", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                var vec2position_m = type.GetMethod(nameof(Vec2Position), BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
                 v2p = vec2position_m.GetBaseDefinition().DeclaringType != vec2position_m.DeclaringType;
             }
             catch (System.Reflection.AmbiguousMatchException) // Still using 1.3 era code

--- a/Source/CombatExtended/CombatExtended/Projectiles/TrajectoryWorkers/LegacyTrajectoryWorker.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/TrajectoryWorkers/LegacyTrajectoryWorker.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using Verse;
+
+namespace CombatExtended
+{
+    public class LegacyTrajectoryWorker : BaseTrajectoryWorker
+    {
+        private ProjectileCE projectile;
+        private bool exactPosition;
+        private bool vec2Position;
+
+        public LegacyTrajectoryWorker(ProjectileCE p, bool v2p, bool ep)
+        {
+            this.projectile = p;
+            this.vec2Position = v2p;
+            this.exactPosition = ep;
+        }
+
+        public override Vector3 MoveForward(ProjectileCE projectile)
+        {
+            if (exactPosition)
+            {
+                return this.projectile.ExactPosition;
+            }
+
+            var v2p = this.projectile.Vec2Position();
+            return new Vector3(v2p.x, this.projectile.Height, v2p.y);
+        }
+
+        public override IEnumerable<Vector3> PredictPositions(ProjectileCE projectile, int tickCount)
+        {
+            return new List<Vector3>();
+        }
+
+    }
+}


### PR DESCRIPTION
## Additions

Added LegacyTrajectoryWorker that moves by querying projectile positions.

## Changes

Projectiles that override Vec2Position now use the LegacyTrajectoryWorker


## Reasoning

Special-casing the default trajectory worker makes for messier code with worse performance.
This keeps the cost relatively low, as the result is cached and early-outs for modern projectiles.


## Alternatives

Require explicitly opting into the legacy worker.
Require mods to move away from legacy code paths.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
