### PR TITLE
Grimworld Shields

### DIFF
--- a/ModPatches/Grimworld Angels of Death/Patches/Grimworld Angels of Death/CE_Patch_Shields.xml
+++ b/ModPatches/Grimworld Angels of Death/Patches/Grimworld Angels of Death/CE_Patch_Shields.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	
+	<!--===== Melee Attacks =====-->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GW_SM_CombatShieldA"]/statBases/StuffEffectMultiplierArmor</xpath>
+		<value>
+			<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GW_SM_StormShieldA" or defName="GW_SM_SalamanderShield"]/statBases/StuffEffectMultiplierArmor</xpath>
+		<value>
+			<StuffEffectMultiplierArmor>14</StuffEffectMultiplierArmor>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GW_SM_PrimarisShield"]/statBases/StuffEffectMultiplierArmor</xpath>
+		<value>
+			<StuffEffectMultiplierArmor>18</StuffEffectMultiplierArmor>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Grimworld Hammer of the Imperium/Patches/Grimworld Hammer of the Imperium/CE_Patch_Shields.xml
+++ b/ModPatches/Grimworld Hammer of the Imperium/Patches/Grimworld Hammer of the Imperium/CE_Patch_Shields.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	
+	<!--===== Melee Attacks =====-->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GM_HotE_ShieldOgryn"]/statBases/StuffEffectMultiplierArmor</xpath>
+		<value>
+			<StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>
+		</value>
+	</Operation>
+
+</Patch>


### PR DESCRIPTION
## Changes
Patches the Ogryn, Assault, Storm, Primaris, and Salamander Shields in Hammer of the Imperium and Angels of Death.

Listed seperately from the #3836 patch as that one's getting a bit unwieldy and this is more important than balance changes since it patches something that is currently entirely unsupported.

A lot of values such as Bulk are already handled on GW's side via MayRequire, so this really only needs to bring the material strength multipliers up to scratch.

## Reasoning
So the shields are usable and not effectively tissuepaper under CE armour strength rules.

Ogryn shield is made equivalent to CE's stock ballistic shield, whilst the Astartes shields are increasingly durable; the unpowered Assault Shield is a little tougher, the powered Storm and Salamander Shields are tougher than that, and the blessed/etc. Primaris Shield is basically equivalent to wearing a whole extra layer of armour.

All of them benefit _immensely_ from being made of GW materials such as Ceramite or Adamantium, so I didn't see much need to get too fancy with the armour strengths.

## Alternatives
GW Shields bad. :(

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
