### PR TITLE
VFE Security EMP Cannon SFX

### DIFF
--- a/ModPatches/Vanilla Furniture Expanded - Security/Defs/Vanilla Furniture Expanded - Security/Ammo_Security.xml
+++ b/ModPatches/Vanilla Furniture Expanded - Security/Defs/Vanilla Furniture Expanded - Security/Ammo_Security.xml
@@ -15,7 +15,7 @@
 			<damageDef>EMP</damageDef>
 			<damageAmountBase>42</damageAmountBase>
 			<explosionRadius>4</explosionRadius>
-			<soundExplode>MortarBomb_Explode</soundExplode>
+			<soundExplode>Explosion_EMP</soundExplode>
 			<speed>129</speed>
 			<flyOverhead>false</flyOverhead>
 			<dropsCasings>false</dropsCasings>


### PR DESCRIPTION
## Changes

Changes the EMP Cannon from VFE: Security to use the EMP Explosion SFX, rather than the generic HE/Mortar Explosion.

## Reasoning

It's an EMP AOE weapon, it should sound like other EMP AOE weapons.

## Alternatives

EMP cannon sounds like a regular HE cannon/mortar, which could cause confusion.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
