### PR TITLE
Rollout Non-Human Parrying

### DIFF
--- a/Anomaly/Patches/ThingDefs_Races/Races_Entities_Misc.xml
+++ b/Anomaly/Patches/ThingDefs_Races/Races_Entities_Misc.xml
@@ -248,7 +248,7 @@
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Humanoid</bodyShape>
 				<canParry>true</canParry>
-				<maxParry>4</maxParry>
+				<maxParry>2</maxParry>
 			</li>
 		</value>
 	</Operation>
@@ -375,7 +375,7 @@
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Humanoid</bodyShape>
 				<canParry>true</canParry>
-				<maxParry>6</maxParry>
+				<maxParry>3</maxParry>
 			</li>
 		</value>
 	</Operation>

--- a/Ideology/Patches/ThingDefs_Misc/Race_Animal_Dryads.xml
+++ b/Ideology/Patches/ThingDefs_Misc/Race_Animal_Dryads.xml
@@ -104,7 +104,7 @@
 		<value>
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<canParry>true</canParry>
-				<maxParry>3</maxParry>
+				<maxParry>2</maxParry>
 			</li>
 		</value>
 	</Operation>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_BlackHive_Psycasts.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_BlackHive_Psycasts.xml
@@ -114,8 +114,6 @@
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>QuadrupedLow</bodyShape>
-							<canParry>true</canParry>
-							<maxParry>3</maxParry>
 						</li>
 					</value>
 				</li>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Animalisk.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Animalisk.xml
@@ -5,8 +5,6 @@
 		<value>
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>QuadrupedLow</bodyShape>
-				<canParry>true</canParry>
-				<maxParry>3</maxParry>
 			</li>
 		</value>
 	</Operation>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Barb_Slinger.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Barb_Slinger.xml
@@ -7,7 +7,7 @@
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>QuadrupedLow</bodyShape>
 				<canParry>true</canParry>
-				<maxParry>4</maxParry>
+				<maxParry>3</maxParry>
 			</li>
 		</value>
 	</Operation>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Black_Hive.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Black_Hive.xml
@@ -106,8 +106,6 @@
 		<value>
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>QuadrupedLow</bodyShape>
-				<canParry>true</canParry>
-				<maxParry>3</maxParry>
 			</li>
 		</value>
 	</Operation>
@@ -223,7 +221,7 @@
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Quadruped</bodyShape>
 				<canParry>true</canParry>
-				<maxParry>4</maxParry>
+				<maxParry>3</maxParry>
 			</li>
 		</value>
 	</Operation>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Blizzarisk.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Blizzarisk.xml
@@ -6,8 +6,6 @@
 		<value>
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>QuadrupedLow</bodyShape>
-				<canParry>true</canParry>
-				<maxParry>3</maxParry>
 			</li>
 		</value>
 	</Operation>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Bloodshrimp.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Bloodshrimp.xml
@@ -6,7 +6,7 @@
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Quadruped</bodyShape>
 				<canParry>true</canParry>
-				<maxParry>4</maxParry>
+				<maxParry>3</maxParry>
 			</li>
 		</value>
 	</Operation>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Cinderlisk.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Cinderlisk.xml
@@ -5,8 +5,6 @@
 		<value>
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>QuadrupedLow</bodyShape>
-				<canParry>true</canParry>
-				<maxParry>3</maxParry>
 			</li>
 		</value>
 	</Operation>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Dunealisk.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Dunealisk.xml
@@ -6,8 +6,6 @@
 		<value>
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>QuadrupedLow</bodyShape>
-				<canParry>true</canParry>
-				<maxParry>3</maxParry>
 			</li>
 		</value>
 	</Operation>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Feralisk.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Feralisk.xml
@@ -6,8 +6,6 @@
 		<value>
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>QuadrupedLow</bodyShape>
-				<canParry>true</canParry>
-				<maxParry>3</maxParry>
 			</li>
 		</value>
 	</Operation>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_FungalHusk.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_FungalHusk.xml
