### PR TITLE
Composable and Ad-Hoc Loadouts

### DIFF
--- a/Defs/Tutor/Concepts_NotedSelfshow.xml
+++ b/Defs/Tutor/Concepts_NotedSelfshow.xml
@@ -59,7 +59,7 @@
 		<defName>CE_ParentLoadouts</defName>
 		<label>CE: Parent loadouts</label>
 		<priority>50</priority>
-		<helpText>Loadouts can be assigned a 'parent loadout'. Colonists will carry everything in the parent loadout in addition to their assigned loadout. This is useful for creating base loadouts across multiple colonists that can be quickly and easily changed.</helpText>
+		<helpText>Loadouts can be assigned a 'parent loadout'. Colonists will carry everything in the parent loadout in addition to their assigned loadout. This is useful for creating base loadouts used across multiple colonists that can be quickly and easily changed.</helpText>
 	</ConceptDef>
 
 	<ConceptDef>

--- a/Defs/Tutor/Concepts_NotedSelfshow.xml
+++ b/Defs/Tutor/Concepts_NotedSelfshow.xml
@@ -55,4 +55,18 @@
 		<helpText>Warning: It is only a matter of time before Mechanoids take notice of your arrival and start attacking. The larger models have heavy armor that is impervious to small-arms fire.\n\nFighting them requires powerful weapons such as heavy machine guns or explosives. You should keep a healthy stockpile of these weapons if you hope to survive for long.</helpText>
 	</ConceptDef>
 
+	<ConceptDef>
+		<defName>CE_ParentLoadouts</defName>
+		<label>CE: Parent loadouts</label>
+		<priority>50</priority>
+		<helpText>Loadouts can be assigned a 'parent loadout'. Colonists will carry everything in the parent loadout in addition to their assigned loadout. This is useful for creating base loadouts across multiple colonists that can be quickly and easily changed.</helpText>
+	</ConceptDef>
+
+	<ConceptDef>
+		<defName>CE_AdHocLoadouts</defName>
+		<label>CE: Ad hoc loadouts</label>
+		<priority>50</priority>
+		<helpText>Loadouts can be designated as 'ad hoc', which automatically includes the colonist's currently equipped weapon and ammo for it as part of their loadout. Ad hoc loadouts include additional options to set how many magazines' worth of ammo your colonst will carry for their weapon, up to set limits of mass and bulk.</helpText>
+	</ConceptDef>
+
 </Defs>

--- a/Languages/English/Keyed/BulkAndWeight.xml
+++ b/Languages/English/Keyed/BulkAndWeight.xml
@@ -26,7 +26,7 @@
 	<CE_SaveLoadout>Save loadout...</CE_SaveLoadout>
 	<CE_LoadLoadout>Load loadout...</CE_LoadLoadout>
 	<CE_ParentLoadout>Parent loadout...</CE_ParentLoadout>
-        <CE_ClearParentLoadout>(clear)</CE_ClearParentLoadout>
+	<CE_ClearParentLoadout>(clear)</CE_ClearParentLoadout>
 	<CE_MissingLoadoutSlots>The following loadout slots could not be loaded as these things do not exist in this world: {0}</CE_MissingLoadoutSlots>
 	<CE_NoLoadoutSelected>No loadout selected</CE_NoLoadoutSelected>
 	<CE_DefaultLoadoutName>Loadout</CE_DefaultLoadoutName>
@@ -49,8 +49,10 @@
 	<CE_LoadOut_DropUndefined_Desc>Drop items which are not part of the loadout</CE_LoadOut_DropUndefined_Desc>
 	<CE_LoadOut_AdHoc>Ad Hoc</CE_LoadOut_AdHoc>
 	<CE_LoadOut_AdHoc_Desc>Automatically add loadout slots for primary equipment and ammo if it's not already in the loadout</CE_LoadOut_AdHoc_Desc>
-        <CE_LoadOut_Mags>Mags</CE_LoadOut_Mags>
-        <CE_LoadOut_AdHoc_Mass>Mass</CE_LoadOut_AdHoc_Mass>
-        <CE_LoadOut_AdHoc_Bulk>Bulk</CE_LoadOut_AdHoc_Bulk>
+	<CE_LoadOut_Mags>Mags</CE_LoadOut_Mags>
+	<CE_LoadOut_Mags_Desc>Sets the desired magazine amount to be carried.</CE_LoadOut_Mags_Desc>
+	<CE_LoadOut_Weight_Desc>Sets the desired ammo weight to be carried.</CE_LoadOut_Weight_Desc>
+	<CE_LoadOut_Bulk_Desc>Sets the desired ammo bulk to be carried.</CE_LoadOut_Bulk_Desc>
+	
 
 </LanguageData>

--- a/Languages/English/Keyed/BulkAndWeight.xml
+++ b/Languages/English/Keyed/BulkAndWeight.xml
@@ -25,6 +25,7 @@
 	<CE_CopyLoadout>Copy loadout</CE_CopyLoadout>
 	<CE_SaveLoadout>Save loadout...</CE_SaveLoadout>
 	<CE_LoadLoadout>Load loadout...</CE_LoadLoadout>
+	<CE_ParentLoadout>Parent loadout...</CE_ParentLoadout>
 	<CE_MissingLoadoutSlots>The following loadout slots could not be loaded as these things do not exist in this world: {0}</CE_MissingLoadoutSlots>
 	<CE_NoLoadoutSelected>No loadout selected</CE_NoLoadoutSelected>
 	<CE_DefaultLoadoutName>Loadout</CE_DefaultLoadoutName>
@@ -43,5 +44,9 @@
 	<CE_PickupMissingAndDropExcess>Pickup missing and drop excess</CE_PickupMissingAndDropExcess>
 	<CE_StatsReport_LoadedAmmo>Loaded ammunition</CE_StatsReport_LoadedAmmo>
 	<CE_InventoryFull_TameFail>Does not have enough space in inventory to pickup the required food for taming.</CE_InventoryFull_TameFail>
+	<CE_LoadOut_ExtraOptionA>Option A</CE_LoadOut_ExtraOptionA>
+	<CE_LoadOut_ExtraOptionA_Desc>Option A Desc</CE_LoadOut_ExtraOptionA_Desc>
+	<CE_LoadOut_ExtraOptionB>Option B</CE_LoadOut_ExtraOptionB>
+	<CE_LoadOut_ExtraOptionB_Desc>Option B Desc</CE_LoadOut_ExtraOptionB_Desc>
 
 </LanguageData>

--- a/Languages/English/Keyed/BulkAndWeight.xml
+++ b/Languages/English/Keyed/BulkAndWeight.xml
@@ -46,13 +46,13 @@
 	<CE_StatsReport_LoadedAmmo>Loaded ammunition</CE_StatsReport_LoadedAmmo>
 	<CE_InventoryFull_TameFail>Does not have enough space in inventory to pickup the required food for taming.</CE_InventoryFull_TameFail>
 	<CE_LoadOut_DropUndefined>Drop Undefined</CE_LoadOut_DropUndefined>
