### PR TITLE
CIWS Turret Implementation

### DIFF
--- a/ModPatches/Vanilla Factions Expanded - Ancients/Patches/Vanilla Factions Expanded - Ancients/ThingDefs_Sentry.xml
+++ b/ModPatches/Vanilla Factions Expanded - Ancients/Patches/Vanilla Factions Expanded - Ancients/ThingDefs_Sentry.xml
@@ -4,25 +4,29 @@
 	<!-- Remove refuelable property -->
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[
-			defName = "VFEA_Turret_AncientSecurityTurret" or
-			defName = "VFEA_Turret_AncientPointDefense"
-			]/comps/li[@Class = "CompProperties_Refuelable"] </xpath>
+			defName="VFEA_Turret_AncientSecurityTurret" or
+			defName="VFEA_Turret_AncientPointDefense"
+			]/comps/li[@Class="CompProperties_Refuelable"] </xpath>
 	</Operation>
 
 	<!-- Replace vanilla thingClass -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[
-			defName = "VFEA_Turret_AncientSecurityTurret" or
-			@Name = "AncientPointDefenseTurretBase"
-			]/thingClass </xpath>
+		<xpath>Defs/ThingDef[defName="VFEA_Turret_AncientSecurityTurret"]/thingClass </xpath>
 		<value>
 			<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[@Name="AncientPointDefenseTurretBase"]/thingClass </xpath>
+		<value>
+			<thingClass>CombatExtended.Building_CIWS_CE</thingClass>
+		</value>
+	</Operation>
+
 	<!-- Make turrets taller -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName = "VFEA_Turret_AncientSecurityTurret"]/fillPercent</xpath>
+		<xpath>Defs/ThingDef[defName="VFEA_Turret_AncientSecurityTurret"]/fillPercent</xpath>
 		<value>
 			<fillPercent>0.85</fillPercent>
 		</value>
@@ -37,8 +41,8 @@
 
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[
-			defName = "VFEA_Turret_AncientSecurityTurret" or
-			defName = "VFEA_Turret_AncientPointDefense"
+			defName="VFEA_Turret_AncientSecurityTurret" or
+			defName="VFEA_Turret_AncientPointDefense"
 			]/statBases </xpath>
 		<value>
 			<AimingAccuracy>0.75</AimingAccuracy>
@@ -46,14 +50,14 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName = "VFEA_Turret_AncientSecurityTurret"]/statBases/ShootingAccuracyTurret</xpath>
+		<xpath>Defs/ThingDef[defName="VFEA_Turret_AncientSecurityTurret"]/statBases/ShootingAccuracyTurret</xpath>
 		<value>
 			<ShootingAccuracyTurret>1.1</ShootingAccuracyTurret>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName = "VFEA_Turret_AncientPointDefense"]/statBases/ShootingAccuracyTurret</xpath>
+		<xpath>Defs/ThingDef[defName="VFEA_Turret_AncientPointDefense"]/statBases/ShootingAccuracyTurret</xpath>
 		<value>
 			<ShootingAccuracyTurret>1.25</ShootingAccuracyTurret>
 		</value>
@@ -61,8 +65,8 @@
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
-			defName = "VFEA_Turret_AncientSecurityTurret" or
-			defName = "VFEA_Turret_AncientPointDefense"
+			defName="VFEA_Turret_AncientSecurityTurret" or
+			defName="VFEA_Turret_AncientPointDefense"
 			]/building/turretBurstCooldownTime </xpath>
 		<value>
 			<turretBurstCooldownTime>1.1</turretBurstCooldownTime>
@@ -70,7 +74,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="VFEA_Turret_AncientSecurityTurret" or defName="VFEA_Turret_AncientPointDefense"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
+		<xpath>Defs/ThingDef[defName="VFEA_Turret_AncientSecurityTurret" or defName="VFEA_Turret_AncientPointDefense"]/comps/li[@Class="CompProperties_Explosive"]</xpath>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
@@ -82,7 +86,7 @@
 
 	<!-- Make turrets taller -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName = "VFEA_Turret_AncientSecurityTurret"]/statBases/MaxHitPoints</xpath>
+		<xpath>Defs/ThingDef[defName="VFEA_Turret_AncientSecurityTurret"]/statBases/MaxHitPoints</xpath>
 		<value>
 			<MaxHitPoints>125</MaxHitPoints>
 		</value>
@@ -164,4 +168,51 @@
 			<noSingleShot>true</noSingleShot>
 		</FireModes>
 	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="VFEA_Gun_AncientPointDefenseTurret"]/verbs</xpath>
+		<value>
+			<li Class="CombatExtended.VerbProperties_CIWSProjectile">
+				<verbClass>CombatExtended.VerbCIWSProjectile</verbClass>
+				<recoilAmount>0.25</recoilAmount>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+				<warmupTime>0.4</warmupTime>
+				<range>105</range>
+				<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+				<burstShotCount>10</burstShotCount>
+				<soundCast>Shot_Minigun</soundCast>
+				<soundCastTail>GunTail_Heavy</soundCastTail>
+				<muzzleFlashScale>9</muzzleFlashScale>
+				<recoilPattern>Mounted</recoilPattern>
+				<holdFireLabel>HoldCloseInProjectilesFire</holdFireLabel>
+				<holdFireDesc>HoldCloseInProjectilesFireDesc</holdFireDesc>
+			</li>
+			<li Class="CombatExtended.VerbProperties_CIWSSkyfaller">
+				<verbClass>CombatExtended.VerbCIWSSkyfaller</verbClass>
+				<recoilAmount>0.25</recoilAmount>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+				<warmupTime>0.4</warmupTime>
+				<range>105</range>
+				<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+				<burstShotCount>10</burstShotCount>
+				<soundCast>Shot_Minigun</soundCast>
+				<soundCastTail>GunTail_Heavy</soundCastTail>
+				<muzzleFlashScale>9</muzzleFlashScale>
+				<recoilPattern>Mounted</recoilPattern>
+				<holdFireLabel>HoldCloseInSkyfallersFire</holdFireLabel>
+			</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="VFEA_Gun_AncientPointDefenseTurret"]/comps</xpath>
+		<value>
+			<li>
+				<compClass>CombatExtended.CompVerbDisabler</compClass>
+			</li>
+		</value>
+	</Operation>
+
 </Patch>