@@ -5,8 +5,6 @@
 		<value>
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Humanoid</bodyShape>
-				<canParry>true</canParry>
-				<maxParry>3</maxParry>
 			</li>
 		</value>
 	</Operation>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Junglelisk.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Junglelisk.xml
@@ -6,8 +6,6 @@
 		<value>
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>QuadrupedLow</bodyShape>
-				<canParry>true</canParry>
-				<maxParry>3</maxParry>
 			</li>
 		</value>
 	</Operation>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Mimes.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Mimes.xml
@@ -6,7 +6,7 @@
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Humanoid</bodyShape>
 				<canParry>true</canParry>
-				<maxParry>5</maxParry>
+				<maxParry>4</maxParry>
 			</li>
 		</value>
 	</Operation>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_MoribundGallatross.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_MoribundGallatross.xml
@@ -6,6 +6,8 @@
 		<value>
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Quadruped</bodyShape>
+				<canParry>true</canParry>
+				<maxParry>4</maxParry>				
 			</li>
 		</value>
 	</Operation>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Raptor_Shrimp.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Raptor_Shrimp.xml
@@ -6,7 +6,7 @@
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Quadruped</bodyShape>
 				<canParry>true</canParry>
-				<maxParry>5</maxParry>
+				<maxParry>4</maxParry>
 			</li>
 		</value>
 	</Operation>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Ravager.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Ravager.xml
@@ -7,7 +7,7 @@
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>QuadrupedLow</bodyShape>
 				<canParry>true</canParry>
-				<maxParry>5</maxParry>
+				<maxParry>4</maxParry>
 			</li>
 		</value>
 	</Operation>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_RipperHound.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_RipperHound.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="AA_RipperHound"]</xpath>
 		<value>
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Quadruped</bodyShape>
-				<canParry>true</canParry>
-				<maxParry>3</maxParry>
 			</li>
 		</value>
 	</Operation>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Apoptosis.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Apoptosis.xml
@@ -14,6 +14,8 @@
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Humanoid</bodyShape>
+							<canParry>true</canParry>
+							<maxParry>4</maxParry>							
 						</li>
 					</value>
 				</li>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Lux.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Lux.xml
@@ -14,6 +14,8 @@
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Humanoid</bodyShape>
+							<canParry>true</canParry>
+							<maxParry>2</maxParry>							
 						</li>
 					</value>
 				</li>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Munifex.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Munifex.xml
@@ -14,6 +14,8 @@
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Humanoid</bodyShape>
+							<canParry>true</canParry>
+							<maxParry>2</maxParry>							
 						</li>
 					</value>
 				</li>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Sagittarius.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_Sagittarius.xml
@@ -14,6 +14,8 @@
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Humanoid</bodyShape>
+							<canParry>true</canParry>
+							<maxParry>2</maxParry>
 						</li>
 					</value>
 				</li>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_WarEmpress.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_WarEmpress.xml
@@ -14,6 +14,8 @@
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>QuadrupedLow</bodyShape>
+							<canParry>true</canParry>
+							<maxParry>4</maxParry>
 						</li>
 					</value>
 				</li>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvAura.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvAura.xml
@@ -15,7 +15,7 @@
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Humanoid</bodyShape>
 							<canParry>true</canParry>
-							<maxParry>7</maxParry>
+							<maxParry>5</maxParry>
 						</li>
 					</value>
 				</li>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvGoliath.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Advanced/AdvGoliath.xml
@@ -14,8 +14,6 @@
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Humanoid</bodyShape>
-							<canParry>true</canParry>
-							<maxParry>4</maxParry>
 						</li>
 					</value>
 				</li>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEAura.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEAura.xml
@@ -15,7 +15,7 @@
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Humanoid</bodyShape>
 							<canParry>true</canParry>
-							<maxParry>6</maxParry>
+							<maxParry>4</maxParry>
 						</li>
 					</value>
 				</li>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEGoliath.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/Clean/VFEGoliath.xml
@@ -14,8 +14,6 @@
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Humanoid</bodyShape>
-							<canParry>true</canParry>
-							<maxParry>3</maxParry>
 						</li>
 					</value>
 				</li>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Aura.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Aura.xml
