### PR TITLE
Notify all things about explosions

### DIFF
--- a/Source/CombatExtended/CombatExtended/ExplosionCE.cs
+++ b/Source/CombatExtended/CombatExtended/ExplosionCE.cs
@@ -371,10 +371,13 @@ namespace CombatExtended
             cellsToAffect.Sort((IntVec3 a, IntVec3 b) => GetCellAffectTick(b).CompareTo(GetCellAffectTick(a)));
             RegionTraverser.BreadthFirstTraverse(Position, Map, (Region from, Region to) => true, delegate (Region x)
             {
-                var list = x.ListerThings.ThingsInGroup(ThingRequestGroup.Pawn);
-                for (var i = list.Count - 1; i >= 0; i--)
+                List<Thing> allThings = x.ListerThings.AllThings;
+                for (int num = allThings.Count - 1; num >= 0; num--)
                 {
-                    ((Pawn)list[i]).mindState.Notify_Explosion(this);
+                    if (allThings[num].Spawned)
+                    {
+                        allThings[num].Notify_Explosion(this);
+                    }
                 }
                 return false;
             }, 25, RegionType.Set_Passable);


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Changes explosions to notify all things, not only pawns. Code copied from decompiled vanilla.

## References

Links to the associated issues or other related pull requests, e.g.
- [Discord discussion](https://discord.com/channels/278818534069501953/286486075466317826/1382054540164993096)

## Reasoning

Why did you choose to implement things this way, e.g.
- Some things might've wanted to get notified about explosions but got excluded because they were not Pawns, even though base `Thing` does have a `Notify_Explosion()` method
- Vanilla does it this way. Seems like our code got outdated

## Alternatives

Describe alternative implementations you have considered, e.g.
- Keep things as is.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
tested FSX stack explosions, grenades in dev colony.
