### PR TITLE
Randomised origin offset for proj vfx

### DIFF
--- a/Defs/Ammo/Medieval/BlunderbussShot.xml
+++ b/Defs/Ammo/Medieval/BlunderbussShot.xml
@@ -73,6 +73,21 @@
 			<armorPenetrationBlunt>3.14</armorPenetrationBlunt>
 			<spreadMult>17.8</spreadMult>
 		</projectile>
+		<comps>
+			<li Class="CombatExtended.CompProperties_ProjectileFleck">
+				<FleckDatas>
+					<li>
+						<startDelayTick>0</startDelayTick>
+						<fleck>Fleck_CEBlackpowderSmoke</fleck>
+						<emissionsPerTick>1</emissionsPerTick>
+						<flecksPerEmission>1</flecksPerEmission>
+						<cutoffTickRange>2</cutoffTickRange>
+						<scale>1.5~1.7</scale>
+						<originOffset>0.0~2.5</originOffset>
+					</li>
+				</FleckDatas>
+			</li>
+		</comps>
 	</ThingDef>
 
 	<!-- ==================== Recipes ========================== -->

--- a/Defs/Ammo/Medieval/CannonBall.xml
+++ b/Defs/Ammo/Medieval/CannonBall.xml
@@ -128,14 +128,14 @@
 			<dropsCasings>false</dropsCasings>
 		</projectile>
 		<modExtensions>
-            <li Class="ProjectileImpactFX.EffectProjectileExtension">
+			<li Class="ProjectileImpactFX.EffectProjectileExtension">
 				<AutoAssign>false</AutoAssign>
 				<CreateTerrainEffects>true</CreateTerrainEffects>
 				<ImpactSoundDef>CE_HeavyProjectileImpact</ImpactSoundDef>
 				<explosionFleckDef>Fleck_CECannonball</explosionFleckDef>
 				<explosionFleckSize>0.8</explosionFleckSize>
-            </li>
-        </modExtensions>
+			</li>
+		</modExtensions>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ProjectileFleck">
 				<FleckDatas>
@@ -220,6 +220,21 @@
 			<armorPenetrationBlunt>420.68</armorPenetrationBlunt>
 			<spreadMult>26.7</spreadMult>
 		</projectile>
+		<comps>
+			<li Class="CombatExtended.CompProperties_ProjectileFleck">
+				<FleckDatas>
+					<li>
+						<startDelayTick>0</startDelayTick>
+						<fleck>Fleck_CEBlackpowderSmoke</fleck>
+						<emissionsPerTick>1</emissionsPerTick>
+						<flecksPerEmission>1</flecksPerEmission>
+						<cutoffTickRange>2</cutoffTickRange>
+						<scale>2.0~2.5</scale>
+						<originOffset>0.0~2.0</originOffset>
+					</li>
+				</FleckDatas>
+			</li>
+		</comps>
 	</ThingDef>
 
 	<!-- ================== Projectiles - Mortar ================== -->

--- a/Defs/Ammo/Medieval/MiniCannonBall.xml
+++ b/Defs/Ammo/Medieval/MiniCannonBall.xml
@@ -139,6 +139,21 @@
 			<armorPenetrationBlunt>20.7</armorPenetrationBlunt>
 			<spreadMult>17.8</spreadMult>
 		</projectile>
+		<comps>
+			<li Class="CombatExtended.CompProperties_ProjectileFleck">
+				<FleckDatas>
+					<li>
+						<startDelayTick>0</startDelayTick>
+						<fleck>Fleck_CEBlackpowderSmoke</fleck>
+						<emissionsPerTick>2</emissionsPerTick>
+						<flecksPerEmission>1</flecksPerEmission>
+						<cutoffTickRange>2</cutoffTickRange>
+						<scale>2.0~2.5</scale>
+						<originOffset>0.0~2.5</originOffset>
+					</li>
+				</FleckDatas>
+			</li>
+		</comps>
 	</ThingDef>
 
 	<!-- ==================== Recipes ========================== -->

--- a/Source/CombatExtended/CombatExtended/Comps/CompThrownFleckEmitterSmooth.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompThrownFleckEmitterSmooth.cs
@@ -66,7 +66,7 @@ namespace CombatExtended
                     Vector3 diff = Vector3.zero;
                     for (int i = 0; i < data.emissionAmount; i++)
                     {
-                        FleckCreationData dataStatic = FleckMaker.GetDataStatic(parent.DrawPos - data.originOffsetInternal * delta + diff, parent.MapHeld, data.fleck, (data.scale.RandomInRange + scaleoffset) * data.cutoffScaleOffset(age));
+                        FleckCreationData dataStatic = FleckMaker.GetDataStatic(parent.DrawPos - data.originOffset.RandomInRange * delta + diff, parent.MapHeld, data.fleck, (data.scale.RandomInRange + scaleoffset) * data.cutoffScaleOffset(age));
                         dataStatic.rotation = data.rotation.RandomInRange;
                         for (int j = 0; j < data.flecksPerEmission; j++)
                         {
@@ -116,10 +116,10 @@ namespace CombatExtended
 
         public int startDelayTick = 1;
 
-        public float originOffset = 0.7f;
+        public FloatRange originOffset = new FloatRange(0.7f, 0.7f);
 
         public int emissionAmount => emissionsPerTick > 1 ? (int)emissionsPerTick : 1;
-        public float originOffsetInternal => 1 - originOffset;
+        public float originOffsetInternal => 1 - originOffset.RandomInRange; //deprecated field, left to not break mod xml
         public float scaleOffsetInternal => fleck.growthRate / (emissionsPerTick * 60);
 
         public float cutoffScaleOffset(int age)

--- a/Source/CombatExtended/CombatExtended/Comps/CompThrownFleckEmitterSmooth.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompThrownFleckEmitterSmooth.cs
@@ -119,6 +119,8 @@ namespace CombatExtended
         public FloatRange originOffset = new FloatRange(0.7f, 0.7f);
 
         public int emissionAmount => emissionsPerTick > 1 ? (int)emissionsPerTick : 1;
+
+        [Obsolete("This property is obsolete. Use the FloatRange originOffset instead.", true)]
         public float originOffsetInternal => 1 - originOffset.RandomInRange; //deprecated field, left to not break mod xml
         public float scaleOffsetInternal => fleck.growthRate / (emissionsPerTick * 60);
 


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Adds smoke vfx for BP multi pellet projectiles

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Changed `offsetOrigin` field to be a FloatRange instead of Float

## References

Links to the associated issues or other related pull requests, e.g.
- Continuation of #3946, requires that PR
- Fixes [the issues described here](https://discord.com/channels/278818534069501953/310869202892488705/1380932035379462144)

## Reasoning

Why did you choose to implement things this way, e.g.
- Quick fix to multipellet projectiles creating too much projectile vfx 
- Will be useful for creating other effects down the line.
- Doesn't break existing xml as FloatRange accepts not only "5~5" input, but input in form of "5" too

## Alternatives

Describe alternative implementations you have considered, e.g.
- Do bp smoke through a single effecter spawned by Verb_Shoot
- Implement chance to emit flecks

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
