### PR TITLE
More Stabilization QoL

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_FloatMenuMakerMap.cs
+++ b/Source/CombatExtended/Harmony/Harmony_FloatMenuMakerMap.cs
@@ -90,14 +90,11 @@ namespace CombatExtended.HarmonyCE
             // Stabilize
             if (pawn.health.capacities.CapableOf(PawnCapacityDefOf.Manipulation))
             {
-#pragma warning disable CS0618 // You're supposed to migrate to GenUI.TargetsAt_NewTemp? But that scares me.
-                foreach (LocalTargetInfo curTarget in GenUI.TargetsAt(clickPos, TargetingParameters.ForTend(pawn), true)) // !! This needs to be patched into A17
-#pragma warning restore CS0618
+
+                foreach (LocalTargetInfo curTarget in GenUI.TargetsAt(clickPos, TargetingParameters.ForTend(pawn), true))
                 {
                     Pawn patient = (Pawn)curTarget.Thing;
-                    if (    //&& pawn.CanReserveAndReach(patient, PathEndMode.InteractionCell, Danger.Deadly)
-                            pawn.CanReach(patient, PathEndMode.InteractionCell, Danger.Deadly)
-                            && patient.health.hediffSet.GetHediffsTendable().Any(h => h.CanBeStabilized()))
+                    if (pawn.CanReach(patient, PathEndMode.InteractionCell, Danger.Deadly) && patient.health.hediffSet.GetHediffsTendable().Any(h => h.CanBeStabilized()))
                     {
                         if (pawn.WorkTypeIsDisabled(WorkTypeDefOf.Doctor))
                         {
@@ -159,39 +156,98 @@ namespace CombatExtended.HarmonyCE
                 }
             }
         }
+        const float MaxSearchRadius = 5f;
+        const float MaxDistSq = MaxSearchRadius * MaxSearchRadius;
+        private readonly static List<Thing> AllMedicine = [];
 
         [global::CombatExtended.Compatibility.Multiplayer.SyncMethod]
         private static void Stabilize(Pawn pawn, Pawn patient)
         {
-            bool pawnHasMedicine = (pawn.inventory?.innerContainer?.Any(t => t.def.IsMedicine) ?? false);
+            bool pawnHasMedicine = pawn.inventory?.innerContainer?.Any(t => t.def.IsMedicine) ?? false;
+            bool patientHasMedicine = patient.inventory?.innerContainer?.Any(t => t.def.IsMedicine) ?? false;
             bool pawnCarryingMedicine = pawn.carryTracker.CarriedThing?.def.IsMedicine ?? false;
-            if (!pawnHasMedicine && !pawnCarryingMedicine)
+
+            if (!pawnHasMedicine && !pawnCarryingMedicine && !patientHasMedicine)
             {
-                Messages.Message("CE_CannotStabilize".Translate() + ": " + "CE_NoMedicine".Translate(pawn), patient, MessageTypeDefOf.RejectInput);
+                if (TryFindNearbyMedicine(pawn, patient.Position, out Thing closestMedicine))
+                {
+                    AssignStabilizeJob(pawn, patient, closestMedicine);
+                }
+                else
+                {
+                    Messages.Message("CE_CannotStabilize".Translate() + ": " + "CE_NoMedicine".Translate(pawn), patient, MessageTypeDefOf.RejectInput);
+                }
                 return;
             }
-            Medicine bestMedicine = null;
-            float bestPotency = -1f;
-            if (pawnCarryingMedicine)
-            {
-                TryUpdateBestMedicine(pawn.carryTracker.CarriedThing, ref bestPotency, ref bestMedicine);
-            }
-            if (pawnHasMedicine)
-            {
-                foreach (Thing thing in pawn.inventory.innerContainer)
-                {
-                    TryUpdateBestMedicine(thing, ref bestPotency, ref bestMedicine);
-                }
-            }
+
+            Medicine bestMedicine = FindBestMedicine(pawn, patient, pawnHasMedicine, patientHasMedicine, pawnCarryingMedicine);
             if (bestMedicine != null)
             {
-                Job job = JobMaker.MakeJob(CE_JobDefOf.Stabilize, patient, bestMedicine);
-                job.count = 1;
-                pawn.jobs.TryTakeOrderedJob(job);
-                PlayerKnowledgeDatabase.KnowledgeDemonstrated(CE_ConceptDefOf.CE_Stabilizing, KnowledgeAmount.Total);
+                AssignStabilizeJob(pawn, patient, bestMedicine);
             }
         }
 
+        [global::CombatExtended.Compatibility.Multiplayer.SyncMethod]
+        private static bool TryFindNearbyMedicine(Pawn pawn, IntVec3 position, out Thing closestMedicine)
+        {
+            closestMedicine = null;
+            float closestDistSq = float.MaxValue;
+            AllMedicine.Clear();
+            AllMedicine.AddRange(pawn.Map.listerThings.ThingsInGroup(ThingRequestGroup.Medicine));
+            for (int i = 0; i < AllMedicine.Count; i++)
+            {
+                Thing medicine = AllMedicine[i];
+                if (!medicine.Spawned || medicine.IsForbidden(pawn))
+                {
+                    continue;
+                }
+                var distance = medicine.Position.DistanceToSquared(position);
+                if (distance <= MaxDistSq && distance < closestDistSq)
+                {
+                    closestDistSq = distance;
+                    closestMedicine = medicine;
+                }
+            }
+            return closestMedicine != null;
+        }
+
+        [global::CombatExtended.Compatibility.Multiplayer.SyncMethod]
+        private static Medicine FindBestMedicine(Pawn pawn, Pawn patient, bool doctorHas, bool patientHas, bool doctorCarrying)
+        {
+            Medicine best = null;
+            float potency = -1f;
+
+            if (patientHas)
+            {
+                foreach (Thing t in patient.inventory.innerContainer)
+                {
+                    TryUpdateBestMedicine(t, ref potency, ref best);
+                }
+            }
+            if (doctorCarrying)
+            {
+                TryUpdateBestMedicine(pawn.carryTracker.CarriedThing, ref potency, ref best);
+            }
+            if (doctorHas)
+            {
+                foreach (Thing t in pawn.inventory.innerContainer)
+                {
+                    TryUpdateBestMedicine(t, ref potency, ref best);
+                }
+            }
+            return best;
+        }
+
+        [global::CombatExtended.Compatibility.Multiplayer.SyncMethod]
+        private static void AssignStabilizeJob(Pawn pawn, Pawn patient, Thing medicine)
+        {
+            var job = JobMaker.MakeJob(CE_JobDefOf.Stabilize, patient, medicine);
+            job.count = 1;
+            pawn.jobs.TryTakeOrderedJob(job);
+            PlayerKnowledgeDatabase.KnowledgeDemonstrated(CE_ConceptDefOf.CE_Stabilizing, KnowledgeAmount.Total);
+        }
+
+        [global::CombatExtended.Compatibility.Multiplayer.SyncMethod]
         private static void TryUpdateBestMedicine(Thing source, ref float bestPotency, ref Medicine bestMedicine)
         {
             if (source is Medicine medicine)


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Searches patient's inventory for medicine for best medicine
- Last Ditch search around for closest medicine if doctor and patient are out of medicine

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Refactor code to multiple methods for readability

## Reasoning

Why did you choose to implement things this way, e.g.
- Patient Inventory > Carried Medicine > Doctor's Inventory when searching for medicine. This only applies for the best medicine
- If there is no medicine, doctor should just grab closest medicine to try and stabilize patient.
- Vanilla inventory drops on ground when pawn drops, so this gives option to stabilize someone if patient had medicine, but doctor did not.

## Alternatives

Describe alternative implementations you have considered, e.g.
- Radius search adjustable via menu

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