@@ -20,7 +20,7 @@
 							<li Class="CombatExtended.RacePropertiesExtensionCE">
 								<bodyShape>Humanoid</bodyShape>
 								<canParry>true</canParry>
-								<maxParry>7</maxParry>
+								<maxParry>5</maxParry>
 							</li>
 						</value>
 					</li>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Goliath.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/VFE_Mechs/PlayerControlled/PC_Goliath.xml
@@ -19,8 +19,6 @@
 						<value>
 							<li Class="CombatExtended.RacePropertiesExtensionCE">
 								<bodyShape>Humanoid</bodyShape>
-								<canParry>true</canParry>
-								<maxParry>4</maxParry>
 							</li>
 						</value>
 					</li>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Aura.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Aura.xml
@@ -7,7 +7,7 @@
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Humanoid</bodyShape>
 				<canParry>true</canParry>
-				<maxParry>6</maxParry>
+				<maxParry>4</maxParry>
 			</li>
 		</value>
 	</Operation>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Goliath.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/ThingDefs_Races/AlphaMechs_Race_Goliath.xml
@@ -6,8 +6,6 @@
 		<value>
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Humanoid</bodyShape>
-				<canParry>true</canParry>
-				<maxParry>3</maxParry>
 			</li>
 		</value>
 	</Operation>

--- a/ModPatches/RH2 Faction - VOID/Patches/RH2 Faction - VOID/Monsters/Races.xml
+++ b/ModPatches/RH2 Faction - VOID/Patches/RH2 Faction - VOID/Monsters/Races.xml
@@ -321,7 +321,7 @@
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Quadruped</bodyShape>
 				<canParry>true</canParry>
-				<maxParry>4</maxParry>
+				<maxParry>3</maxParry>
 			</li>
 		</value>
 	</Operation>
@@ -431,7 +431,7 @@
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Humanoid</bodyShape>
 				<canParry>true</canParry>
-				<maxParry>5</maxParry>
+				<maxParry>4</maxParry>
 			</li>
 		</value>
 	</Operation>

--- a/ModPatches/RH2 Faction - VOID/Patches/RH2 Faction - VOID/Monsters/Races_Evolved.xml
+++ b/ModPatches/RH2 Faction - VOID/Patches/RH2 Faction - VOID/Monsters/Races_Evolved.xml
@@ -9,7 +9,7 @@
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Humanoid</bodyShape>
 				<canParry>true</canParry>
-				<maxParry>4</maxParry>
+				<maxParry>3</maxParry>
 			</li>
 		</value>
 	</Operation>
@@ -515,7 +515,7 @@
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Humanoid</bodyShape>
 				<canParry>true</canParry>
-				<maxParry>4</maxParry>
+				<maxParry>5</maxParry>
 			</li>
 		</value>
 	</Operation>
@@ -617,7 +617,7 @@
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Humanoid</bodyShape>
 				<canParry>true</canParry>
-				<maxParry>5</maxParry>
+				<maxParry>4</maxParry>
 			</li>
 		</value>
 	</Operation>
@@ -719,7 +719,7 @@
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Quadruped</bodyShape>
 				<canParry>true</canParry>
-				<maxParry>5</maxParry>
+				<maxParry>2</maxParry>
 			</li>
 		</value>
 	</Operation>
@@ -821,7 +821,7 @@
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Humanoid</bodyShape>
 				<canParry>true</canParry>
-				<maxParry>5</maxParry>
+				<maxParry>3</maxParry>
 			</li>
 		</value>
 	</Operation>

--- a/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Races/Race_Hulk.xml
+++ b/ModPatches/Rimsenal Federation/Patches/Rimsenal Federation/ThingDefs_Races/Race_Hulk.xml
@@ -7,7 +7,7 @@
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Humanoid</bodyShape>
 				<canParry>true</canParry>
-				<maxParry>5</maxParry>
+				<maxParry>4</maxParry>
 			</li>
 		</value>
 	</Operation>