-	<CE_LoadOut_DropUndefined_Desc>Drop items which are not part of the loadout</CE_LoadOut_DropUndefined_Desc>
+	<CE_LoadOut_DropUndefined_Desc>Drop any non-forced items which are not part of the loadout.</CE_LoadOut_DropUndefined_Desc>
 	<CE_LoadOut_AdHoc>Ad Hoc</CE_LoadOut_AdHoc>
-	<CE_LoadOut_AdHoc_Desc>Automatically add loadout slots for primary equipment and ammo if it's not already in the loadout</CE_LoadOut_AdHoc_Desc>
+	<CE_LoadOut_AdHoc_Desc>Automatically include the pawn's equipped weapon and ammo for it if they're not already in the loadout.</CE_LoadOut_AdHoc_Desc>
 	<CE_LoadOut_Mags>Mags</CE_LoadOut_Mags>
-	<CE_LoadOut_Mags_Desc>Sets the desired magazine amount to be carried.</CE_LoadOut_Mags_Desc>
-	<CE_LoadOut_Weight_Desc>Sets the desired ammo weight to be carried.</CE_LoadOut_Weight_Desc>
-	<CE_LoadOut_Bulk_Desc>Sets the desired ammo bulk to be carried.</CE_LoadOut_Bulk_Desc>
+	<CE_LoadOut_Mags_Desc>Sets the desired number of magazines to be carried.</CE_LoadOut_Mags_Desc>
+	<CE_LoadOut_Weight_Desc>Limits the max ammo weight to be carried. Limit disabled if set to 0.</CE_LoadOut_Weight_Desc>
+	<CE_LoadOut_Bulk_Desc>Limits the max ammo bulk to be carried. Limit disabled if set to 0.</CE_LoadOut_Bulk_Desc>
 	
 
 </LanguageData>

--- a/Languages/English/Keyed/BulkAndWeight.xml
+++ b/Languages/English/Keyed/BulkAndWeight.xml
@@ -26,6 +26,7 @@
 	<CE_SaveLoadout>Save loadout...</CE_SaveLoadout>
 	<CE_LoadLoadout>Load loadout...</CE_LoadLoadout>
 	<CE_ParentLoadout>Parent loadout...</CE_ParentLoadout>
+        <CE_ClearParentLoadout>(clear)</CE_ClearParentLoadout>
 	<CE_MissingLoadoutSlots>The following loadout slots could not be loaded as these things do not exist in this world: {0}</CE_MissingLoadoutSlots>
 	<CE_NoLoadoutSelected>No loadout selected</CE_NoLoadoutSelected>
 	<CE_DefaultLoadoutName>Loadout</CE_DefaultLoadoutName>
@@ -44,9 +45,9 @@
 	<CE_PickupMissingAndDropExcess>Pickup missing and drop excess</CE_PickupMissingAndDropExcess>
 	<CE_StatsReport_LoadedAmmo>Loaded ammunition</CE_StatsReport_LoadedAmmo>
 	<CE_InventoryFull_TameFail>Does not have enough space in inventory to pickup the required food for taming.</CE_InventoryFull_TameFail>
-	<CE_LoadOut_ExtraOptionA>Option A</CE_LoadOut_ExtraOptionA>
-	<CE_LoadOut_ExtraOptionA_Desc>Option A Desc</CE_LoadOut_ExtraOptionA_Desc>
-	<CE_LoadOut_ExtraOptionB>Option B</CE_LoadOut_ExtraOptionB>
-	<CE_LoadOut_ExtraOptionB_Desc>Option B Desc</CE_LoadOut_ExtraOptionB_Desc>
+	<CE_LoadOut_DropUndefined>Drop Undefined</CE_LoadOut_DropUndefined>
+	<CE_LoadOut_DropUndefined_Desc>Drop items which are not part of the loadout</CE_LoadOut_DropUndefined_Desc>
+	<CE_LoadOut_AdHoc>Ad Hoc</CE_LoadOut_AdHoc>
+	<CE_LoadOut_AdHoc_Desc>Automatically add loadout slots for primary verb ammo if it's not already in the loadout</CE_LoadOut_AdHoc_Desc>
 
 </LanguageData>

--- a/Languages/English/Keyed/BulkAndWeight.xml
+++ b/Languages/English/Keyed/BulkAndWeight.xml
@@ -48,6 +48,9 @@
 	<CE_LoadOut_DropUndefined>Drop Undefined</CE_LoadOut_DropUndefined>
 	<CE_LoadOut_DropUndefined_Desc>Drop items which are not part of the loadout</CE_LoadOut_DropUndefined_Desc>
 	<CE_LoadOut_AdHoc>Ad Hoc</CE_LoadOut_AdHoc>
-	<CE_LoadOut_AdHoc_Desc>Automatically add loadout slots for primary verb ammo if it's not already in the loadout</CE_LoadOut_AdHoc_Desc>
+	<CE_LoadOut_AdHoc_Desc>Automatically add loadout slots for primary equipment and ammo if it's not already in the loadout</CE_LoadOut_AdHoc_Desc>
+        <CE_LoadOut_Mags>Mags</CE_LoadOut_Mags>
+        <CE_LoadOut_AdHoc_Mass>Mass</CE_LoadOut_AdHoc_Mass>
+        <CE_LoadOut_AdHoc_Bulk>Bulk</CE_LoadOut_AdHoc_Bulk>
 
 </LanguageData>

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -113,7 +113,7 @@ namespace CombatExtended
             {
                 return false;
             }
