### PR TITLE
Gun Statsheet Rebalances (Part: 2 - Weapon Handedness)

### DIFF
--- a/Defs/ThingDefs_Misc/Apparel_Shield.xml
+++ b/Defs/ThingDefs_Misc/Apparel_Shield.xml
@@ -57,7 +57,7 @@
 		<equippedStatOffsets>
 			<ReloadSpeed>-0.2</ReloadSpeed>
 			<MeleeHitChance>-1</MeleeHitChance>
-			<ShootingAccuracyPawn>-0.15</ShootingAccuracyPawn>
+			<ShootingAccuracyPawn>-1.5</ShootingAccuracyPawn>
 			<AimingAccuracy>-0.08</AimingAccuracy>
 			<Suppressability>-0.25</Suppressability>
 			<MeleeCritChance>-0.05</MeleeCritChance>
@@ -146,7 +146,7 @@
 		<equippedStatOffsets>
 			<ReloadSpeed>-0.3</ReloadSpeed>
 			<MeleeHitChance>-4</MeleeHitChance>
-			<ShootingAccuracyPawn>-0.4</ShootingAccuracyPawn>
+			<ShootingAccuracyPawn>-1.5</ShootingAccuracyPawn>
 			<AimingAccuracy>-0.2</AimingAccuracy>
 			<Suppressability>-0.5</Suppressability>
 			<MeleeCritChance>-0.2</MeleeCritChance>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -136,7 +136,7 @@
 			<ComponentIndustrial>2</ComponentIndustrial>
 		</costList>
 		<Properties>
-			<recoilAmount>3.01</recoilAmount>
+			<recoilAmount>2.96</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_44Magnum_FMJ</defaultProjectile>
@@ -200,7 +200,7 @@
 			<ComponentIndustrial>3</ComponentIndustrial>
 		</costList>
 		<Properties>
-			<recoilAmount>2.76</recoilAmount>
+			<recoilAmount>2.72</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -124,7 +124,7 @@
 			<RangedWeapon_Cooldown>0.49</RangedWeapon_Cooldown>
 			<SightsEfficiency>0.7</SightsEfficiency>
 			<ShotSpread>0.16</ShotSpread>
-			<SwayFactor>1.39</SwayFactor>
+			<SwayFactor>1.05</SwayFactor>
 			<Bulk>2.79</Bulk>
 			<!-- <ToughnessRating>2.5</ToughnessRating> -->
 			<!-- Base toughness rating of a weapon -->
@@ -136,7 +136,7 @@
 			<ComponentIndustrial>2</ComponentIndustrial>
 		</costList>
 		<Properties>
-			<recoilAmount>2.96</recoilAmount>
+			<recoilAmount>3.01</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_44Magnum_FMJ</defaultProjectile>
@@ -188,10 +188,10 @@
 		<defName>Gun_Autopistol</defName>
 		<statBases>
 			<Mass>1.11</Mass>
-			<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
+			<RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
 			<SightsEfficiency>0.7</SightsEfficiency>
 			<ShotSpread>0.17</ShotSpread>
-			<SwayFactor>1.07</SwayFactor>
+			<SwayFactor>0.80</SwayFactor>
 			<Bulk>2.10</Bulk>
 			<WorkToMake>7000</WorkToMake>
 		</statBases>
@@ -200,7 +200,7 @@
 			<ComponentIndustrial>3</ComponentIndustrial>
 		</costList>
 		<Properties>
-			<recoilAmount>2.72</recoilAmount>
+			<recoilAmount>2.76</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
@@ -568,9 +568,9 @@
 		<statBases>
 			<Mass>2.84</Mass>
 			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-			<SightsEfficiency>0.7</SightsEfficiency>
+			<SightsEfficiency>1.0</SightsEfficiency>
 			<ShotSpread>0.16</ShotSpread>
-			<SwayFactor>1.93</SwayFactor>
+			<SwayFactor>1.39</SwayFactor>
 			<Bulk>2.95</Bulk>
 			<WorkToMake>24500</WorkToMake>
 		</statBases>
@@ -579,7 +579,7 @@
 			<ComponentIndustrial>3</ComponentIndustrial>
 		</costList>
 		<Properties>
-			<recoilAmount>1.71</recoilAmount>
+			<recoilAmount>1.68</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>


### PR DESCRIPTION
## Changes
- Reworked mounting into 4 main categories "Handgun", "Handgun/Stocked", "LongGun", and "LongGun/Stockless". (Bipods and fixed guns still separate.)
- "Handgun" mounting works like OneHanded as before but with slightly reduced sway.
- "Handgun/Stocked" mounting works like OneHanded but with TwoHanded sights efficiency and recoil, and slightly reduced sway.
- "LongGun" mounting works like TwoHanded as before.
- "LongGun/Stockless" mounting works like TwoHanded but with OneHanded sight efficiency and recoil.
- Greatly increased the handling penalties for using a shield with a ranged weapon.

## References
Spreadsheet from Hell:
https://docs.google.com/spreadsheets/d/15hS6kxv7X2Z8Wz1PJJf35pC2-uX6ceFbl60IPTOBg-Q/edit?usp=sharing

## Reasoning
- Gives more flexibility for certain guns which don't fit the typical one/two handed categories. Examples being the Mac-10 which currently uses one-handed stats, giving it insanely high sway and lower sight efficiency despite having a stock, or the Sawn-off Shotgun from Armory which uses two-handed weapon stats, giving it normal sights efficiency and recoil despite having no stock.
- Moves the idea of weapons with the one-handed tag to refer to guns which _can_ be used one-handed, instead of _always_ used one-handed. Pawns will now be assumed to hold **all** weapons with both hands, giving pistols a buff to sway, but will switch to one hand when using a shield and will suffer much greater penalties than before. This gives more flexibility in determining which guns can be used with a shield. Currently discussed examples include lightweight SMGs such as the P90, Charge SMG, AM-180, etc. but may also extend to small carbines if determined to be feasible.
- All shields will give a flat -1.5 weapon handling penalty to represent the general loss in effectiveness from using one hand (about half for an 8 skill shooter). The additional shooting accuracy penalty will vary depending on how cumbersome the shield is, same as before.
## Alternatives
- Idk, not doing it?

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
