### PR TITLE
Fix NRE MoteMaker

### DIFF
--- a/Source/CombatExtended/CombatExtended/MoteMakerCE.cs
+++ b/Source/CombatExtended/CombatExtended/MoteMakerCE.cs
@@ -8,6 +8,7 @@ namespace CombatExtended
     {
         public static void ThrowText(Vector3 loc, Map map, string text, float timeBeforeStartFadeout = -1f)
         {
+            if (map == null) return;
             Rand.PushState();
             MoteMaker.ThrowText(loc, map, text, timeBeforeStartFadeout);
             Rand.PopState();
@@ -15,6 +16,7 @@ namespace CombatExtended
 
         public static void ThrowText(Vector3 loc, Map map, string text, Color color, float timeBeforeStartFadeout = -1f)
         {
+            if (map == null) return;
             Rand.PushState();
             MoteMaker.ThrowText(loc, map, text, color, timeBeforeStartFadeout);
             Rand.PopState();

--- a/Source/CombatExtended/CombatExtended/MoteMakerCE.cs
+++ b/Source/CombatExtended/CombatExtended/MoteMakerCE.cs
@@ -8,7 +8,10 @@ namespace CombatExtended
     {
         public static void ThrowText(Vector3 loc, Map map, string text, float timeBeforeStartFadeout = -1f)
         {
-            if (map == null) return;
+            if (map == null)
+            {
+                return;
+            }
             Rand.PushState();
             MoteMaker.ThrowText(loc, map, text, timeBeforeStartFadeout);
             Rand.PopState();
@@ -16,7 +19,10 @@ namespace CombatExtended
 
         public static void ThrowText(Vector3 loc, Map map, string text, Color color, float timeBeforeStartFadeout = -1f)
         {
-            if (map == null) return;
+            if (map == null)
+            {
+                return;
+            }
             Rand.PushState();
             MoteMaker.ThrowText(loc, map, text, color, timeBeforeStartFadeout);
             Rand.PopState();


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Adds null check for map on MoteMaker

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #3868 
- May Close #3750

## Reasoning

Why did you choose to implement things this way, e.g.
- Motemaker was throwing constant errors when killing TriSpike in numerous ways as the corpse gets fully destroyed.
- Easily replicated with using VPE KillSkip on a tripspike

## Alternatives

Describe alternative implementations you have considered, e.g.
- Prevents constant error spam

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Kill a trispike)
