### PR TITLE
Fix Full Auto Underbarrel Burst Fire Gizmo

### DIFF
--- a/ModPatches/Vanilla Weapons Expanded - Bioferrite/Patches/VWE_BioferriteRanged.xml
+++ b/ModPatches/Vanilla Weapons Expanded - Bioferrite/Patches/VWE_BioferriteRanged.xml
@@ -345,7 +345,7 @@
 		<xpath>Defs/ThingDef[defName="VWEB_Gun_CycloneMinigun"]/comps/li[@Class="CompProperties_EquippableAbilityReloadable"]</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_UnderBarrel">
-				<standardLabel>switch to normalfire</standardLabel>
+				<standardLabel>switch to normal fire</standardLabel>
 				<underBarrelLabel>switch to cyclone engine</underBarrelLabel>
 				<oneAmmoHolder>True</oneAmmoHolder>
 				<propsUnderBarrel>

--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmosetSwitcher.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmosetSwitcher.cs
@@ -141,6 +141,9 @@ namespace CombatExtended
                     CompAmmo.Wielder.jobs.EndCurrentJob(Verse.AI.JobCondition.InterruptForced);
                 }
             }
+            // Setting main verbProp burstShotCount equal to the underBarrel's burstShotCount
+            // Ensures that there should be a burstFire option
+            // If set to aimedBurstShotCount, will result in warning and no burst fire mode. Only full auto
             CompEq.PrimaryVerb.verbProps.burstShotCount = this.Props.verbPropsUnderBarrel.burstShotCount;
             usingUnderBarrel = true;
             CompFireModes.InitAvailableFireModes();

--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmosetSwitcher.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmosetSwitcher.cs
@@ -141,7 +141,7 @@ namespace CombatExtended
                     CompAmmo.Wielder.jobs.EndCurrentJob(Verse.AI.JobCondition.InterruptForced);
                 }
             }
-            CompEq.PrimaryVerb.verbProps.burstShotCount = this.Props.propsFireModesUnderBarrel.aimedBurstShotCount;
+            CompEq.PrimaryVerb.verbProps.burstShotCount = this.Props.verbPropsUnderBarrel.burstShotCount;
             usingUnderBarrel = true;
             CompFireModes.InitAvailableFireModes();
         }


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Fixes burst fire option availability due to burstShotCount equaling aimedBurstShotCount during CompFireModes.InitAvailableFireModes

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #3341 

## Reasoning

Why did you choose to implement things this way, e.g.
- Annoying warning
- Missing gizmo option is bad player experience

## Alternatives

Describe alternative implementations you have considered, e.g.
- Completely change shooting when underbarrel is active

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (Full Auto M16 UBGL)
