### PR TITLE
Check if projectile already inside target bounds

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -1019,6 +1019,11 @@ namespace CombatExtended
             }
 
             var bounds = CE_Utility.GetBoundsFor(thing);
+            if (bounds.Contains(LastPos) || bounds.Contains(ExactPosition))
+            {
+                dist = 0f;
+                return true;
+            }
             if (!bounds.IntersectRay(ShotLine, out dist))
             {
                 return false;


### PR DESCRIPTION
## Changes

- Check if projectile already inside target bounds

## Reasoning

- Slow projectiles may miss the target even if projectile is already inside the target - `dist * dist > (ExactPosition - LastPos).sqrMagnitude` fails there due to low speed of bullet 

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (tested my custom slow bullet)