--- a/ModPatches/Rimsenal Feral/Patches/Rimsenal Feral/ThingDefs_Races/Race_Ogrons.xml
+++ b/ModPatches/Rimsenal Feral/Patches/Rimsenal Feral/ThingDefs_Races/Race_Ogrons.xml
@@ -7,7 +7,7 @@
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Humanoid</bodyShape>
 				<canParry>true</canParry>
-				<maxParry>4</maxParry>
+				<maxParry>2</maxParry>
 			</li>
 		</value>
 	</Operation>

--- a/ModPatches/Rimsenal Feral/Patches/Rimsenal Feral/ThingDefs_Races/Race_Twisted.xml
+++ b/ModPatches/Rimsenal Feral/Patches/Rimsenal Feral/ThingDefs_Races/Race_Twisted.xml
@@ -7,7 +7,7 @@
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Humanoid</bodyShape>
 				<canParry>true</canParry>
-				<maxParry>2</maxParry>
+				<maxParry>1</maxParry>
 			</li>
 		</value>
 	</Operation>

--- a/ModPatches/Robotic Servitude/Patches/ThingDefs_Races/Races_Mechanoid.xml
+++ b/ModPatches/Robotic Servitude/Patches/ThingDefs_Races/Races_Mechanoid.xml
@@ -164,7 +164,7 @@
 		<value>
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<canParry>true</canParry>
-				<maxParry>4</maxParry>
+				<maxParry>3</maxParry>
 			</li>
 		</value>
 	</Operation>
@@ -195,7 +195,7 @@
 		<value>
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<canParry>true</canParry>
-				<maxParry>6</maxParry>
+				<maxParry>5</maxParry>
 			</li>
 		</value>
 	</Operation>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_AcidSpitter.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_AcidSpitter.xml
@@ -1,16 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="VFEI2_Acidspitter"]</xpath>
-		<value>
-			<li Class="CombatExtended.RacePropertiesExtensionCE">
-				<canParry>true</canParry>
-				<maxParry>3</maxParry>
-			</li>
-		</value>
-	</Operation>
-
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="VFEI2_Acidspitter"]/statBases/MoveSpeed</xpath>
 		<value>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Durapod.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Durapod.xml
@@ -6,7 +6,7 @@
 		<value>
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<canParry>true</canParry>
-				<maxParry>2</maxParry>
+				<maxParry>1</maxParry>
 			</li>
 		</value>
 	</Operation>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Gigamite.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Gigamite.xml
@@ -1,16 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="VFEI2_Gigamite"]</xpath>
-		<value>
-			<li Class="CombatExtended.RacePropertiesExtensionCE">
-				<canParry>true</canParry>
-				<maxParry>3</maxParry>
-			</li>
-		</value>
-	</Operation>
-
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="VFEI2_Gigamite"]/statBases/MoveSpeed</xpath>
 		<value>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Macrofly.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Macrofly.xml
@@ -1,16 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="VFEI2_Macrofly"]</xpath>
-		<value>
-			<li Class="CombatExtended.RacePropertiesExtensionCE">
-				<canParry>true</canParry>
-				<maxParry>3</maxParry>
-			</li>
-		</value>
-	</Operation>
-
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="VFEI2_Macrofly"]/statBases/MoveSpeed</xpath>
 		<value>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_RoyalSpelopede.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_RoyalSpelopede.xml
@@ -6,7 +6,7 @@
 		<value>
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<canParry>true</canParry>
-				<maxParry>3</maxParry>
+				<maxParry>1</maxParry>
 			</li>
 		</value>
 	</Operation>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Silverfish.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Silverfish.xml
@@ -6,7 +6,7 @@
 		<value>
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<canParry>true</canParry>
-				<maxParry>4</maxParry>
+				<maxParry>2</maxParry>
 			</li>
 		</value>
 	</Operation>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Titantick.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Titantick.xml
@@ -1,16 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="VFEI2_Titantick"]</xpath>
-		<value>
-			<li Class="CombatExtended.RacePropertiesExtensionCE">
-				<canParry>true</canParry>
-				<maxParry>4</maxParry>
-			</li>
-		</value>
-	</Operation>
-
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="VFEI2_Titantick"]/statBases/MoveSpeed</xpath>
 		<value>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Venomite.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Venomite.xml
