### PR TITLE
Fix VOID base turrets ammo

### DIFF
--- a/ModPatches/RH2 Faction - VOID/Defs/RH2 Faction - VOID/ShellingResponse_VOID.xml
+++ b/ModPatches/RH2 Faction - VOID/Defs/RH2 Faction - VOID/ShellingResponse_VOID.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+	<!-- Let VOID respond to anyone stupid enough to shell their landing site. -->
+
+	<CombatExtended.ShellingResponseDef ParentName="ShellingPreset_UltraBase">
+		<defName>CE_ShellingPreset_VOID</defName>
+		<projectiles>
+			<li>
+				<projectile>Bullet_81mmMortarShell_HE</projectile>
+				<points>100</points>
+				<weight>0.75</weight>
+			</li>
+			<li>
+				<projectile>Bullet_81mmMortarShell_Incendiary</projectile>
+				<points>200</points>
+				<weight>0.40</weight>
+			</li>
+			<li>
+				<projectile>Bullet_105mmHowitzerShell_HE</projectile>
+				<points>800</points>
+				<weight>0.30</weight>
+			</li>
+			<li>
+				<projectile>Bullet_105mmHowitzerShell_Incendiary</projectile>
+				<points>1000</points>
+				<weight>0.20</weight>
+			</li>
+			<li>
+				<projectile>Bullet_81mmMortarShell_Antigrain</projectile>
+				<points>2000</points>
+				<weight>0.1</weight>
+			</li>			
+		</projectiles>
+		<worldObjects>
+			<li>
+				<worldObject>Site</worldObject>
+				<shellingPropability>0.75</shellingPropability>
+				<raidPropability>0.75</raidPropability>
+				<raidMTBDays>2</raidMTBDays>
+			</li>				
+		</worldObjects>					
+	</CombatExtended.ShellingResponseDef>
+
+</Defs>

--- a/ModPatches/RH2 Faction - VOID/Patches/RH2 Faction - VOID/FactionDefs/Factions_VOID.xml
+++ b/ModPatches/RH2 Faction - VOID/Patches/RH2 Faction - VOID/FactionDefs/Factions_VOID.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- Let VOID respond to anyone stupid enough to shell their landing site. -->
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/FactionDef[defName="RH_VOID"]</xpath>
+		<value>
+			<li Class="CombatExtended.FactionDefExtensionCE">
+				<shellingResponse>CE_ShellingPreset_VOID</shellingResponse>
+			</li>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/RH2 Faction - VOID/Patches/RH2 Faction - VOID/ThingDefs_Buildings/CE_VOID_PowerCell.xml
+++ b/ModPatches/RH2 Faction - VOID/Patches/RH2 Faction - VOID/ThingDefs_Buildings/CE_VOID_PowerCell.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="RH_VOIDPowerCell"]/comps/li[@Class="CompProperties_Power"]/basePowerConsumption</xpath>
+		<value>
+			<basePowerConsumption>-2000</basePowerConsumption>
+		</value>
+	</Operation>
+
+</Patch>

--- a/Source/CombatExtended/CombatExtended/DefOfs/CE_AmmoCategoryDefOf.cs
+++ b/Source/CombatExtended/CombatExtended/DefOfs/CE_AmmoCategoryDefOf.cs
@@ -1,0 +1,15 @@
+﻿using RimWorld;
+
+namespace CombatExtended
+{
+    [DefOf]
+    public class CE_AmmoCategoryDefOf
+    {
+
+        static CE_AmmoCategoryDefOf()
+        {
+            DefOfHelper.EnsureInitializedInCtor(typeof(CE_AmmoCategoryDefOf));
+        }
+        public static AmmoCategoryDef ExplosiveAP;
+    }
+}

--- a/Source/CombatExtended/Harmony/Compatibility/Harmony_VOID.cs
+++ b/Source/CombatExtended/Harmony/Compatibility/Harmony_VOID.cs
@@ -16,10 +16,11 @@ namespace CombatExtended.HarmonyCE.Compatibility
                 return AccessTools.TypeByName("EncounterFramework.Utils");
             }
         }
+
         [HarmonyPatch]
         public static class Harmony_Utils_Patch
         {
-            
+
             public static bool Prepare()
             {
                 return Utils_Patch_HarmonyPatches != null;
@@ -29,10 +30,9 @@ namespace CombatExtended.HarmonyCE.Compatibility
             {
                 return AccessTools.Method("EncounterFramework.Utils:DoGeneration");
             }
-            
+
             public static void Postfix(Map map)
             {
-                Log.Message("EncounterFramework.Utils:DoGeneration");
                 var buildingList = map.listerBuildings.allBuildingsNonColonist.ToList();
                 foreach (var thing in buildingList)
                 {
@@ -42,27 +42,27 @@ namespace CombatExtended.HarmonyCE.Compatibility
                     }
                 }
             }
-            
+
             private static void ReplaceTurret(Thing oldThing)
             {
-                // Saving all the old turrets information
+                //Saving all the old turrets information
                 var map = oldThing.Map;
                 var position = oldThing.Position;
                 var stuff = oldThing.Stuff;
                 var faction = oldThing.Faction;
                 var def = oldThing.def;
-                
+
                 oldThing.Destroy();
-                
-                // Make new Turret
+
+                //Make new Turret
                 if (ThingMaker.MakeThing(def, stuff) is not Building_TurretGunCE newThing)
                 {
                     return;
                 }
                 GenPlace.TryPlaceThing(newThing, position, map, ThingPlaceMode.Direct);
                 newThing.SetFaction(faction);
-                
-                // Turret Ammo
+
+                //Turret Ammo
                 var ammoComp = newThing.CompAmmo;
                 var ammoTypes = ammoComp.Props.ammoSet.ammoTypes;
                 foreach (var ammoType in ammoTypes)
@@ -73,8 +73,8 @@ namespace CombatExtended.HarmonyCE.Compatibility
                     }
                 }
                 ammoComp.CurMagCount = ammoComp.MagSize;