--- a/Royalty/Defs/ThingDefs_Buildings/Weapons_Turrets.xml
+++ b/Royalty/Defs/ThingDefs_Buildings/Weapons_Turrets.xml
@@ -78,6 +78,37 @@
 				<soundCastTail>GunTail_Heavy</soundCastTail>
 				<muzzleFlashScale>9</muzzleFlashScale>
 			</li>
+			<li Class="CombatExtended.VerbProperties_CIWSProjectile">
+				<verbClass>CombatExtended.VerbCIWSProjectile</verbClass>
+				<recoilAmount>1.08</recoilAmount>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_12x64mmCharged</defaultProjectile>
+				<warmupTime>0.8</warmupTime>
+				<range>112</range>
+				<ticksBetweenBurstShots>7</ticksBetweenBurstShots>
+				<burstShotCount>10</burstShotCount>
+				<soundCast>Shot_ChargeBlaster</soundCast>
+				<soundCastTail>GunTail_Heavy</soundCastTail>
+				<muzzleFlashScale>9</muzzleFlashScale>
+				<recoilPattern>Mounted</recoilPattern>
+				<holdFireLabel>HoldCloseInProjectilesFire</holdFireLabel>
+				<holdFireDesc>HoldCloseInProjectilesFireDesc</holdFireDesc>
+			</li>
+			<li Class="CombatExtended.VerbProperties_CIWSSkyfaller">
+				<verbClass>CombatExtended.VerbCIWSSkyfaller</verbClass>
+				<recoilAmount>1.08</recoilAmount>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_12x64mmCharged</defaultProjectile>
+				<warmupTime>0.8</warmupTime>
+				<range>112</range>
+				<ticksBetweenBurstShots>7</ticksBetweenBurstShots>
+				<burstShotCount>10</burstShotCount>
+				<soundCast>Shot_ChargeBlaster</soundCast>
+				<soundCastTail>GunTail_Heavy</soundCastTail>
+				<muzzleFlashScale>9</muzzleFlashScale>
+				<recoilPattern>Mounted</recoilPattern>
+				<holdFireLabel>HoldCloseInSkyfallersFire</holdFireLabel>
+			</li>			
 		</verbs>
 		<comps>
 			<li Class="CombatExtended.CompProperties_AmmoUser">

--- a/Royalty/Patches/ThingDefs_Buildings/Buildings_Mechanoid.xml
+++ b/Royalty/Patches/ThingDefs_Buildings/Buildings_Mechanoid.xml
@@ -121,12 +121,16 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_AutoChargeBlaster"]/thingClass</xpath>
 		<value>
-			<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+			<thingClass>CombatExtended.Building_CIWS_CE</thingClass>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Turret_AutoChargeBlaster"]/comps/li[@Class="CompProperties_Stunnable"]/affectedDamageDefs/li[.="Stun"]</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Turret_AutoChargeBlaster"]/comps/li[@Class="CompProperties_Explosive"]</xpath>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
@@ -151,10 +155,6 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="Turret_AutoChargeBlaster"]/comps/li[@Class="CompProperties_Explosive"]</xpath>
-	</Operation>
-
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_AutoChargeBlaster"]/fillPercent</xpath>
 		<value>
@@ -173,6 +173,15 @@
 		<xpath>Defs/ThingDef[defName="Turret_AutoChargeBlaster"]/building/turretGunDef</xpath>
 		<value>
 			<turretGunDef>Gun_ChargeBlasterHeavyTurret</turretGunDef>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Turret_AutoChargeBlaster"]/comps</xpath>
+		<value>
+			<li>
+				<compClass>CombatExtended.CompVerbDisabler</compClass>
+			</li>
 		</value>
 	</Operation>
 

--- a/Source/CombatExtended/CombatExtended/Things/Building_CIWS_CE.cs
+++ b/Source/CombatExtended/CombatExtended/Things/Building_CIWS_CE.cs
@@ -48,7 +48,7 @@ namespace CombatExtended
             {
                 yield return gizmo;
             }
-            if (Controller.settings.EnableCIWS)
+            if (Controller.settings.EnableCIWS && this.Faction == Faction.OfPlayer)
             {
                 yield return new Command_Action()
                 {


### PR DESCRIPTION
## Additions
- Allows the following turrets to function as CIWS turrets:
  - VFE: Ancients Point Defense
  - Royalty Mech Charge Blaster turrets to function as CIWS.

## Changes
- Some whitespace changes.

## Reasoning
- It only makes sense that the VFE turret be able to function as a CIWS turret, give that the base mod allows it to engage shells and drop pods. Is effective against shells, but 5.56mm isn't as good at destroying pods in-flight.
- Allowing the mech blasters to engage incoming drop pods and shells increases the threat they present, making it more difficult to simply shell them from afar.

## Alternatives
- Don't, I guess?

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