@@ -6,7 +6,7 @@
 		<value>
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<canParry>true</canParry>
-				<maxParry>3</maxParry>
+				<maxParry>1</maxParry>
 			</li>
 		</value>
 	</Operation>

--- a/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
+++ b/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
@@ -143,7 +143,7 @@
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Humanoid</bodyShape>
 				<canParry>true</canParry>
-				<maxParry>6</maxParry>
+				<maxParry>5</maxParry>
 			</li>
 		</value>
 	</Operation>

--- a/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid_PlayerControlled.xml
+++ b/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid_PlayerControlled.xml
@@ -106,7 +106,7 @@
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Humanoid</bodyShape>
 							<canParry>true</canParry>
-							<maxParry>6</maxParry>
+							<maxParry>5</maxParry>
 						</li>
 					</value>
 				</li>

--- a/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Machines.xml
+++ b/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Machines.xml
@@ -222,7 +222,7 @@
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Humanoid</bodyShape>
 				<canParry>true</canParry>
-				<maxParry>5</maxParry>
+				<maxParry>4</maxParry>
 			</li>
 		</value>
 	</Operation>

--- a/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -158,7 +158,7 @@
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Humanoid</bodyShape>
 				<canParry>true</canParry>
-				<maxParry>5</maxParry>
+				<maxParry>4</maxParry>
 			</li>
 		</value>
 	</Operation>

--- a/ModPatches/Vanilla Ideology Expanded - Dryads/Patches/Vanilla Ideology Expanded - Dryads/ThingDefs_Races/Races_Animal_AwakenedDryads.xml
+++ b/ModPatches/Vanilla Ideology Expanded - Dryads/Patches/Vanilla Ideology Expanded - Dryads/ThingDefs_Races/Races_Animal_AwakenedDryads.xml
@@ -119,7 +119,7 @@
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Quadruped</bodyShape>
 				<canParry>true</canParry>
-				<maxParry>5</maxParry>
+				<maxParry>3</maxParry>
 			</li>
 		</value>
 	</Operation>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Arid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Arid.xml
@@ -341,6 +341,8 @@
 		<value>
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Quadruped</bodyShape>
+				<canParry>true</canParry>
+				<maxParry>1</maxParry>
 			</li>
 		</value>
 	</Operation>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Giant.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Giant.xml
@@ -69,6 +69,8 @@
 		<value>
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Quadruped</bodyShape>
+				<canParry>true</canParry>
+				<maxParry>1</maxParry>
 			</li>
 		</value>
 	</Operation>
@@ -304,6 +306,8 @@
 		<value>
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Birdlike</bodyShape>
+				<canParry>true</canParry>
+				<maxParry>3</maxParry>
 			</li>
 		</value>
 	</Operation>

--- a/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
@@ -226,7 +226,7 @@
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Humanoid</bodyShape>
 				<canParry>true</canParry>
-				<maxParry>5</maxParry>
+				<maxParry>4</maxParry>
 			</li>
 		</value>
 	</Operation>


### PR DESCRIPTION
## Additions
- Give various creatures the ability to parry.

## References
- Continues #3741
- Based on #3765, but pared down.

## Reasoning
Parrying requires both a reasonable degree of intelligence and self-preservation, as well as a suitable body part (such as a limb, horn, or tusk) that is suitably maneuverable for the task. Baseline humans get 1 parry for every 4 levels of Melee skill, so use that as the standard.

We can presume that most non-humanoid creatures intelligent or adept enough at melee to parry in the first place are *at least* as capable in melee as a Level 4 Melee colonist, with many likely falling somewhere between levels 4 - 12, depending upon how you rate their "effectiveness". As a result, while creatures that are slower or have less suitable parts with which to parry might only have one, most creatures have 2 - 4 parries--with faster or powerful and multi-limbed typically having more. Only especially dangerous and capable melee creatures can match the speed and skill of a Level 20 fighter. 

## Alternatives
- Expand parrying to a wider or narrower variety of animals.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
