### PR TITLE
Fix Pickup Cooking Off Ammo

### DIFF
--- a/Languages/English/Keyed/Keys.xml
+++ b/Languages/English/Keyed/Keys.xml
@@ -97,6 +97,7 @@
 	<CE_PickUp>Pick up</CE_PickUp>
 	<CE_PickUpHalf>Pick up half</CE_PickUpHalf>
 	<CE_CannotPickUp>Cannot pick up</CE_CannotPickUp>
+	<CE_CookingOff>Cooking off</CE_CookingOff>
 	<CE_OutOfAmmo>Out of ammo</CE_OutOfAmmo>
 	<CE_PutAway>Put away {0}</CE_PutAway>
 	<CE_ReloadApparel>Reload {0} with {1}</CE_ReloadApparel>

--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_TakeAndEquip.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_TakeAndEquip.cs
@@ -214,9 +214,9 @@ namespace CombatExtended
 
             //Log.Message(pawn.ThingID +  " - priority:" + (GetPriorityWork(pawn)).ToString() + " capacityWeight: " + pawn.TryGetComp<CompInventory>().capacityWeight.ToString() + " currentWeight: " + pawn.TryGetComp<CompInventory>().currentWeight.ToString() + " capacityBulk: " + pawn.TryGetComp<CompInventory>().capacityBulk.ToString() + " currentBulk: " + pawn.TryGetComp<CompInventory>().currentBulk.ToString());
 
-            var brawler = (pawn.story != null && pawn.story.traits != null && pawn.story.traits.HasTrait(TraitDefOf.Brawler));
+            var brawler = (pawn.story is { traits: not null } && pawn.story.traits.HasTrait(TraitDefOf.Brawler));
             CompInventory inventory = pawn.TryGetComp<CompInventory>();
-            bool hasPrimary = (pawn.equipment != null && pawn.equipment.Primary != null);
+            bool hasPrimary = pawn.equipment is { Primary: not null };
             CompAmmoUser primaryAmmoUser = hasPrimary ? pawn.equipment.Primary.TryGetComp<CompAmmoUser>() : null;
             CompAmmoUser primaryAmmoUserWithInventoryCheck = hasPrimary ? pawn.equipment.Primary.TryGetComp<CompAmmoUser>() : hasWeaponInInventory(pawn) ? weaponInInventory(pawn) : null;
             if (inventory != null)
@@ -392,10 +392,10 @@ namespace CombatExtended
                                     List<ThingDef> thingDefAmmoList = thing.TryGetComp<CompAmmoUser>().Props.ammoSet.ammoTypes.Select(g => g.ammo as ThingDef).ToList();
 
                                     Predicate<Thing> validatorA = (Thing t) => t.def.category == ThingCategory.Item
-                                                                  && t is AmmoThing && pawn.CanReserve(t, 1)
-                                                                  && pawn.Position.InHorDistOf(t.Position, 25f)
-                                                                  && pawn.CanReach(t, PathEndMode.Touch, Danger.Deadly, true)
-                                                                  && (pawn.Faction.HostileTo(Faction.OfPlayer) || pawn.Faction == Faction.OfPlayer || !pawn.Map.areaManager.Home[t.Position]);
+                                            && t is AmmoThing { IsCookingOff: false } && pawn.CanReserve(t, 1)
+                                            && pawn.Position.InHorDistOf(t.Position, 25f)
+                                            && pawn.CanReach(t, PathEndMode.Touch, Danger.Deadly, true)
+                                            && (pawn.Faction.HostileTo(Faction.OfPlayer) || pawn.Faction == Faction.OfPlayer || !pawn.Map.areaManager.Home[t.Position]);
 
                                     List<Thing> thingAmmoList = (
                                                                     from t in pawn.Map.listerThings.ThingsInGroup(ThingRequestGroup.HaulableAlways)
@@ -421,7 +421,7 @@ namespace CombatExtended
                         }
 
                         // else if no ranged weapons with nearby ammo was found, lets consider a melee weapon.
