### PR TITLE
Add tooltip to artillery marker

### DIFF
--- a/Defs/ThingDefs_Misc/Things_Special.xml
+++ b/Defs/ThingDefs_Misc/Things_Special.xml
@@ -14,6 +14,7 @@
 		</graphicData>
 		<altitudeLayer>MetaOverlays</altitudeLayer>
 		<useHitPoints>false</useHitPoints>
+		<hasTooltip>true</hasTooltip>
 	</ThingDef>
 
 </Defs>

--- a/Languages/English/Keyed/Keys.xml
+++ b/Languages/English/Keyed/Keys.xml
@@ -67,6 +67,7 @@
 	<CE_ArtilleryTargetDesc>Attack a world tile. If the selected tile contains a map, you can select the attack target within that map.</CE_ArtilleryTargetDesc>
 	<CE_ArtilleryTarget_AlreadyDestroyed>Selected target already destroyed</CE_ArtilleryTarget_AlreadyDestroyed>
 	<CE_ArtilleryTarget_MustTargetMark>Can only target artillery mark</CE_ArtilleryTarget_MustTargetMark>
+	<CE_ArtilleryTarget_MarkerHoverHeader>Aiming artillery at this position will improve accuracy by:</CE_ArtilleryTarget_MarkerHoverHeader>
 
 	<!-- Marking -->
 	<CE_MarkingUnavailableReason>Pawn cannot mark targets for artillery because they are on a map with no local artillery and they need a radio pack to communicate with the artillery crew.\n\nMarking targets is disabled when no artillery is available in local map and the pawn doesn't have access to long range radios.</CE_MarkingUnavailableReason>

--- a/Source/CombatExtended/CombatExtended/Projectiles/ArtilleryMarker.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ArtilleryMarker.cs
@@ -19,12 +19,30 @@ namespace CombatExtended
 
         private int lifetimeTicks = 1800;
 
+        public override string Label
+        {
+            get
+            {
+                return string.Concat("CE_MarkedForArtillery".Translate(), " ", ((int)(lifetimeTicks / 60)).ToString(), " ", "LetterSecond".Translate());
+            }
+        }
+
         public override string InspectStringAddon
         {
             get
             {
-                return "CE_MarkedForArtillery".Translate() + " " + ((int)(lifetimeTicks / 60)).ToString() + " s";
+                return string.Concat("CE_MarkedForArtillery".Translate(), " ", ((int)(lifetimeTicks / 60)).ToString(), " ", "LetterSecond".Translate());
             }
+        }
+
+        public override TipSignal GetTooltip()
+        {
+            string text = string.Concat(this.LabelCap,
+                "\n\n", "CE_ArtilleryTarget_MarkerHoverHeader".Translate(),
+                "\n\n", CE_StatDefOf.SightsEfficiency.LabelCap, ": ", sightsEfficiency,
+                "\n", CE_StatDefOf.AimingAccuracy.LabelCap, ": ", aimingAccuracy);
+
+            return new TipSignal(text);
         }
 
         public override void ExposeData()

--- a/Source/CombatExtended/CombatExtended/Projectiles/ArtilleryMarker.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ArtilleryMarker.cs
@@ -23,7 +23,7 @@ namespace CombatExtended
         {
             get
             {
-                return string.Concat("CE_MarkedForArtillery".Translate(), " ", ((int)(lifetimeTicks / 60)).ToString(), " ", "LetterSecond".Translate());
+                return string.Concat("CE_MarkedForArtillery".Translate(), " ", ((int)(lifetimeTicks / GenTicks.TicksPerRealSecond)).ToString(), " ", "LetterSecond".Translate());
             }
         }
 
@@ -31,7 +31,7 @@ namespace CombatExtended
         {
             get
             {
-                return string.Concat("CE_MarkedForArtillery".Translate(), " ", ((int)(lifetimeTicks / 60)).ToString(), " ", "LetterSecond".Translate());
+                return string.Concat("CE_MarkedForArtillery".Translate(), " ", ((int)(lifetimeTicks / GenTicks.TicksPerRealSecond)).ToString(), " ", "LetterSecond".Translate());
             }
         }
 


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Adds a tooltip when hovering above an artillery marker that shows stats of the marker.
- Adds expiration time to marker's label in bottom left; and to pawn's bottom left menu when marker is attached to pawn.

![image](https://i.postimg.cc/Kzxq35HY/image.png)

## Reasoning

Why did you choose to implement things this way, e.g.
- It was difficult to understand how much of a bonus a particular arty marker gives.
- Shows aiming accuracy, because it comes from pawn skill, and sight efficiency, because it comes from binocular quality.
- Marker also affects weather and light shifts, but I didn't include those into the tooltip, because during inter-tile bombardments, those stats are disregarded and replaced with a fixed value.

## Alternatives

Describe alternative implementations you have considered, e.g.
- Include weather and light, but make a special case to not show them on foreign tiles?..
- Make a note that binocular quality affects marker quality?
- Use marker's colors to show efficiency.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (created devmode colony, made markers, tried shooting at them)
