### PR TITLE
Firefoam Marketvalue

### DIFF
--- a/Defs/Ammo/Shell/60mmMortar.xml
+++ b/Defs/Ammo/Shell/60mmMortar.xml
@@ -89,6 +89,9 @@
 			<texPath>Things/Ammo/Mortar/Firefoam</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
+		<statBases>
+			<MarketValue>26.51</MarketValue>
+		</statBases>
 		<ammoClass>FoamFuel</ammoClass>
 		<detonateProjectile>Bullet_60mmMortarShell_Firefoam</detonateProjectile>
 	</ThingDef>

--- a/Defs/Ammo/Shell/81mmMortar.xml
+++ b/Defs/Ammo/Shell/81mmMortar.xml
@@ -148,6 +148,7 @@
 		<statBases>
 			<Mass>4.1</Mass>
 			<Bulk>10.01</Bulk>
+			<MarketValue>42.70</MarketValue>
 		</statBases>
 		<ammoClass>FoamFuel</ammoClass>
 		<detonateProjectile>Bullet_81mmMortarShell_Firefoam</detonateProjectile>

--- a/Defs/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Grenades.xml
@@ -421,6 +421,7 @@
 		<statBases>
 			<Mass>0.5</Mass>
 			<Bulk>1.05</Bulk>
+			<MarketValue>18</MarketValue>
 			<SightsEfficiency>1.0</SightsEfficiency>
 			<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 		</statBases>


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Hardsets firefoam marketvalue

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #3926 

## Reasoning

Why did you choose to implement things this way, e.g.
- Game is failing to calculate value due to not being stuffed, but using category for meat.
- Market Value based on RW formula of M = (I + W × 0.0036) where I = ingredient values and W is workTicks. Use generic meat value of 2 silver for calculation

## Alternatives

Describe alternative implementations you have considered, e.g.
- Overengineered recipe maker C# for 3 items...

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
