### PR TITLE
Add screenshake field in CompProperties_ExplosiveCE

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompExplosiveCE.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompExplosiveCE.cs
@@ -65,7 +65,7 @@ namespace CombatExtended
                     Props.damageFalloff,
                     direction,
                     ignoredThings,
-                    screenShakeFactor : Props.screenShakeFactor,
+                    screenShakeFactor: Props.screenShakeFactor,
                     height: pos.y,
                     scaleFactor: scaleFactor);
             }

--- a/Source/CombatExtended/CombatExtended/Comps/CompExplosiveCE.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompExplosiveCE.cs
@@ -65,6 +65,7 @@ namespace CombatExtended
                     Props.damageFalloff,
                     direction,
                     ignoredThings,
+					screenShakeFactor : Props.screenShakeFactor,
                     height: pos.y,
                     scaleFactor: scaleFactor);
             }

--- a/Source/CombatExtended/CombatExtended/Comps/CompExplosiveCE.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompExplosiveCE.cs
@@ -65,7 +65,7 @@ namespace CombatExtended
                     Props.damageFalloff,
                     direction,
                     ignoredThings,
-					screenShakeFactor : Props.screenShakeFactor,
+                    screenShakeFactor : Props.screenShakeFactor,
                     height: pos.y,
                     scaleFactor: scaleFactor);
             }

--- a/Source/CombatExtended/CombatExtended/Comps/CompProperties_ExplosiveCE.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompProperties_ExplosiveCE.cs
@@ -33,7 +33,7 @@ namespace CombatExtended
         public int preExplosionSpawnThingCount = 1;
         public bool damageFalloff = true;
         public float chanceToStartFire;
-		public float screenShakeFactor;
+        public float screenShakeFactor;
 
         /// <summary>
         /// The type of built-in core game gas to spawn on detonation.

--- a/Source/CombatExtended/CombatExtended/Comps/CompProperties_ExplosiveCE.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompProperties_ExplosiveCE.cs
@@ -33,6 +33,7 @@ namespace CombatExtended
         public int preExplosionSpawnThingCount = 1;
         public bool damageFalloff = true;
         public float chanceToStartFire;
+		public float screenShakeFactor;
 
         /// <summary>
         /// The type of built-in core game gas to spawn on detonation.


### PR DESCRIPTION

## Additions

Adds prop for screenShakeFactor in CompProperties_ExplosiveCE and uses it when it generates an explosion, allowing for comp explosions to alter the level of screenshake like regular projecitle explosiosn do

## Reasoning

Assists with feature parity for CompProperties_ExplosiveCE.


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