-                        if (allWeapons != null && allWeapons.Count > 0)
+                        if (allWeapons is { Count: > 0 })
                         {
                             // since we don't need to worry about ammo, just pick one.
                             Thing meleeWeapon = allWeapons.FirstOrDefault(w => !w.def.IsRangedWeapon && w.def.IsMeleeWeapon);
@@ -443,10 +443,10 @@ namespace CombatExtended
 
                     if (curAmmoList.Count > 0)
                     {
-                        Predicate<Thing> validator = (Thing t) => t is AmmoThing && pawn.CanReserve(t, 1)
-                                                     && pawn.CanReach(t, PathEndMode.Touch, Danger.Deadly, true)
-                                                     && ((pawn.Faction.IsPlayer && !ForbidUtility.IsForbidden(t, pawn)) || (!pawn.Faction.IsPlayer && pawn.Position.InHorDistOf(t.Position, 35f)))
-                                                     && (pawn.Faction.HostileTo(Faction.OfPlayer) || pawn.Faction == Faction.OfPlayer || !pawn.Map.areaManager.Home[t.Position]);
+                        Predicate<Thing> validator = (Thing t) => t is AmmoThing { IsCookingOff: false } && pawn.CanReserve(t, 1)
+                                && pawn.CanReach(t, PathEndMode.Touch, Danger.Deadly, true)
+                                && ((pawn.Faction.IsPlayer && !ForbidUtility.IsForbidden(t, pawn)) || (!pawn.Faction.IsPlayer && pawn.Position.InHorDistOf(t.Position, 35f)))
+                                && (pawn.Faction.HostileTo(Faction.OfPlayer) || pawn.Faction == Faction.OfPlayer || !pawn.Map.areaManager.Home[t.Position]);
                         List<Thing> curThingList = (
                                                        from t in pawn.Map.listerThings.ThingsInGroup(ThingRequestGroup.HaulableAlways)
                                                        where validator(t)

--- a/Source/CombatExtended/Harmony/Harmony_FloatMenuMakerMap.cs
+++ b/Source/CombatExtended/Harmony/Harmony_FloatMenuMakerMap.cs
@@ -120,7 +120,7 @@ namespace CombatExtended.HarmonyCE
                 List<Thing> thingList = c.GetThingList(pawn.Map);
                 foreach (Thing item in thingList)
                 {
-                    if (item is null or Corpse)
+                    if (item is null or Corpse || !item.def.alwaysHaulable)
                     {
                         continue;
                     }

--- a/Source/CombatExtended/Harmony/Harmony_FloatMenuMakerMap.cs
+++ b/Source/CombatExtended/Harmony/Harmony_FloatMenuMakerMap.cs
@@ -120,42 +120,47 @@ namespace CombatExtended.HarmonyCE
                 List<Thing> thingList = c.GetThingList(pawn.Map);
                 foreach (Thing item in thingList)
                 {
-                    if (item != null && item.def.alwaysHaulable && !(item is Corpse))
+                    if (item is null or Corpse)
                     {
-                        //FloatMenuOption pickUpOption;
-                        int count = 0;
-                        if (!pawn.CanReach(item, PathEndMode.Touch, Danger.Deadly))
+                        continue;
+                    }
+                    //FloatMenuOption pickUpOption;
+                    if (item is AmmoThing { IsCookingOff: true })
+                    {
+                        opts.Add(new FloatMenuOption("CannotPickUp".Translate(item.LabelShort, item) + " (" + "CE_CookingOff".Translate() + ")", null));
+                    }
+                    else if (!pawn.CanReach(item, PathEndMode.Touch, Danger.Deadly))
+                    {
+                        opts.Add(new FloatMenuOption("CannotPickUp".Translate(item.LabelShort, item) + " (" + "NoPath".Translate() + ")", null));
+                    }
+                    else if (!compInventory.CanFitInInventory(item, out int count))
+                    {
+                        opts.Add(new FloatMenuOption("CannotPickUp".Translate(item.LabelShort, item) + " (" + "CE_InventoryFull".Translate() + ")", null));
+                    }
+                    // Pick up x
+                    else if (count == 1)
+                    {
+                        opts.Add(FloatMenuUtility.DecoratePrioritizedTask(new FloatMenuOption("PickUpOne".Translate(item.Label, item), () => Pickup(pawn, item), MenuOptionPriority.High, null, null, 0f, null, null), pawn, item, "ReservedBy"));
+                    }
+                    else
+                    {
+                        if (count < item.stackCount)
                         {
-                            opts.Add(new FloatMenuOption("CannotPickUp".Translate(item.LabelShort, item) + " (" + "NoPath".Translate() + ")", null));
-                        }
-                        else if (!compInventory.CanFitInInventory(item, out count))
-                        {
-                            opts.Add(new FloatMenuOption("CannotPickUp".Translate(item.LabelShort, item) + " (" + "CE_InventoryFull".Translate() + ")", null));
-                        }
-                        // Pick up x
-                        else if (count == 1)
-                        {
-                            opts.Add(FloatMenuUtility.DecoratePrioritizedTask(new FloatMenuOption("PickUpOne".Translate(item.Label, item), () => Pickup(pawn, item), MenuOptionPriority.High, null, null, 0f, null, null), pawn, item, "ReservedBy"));
+                            opts.Add(new FloatMenuOption("CannotPickUpAll".Translate(item.Label, item) + " (" + "CE_InventoryFull".Translate() + ")", null, MenuOptionPriority.Default, null, null, 0f, null, null));
                         }
                         else
                         {
-                            if (count < item.stackCount)
-                            {
-                                opts.Add(new FloatMenuOption("CannotPickUpAll".Translate(item.Label, item) + " (" + "CE_InventoryFull".Translate() + ")", null, MenuOptionPriority.Default, null, null, 0f, null, null));
-                            }
-                            else
-                            {
-                                opts.Add(FloatMenuUtility.DecoratePrioritizedTask(new FloatMenuOption("PickUpAll".Translate(item.Label, item), () => PickupAll(pawn, item), MenuOptionPriority.High, null, null, 0f, null, null), pawn, item, "ReservedBy"));
-                            }
-                            opts.Add(FloatMenuUtility.DecoratePrioritizedTask(new FloatMenuOption("PickUpSome".Translate(item.Label, item), delegate
-                            {
-                                int to = Mathf.Min(count, item.stackCount);
-                                Dialog_Slider window = new Dialog_Slider("PickUpCount".Translate(item.LabelShort, item), 1, to, (selectCount) => PickupCount(pawn, item, selectCount), -2147483648);
-                                Find.WindowStack.Add(window);
-                                PlayerKnowledgeDatabase.KnowledgeDemonstrated(CE_ConceptDefOf.CE_InventoryWeightBulk, KnowledgeAmount.SpecificInteraction);
-                            }, MenuOptionPriority.High, null, null, 0f, null, null), pawn, item, "ReservedBy"));
+                            opts.Add(FloatMenuUtility.DecoratePrioritizedTask(new FloatMenuOption("PickUpAll".Translate(item.Label, item), () => PickupAll(pawn, item), MenuOptionPriority.High, null, null, 0f, null, null), pawn, item, "ReservedBy"));
                         }
+                        opts.Add(FloatMenuUtility.DecoratePrioritizedTask(new FloatMenuOption("PickUpSome".Translate(item.Label, item), delegate
+                        {
+                            int to = Mathf.Min(count, item.stackCount);
+                            Dialog_Slider window = new Dialog_Slider("PickUpCount".Translate(item.LabelShort, item), 1, to, (selectCount) => PickupCount(pawn, item, selectCount), -2147483648);
+                            Find.WindowStack.Add(window);
+                            PlayerKnowledgeDatabase.KnowledgeDemonstrated(CE_ConceptDefOf.CE_InventoryWeightBulk, KnowledgeAmount.SpecificInteraction);
+                        }, MenuOptionPriority.High, null, null, 0f, null, null), pawn, item, "ReservedBy"));
                     }
+
                 }
             }
         }


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Changes float menu to check if ammo is cooking off. Prevents picking up if so
- JobDriver_EquipAndReload to check if ammo is cooking off

## References

Links to the associated issues or other related pull requests, e.g.
- Related #687 

## Reasoning

Why did you choose to implement things this way, e.g.
- Ammo will now cease cooking off when picked up, but will continue cooking off when set back down. Be it immediately or a year later
- Simplifies the issue, by preventing picking up cooking off ammo

## Alternatives

Describe alternative implementations you have considered, e.g.
- Make them cook off while in inventory

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (Impid fire to set off ammo and check)
