### PR TITLE
Miho Patch Fix

### DIFF
--- a/ModPatches/Miho Race/Patches/Miho Race/ThingDefs_Races/Race_MihoHediff.xml
+++ b/ModPatches/Miho Race/Patches/Miho Race/ThingDefs_Races/Race_MihoHediff.xml
@@ -119,23 +119,7 @@
 			<ReloadSpeed>2</ReloadSpeed>
 		</value>
 	</Operation>
-	
-	<!-- ========== Weaver =========== -->
-	
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/HediffDef[defName="Miho_Ability_HeatArmor_Hediff"]/stages/li/statOffsets/ArmorRating_Sharp</xpath>
-		<value>
-			<ArmorRating_Sharp>2.5</ArmorRating_Sharp>
-		</value>
-	</Operation>
-	
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/HediffDef[defName="Miho_Ability_HeatArmor_Hediff"]/stages/li/statOffsets/ArmorRating_Blunt</xpath>
-		<value>
-			<ArmorRating_Blunt>2.5</ArmorRating_Blunt>
-		</value>
-	</Operation>
-	
+
 	<!-- ========== Apparel =========== -->
 	
 	<Operation Class="PatchOperationAdd">


### PR DESCRIPTION

## Changes
- Remove obsolete patch operations changing the sharp and blunt values for one of the Miho hediffs.

## References
- Close #3918 

## Reasoning
The sharp and blunt armor changes no longer exist within the target def (nor its parent). 
![image](https://github.com/user-attachments/assets/1349e658-b2ed-4a1e-9fa0-38441aacaded)
I'm admittedly not entirely certain _why_ the mod author went this route, but not really my place to question it. Since the original version of the hediff no longer affects sharp or blunt armor, there's no reason for us to, either.

## Alternatives
- Turn them to an 'add' operation, if we really felt it was necessary.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