-                
-                // Force power on
+
+                //Force power on
                 var newPowerTrader = newThing.TryGetComp<CompPowerTrader>();
                 if (newPowerTrader != null)
                 {

--- a/Source/CombatExtended/Harmony/Compatibility/Harmony_VOID.cs
+++ b/Source/CombatExtended/Harmony/Compatibility/Harmony_VOID.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Reflection;
+using System.Linq;
+using HarmonyLib;
+using RimWorld;
+using Verse;
+
+namespace CombatExtended.HarmonyCE.Compatibility
+{
+    public static class Harmony_VOID
+    {
+        private static Type Utils_Patch_HarmonyPatches
+        {
+            get
+            {
+                return AccessTools.TypeByName("EncounterFramework.Utils");
+            }
+        }
+        [HarmonyPatch]
+        public static class Harmony_Utils_Patch
+        {
+            
+            public static bool Prepare()
+            {
+                return Utils_Patch_HarmonyPatches != null;
+            }
+
+            public static MethodBase TargetMethod()
+            {
+                return AccessTools.Method("EncounterFramework.Utils:DoGeneration");
+            }
+            
+            public static void Postfix(Map map)
+            {
+                Log.Message("EncounterFramework.Utils:DoGeneration");
+                var buildingList = map.listerBuildings.allBuildingsNonColonist.ToList();
+                foreach (var thing in buildingList)
+                {
+                    if (thing is Building_Turret turret)
+                    {
+                        ReplaceTurret(turret);
+                    }
+                }
+            }
+            
+            private static void ReplaceTurret(Thing oldThing)
+            {
+                // Saving all the old turrets information
+                var map = oldThing.Map;
+                var position = oldThing.Position;
+                var stuff = oldThing.Stuff;
+                var faction = oldThing.Faction;
+                var def = oldThing.def;
+                
+                oldThing.Destroy();
+                
+                // Make new Turret
+                if (ThingMaker.MakeThing(def, stuff) is not Building_TurretGunCE newThing)
+                {
+                    return;
+                }
+                GenPlace.TryPlaceThing(newThing, position, map, ThingPlaceMode.Direct);
+                newThing.SetFaction(faction);
+                
+                // Turret Ammo
+                var ammoComp = newThing.CompAmmo;
+                var ammoTypes = ammoComp.Props.ammoSet.ammoTypes;
+                foreach (var ammoType in ammoTypes)
+                {
+                    if (ammoType.ammo.ammoClass == CE_AmmoCategoryDefOf.ExplosiveAP)
+                    {
+                        ammoComp.CurrentAmmo = ammoType.ammo;
+                    }
+                }
+                ammoComp.CurMagCount = ammoComp.MagSize;
+                
+                // Force power on
+                var newPowerTrader = newThing.TryGetComp<CompPowerTrader>();
+                if (newPowerTrader != null)
+                {
+                    newPowerTrader.PowerOn = true;
+                }
+
+            }
+        }
+    }
+}

--- a/Source/CombatExtended/Harmony/Compatibility/Harmony_VOID.cs
+++ b/Source/CombatExtended/Harmony/Compatibility/Harmony_VOID.cs
@@ -51,8 +51,12 @@ namespace CombatExtended.HarmonyCE.Compatibility
                 var stuff = oldThing.Stuff;
                 var faction = oldThing.Faction;
                 var def = oldThing.def;
+                var rot = oldThing.Rotation;
+                var hp = oldThing.HitPoints;
+                var powerComp = oldThing.TryGetComp<CompPowerTrader>();
+                PowerNet net = powerComp?.PowerNet;
 
-                oldThing.Destroy();
+                oldThing.Destroy(DestroyMode.Vanish);
 
                 //Make new Turret
                 if (ThingMaker.MakeThing(def, stuff) is not Building_TurretGunCE newThing)
@@ -61,6 +65,8 @@ namespace CombatExtended.HarmonyCE.Compatibility
                 }
                 GenPlace.TryPlaceThing(newThing, position, map, ThingPlaceMode.Direct);
                 newThing.SetFaction(faction);
+                newThing.HitPoints = hp;
+                newThing.Rotation = rot;
 
                 //Turret Ammo
                 var ammoComp = newThing.CompAmmo;
@@ -78,6 +84,7 @@ namespace CombatExtended.HarmonyCE.Compatibility
                 var newPowerTrader = newThing.TryGetComp<CompPowerTrader>();
                 if (newPowerTrader != null)
                 {
+                    net?.RegisterConnector(newPowerTrader);
                     newPowerTrader.PowerOn = true;
                 }
 


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Adds code to check and respawn turrets as proper class
- Maxes ammo for turrets
- Makes ammo as AP-HE as VOID is supposed to be top tier
- Changes Void power cell to 2000kw due to power changes in CE turret's. This maintains the integrity of the power network and all the turrets to be powered.

## Reasoning

Why did you choose to implement things this way, e.g.
- VOID base turrets will not shoot lacking ammo and improper thing class
- Due to unique spawning code of VOID code requiring destroying turrets as they will spawn with wrong ThingClass and respawning them
- Void Power Cell is worth 100k silver normally for 1kw power cell, while vanilla Vanometric power cell is 1200 silver for 1kw. Adding extra 1000 watts of power to maintain turrets, won't effect any balance in a significant way for item worth 100K silver.

## Alternatives

Describe alternative implementations you have considered, e.g.
- Weak Ultra Tier Boss Group

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (Attack VOID base on normal and generic ammo mode)
