### PR TITLE
Fix Stabilization Issues

### DIFF
--- a/Source/CombatExtended/CombatExtended/Jobs/JobDriver_Stabilize.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobDriver_Stabilize.cs
@@ -115,13 +115,16 @@ namespace CombatExtended
             };
             yield return carryMedicine;
             yield return Toils_Goto.GotoThing(TargetIndex.A, PathEndMode.InteractionCell);
-            if (pawn != Patient)
-            {
-                pawn.rotationTracker.FaceCell(Patient.Position);
-            }
             // Stabilize patient
             int duration = (int)(1f / this.pawn.GetStatValue(StatDefOf.MedicalTendSpeed, true) * BaseTendDuration);
             Toil waitToil = Toils_General.WaitWith(TargetIndex.A, duration, maintainPosture: true, maintainSleep: false).WithProgressBarToilDelay(TargetIndex.A).PlaySustainerOrSound(SoundDefOf.Interact_Tend);
+            waitToil.tickAction = delegate
+            {
+                if (pawn != Patient)
+                {
+                    pawn.rotationTracker.FaceCell(Patient.Position);
+                }
+            };
             yield return waitToil;
             Toil stabilizeToil = new Toil
             {

--- a/Source/CombatExtended/CombatExtended/Jobs/JobDriver_Stabilize.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobDriver_Stabilize.cs
@@ -78,9 +78,13 @@ namespace CombatExtended
                 if (didStabilize)
                 {
                     MakeMedicineFilth(Medicine);
-                    if (_usedMedicine is { stackCount: > 0 })
+                    if (_usedMedicine.stackCount > 1)
                     {
-                        _usedMedicine.SplitOff(1).Destroy();
+                        _usedMedicine.stackCount--;
+                    }
+                    else if (!_usedMedicine.Destroyed)
+                    {
+                        _usedMedicine.Destroy();
                     }
                 }
             });

--- a/Source/CombatExtended/CombatExtended/Jobs/JobDriver_Stabilize.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobDriver_Stabilize.cs
@@ -28,6 +28,13 @@ namespace CombatExtended
             }
         }
 
+        public override void ExposeData()
+        {
+            base.ExposeData();
+            Scribe_Values.Look(ref didStabilize, "didStabilize", defaultValue: false);
+            Scribe_References.Look(ref _usedMedicine, "_usedMedicine");
+        }
+
         public override bool TryMakePreToilReservations(bool errorOnFailed)
         {
             return pawn.Reserve(TargetA, job) && pawn.Reserve(TargetB, job);

--- a/Source/CombatExtended/CombatExtended/Jobs/JobDriver_Stabilize.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobDriver_Stabilize.cs
@@ -90,7 +90,6 @@ namespace CombatExtended
             });
             yield return Toils_Goto.GotoThing(TargetIndex.A, PathEndMode.InteractionCell);
             // Stabilize patient
-            int duration = (int)(1f / this.pawn.GetStatValue(StatDefOf.MedicalTendSpeed, true) * baseTendDuration);
             Toil carryMedicine = new Toil
             {
                 initAction = delegate

--- a/Source/CombatExtended/CombatExtended/Jobs/JobDriver_Stabilize.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobDriver_Stabilize.cs
@@ -103,6 +103,7 @@ namespace CombatExtended
                 }
             };
             yield return carryMedicine;
+            yield return Toils_Goto.GotoThing(TargetIndex.A, PathEndMode.InteractionCell);
             if (pawn != Patient)
             {
                 pawn.rotationTracker.FaceCell(Patient.Position);

--- a/Source/CombatExtended/CombatExtended/Jobs/JobDriver_Stabilize.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobDriver_Stabilize.cs
@@ -11,6 +11,7 @@ namespace CombatExtended
     {
         private const float BaseTendDuration = 60f;
         private Thing _usedMedicine;
+        private bool didStabilize = false;
 
         private Pawn Patient
         {
@@ -67,10 +68,13 @@ namespace CombatExtended
             });
             this.AddFinishAction(delegate
             {
-                MakeMedicineFilth(Medicine);
-                if (_usedMedicine is { stackCount: > 0 })
+                if (didStabilize)
                 {
-                    _usedMedicine.SplitOff(1).Destroy();
+                    MakeMedicineFilth(Medicine);
+                    if (_usedMedicine is { stackCount: > 0 })
+                    {
+                        _usedMedicine.SplitOff(1).Destroy();
+                    }
                 }
             });
             yield return Toils_Goto.GotoThing(TargetIndex.A, PathEndMode.InteractionCell);
@@ -119,6 +123,7 @@ namespace CombatExtended
                         {
                             HediffComp_Stabilize comp = curInjury.TryGetComp<HediffComp_Stabilize>();
                             comp.Stabilize(pawn, Medicine);
+                            didStabilize = true;
                             break;
                         }
                     }

--- a/Source/CombatExtended/CombatExtended/Jobs/JobDriver_Stabilize.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobDriver_Stabilize.cs
@@ -3,12 +3,14 @@ using System.Collections.Generic;
 using System.Linq;
 using Verse;
 using Verse.AI;
