### PR TITLE
Remove Avoid Friendly Fire from incompatibility list

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -27,7 +27,6 @@
 		<li>me.samboycoding.betterloading</li>
 		<li>me.samboycoding.betterloading.dev</li>
 		<li>majorhoff.rimthreaded</li>
-		<li>falconne.AFF</li>
 		<li>Sk.FlankingBonus</li>
 		<li>Mlie.TheyreInTheTrees</li>
 		<li>Mlie.YayosCombat3</li>


### PR DESCRIPTION
## Changes

Avoid Friendly Fire's mod Id is removed from the incompatiblity list.

## Reasoning

Avoid Friendly Fire is TPS heavy, but works without errors with CE. It's TPS heavy without CE too. It's friendly-fire avoidance code is more robust than ours, which can be important for some players.

## Alternatives

Encourage people to ignore red errors in their mod list, because compatible mods are marked incompatible.

It may be worth adding an entry to the learning helper, suggesting disabling it for drafted colonists in the late game. It has a mod option to do exactly that.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (months)