-            LoadoutSlot slot = loadout.Slots.FirstOrFallback(s => s.weaponPlatformDef == platform.Platform);
+            LoadoutSlot slot = loadout.GetSlotsFor(pawn).FirstOrFallback(s => s.weaponPlatformDef == platform.Platform);
             // if no slot mention this or it allows everything return false
             if (slot == null || slot.allowAllAttachments)
             {

--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_CheckReload.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_CheckReload.cs
@@ -186,7 +186,7 @@ namespace CombatExtended
             // first check loadouts...
             Loadout loadout = pawn.GetLoadout();
 
-            foreach (LoadoutSlot slot in loadout.Slots)
+            foreach (LoadoutSlot slot in loadout.GetSlotsFor(pawn))
             {
                 if (slot.thingDef != null)
                 {

--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_CheckReload.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_CheckReload.cs
@@ -107,7 +107,7 @@ namespace CombatExtended
             CompInventory inventory = pawn.TryGetComp<CompInventory>();
             CompAmmoUser tmpComp;
             Loadout loadout = pawn.GetLoadout();
-            bool pawnHasLoadout = loadout != null && !loadout.Slots.NullOrEmpty();
+            bool pawnHasLoadout = loadout?.Slots.Any() ?? false;
 
             if (inventory == null)
             {

--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_CheckReload.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_CheckReload.cs
@@ -107,7 +107,7 @@ namespace CombatExtended
             CompInventory inventory = pawn.TryGetComp<CompInventory>();
             CompAmmoUser tmpComp;
             Loadout loadout = pawn.GetLoadout();
-            bool pawnHasLoadout = loadout?.Slots.Any() ?? false;
+            bool pawnHasLoadout = loadout != null && !loadout.defaultLoadout && loadout.Slots.Any();
 
             if (inventory == null)
             {

--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_UpdateLoadout.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_UpdateLoadout.cs
@@ -103,13 +103,13 @@ namespace CombatExtended
             if (inventory != null && inventory.container != null)
             {
                 Loadout loadout = pawn.GetLoadout();
-                if (loadout != null && !loadout.Slots.NullOrEmpty())
+                if (loadout != null)
                 {
                     // Need to generate a dictionary and nibble like when dropping in order to allow for conflicting loadouts to work properly.
                     Dictionary<ThingDef, Integer> listing = pawn.GetStorageByThingDef();
 
                     // process each loadout slot... (While the LoadoutSlot.countType property only really makes sense in the context of genericDef != null, it should be the correct value (pickupDrop) on .thingDef != null.)
-                    foreach (LoadoutSlot curSlot in loadout.Slots.Where(s => s.countType != LoadoutCountType.dropExcess))
+                    foreach (LoadoutSlot curSlot in loadout.GetSlotsFor(pawn).Where(s => s.countType != LoadoutCountType.dropExcess))
                     {
                         Thing curThing = null;
                         ItemPriority curPriority = ItemPriority.None;

--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_UpdateLoadout.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_UpdateLoadout.cs
@@ -379,7 +379,7 @@ namespace CombatExtended
                             && !(pawn.story != null && pawn.WorkTagIsDisabled(WorkTags.Violent))
                             && (pawn.health != null && pawn.health.capacities.CapableOf(PawnCapacityDefOf.Manipulation))
                             && (!pawn.IsItemQuestLocked(pawn.equipment?.Primary))
-                            && (pawn.equipment == null || pawn.equipment.Primary == null || !loadout.Slots.Any(s => s.thingDef == pawn.equipment.Primary.def || (s.genericDef != null && s.countType == LoadoutCountType.pickupDrop
+                            && (pawn.equipment == null || pawn.equipment.Primary == null || !loadout.GetSlotsFor(pawn).Any(s => s.thingDef == pawn.equipment.Primary.def || (s.genericDef != null && s.countType == LoadoutCountType.pickupDrop
                                     && s.genericDef.lambda(pawn.equipment.Primary.def)))))
                     {
                         doEquip = true;

--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_UpdateLoadout.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_UpdateLoadout.cs
@@ -103,7 +103,7 @@ namespace CombatExtended
             if (inventory != null && inventory.container != null)
             {
                 Loadout loadout = pawn.GetLoadout();
-                if (loadout != null)
+                if (loadout != null && !loadout.defaultLoadout)
                 {
                     // Need to generate a dictionary and nibble like when dropping in order to allow for conflicting loadouts to work properly.
                     Dictionary<ThingDef, Integer> listing = pawn.GetStorageByThingDef();
@@ -335,7 +335,7 @@ namespace CombatExtended
             }
 
             Loadout loadout = pawn.GetLoadout();
-            if (loadout != null)
+            if (loadout != null && !loadout.defaultLoadout)
             {
                 ThingWithComps dropEq;
                 if (pawn.GetExcessEquipment(out dropEq))

--- a/Source/CombatExtended/CombatExtended/Loadouts/Dialog_ManageLoadouts.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/Dialog_ManageLoadouts.cs
@@ -422,13 +422,13 @@ namespace CombatExtended
             if (CurrentLoadout.adHoc)
             {
                 Rect magsRect = new Rect(rect.x, rect.y + rect.height / 2, checkboxWidth, rect.height / 2);
-                CustomWidgets.DrawIntOptionWithSpinners(magsRect, "CE_LoadOut_Mags".Translate(), "CE_LoadOut_Mags_Desc".Translate(), ref CurrentLoadout.adHocMags, 0f, 100, 1);
+                CustomWidgets.DrawIntOptionWithSpinners(magsRect, "CE_LoadOut_Mags".Translate(), "CE_LoadOut_Mags_Desc".Translate(), ref CurrentLoadout.adHocMags, 0f, 999, 1);
 
                 Rect massRect = new Rect(rect.x + checkboxWidth + 5f, rect.y + rect.height / 2, checkboxWidth, rect.height / 2);
-                CustomWidgets.DrawIntOptionWithSpinners(massRect, "CE_Weight".Translate(), "CE_LoadOut_Weight_Desc".Translate(), ref CurrentLoadout.adHocMass, 0f, 100, 1);
+                CustomWidgets.DrawIntOptionWithSpinners(massRect, "CE_Weight".Translate(), "CE_LoadOut_Weight_Desc".Translate(), ref CurrentLoadout.adHocMass, 0f, 999, 1);
 
                 Rect bulkRect = new Rect(rect.x + checkboxWidth * 2 + 5f, rect.y + rect.height / 2, checkboxWidth, rect.height / 2);
-                CustomWidgets.DrawIntOptionWithSpinners(bulkRect, "CE_Bulk".Translate(), "CE_LoadOut_Bulk_Desc".Translate(), ref CurrentLoadout.adHocBulk, 0f, 100, 1);
+                CustomWidgets.DrawIntOptionWithSpinners(bulkRect, "CE_Bulk".Translate(), "CE_LoadOut_Bulk_Desc".Translate(), ref CurrentLoadout.adHocBulk, 0f, 999, 1);
             }
         }
 

--- a/Source/CombatExtended/CombatExtended/Loadouts/Dialog_ManageLoadouts.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/Dialog_ManageLoadouts.cs
@@ -60,9 +60,6 @@ namespace CombatExtended
         private LoadoutSlot _draggedSlot;
         private bool _dragging;
         private string _filter = "";
-        private string _adHocMagsEditBuffer = "";
-        private string _adHocMassEditBuffer = "";
-        private string _adHocBulkEditBuffer = "";
         private const float _iconSize = 16f;
         private const float _margin = 6f;
         private const float _rowHeight = 28f;
@@ -425,16 +422,13 @@ namespace CombatExtended
             if (CurrentLoadout.adHoc)
             {
                 Rect magsRect = new Rect(rect.x, rect.y + rect.height / 2, checkboxWidth, rect.height / 2);
-                _adHocMagsEditBuffer = "" + CurrentLoadout.adHocMags;
-                _adHocMassEditBuffer = "" + CurrentLoadout.adHocMass;
-                _adHocBulkEditBuffer = "" + CurrentLoadout.adHocBulk;
-                Widgets.TextFieldNumericLabeled<int>(magsRect, "CE_LoadOut_Mags".Translate(), ref CurrentLoadout.adHocMags, ref _adHocMagsEditBuffer, 0f, 100);
+                CustomWidgets.DrawIntOptionWithSpinners(magsRect, "CE_LoadOut_Mags".Translate(), "CE_LoadOut_Mags_Desc".Translate(), ref CurrentLoadout.adHocMags, 0f, 100, 1);
 
                 Rect massRect = new Rect(rect.x + checkboxWidth + 5f, rect.y + rect.height / 2, checkboxWidth, rect.height / 2);
-                Widgets.TextFieldNumericLabeled<int>(massRect, "CE_LoadOut_AdHoc_Mass".Translate(), ref CurrentLoadout.adHocMass, ref _adHocMassEditBuffer, 0f, 100);
+                CustomWidgets.DrawIntOptionWithSpinners(massRect, "CE_Weight".Translate(), "CE_LoadOut_Weight_Desc".Translate(), ref CurrentLoadout.adHocMass, 0f, 100, 1);
 
                 Rect bulkRect = new Rect(rect.x + checkboxWidth * 2 + 5f, rect.y + rect.height / 2, checkboxWidth, rect.height / 2);
-                Widgets.TextFieldNumericLabeled<int>(bulkRect, "CE_LoadOut_AdHoc_Bulk".Translate(), ref CurrentLoadout.adHocBulk, ref _adHocBulkEditBuffer, 0f, 100);
+                CustomWidgets.DrawIntOptionWithSpinners(bulkRect, "CE_Bulk".Translate(), "CE_LoadOut_Bulk_Desc".Translate(), ref CurrentLoadout.adHocBulk, 0f, 100, 1);
             }
         }
 

--- a/Source/CombatExtended/CombatExtended/Loadouts/Dialog_ManageLoadouts.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/Dialog_ManageLoadouts.cs
@@ -346,7 +346,7 @@ namespace CombatExtended
                     for (int i = 0; i < loadouts.Count; i++)
                     {
                         int local_i = i;
-                        if (loadouts[i] == CurrentLoadout)
+                        if (loadouts[i] == CurrentLoadout || loadouts[i].Ancestors.Contains(CurrentLoadout))
                         {
                             continue;
                         }
@@ -794,13 +794,11 @@ namespace CombatExtended
         {
             // set up content canvas
             int totalSlotCount = CurrentLoadout.SlotCount + 2;
-            var parentLoadout = CurrentLoadout.ParentLoadout;
-            bool usingParent = parentLoadout != null;
+            bool usingParent = CurrentLoadout.ParentLoadout != null;
 
-            while (parentLoadout != null)
+            foreach (var parentLoadout in CurrentLoadout.Ancestors)
             {
                 totalSlotCount += parentLoadout.SlotCount;
-                parentLoadout = parentLoadout.ParentLoadout;
             }
             Rect viewRect = new Rect(0f, 0f, canvas.width, _rowHeight * totalSlotCount);
 
@@ -822,14 +820,8 @@ namespace CombatExtended
             Widgets.BeginScrollView(canvas, ref _slotScrollPosition, viewRect);
             float curY = 0f;
             GUI.enabled = false;
-            var ancestorLoadout = CurrentLoadout.ParentLoadout;
-            Stack<Loadout> lineage = [];
+            Stack<Loadout> lineage = new Stack<Loadout>(CurrentLoadout.Ancestors);
 
-            while (ancestorLoadout != null)
-            {
-                lineage.Push(ancestorLoadout);
-                ancestorLoadout = ancestorLoadout.ParentLoadout;
-            }
             int rowIndex = 0;
             while (lineage.Count > 0)
             {

--- a/Source/CombatExtended/CombatExtended/Loadouts/Dialog_ManageLoadouts.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/Dialog_ManageLoadouts.cs
@@ -848,7 +848,7 @@ namespace CombatExtended
                 curY += _rowHeight;
             }
             GUI.enabled = true;
-            
+
             for (int i = 0; i < CurrentLoadout.SlotCount; i++)
             {
                 // create row rect

--- a/Source/CombatExtended/CombatExtended/Loadouts/Dialog_ManageLoadouts.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/Dialog_ManageLoadouts.cs
@@ -600,7 +600,7 @@ namespace CombatExtended
             draggingHandle.width = row.height;
 
             Rect labelRect = new Rect(row);
-            if (slotDraggable)
+            if (slotDraggable || usingParent)
             {
                 labelRect.xMin = draggingHandle.xMax;
             }
@@ -700,7 +700,7 @@ namespace CombatExtended
             // easy ammo adder, ranged weapons only
             if (slot.thingDef is { IsRangedWeapon: true })
             {
-                // make sure there's an ammoset defined
+                // make sure there's an ammoSet defined
                 AmmoSetDef ammoSet = ((slot.thingDef.GetCompProperties<CompProperties_AmmoUser>() == null) ? null : slot.thingDef.GetCompProperties<CompProperties_AmmoUser>().ammoSet);
 
                 if (ammoSet is { ammoTypes.Count: > 0 })
@@ -777,11 +777,7 @@ namespace CombatExtended
             // set up content canvas
             int totalSlotCount = CurrentLoadout.SlotCount + 2;
             var parentLoadout = CurrentLoadout.ParentLoadout;
-            var usingParent = false;
-            if (parentLoadout != null)
-            {
-                usingParent = true;
-            }
+            bool usingParent = parentLoadout != null;
 
             while (parentLoadout != null)
             {
@@ -809,7 +805,7 @@ namespace CombatExtended
             float curY = 0f;
             GUI.enabled = false;
             var ancestorLoadout = CurrentLoadout.ParentLoadout;
-            Stack<Loadout> lineage = new();
+            Stack<Loadout> lineage = [];
 
             while (ancestorLoadout != null)
             {
@@ -839,7 +835,7 @@ namespace CombatExtended
             if (usingParent)
             {
                 Rect row = new Rect(0f, curY, viewRect.width, _rowHeight);
-                Widgets.DrawLineHorizontal(0f, curY + (_rowHeight / 2), viewRect.width);
+                Widgets.DrawLineHorizontal(10f, curY + (_rowHeight / 2), row.width - 20f);
                 if (rowIndex % 2 == 0)
                 {
                     GUI.DrawTexture(row, _darkBackground);
@@ -877,7 +873,7 @@ namespace CombatExtended
                         Dragging = null;
                     }
 
-                    // ofset further slots down
+                    // offset further slots down
                     row.y += _rowHeight;
                     curY += _rowHeight;
                 }
@@ -888,7 +884,7 @@ namespace CombatExtended
                     GUI.DrawTexture(row, _darkBackground);
                 }
 
-                // draw the slot - grey out if draggin this, but only when dragged over somewhere else
+                // draw the slot - grey out if dragging this, but only when dragged over somewhere else
                 if (Dragging == CurrentLoadout.OwnSlots[i] && !Mouse.IsOver(row))
                 {
                     GUI.color = new Color(.6f, .6f, .6f, .4f);
@@ -1049,7 +1045,7 @@ namespace CombatExtended
         private static void AddLoadoutSlotSpecific(Loadout loadout, ThingDef def, int count = 1)
         => loadout.AddSlot(new LoadoutSlot(def, count));
 
-        // We prefer syncing loadout and slot index, as it's faster than iterating over all of the loadouts first to find the current one.
+        // We prefer syncing loadout and slot index, as it's faster than iterating overall of the loadouts first to find the current one.
         // We don't have direct reference to Loadout from LoadoutSlot, so we can't really speed up the SyncWorker for it.
         [Compatibility.Multiplayer.SyncMethod]
         private static void RemoveSlot(Loadout loadout, int index)

--- a/Source/CombatExtended/CombatExtended/Loadouts/Dialog_ManageLoadouts.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/Dialog_ManageLoadouts.cs
@@ -64,6 +64,8 @@ namespace CombatExtended
         private const float _margin = 6f;
         private const float _rowHeight = 28f;
         private const float _topAreaHeight = 30f;
+        private const float _padding = 24;
+        private const float _selectionAreaPadding = 84;
         private Vector2 _slotScrollPosition = Vector2.zero;
         private List<SelectableItem> _source;
         private List<LoadoutGenericDef> _sourceGeneric;
@@ -186,13 +188,14 @@ namespace CombatExtended
             Rect deleteRect = new Rect(copyRect.xMax + _margin, 0f, buttonWidth, _topAreaHeight);
             Rect loadRect = new Rect(deleteRect.xMax + _margin, 0f, buttonWidth, _topAreaHeight);
             Rect saveRect = new Rect(loadRect.xMax + _margin, 0f, buttonWidth, _topAreaHeight);
+            Rect parentRect = new Rect(saveRect.xMax + _margin, 0f, buttonWidth, _topAreaHeight);
 
             // main areas
             Rect nameRect = new Rect(
                 0f,
                 _topAreaHeight + _margin * 2,
                 (canvas.width - _margin) / 2f,
-                24f);
+                _padding);
 
             Rect slotListRect = new Rect(
                 0f,
@@ -207,14 +210,20 @@ namespace CombatExtended
                 slotListRect.xMax + _margin,
                 _topAreaHeight + _margin * 2,
                 (canvas.width - _margin) / 2f,
-                24f);
+                _padding);
 
             Rect selectionRect = new Rect(
                 slotListRect.xMax + _margin,
                 sourceButtonRect.yMax + _margin,
                 (canvas.width - _margin) / 2f,
-                canvas.height - 24f - _topAreaHeight - _margin * 3);
+                canvas.height - _selectionAreaPadding - _topAreaHeight - _margin * 3);
 
+            Rect optionRect = new Rect(
+                slotListRect.xMax + _margin,
+                selectionRect.yMax + _margin,
+                (canvas.width - _margin) / 2f,
+                _barHeight * 2);
+            //canvas.height - selectionRect.height - _topAreaHeight - _margin * 3);
             LoadoutManager.SortLoadouts();
             List<Loadout> loadouts = LoadoutManager.Loadouts.Where(l => !l.defaultLoadout).ToList();
 
@@ -316,6 +325,32 @@ namespace CombatExtended
                     dialog.Close();
                 }, CurrentLoadout.label));
             }
+#if DEBUG
+            if (CurrentLoadout != null && Widgets.ButtonText(parentRect, "CE_ParentLoadout".Translate()))
+            {
+
+                List<FloatMenuOption> options = new List<FloatMenuOption>();
+
+                if (loadouts.Count == 0)
+                {
+                    options.Add(new FloatMenuOption("CE_NoLoadouts".Translate(), null));
+                }
+                else
+                {
+                    for (int i = 0; i < loadouts.Count; i++)
+                    {
+                        int local_i = i;
+                        options.Add(new FloatMenuOption(loadouts[i].LabelCap, delegate
+                        {
+                            CurrentLoadout = loadouts[local_i];
+                        }));
+                    }
+                }
+
+                Find.WindowStack.Add(new FloatMenu(options));
+            }
+#endif
+
 
             // draw notification if no loadout selected
             if (CurrentLoadout == null)
@@ -342,6 +377,11 @@ namespace CombatExtended
             // current slots
             DrawSlotList(slotListRect);
 
+            // extra options
+#if DEBUG
+            DrawExtraOptions(optionRect);
+#endif
+
             // bars
             if (CurrentLoadout != null)
             {
@@ -358,6 +398,24 @@ namespace CombatExtended
                 Text.Anchor = TextAnchor.UpperLeft;
             }
             // done!
+        }
+        private bool ExtraOptionButtonA = false;
+        private bool ExtraOptionButtonB = false;
+        private void DrawExtraOptions(Rect rect)
+        {
+            float checkboxWidth = (rect.width - 10f) / 2f;
+
+            Rect leftRect = new Rect(rect.x, rect.y, checkboxWidth, rect.height);
+            Listing_Standard listingLeft = new Listing_Standard();
+            listingLeft.Begin(leftRect);
+            listingLeft.CheckboxLabeled("CE_LoadOut_ExtraOptionA".Translate(), ref ExtraOptionButtonA, "CE_LoadOut_ExtraOptionA_Desc".Translate());
+            listingLeft.End();
+
+            Rect rightRect = new Rect(rect.x + checkboxWidth + 10f, rect.y, checkboxWidth, rect.height);
+            Listing_Standard listingRight = new Listing_Standard();
+            listingRight.Begin(rightRect);
+            listingRight.CheckboxLabeled("CE_LoadOut_ExtraOptionB".Translate(), ref ExtraOptionButtonB, "CE_LoadOut_ExtraOptionB_Desc".Translate());
+            listingRight.End();
         }
 
         public void DrawSourceSelection(Rect canvas)

--- a/Source/CombatExtended/CombatExtended/Loadouts/Dialog_ManageLoadouts.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/Dialog_ManageLoadouts.cs
@@ -60,6 +60,9 @@ namespace CombatExtended
         private LoadoutSlot _draggedSlot;
         private bool _dragging;
         private string _filter = "";
+        private string _adHocMagsEditBuffer = "";
+        private string _adHocMassEditBuffer = "";
+        private string _adHocBulkEditBuffer = "";
         private const float _iconSize = 16f;
         private const float _margin = 6f;
         private const float _rowHeight = 28f;
@@ -405,19 +408,34 @@ namespace CombatExtended
         }
         private void DrawExtraOptions(Rect rect)
         {
-            float checkboxWidth = (rect.width - 10f) / 2f;
+            float checkboxWidth = (rect.width - 10f) / 3f;
 
-            Rect leftRect = new Rect(rect.x, rect.y, checkboxWidth, rect.height);
+            Rect leftRect = new Rect(rect.x, rect.y, checkboxWidth, rect.height / 2);
             Listing_Standard listingLeft = new Listing_Standard();
             listingLeft.Begin(leftRect);
             listingLeft.CheckboxLabeled("CE_LoadOut_DropUndefined".Translate(), ref CurrentLoadout.dropUndefined, "CE_LoadOut_DropUndefined_Desc".Translate());
             listingLeft.End();
 
-            Rect rightRect = new Rect(rect.x + checkboxWidth + 10f, rect.y, checkboxWidth, rect.height);
+            Rect rightRect = new Rect(rect.x + checkboxWidth + 5f, rect.y, checkboxWidth, rect.height / 2);
             Listing_Standard listingRight = new Listing_Standard();
             listingRight.Begin(rightRect);
             listingRight.CheckboxLabeled("CE_LoadOut_AdHoc".Translate(), ref CurrentLoadout.adHoc, "CE_LoadOut_AdHoc_Desc".Translate());
             listingRight.End();
+
+            if (CurrentLoadout.adHoc)
+            {
+                Rect magsRect = new Rect(rect.x, rect.y + rect.height / 2, checkboxWidth, rect.height / 2);
+                _adHocMagsEditBuffer = "" + CurrentLoadout.adHocMags;
+                _adHocMassEditBuffer = "" + CurrentLoadout.adHocMass;
+                _adHocBulkEditBuffer = "" + CurrentLoadout.adHocBulk;
+                Widgets.TextFieldNumericLabeled<int>(magsRect, "CE_LoadOut_Mags".Translate(), ref CurrentLoadout.adHocMags, ref _adHocMagsEditBuffer, 0f, 100);
+
+                Rect massRect = new Rect(rect.x + checkboxWidth + 5f, rect.y + rect.height / 2, checkboxWidth, rect.height / 2);
+                Widgets.TextFieldNumericLabeled<int>(massRect, "CE_LoadOut_AdHoc_Mass".Translate(), ref CurrentLoadout.adHocMass, ref _adHocMassEditBuffer, 0f, 100);
+
+                Rect bulkRect = new Rect(rect.x + checkboxWidth * 2 + 5f, rect.y + rect.height / 2, checkboxWidth, rect.height / 2);
+                Widgets.TextFieldNumericLabeled<int>(bulkRect, "CE_LoadOut_AdHoc_Bulk".Translate(), ref CurrentLoadout.adHocBulk, ref _adHocBulkEditBuffer, 0f, 100);
+            }
         }
 
         public void DrawSourceSelection(Rect canvas)

--- a/Source/CombatExtended/CombatExtended/Loadouts/FileListDialog.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/FileListDialog.cs
@@ -62,6 +62,10 @@ namespace CombatExtended
             float height = (float)this.files.Count * num;
             Rect viewRect = new Rect(0f, 0f, inRect.width - 16f, height);
             Rect outRect = new Rect(inRect.x, inRect.y, inRect.width, inRect.height);
+            if (this.ShouldDoTypeInField)
+            {
+                this.bottomAreaHeight = 40;
+            }
             outRect.height -= this.bottomAreaHeight;
             Widgets.BeginScrollView(outRect, ref this.scrollPosition, viewRect, true);
             float num2 = 0f;
@@ -137,12 +141,12 @@ namespace CombatExtended
         {
             GUI.BeginGroup(rect);
             bool flag = Event.current.type == EventType.KeyDown && Event.current.keyCode == KeyCode.Return;
-            float y = rect.height - 52f;
+            float y = rect.height - 35f;
             Text.Font = GameFont.Small;
             Text.Anchor = TextAnchor.MiddleLeft;
             GUI.SetNextControlName("MapNameField");
-            Rect rect2 = new Rect(5f, y, 400f, 35f);
-            string str = Widgets.TextField(rect2, this.typingName);
+            Rect textFieldRect = new Rect(5f, y, 400f, 35f);
+            string str = Widgets.TextField(textFieldRect, this.typingName);
             if (GenText.IsValidFilename(str))
             {
                 this.typingName = str;
@@ -152,8 +156,8 @@ namespace CombatExtended
                 UI.FocusControl("MapNameField", this);
                 this.focusedNameArea = true;
             }
-            Rect rect3 = new Rect(420f, y, rect.width - 400f - 20f, 35f);
-            if (Widgets.ButtonText(rect3, "SaveGameButton".Translate(), true, false, true) || flag)
+            Rect saveButtonRect = new Rect(420f, y, rect.width - 400f - 20f, 35f);
+            if (Widgets.ButtonText(saveButtonRect, "SaveGameButton".Translate(), true, false, true) || flag)
             {
                 if (this.typingName.NullOrEmpty())
                 {

--- a/Source/CombatExtended/CombatExtended/Loadouts/FileListDialog.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/FileListDialog.cs
@@ -92,13 +92,13 @@ namespace CombatExtended
                 Text.Anchor = TextAnchor.UpperLeft;
                 Text.Font = GameFont.Small;
                 float num4 = vector.x - 2f - vector2.x - vector2.y;
-                Rect rect4 = new Rect(num4, 0f, vector2.x, vector2.y);
-                if (Widgets.ButtonText(rect4, this.interactButLabel, true, false, true))
+                Rect interactionButtonRect = new Rect(num4, 0f, vector2.x, vector2.y);
+                if (Widgets.ButtonText(interactionButtonRect, this.interactButLabel, true, false, true))
                 {
                     fileAction(current, this);
                 }
-                Rect rect5 = new Rect(num4 + vector2.x + 5f, 0f, vector2.y, vector2.y);
-                if (Widgets.ButtonImage(rect5, Texture.DeleteX))
+                Rect deleteXRect = new Rect(num4 + vector2.x + 5f, 0f, vector2.y, vector2.y);
+                if (Widgets.ButtonImage(deleteXRect, Texture.DeleteX))
                 {
                     FileInfo localFile = current;
                     Find.WindowStack.Add(Dialog_MessageBox.CreateConfirmation("ConfirmDelete".Translate(localFile.Name), delegate
@@ -107,7 +107,7 @@ namespace CombatExtended
                         ReloadFiles();
                     }, destructive: true));
                 }
-                TooltipHandler.TipRegion(rect5, "DeleteThisSavegame".Translate());
+                TooltipHandler.TipRegion(deleteXRect, "DeleteThisSavegame".Translate());
                 GUI.EndGroup();
                 num2 += vector.y + 3f;
                 num3++;
@@ -145,7 +145,7 @@ namespace CombatExtended
             Text.Font = GameFont.Small;
             Text.Anchor = TextAnchor.MiddleLeft;
             GUI.SetNextControlName("MapNameField");
-            Rect textFieldRect = new Rect(5f, y, 400f, 35f);
+            Rect textFieldRect = new Rect(0f, y, 400f, 35f);
             string str = Widgets.TextField(textFieldRect, this.typingName);
             if (GenText.IsValidFilename(str))
             {
@@ -156,7 +156,7 @@ namespace CombatExtended
                 UI.FocusControl("MapNameField", this);
                 this.focusedNameArea = true;
             }
-            Rect saveButtonRect = new Rect(420f, y, rect.width - 400f - 20f, 35f);
+            Rect saveButtonRect = new Rect(413f, y, rect.width - 400f - 20f, 35f);
             if (Widgets.ButtonText(saveButtonRect, "SaveGameButton".Translate(), true, false, true) || flag)
             {
                 if (this.typingName.NullOrEmpty())

--- a/Source/CombatExtended/CombatExtended/Loadouts/GameComp_LoadoutManager.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/GameComp_LoadoutManager.cs
@@ -319,6 +319,16 @@ namespace CombatExtended
             }
             return Loadouts.Find(x => x.uniqueID == id);
         }
+
+        public static Loadout GetLoadoutByLabel(string label)
+        {
+            if (_current == null)
+            {
+                return null;
+            }
+            return Loadouts.Find(x => x.label == label);
+        }
+
         #endregion Methods
     }
 }

--- a/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
@@ -159,7 +159,7 @@ namespace CombatExtended
                 // get the loadout so we can make a decision to show a button.
                 bool showMakeLoadout = false;
                 Loadout curLoadout = SelPawnForGear.GetLoadout();
-                if (SelPawnForGear.IsColonist && (curLoadout == null || curLoadout.Slots.NullOrEmpty()) && (SelPawnForGear.inventory.innerContainer.Any() || SelPawnForGear.equipment?.Primary != null))
+                if (SelPawnForGear.IsColonist && (curLoadout == null || !curLoadout.Slots.Any()) && (SelPawnForGear.inventory.innerContainer.Any() || SelPawnForGear.equipment?.Primary != null))
                 {
                     showMakeLoadout = true;
                 }

--- a/Source/CombatExtended/CombatExtended/Loadouts/Loadout.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/Loadout.cs
@@ -489,7 +489,7 @@ namespace CombatExtended
                 Dictionary<ThingDef, Integer> inventory = pawn.GetStorageByThingDef();
                 Dictionary<ThingDef, int> haveAmmo = new Dictionary<ThingDef, int>();
                 int totalAmmo = 0;
-                
+
                 foreach (ThingDef def in inventory.Keys)
                 {
                     if (ammoTypes.Contains(def))

--- a/Source/CombatExtended/CombatExtended/Loadouts/Loadout.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/Loadout.cs
@@ -512,7 +512,19 @@ namespace CombatExtended
                             magLimit = Math.Min(magLimit, (int)(adHocBulk / ammo.GetStatValueAbstract(CE_StatDefOf.Bulk)));
                         }
                         magLimit -= (totalAmmo - haveAmmo[ammo]); // reduce mag limit by total of all other ammo types we already have
-                        if (haveAmmo[ammo] < magLimit - magSize || haveAmmo[ammo] > magLimit)
+
+                        int magCount = magLimit / magSize;
+                        int minMags = (int)(magCount * 0.75f); // works out to 3 out of 4 mags with default settings
+                        int minAmmo = minMags * magSize;
+                        if (magCount < 2)
+                        {
+                            minAmmo = magSize;
+                        }
+                        else if (minMags < 4)
+                        {
+                            minAmmo = (magCount - 1) * magSize;
+                        }
+                        if (haveAmmo[ammo] < minAmmo || haveAmmo[ammo] > magLimit)
                         {
                             yield return new LoadoutSlot(ammo, magLimit);
                         }

--- a/Source/CombatExtended/CombatExtended/Loadouts/Loadout.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/Loadout.cs
@@ -184,7 +184,7 @@ namespace CombatExtended
             dest.adHoc = source.adHoc;
             dest.parentID = source.parentID;
             dest._slots = new List<LoadoutSlot>();
-            foreach (LoadoutSlot slot in source.Slots)
+            foreach (LoadoutSlot slot in source.OwnSlots)
             {
                 dest.AddSlot(slot.Copy());
             }

--- a/Source/CombatExtended/CombatExtended/Loadouts/Loadout.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/Loadout.cs
@@ -431,9 +431,30 @@ namespace CombatExtended
             }
             if (!ammoInLoadout)
             {
-                foreach (var ammo in ammoTypes)
+                // Check if we have ammo in inventory, if so only ask for the same or more of that
+                Dictionary<ThingDef, Integer> inventory = pawn.GetStorageByThingDef();
+                bool haveAmmo = false;
+                foreach (ThingDef def in inventory.Keys)
                 {
-                    yield return new LoadoutSlot(ammo, magSize * 3);
+                    if (ammoTypes.Contains(def))
+                    {
+                        haveAmmo = true;
+                        if (inventory[def].value < magSize * 2 || inventory[def].value >= magSize * 3)
+                        {
+                            yield return new LoadoutSlot(def, magSize * 3);
+                        }
+                        else // have a reasonable number, just sit on it.
+                        {
+                            yield return new LoadoutSlot(def, inventory[def].value);
+                        }
+                    }
+                }
+                if (!haveAmmo) // don't have any ammo, ask for some of everything.
+                {
+                    foreach (var ammo in ammoTypes)
+                    {
+                        yield return new LoadoutSlot(ammo, magSize * 3);
+                    }
                 }
             }
         }

--- a/Source/CombatExtended/CombatExtended/Loadouts/Loadout.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/Loadout.cs
@@ -20,7 +20,7 @@ namespace CombatExtended
         internal int uniqueID;
         public bool dropUndefined = true;
         public bool adHoc = false;
-        public int adHocMags = 3;
+        public int adHocMags = 4;
         public int adHocMass = 0;
         public int adHocBulk = 0;
         private int _parentID = 0;

--- a/Source/CombatExtended/CombatExtended/Loadouts/Loadout.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/Loadout.cs
@@ -398,6 +398,7 @@ namespace CombatExtended
                     /// if it isn't, provide a virtual slot for it
                     trivial = false;
                     bool ammoInLoadout = false;
+                    bool weaponInLoadout = false;
                     HashSet<ThingDef> ammoTypes = new HashSet<ThingDef>();
                     foreach (AmmoLink link in primaryAmmoUser.Props.ammoSet.ammoTypes)
                     {
@@ -410,6 +411,14 @@ namespace CombatExtended
                         {
                             ammoInLoadout = ammoTypes.Contains(slot.thingDef);
                         }
+                        if (!weaponInLoadout)
+                        {
+                            weaponInLoadout = pawn.equipment.Primary.def == slot.thingDef;
+                        }
+                    }
+                    if (!weaponInLoadout)
+                    {
+                        yield return new LoadoutSlot(pawn.equipment.Primary.def, 1);
                     }
                     if (!ammoInLoadout)
                     {

--- a/Source/CombatExtended/CombatExtended/Loadouts/LoadoutConfig.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/LoadoutConfig.cs
@@ -11,6 +11,9 @@ namespace CombatExtended
         public LoadoutSlotConfig[] slots;
         public bool dropUndefined = true;
         public bool adHoc = false;
+        public int adHocMags = 3;
+        public int adHocMass = 0;
+        public int adHocBulk = 0;
         public string parentLabel = String.Empty;
     }
 

--- a/Source/CombatExtended/CombatExtended/Loadouts/LoadoutConfig.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/LoadoutConfig.cs
@@ -11,7 +11,7 @@ namespace CombatExtended
         public LoadoutSlotConfig[] slots;
         public bool dropUndefined = true;
         public bool adHoc = false;
-        public int adHocMags = 3;
+        public int adHocMags = 4;
         public int adHocMass = 0;
         public int adHocBulk = 0;
         public string parentLabel = String.Empty;

--- a/Source/CombatExtended/CombatExtended/Loadouts/LoadoutConfig.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/LoadoutConfig.cs
@@ -9,6 +9,9 @@ namespace CombatExtended
     {
         public string label;
         public LoadoutSlotConfig[] slots;
+        public bool dropUndefined = true;
+        public bool adHoc = false;
+        public string parentLabel = String.Empty;
     }
 
     [Serializable]

--- a/Source/CombatExtended/CombatExtended/Loadouts/Utility_HoldTracker.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/Utility_HoldTracker.cs
@@ -201,7 +201,7 @@ namespace CombatExtended
         {
             Loadout loadout = pawn.GetLoadout();
             dropEquipment = null;
-            if (loadout == null || (loadout != null && (!loadout.dropUndefined || loadout.adHoc)) || pawn.equipment?.Primary == null)
+            if (loadout == null || loadout.defaultLoadout || !loadout.dropUndefined || loadout.adHoc || pawn.equipment?.Primary == null)
             {
                 return false;
             }
@@ -366,7 +366,7 @@ namespace CombatExtended
             dropThing = null;
             dropCount = 0;
 
-            if (inventory == null || inventory.container == null || loadout == null)
+            if (inventory == null || inventory.container == null || loadout == null || loadout.defaultLoadout)
             {
                 return false;
             }

--- a/Source/CombatExtended/CombatExtended/Loadouts/Utility_HoldTracker.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/Utility_HoldTracker.cs
@@ -256,7 +256,7 @@ namespace CombatExtended
             }
 
             Loadout loadout = pawn.GetLoadout();
-            if (loadout == null || !loadout.Slots.Any())
+            if (loadout == null || loadout.defaultLoadout || !loadout.Slots.Any())
             {
                 List<HoldRecord> recs = LoadoutManager.GetHoldRecords(pawn);
                 if (recs != null)

--- a/Source/CombatExtended/CombatExtended/Loadouts/Utility_HoldTracker.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/Utility_HoldTracker.cs
@@ -212,7 +212,7 @@ namespace CombatExtended
             }
 
             //Check if equipment is part of the loadout
-            LoadoutSlot eqSlot = loadout.Slots.FirstOrDefault(s => s.count >= 1 && ((s.thingDef != null && s.thingDef == pawn.equipment.Primary.def)
+            LoadoutSlot eqSlot = loadout.GetSlotsFor(pawn).FirstOrDefault(s => s.count >= 1 && ((s.thingDef != null && s.thingDef == pawn.equipment.Primary.def)
                                  || (s.genericDef != null && s.genericDef.lambda(pawn.equipment.Primary.def))));
 
             //Check if equipment is in the forced pick-up items list
@@ -375,7 +375,7 @@ namespace CombatExtended
             HashSet<ThingDef> inLoadout = new HashSet<ThingDef>();
 
             // iterate over specifics and generics and Chip away at the dictionary.
-            foreach (LoadoutSlot slot in loadout.Slots)
+            foreach (LoadoutSlot slot in loadout.GetSlotsFor(pawn))
             {
                 if (slot.thingDef != null && listing.ContainsKey(slot.thingDef))
                 {

--- a/Source/CombatExtended/CombatExtended/ThinkNodes/ThinkNode_ConditionalHasLoadout.cs
+++ b/Source/CombatExtended/CombatExtended/ThinkNodes/ThinkNode_ConditionalHasLoadout.cs
@@ -14,7 +14,7 @@ namespace CombatExtended
         public override bool Satisfied(Pawn pawn)
         {
             var loadout = pawn.GetLoadout();
-            return loadout != null && loadout.Slots.Any();
+            return loadout != null && !loadout.defaultLoadout && loadout.Slots.Any();
         }
     }
 }

--- a/Source/CombatExtended/CombatExtended/ThinkNodes/ThinkNode_ConditionalHasLoadout.cs
+++ b/Source/CombatExtended/CombatExtended/ThinkNodes/ThinkNode_ConditionalHasLoadout.cs
@@ -14,7 +14,7 @@ namespace CombatExtended
         public override bool Satisfied(Pawn pawn)
         {
             var loadout = pawn.GetLoadout();
-            return loadout != null && !loadout.Slots.NullOrEmpty();
+            return loadout != null && loadout.Slots.Any();
         }
     }
 }

--- a/Source/CombatExtended/Utilities/CustomWidgets.cs
+++ b/Source/CombatExtended/Utilities/CustomWidgets.cs
@@ -1,0 +1,62 @@
+﻿using Verse;
+using UnityEngine;
+using System;
+
+namespace CombatExtended
+{
+    public static class CustomWidgets
+    {
+        private const float ButtonWidth = 30f;
+        private const float TextWidth = 50f;
+        private const float Padding = 5f;
+
+        public static void DrawIntOptionWithSpinners(Rect rect, string label, string tooltip, ref int value, float minValue, int maxValue, int stepperValue)
+        {
+
+            TextAnchor anchor = Text.Anchor;
+            Text.Anchor = TextAnchor.MiddleLeft;
+
+            Vector2 labelSize = Text.CalcSize(label);
+            Rect labelRect = new Rect(rect.x, rect.y, labelSize.x, rect.height);
+            Widgets.Label(labelRect, label);
+
+            string buffer = value.ToString();
+            Rect textField = new Rect(labelRect.xMax + Padding, rect.y, TextWidth, rect.height);
+            Widgets.TextFieldNumeric(textField, ref value, ref buffer, minValue, maxValue);
+
+            float halfHeight = rect.height / 2f;
+            Rect spinnerRect = new Rect(textField.xMax + Padding, rect.y, ButtonWidth, halfHeight);
+            float step = Event.current.control ? stepperValue * 10 : stepperValue;
+            if (Widgets.ButtonText(spinnerRect, "▲"))
+            {
+                value = (int)Math.Min(value + step, maxValue);
+            }
+            spinnerRect.y += halfHeight;
+            if (Widgets.ButtonText(spinnerRect, "▼"))
+            {
+                value = (int)Math.Max(value - step, minValue);
+            }
+            if (Mouse.IsOver(rect))
+            {
+                if (Event.current.isScrollWheel)
+                {
+                    if (Event.current.delta.y < 0f) // Scroll Up
+                    {
+                        value = (int)Math.Min(value + step, maxValue);
+                    }
+                    else if (Event.current.delta.y > 0f) // Scroll Down
+                    {
+                        value = (int)Math.Max(value - step, minValue);
+                    }
+                }
+                if (!tooltip.NullOrEmpty())
+                {
+                    TooltipHandler.TipRegion(rect, tooltip);
+                }
+                Widgets.DrawHighlight(rect);
+            }
+
+            Text.Anchor = anchor;
+        }
+    }
+}


### PR DESCRIPTION
## Additions

- Loadouts can inherit slots from a parent loadout
- Loadouts can be marked ad-hoc to auto-manage ammunition
- Loadouts can have auto-removal of undefined items disabled


## References

Links to the associated issues or other related pull requests, e.g.
- Closes #3900 

## Reasoning

Allows partial use of loadout system, without breaking taming jobs or simple sidearms or similar mods

## Alternatives

Keep doing it via harmony patching in its own sub-mod.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