+using UnityEngine;
 
 namespace CombatExtended
 {
     public class JobDriver_Stabilize : JobDriver
     {
-        private const float baseTendDuration = 60f;
+        private const float BaseTendDuration = 60f;
+        private Thing _usedMedicine;
 
         private Pawn Patient
         {
@@ -61,37 +63,69 @@ namespace CombatExtended
                 {
                     return JobCondition.Ongoing;
                 }
-                Medicine.Destroy();
-                MakeMedicineFilth(Medicine);
                 return JobCondition.Incompletable;
             });
-
-            // Pick up medicine and haul to patient
-            yield return Toils_Goto.GotoThing(TargetIndex.B, PathEndMode.ClosestTouch);
-            yield return Toils_Haul.StartCarryThing(TargetIndex.B);
+            this.AddFinishAction(delegate
+            {
+                MakeMedicineFilth(Medicine);
+                if (_usedMedicine is { stackCount: > 0 })
+                {
+                    _usedMedicine.SplitOff(1).Destroy();
+                }
+            });
             yield return Toils_Goto.GotoThing(TargetIndex.A, PathEndMode.InteractionCell);
-            yield return Toils_Haul.PlaceHauledThingInCell(TargetIndex.A, null, false);
             // Stabilize patient
             int duration = (int)(1f / this.pawn.GetStatValue(StatDefOf.MedicalTendSpeed, true) * baseTendDuration);
+            Toil carryMedicine = new Toil
+            {
+                initAction = delegate
+                {
+                    var curJob = pawn.jobs.curJob;
+                    if (pawn.carryTracker.CarriedThing != Medicine)
+                    {
+                        int toCarry = Mathf.Min(1, pawn.Map.reservationManager.CanReserveStack(pawn, Medicine, 1));
+                        if (toCarry > 0)
+                        {
+                            pawn.carryTracker.TryStartCarry(Medicine, toCarry);
+                        }
+                    }
+                    curJob.count = 0;
+                    if (Medicine.Spawned)
+                    {
+                        pawn.Map.reservationManager.Release(Medicine, pawn, job);
+                    }
+                    curJob.SetTarget(TargetIndex.B, pawn.carryTracker.CarriedThing);
+                    _usedMedicine = pawn.carryTracker.CarriedThing;
+                }
+            };
+            yield return carryMedicine;
+            if (pawn != Patient)
+            {
+                pawn.rotationTracker.FaceCell(Patient.Position);
+            }
+            // Stabilize patient
+            int duration = (int)(1f / this.pawn.GetStatValue(StatDefOf.MedicalTendSpeed, true) * BaseTendDuration);
             Toil waitToil = Toils_General.WaitWith(TargetIndex.A, duration, maintainPosture: true, maintainSleep: false).WithProgressBarToilDelay(TargetIndex.A).PlaySustainerOrSound(SoundDefOf.Interact_Tend);
             yield return waitToil;
-            Toil stabilizeToil = new Toil();
-            stabilizeToil.initAction = delegate
+            Toil stabilizeToil = new Toil
             {
-                float xp = (!Patient.RaceProps.Animal) ? 125f : 50f * Medicine.def.MedicineTendXpGainFactor;
-                pawn.skills.Learn(SkillDefOf.Medicine, xp);
-                foreach (Hediff curInjury in from x in Patient.health.hediffSet.GetHediffsTendable() orderby x.BleedRate descending select x)
+                initAction = delegate
                 {
-                    if (curInjury.CanBeStabilized())
+                    float xp = (!Patient.RaceProps.Animal) ? 125f : 50f * Medicine.def.MedicineTendXpGainFactor;
+                    pawn.skills.Learn(SkillDefOf.Medicine, xp);
+                    foreach (Hediff curInjury in from x in Patient.health.hediffSet.GetHediffsTendable() orderby x.BleedRate descending select x)
                     {
-                        HediffComp_Stabilize comp = curInjury.TryGetComp<HediffComp_Stabilize>();
-                        comp.Stabilize(pawn, Medicine);
-                        break;
+                        if (curInjury.CanBeStabilized())
+                        {
+                            HediffComp_Stabilize comp = curInjury.TryGetComp<HediffComp_Stabilize>();
+                            comp.Stabilize(pawn, Medicine);
+                            break;
+                        }
                     }
-                }
 
+                },
+                defaultCompleteMode = ToilCompleteMode.Instant
             };
-            stabilizeToil.defaultCompleteMode = ToilCompleteMode.Instant;
             yield return stabilizeToil;
             yield return Toils_Jump.Jump(waitToil);
         }


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Pawn faces patient if north spot is blocked
- Checks if pawn is carrying medicine when called to stabilize and will use that if no better medicine in inventory. Can be checked by creating a storage zone and tell pawn to haul medicine. While carrying the medicine in arms to storage you can tell it to stabilize and it will drop the stack and take one medicine to the pawn in need.

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Pawn carries medicine instead of dropping.
- Carried medicine is destroyed if patient dies between hediff stabilization or job interrupted after stabilizing first hediff on patient
- Pawn checks if carrying medicine (This is in addition to the inventory)

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #3943 

## Reasoning

Why did you choose to implement things this way, e.g.
- Mimics vanilla tending instead of dropping medicine on ground
- If pawn gets called to stabilize in middle of hauling medicine, but does not have any in inventory they can still stabilize.
- Medicine usage could be scummed by canceling job on second to last hediff.


## Alternatives

Describe alternative implementations you have considered, e.g.
- Remove all LINQ
- Cache hediffList on first tend and don't constantly check all the pawn's hediffs to improve performance
- Don't check carried
- Add small radius search to see if patient dropped medicine to be used

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (Shot some pawns and healed em)
