### PR TITLE
1.6 defName changes

### DIFF
--- a/Defs/Ammo/Recipes_HandGrenades.xml
+++ b/Defs/Ammo/Recipes_HandGrenades.xml
@@ -42,7 +42,7 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Weapon_GrenadeConcussion>10</Weapon_GrenadeConcussion>
+			<CE_Weapon_GrenadeConcussion>10</CE_Weapon_GrenadeConcussion>
 		</products>
 	</RecipeDef>
 
@@ -208,7 +208,7 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Weapon_GrenadeFlashbang>10</Weapon_GrenadeFlashbang>
+			<CE_Weapon_GrenadeFlashbang>10</CE_Weapon_GrenadeFlashbang>
 		</products>
 	</RecipeDef>
 
@@ -257,7 +257,7 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Weapon_GrenadeStickBomb>10</Weapon_GrenadeStickBomb>
+			<CE_Weapon_GrenadeStickBomb>10</CE_Weapon_GrenadeStickBomb>
 		</products>
 	</RecipeDef>
 
@@ -302,7 +302,7 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Weapon_GrenadeSmoke>10</Weapon_GrenadeSmoke>
+			<CE_Weapon_GrenadeSmoke>10</CE_Weapon_GrenadeSmoke>
 		</products>
 	</RecipeDef>
 
@@ -349,7 +349,7 @@
 			</categories>
 		</fixedIngredientFilter>
 		<products>
-			<Weapon_GrenadeFirefoam>10</Weapon_GrenadeFirefoam>
+			<CE_Weapon_GrenadeFirefoam>10</CE_Weapon_GrenadeFirefoam>
 		</products>
 	</RecipeDef>
 

--- a/Defs/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Grenades.xml
@@ -136,13 +136,13 @@
 				<targetParams>
 					<canTargetLocations>true</canTargetLocations>
 				</targetParams>
-				<defaultProjectile>Proj_GrenadeConcussion</defaultProjectile>
+				<defaultProjectile>CE_Proj_GrenadeConcussion</defaultProjectile>
 				<onlyManualCast>true</onlyManualCast>
 				<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
 				<ai_AvoidFriendlyFireRadius>6</ai_AvoidFriendlyFireRadius>
 			</li>
 		</verbs>
-		<detonateProjectile>Proj_GrenadeConcussion</detonateProjectile>
+		<detonateProjectile>CE_Proj_GrenadeConcussion</detonateProjectile>
 	</ThingDef>
 
 	<!-- ==================== Flashbang grenade ========================== -->
@@ -217,7 +217,7 @@
 				<targetParams>
 					<canTargetLocations>true</canTargetLocations>
 				</targetParams>
-				<defaultProjectile>Proj_GrenadeFlashbang</defaultProjectile>
+				<defaultProjectile>CE_Proj_GrenadeFlashbang</defaultProjectile>
 				<onlyManualCast>true</onlyManualCast>
 				<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
 				<ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
@@ -296,13 +296,13 @@
 				<targetParams>
 					<canTargetLocations>true</canTargetLocations>
 				</targetParams>
-				<defaultProjectile>Proj_GrenadeStickBomb</defaultProjectile>
+				<defaultProjectile>CE_Proj_GrenadeStickBomb</defaultProjectile>
 				<onlyManualCast>true</onlyManualCast>
 				<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
 				<ai_AvoidFriendlyFireRadius>6</ai_AvoidFriendlyFireRadius>
 			</li>
 		</verbs>
-		<detonateProjectile>Proj_GrenadeStickBomb</detonateProjectile>
+		<detonateProjectile>CE_Proj_GrenadeStickBomb</detonateProjectile>
 	</ThingDef>
 
 	<!-- ==================== Smoke grenade ========================== -->
@@ -367,7 +367,7 @@
 				<targetParams>
 					<canTargetLocations>true</canTargetLocations>
 				</targetParams>
-				<defaultProjectile>Proj_GrenadeSmoke</defaultProjectile>
+				<defaultProjectile>CE_Proj_GrenadeSmoke</defaultProjectile>
 				<onlyManualCast>true</onlyManualCast>
 				<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
 			</li>
@@ -408,7 +408,7 @@
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseGrenadeEquipment">
-		<defName>Weapon_GrenadeFirefoam</defName>
+		<defName>CE_Weapon_GrenadeFirefoam</defName>
 		<equipmentType>Primary</equipmentType>
 		<label>firefoam grenade</label>
 		<description>Special firefighting grenade. Releases a cloud of firefoam upon impact.</description>
@@ -444,7 +444,7 @@
 				<targetParams>
 					<canTargetLocations>true</canTargetLocations>
 				</targetParams>
-				<defaultProjectile>Proj_GrenadeFirefoam</defaultProjectile>
+				<defaultProjectile>CE_Proj_GrenadeFirefoam</defaultProjectile>
 				<onlyManualCast>true</onlyManualCast>
 				<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
 			</li>

--- a/Defs/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Grenades.xml
@@ -65,7 +65,7 @@
 	<!-- ==================== Concussion grenade ========================== -->
 
 	<ThingDef ParentName="BaseGrenadeProjectile">
-		<defName>Proj_GrenadeConcussion</defName>
+		<defName>CE_Proj_GrenadeConcussion</defName>
 		<label>concussion grenade</label>
 		<graphicData>
 			<texPath>Things/Projectile/Grenades/Concussion</texPath>
@@ -96,7 +96,7 @@
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseGrenadeEquipment">
-		<defName>Weapon_GrenadeConcussion</defName>
+		<defName>CE_Weapon_GrenadeConcussion</defName>
 		<equipmentType>Primary</equipmentType>
 		<label>concussion grenade</label>
 		<description>A cylindrical concussion grenade designed to produce casualties during close combat while minimizing danger to friendly personnel exposed in the open owing to minimal fragmentation.</description>
@@ -148,7 +148,7 @@
 	<!-- ==================== Flashbang grenade ========================== -->
 
 	<ThingDef ParentName="BaseGrenadeProjectile">
-		<defName>Proj_GrenadeFlashbang</defName>
+		<defName>CE_Proj_GrenadeFlashbang</defName>
 		<label>flashbang grenade</label>
 		<graphicData>
 			<texPath>Things/Projectile/Grenades/Flashbang</texPath>
@@ -180,7 +180,7 @@
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseGrenadeEquipment">
-		<defName>Weapon_GrenadeFlashbang</defName>
+		<defName>CE_Weapon_GrenadeFlashbang</defName>
 		<equipmentType>Primary</equipmentType>
 		<label>flashbang grenade</label>
 		<description>Pyrotechnic charge designed to produce a blinding flash of light and loud noise, temporarily blinding and disorienting anyone nearby.</description>
@@ -236,7 +236,7 @@
 	<!-- ==================== Stick bomb ========================== -->
 
 	<ThingDef ParentName="BaseGrenadeProjectile">
-		<defName>Proj_GrenadeStickBomb</defName>
+		<defName>CE_Proj_GrenadeStickBomb</defName>
 		<label>stick bomb</label>
 		<graphicData>
 			<texPath>Things/Projectile/Grenades/StickBomb</texPath>
@@ -259,7 +259,7 @@
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseGrenadeEquipment">
-		<defName>Weapon_GrenadeStickBomb</defName>
+		<defName>CE_Weapon_GrenadeStickBomb</defName>
 		<equipmentType>Primary</equipmentType>
 		<label>stick bomb</label>
 		<description>Primitive fuse-lit explosive. A favorite of tribals who use these to fight technologically advanced enemies with heavy armor.</description>
@@ -308,7 +308,7 @@
 	<!-- ==================== Smoke grenade ========================== -->
 
 	<ThingDef ParentName="BaseGrenadeProjectile">
-		<defName>Proj_GrenadeSmoke</defName>
+		<defName>CE_Proj_GrenadeSmoke</defName>
 		<label>smoke grenade</label>
 		<graphicData>
 			<texPath>Things/Projectile/Grenades/Smoke</texPath>
@@ -331,7 +331,7 @@
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseGrenadeEquipment">
-		<defName>Weapon_GrenadeSmoke</defName>
+		<defName>CE_Weapon_GrenadeSmoke</defName>
 		<equipmentType>Primary</equipmentType>
 		<label>smoke grenade</label>
 		<description>Releases a large cloud of defensive smoke, providing concealment against gunfire.</description>
@@ -385,7 +385,7 @@
 	<!-- ==================== Firefoam grenade ========================== -->
 
 	<ThingDef ParentName="BaseGrenadeProjectile">
-		<defName>Proj_GrenadeFirefoam</defName>
+		<defName>CE_Proj_GrenadeFirefoam</defName>
 		<label>firefoam grenade</label>
 		<graphicData>
 			<texPath>Things/Projectile/Grenades/Firefoam</texPath>

--- a/Languages/ChineseSimplified/DefInjected/ThingDef/Weapons_Grenades.xml
+++ b/Languages/ChineseSimplified/DefInjected/ThingDef/Weapons_Grenades.xml
@@ -2,53 +2,53 @@
 <LanguageData>
 	
 	<!-- EN: concussion grenade -->
-	<Proj_GrenadeConcussion.label>震撼手榴弹</Proj_GrenadeConcussion.label>
+	<CE_Proj_GrenadeConcussion.label>震撼手榴弹</CE_Proj_GrenadeConcussion.label>
 	
 	<!-- EN: firefoam grenade -->
-	<Proj_GrenadeFirefoam.label>泡沫手榴弹</Proj_GrenadeFirefoam.label>
+	<CE_Proj_GrenadeFirefoam.label>泡沫手榴弹</CE_Proj_GrenadeFirefoam.label>
 	
 	<!-- EN: flashbang grenade -->
-	<Proj_GrenadeFlashbang.label>闪光手榴弹</Proj_GrenadeFlashbang.label>
+	<CE_Proj_GrenadeFlashbang.label>闪光手榴弹</CE_Proj_GrenadeFlashbang.label>
 	
 	<!-- EN: smoke grenade -->
-	<Proj_GrenadeSmoke.label>烟雾手榴弹</Proj_GrenadeSmoke.label>
+	<CE_Proj_GrenadeSmoke.label>烟雾手榴弹</CE_Proj_GrenadeSmoke.label>
 	
 	<!-- EN: stick bomb -->
-	<Proj_GrenadeStickBomb.label>棒状炸弹</Proj_GrenadeStickBomb.label>
+	<CE_Proj_GrenadeStickBomb.label>棒状炸弹</CE_Proj_GrenadeStickBomb.label>
 	
 	<!-- EN: concussion grenade -->
-	<Weapon_GrenadeConcussion.label>震撼手榴弹</Weapon_GrenadeConcussion.label>
+	<CE_Weapon_GrenadeConcussion.label>震撼手榴弹</CE_Weapon_GrenadeConcussion.label>
 	<!-- EN: A cylindrical concussion grenade designed to produce casualties during close combat while minimizing danger to friendly personnel exposed in the open owing to minimal fragmentation. -->
-	<Weapon_GrenadeConcussion.description>爆炸时，伴随著巨大的声响或者闪光，使爆炸范围内的敌人暂时失明和失去方向感，从而短暂丧失反抗能力。</Weapon_GrenadeConcussion.description>
+	<CE_Weapon_GrenadeConcussion.description>爆炸时，伴随著巨大的声响或者闪光，使爆炸范围内的敌人暂时失明和失去方向感，从而短暂丧失反抗能力。</CE_Weapon_GrenadeConcussion.description>
 	<!-- EN: Body -->
-	<Weapon_GrenadeConcussion.tools.Body.label>弹体</Weapon_GrenadeConcussion.tools.Body.label>
+	<CE_Weapon_GrenadeConcussion.tools.Body.label>弹体</CE_Weapon_GrenadeConcussion.tools.Body.label>
 	
 	<!-- EN: firefoam grenade -->
-	<Weapon_GrenadeFirefoam.label>泡沫手榴弹</Weapon_GrenadeFirefoam.label>
+	<CE_Weapon_GrenadeFirefoam.label>泡沫手榴弹</CE_Weapon_GrenadeFirefoam.label>
 	<!-- EN: Special firefighting grenade. Releases a cloud of firefoam upon impact. -->
-	<Weapon_GrenadeFirefoam.description>特种消防手榴弹，撞击时释放出一团灭火用泡沫。</Weapon_GrenadeFirefoam.description>
+	<CE_Weapon_GrenadeFirefoam.description>特种消防手榴弹，撞击时释放出一团灭火用泡沫。</CE_Weapon_GrenadeFirefoam.description>
 	<!-- EN: Body -->
-	<Weapon_GrenadeFirefoam.tools.Body.label>弹体</Weapon_GrenadeFirefoam.tools.Body.label>
+	<CE_Weapon_GrenadeFirefoam.tools.Body.label>弹体</CE_Weapon_GrenadeFirefoam.tools.Body.label>
 	
 	<!-- EN: flashbang grenade -->
-	<Weapon_GrenadeFlashbang.label>闪光手榴弹</Weapon_GrenadeFlashbang.label>
+	<CE_Weapon_GrenadeFlashbang.label>闪光手榴弹</CE_Weapon_GrenadeFlashbang.label>
 	<!-- EN: Pyrotechnic charge designed to produce a blinding flash of light and loud noise, temporarily blinding and disorienting anyone nearby. -->
-	<Weapon_GrenadeFlashbang.description>设计用于产生令人炫目致晕眩的强光，可以致使被攻击目标短暂失明。</Weapon_GrenadeFlashbang.description>
+	<CE_Weapon_GrenadeFlashbang.description>设计用于产生令人炫目致晕眩的强光，可以致使被攻击目标短暂失明。</CE_Weapon_GrenadeFlashbang.description>
 	<!-- EN: Body -->
-	<Weapon_GrenadeFlashbang.tools.Body.label>弹体</Weapon_GrenadeFlashbang.tools.Body.label>
+	<CE_Weapon_GrenadeFlashbang.tools.Body.label>弹体</CE_Weapon_GrenadeFlashbang.tools.Body.label>
 	
 	<!-- EN: smoke grenade -->
-	<Weapon_GrenadeSmoke.label>烟雾手榴弹</Weapon_GrenadeSmoke.label>
+	<CE_Weapon_GrenadeSmoke.label>烟雾手榴弹</CE_Weapon_GrenadeSmoke.label>
 	<!-- EN: Releases a large cloud of defensive smoke, providing concealment against gunfire. -->
-	<Weapon_GrenadeSmoke.description>释放大量烟雾，提供隐蔽性以防止被击中。</Weapon_GrenadeSmoke.description>
+	<CE_Weapon_GrenadeSmoke.description>释放大量烟雾，提供隐蔽性以防止被击中。</CE_Weapon_GrenadeSmoke.description>
 	<!-- EN: Body -->
-	<Weapon_GrenadeSmoke.tools.Body.label>弹体</Weapon_GrenadeSmoke.tools.Body.label>
+	<CE_Weapon_GrenadeSmoke.tools.Body.label>弹体</CE_Weapon_GrenadeSmoke.tools.Body.label>
 	
 	<!-- EN: stick bomb -->
-	<Weapon_GrenadeStickBomb.label>棒状炸弹</Weapon_GrenadeStickBomb.label>
+	<CE_Weapon_GrenadeStickBomb.label>棒状炸弹</CE_Weapon_GrenadeStickBomb.label>
 	<!-- EN: Primitive fuse-lit explosive. A favorite of tribals who use these to fight technologically advanced enemies with heavy armor. -->
-	<Weapon_GrenadeStickBomb.description>一种原始的用导火索点燃的炸药，部落最爱使用这种炸弹重击身穿先进装甲的敌人。</Weapon_GrenadeStickBomb.description>
+	<CE_Weapon_GrenadeStickBomb.description>一种原始的用导火索点燃的炸药，部落最爱使用这种炸弹重击身穿先进装甲的敌人。</CE_Weapon_GrenadeStickBomb.description>
 	<!-- EN: Body -->
-	<Weapon_GrenadeStickBomb.tools.Body.label>弹体</Weapon_GrenadeStickBomb.tools.Body.label>
+	<CE_Weapon_GrenadeStickBomb.tools.Body.label>弹体</CE_Weapon_GrenadeStickBomb.tools.Body.label>
 	
 </LanguageData>

--- a/Languages/ChineseTraditional/DefInjected/ThingDef/Weapons_Grenades.xml
+++ b/Languages/ChineseTraditional/DefInjected/ThingDef/Weapons_Grenades.xml
@@ -3,34 +3,34 @@
 
 	<!-- Flashbang grenade -->
 
-	<Proj_GrenadeFlashbang.label>閃光手榴彈</Proj_GrenadeFlashbang.label>
+	<CE_Proj_GrenadeFlashbang.label>閃光手榴彈</CE_Proj_GrenadeFlashbang.label>
 
-	<Weapon_GrenadeFlashbang.label>閃光手榴彈</Weapon_GrenadeFlashbang.label>
-	<Weapon_GrenadeFlashbang.description>爆炸時，伴隨著巨大的聲響或者閃光，使到爆炸範圍內的敵人即時短暫盲聾，從而喪失反抗能力。</Weapon_GrenadeFlashbang.description>
-	<Weapon_GrenadeFlashbang.verbs.0.label>throw flashbang grenade</Weapon_GrenadeFlashbang.verbs.0.label>
+	<CE_Weapon_GrenadeFlashbang.label>閃光手榴彈</CE_Weapon_GrenadeFlashbang.label>
+	<CE_Weapon_GrenadeFlashbang.description>爆炸時，伴隨著巨大的聲響或者閃光，使到爆炸範圍內的敵人即時短暫盲聾，從而喪失反抗能力。</CE_Weapon_GrenadeFlashbang.description>
+	<CE_Weapon_GrenadeFlashbang.verbs.0.label>throw flashbang grenade</CE_Weapon_GrenadeFlashbang.verbs.0.label>
 
 	<!-- Stick bomb -->
 
-	<Proj_GrenadeStickBomb.label>棒狀炸彈</Proj_GrenadeStickBomb.label>
+	<CE_Proj_GrenadeStickBomb.label>棒狀炸彈</CE_Proj_GrenadeStickBomb.label>
 
-	<Weapon_GrenadeStickBomb.label>棒狀炸彈</Weapon_GrenadeStickBomb.label>
-	<Weapon_GrenadeStickBomb.description>一種原始的用導火索點燃的炸藥。一個部落的最愛用使用這些方式打擊技術先進的重裝甲敵人。</Weapon_GrenadeStickBomb.description>
-	<Weapon_GrenadeStickBomb.verbs.0.label>扔棒狀炸彈</Weapon_GrenadeStickBomb.verbs.0.label>
+	<CE_Weapon_GrenadeStickBomb.label>棒狀炸彈</CE_Weapon_GrenadeStickBomb.label>
+	<CE_Weapon_GrenadeStickBomb.description>一種原始的用導火索點燃的炸藥。一個部落的最愛用使用這些方式打擊技術先進的重裝甲敵人。</CE_Weapon_GrenadeStickBomb.description>
+	<CE_Weapon_GrenadeStickBomb.verbs.0.label>扔棒狀炸彈</CE_Weapon_GrenadeStickBomb.verbs.0.label>
 
 	<!-- Smoke grenade -->
 
-	<Proj_GrenadeSmoke.label>煙霧彈</Proj_GrenadeSmoke.label>
+	<CE_Proj_GrenadeSmoke.label>煙霧彈</CE_Proj_GrenadeSmoke.label>
 
-	<Weapon_GrenadeSmoke.label>煙霧彈</Weapon_GrenadeSmoke.label>
-	<Weapon_GrenadeSmoke.description>釋放大量煙霧，提供隱蔽性以防止被擊中。</Weapon_GrenadeSmoke.description>
-	<Weapon_GrenadeSmoke.verbs.0.label>扔煙霧彈</Weapon_GrenadeSmoke.verbs.0.label>
+	<CE_Weapon_GrenadeSmoke.label>煙霧彈</CE_Weapon_GrenadeSmoke.label>
+	<CE_Weapon_GrenadeSmoke.description>釋放大量煙霧，提供隱蔽性以防止被擊中。</CE_Weapon_GrenadeSmoke.description>
+	<CE_Weapon_GrenadeSmoke.verbs.0.label>扔煙霧彈</CE_Weapon_GrenadeSmoke.verbs.0.label>
 
 	<!-- Firefoam grenade -->
 
-	<Proj_GrenadeFirefoam.label>泡沫手榴彈</Proj_GrenadeFirefoam.label>
+	<CE_Proj_GrenadeFirefoam.label>泡沫手榴彈</CE_Proj_GrenadeFirefoam.label>
 
-	<Weapon_GrenadeFirefoam.label>泡沫手榴彈</Weapon_GrenadeFirefoam.label>
-	<Weapon_GrenadeFirefoam.description>特種消防手榴彈。撞擊時釋放出一團滅火用泡沫。</Weapon_GrenadeFirefoam.description>
-	<Weapon_GrenadeFirefoam.verbs.0.label>扔泡沫手榴彈</Weapon_GrenadeFirefoam.verbs.0.label>
+	<CE_Weapon_GrenadeFirefoam.label>泡沫手榴彈</CE_Weapon_GrenadeFirefoam.label>
+	<CE_Weapon_GrenadeFirefoam.description>特種消防手榴彈。撞擊時釋放出一團滅火用泡沫。</CE_Weapon_GrenadeFirefoam.description>
+	<CE_Weapon_GrenadeFirefoam.verbs.0.label>扔泡沫手榴彈</CE_Weapon_GrenadeFirefoam.verbs.0.label>
 
 </LanguageData>

--- a/Languages/Korean/defInjected/ThingDefs/Weapons_Grenades.xml
+++ b/Languages/Korean/defInjected/ThingDefs/Weapons_Grenades.xml
@@ -1,28 +1,28 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <LanguageData>
 
-	<Proj_GrenadeFlashbang.label>섬광탄</Proj_GrenadeFlashbang.label>
+	<CE_Proj_GrenadeFlashbang.label>섬광탄</CE_Proj_GrenadeFlashbang.label>
 
-	<Weapon_GrenadeFlashbang.label>섬광탄</Weapon_GrenadeFlashbang.label>
-	<Weapon_GrenadeFlashbang.description>엄청난 빛과 소음을 발생시켜 일시적으로 눈을 멀게하고 방향감각을 상실하게 만드는 수류탄.</Weapon_GrenadeFlashbang.description>
-	<Weapon_GrenadeFlashbang.verbs.0.label>섬광탄 투척</Weapon_GrenadeFlashbang.verbs.0.label>
+	<CE_Weapon_GrenadeFlashbang.label>섬광탄</CE_Weapon_GrenadeFlashbang.label>
+	<CE_Weapon_GrenadeFlashbang.description>엄청난 빛과 소음을 발생시켜 일시적으로 눈을 멀게하고 방향감각을 상실하게 만드는 수류탄.</CE_Weapon_GrenadeFlashbang.description>
+	<CE_Weapon_GrenadeFlashbang.verbs.0.label>섬광탄 투척</CE_Weapon_GrenadeFlashbang.verbs.0.label>
 
-	<Proj_GrenadeStickBomb.label>점착 폭탄</Proj_GrenadeStickBomb.label>
+	<CE_Proj_GrenadeStickBomb.label>점착 폭탄</CE_Proj_GrenadeStickBomb.label>
 
-	<Weapon_GrenadeStickBomb.label>점착 폭탄</Weapon_GrenadeStickBomb.label>
-	<Weapon_GrenadeStickBomb.description>원시적인 퓨즈 점화식 폭발물. 두터운 장갑으로 무장한, 기술적으로 진보된 적과 싸우기위해 부족민들이 즐겨 사용합니다.</Weapon_GrenadeStickBomb.description>
-	<Weapon_GrenadeStickBomb.verbs.0.label>점착 폭탄 투척</Weapon_GrenadeStickBomb.verbs.0.label>
+	<CE_Weapon_GrenadeStickBomb.label>점착 폭탄</CE_Weapon_GrenadeStickBomb.label>
+	<CE_Weapon_GrenadeStickBomb.description>원시적인 퓨즈 점화식 폭발물. 두터운 장갑으로 무장한, 기술적으로 진보된 적과 싸우기위해 부족민들이 즐겨 사용합니다.</CE_Weapon_GrenadeStickBomb.description>
+	<CE_Weapon_GrenadeStickBomb.verbs.0.label>점착 폭탄 투척</CE_Weapon_GrenadeStickBomb.verbs.0.label>
 
-	<Proj_GrenadeSmoke.label>연막탄</Proj_GrenadeSmoke.label>
+	<CE_Proj_GrenadeSmoke.label>연막탄</CE_Proj_GrenadeSmoke.label>
 
-	<Weapon_GrenadeSmoke.label>연막탄</Weapon_GrenadeSmoke.label>
-	<Weapon_GrenadeSmoke.description>화기에 대한 은폐를 제공하는 짙은 연기를 내보냅니다.</Weapon_GrenadeSmoke.description>
-	<Weapon_GrenadeSmoke.verbs.0.label>연막탄 투척</Weapon_GrenadeSmoke.verbs.0.label>
+	<CE_Weapon_GrenadeSmoke.label>연막탄</CE_Weapon_GrenadeSmoke.label>
+	<CE_Weapon_GrenadeSmoke.description>화기에 대한 은폐를 제공하는 짙은 연기를 내보냅니다.</CE_Weapon_GrenadeSmoke.description>
+	<CE_Weapon_GrenadeSmoke.verbs.0.label>연막탄 투척</CE_Weapon_GrenadeSmoke.verbs.0.label>
 
-	<Proj_GrenadeFirefoam.label>화재진압 수류탄</Proj_GrenadeFirefoam.label>
+	<CE_Proj_GrenadeFirefoam.label>화재진압 수류탄</CE_Proj_GrenadeFirefoam.label>
 
-	<Weapon_GrenadeFirefoam.label>화재진압 수류탄</Weapon_GrenadeFirefoam.label>
-	<Weapon_GrenadeFirefoam.description>화재진압용 특수 수류탄. 피격시 소화가스를 방출합니다.</Weapon_GrenadeFirefoam.description>
-	<Weapon_GrenadeFirefoam.verbs.0.label>화재진압 수류탄 투척</Weapon_GrenadeFirefoam.verbs.0.label>
+	<CE_Weapon_GrenadeFirefoam.label>화재진압 수류탄</CE_Weapon_GrenadeFirefoam.label>
+	<CE_Weapon_GrenadeFirefoam.description>화재진압용 특수 수류탄. 피격시 소화가스를 방출합니다.</CE_Weapon_GrenadeFirefoam.description>
+	<CE_Weapon_GrenadeFirefoam.verbs.0.label>화재진압 수류탄 투척</CE_Weapon_GrenadeFirefoam.verbs.0.label>
 
 </LanguageData>

--- a/Languages/Russian/DefInjected/ThingDef/Weapons_Grenades.xml
+++ b/Languages/Russian/DefInjected/ThingDef/Weapons_Grenades.xml
@@ -3,34 +3,34 @@
 
 	<!-- Flashbang grenade -->
 
-	<Proj_GrenadeFlashbang.label>светошумовая граната</Proj_GrenadeFlashbang.label>
+	<CE_Proj_GrenadeFlashbang.label>светошумовая граната</CE_Proj_GrenadeFlashbang.label>
 
-	<Weapon_GrenadeFlashbang.label>светошумовая граната</Weapon_GrenadeFlashbang.label>
-	<Weapon_GrenadeFlashbang.description>Пиротехнический заряд, предназначен для создания ослепляющей вспышки света и громкого хлопка, временно ослепляющего и дезориентирующего любого поблизости.</Weapon_GrenadeFlashbang.description>
-	<Weapon_GrenadeFlashbang.verbs.0.label>метнуть светошумовую гранату</Weapon_GrenadeFlashbang.verbs.0.label>
+	<CE_Weapon_GrenadeFlashbang.label>светошумовая граната</CE_Weapon_GrenadeFlashbang.label>
+	<CE_Weapon_GrenadeFlashbang.description>Пиротехнический заряд, предназначен для создания ослепляющей вспышки света и громкого хлопка, временно ослепляющего и дезориентирующего любого поблизости.</CE_Weapon_GrenadeFlashbang.description>
+	<CE_Weapon_GrenadeFlashbang.verbs.0.label>метнуть светошумовую гранату</CE_Weapon_GrenadeFlashbang.verbs.0.label>
 
 	<!-- Stick bomb -->
 
-	<Proj_GrenadeStickBomb.label>палка с бомбой</Proj_GrenadeStickBomb.label>
+	<CE_Proj_GrenadeStickBomb.label>палка с бомбой</CE_Proj_GrenadeStickBomb.label>
 
-	<Weapon_GrenadeStickBomb.label>палка с бомбой</Weapon_GrenadeStickBomb.label>
-	<Weapon_GrenadeStickBomb.description>Примитивный взрывчатый элемент с запалом. Любимое оружие у племен, которые используют их для борьбы с технологически продвинутыми противниками в тяжелой броне.</Weapon_GrenadeStickBomb.description>
-	<Weapon_GrenadeStickBomb.verbs.0.label>метнуть палку с бомбой</Weapon_GrenadeStickBomb.verbs.0.label>
+	<CE_Weapon_GrenadeStickBomb.label>палка с бомбой</CE_Weapon_GrenadeStickBomb.label>
+	<CE_Weapon_GrenadeStickBomb.description>Примитивный взрывчатый элемент с запалом. Любимое оружие у племен, которые используют их для борьбы с технологически продвинутыми противниками в тяжелой броне.</CE_Weapon_GrenadeStickBomb.description>
+	<CE_Weapon_GrenadeStickBomb.verbs.0.label>метнуть палку с бомбой</CE_Weapon_GrenadeStickBomb.verbs.0.label>
 
 	<!-- Smoke grenade -->
 
-	<Proj_GrenadeSmoke.label>дымовая граната</Proj_GrenadeSmoke.label>
+	<CE_Proj_GrenadeSmoke.label>дымовая граната</CE_Proj_GrenadeSmoke.label>
 
-	<Weapon_GrenadeSmoke.label>дымовая граната</Weapon_GrenadeSmoke.label>
-	<Weapon_GrenadeSmoke.description>Выпускает большое облако дыма, обеспечивая укрытие от стрельбы.</Weapon_GrenadeSmoke.description>
-	<Weapon_GrenadeSmoke.verbs.0.label>метнуть дымовую гранату</Weapon_GrenadeSmoke.verbs.0.label>
+	<CE_Weapon_GrenadeSmoke.label>дымовая граната</CE_Weapon_GrenadeSmoke.label>
+	<CE_Weapon_GrenadeSmoke.description>Выпускает большое облако дыма, обеспечивая укрытие от стрельбы.</CE_Weapon_GrenadeSmoke.description>
+	<CE_Weapon_GrenadeSmoke.verbs.0.label>метнуть дымовую гранату</CE_Weapon_GrenadeSmoke.verbs.0.label>
 
 	<!-- Firefoam grenade -->
 
-	<Proj_GrenadeFirefoam.label>противопожарная граната</Proj_GrenadeFirefoam.label>
+	<CE_Proj_GrenadeFirefoam.label>противопожарная граната</CE_Proj_GrenadeFirefoam.label>
 
-	<Weapon_GrenadeFirefoam.label>противопожарная граната</Weapon_GrenadeFirefoam.label>
-	<Weapon_GrenadeFirefoam.description>Специальная противопожарная граната. Выпускает облако огнетушащей пены при срабатывании.</Weapon_GrenadeFirefoam.description>
-	<Weapon_GrenadeFirefoam.verbs.0.label>метнуть противопожарную гранату</Weapon_GrenadeFirefoam.verbs.0.label>
+	<CE_Weapon_GrenadeFirefoam.label>противопожарная граната</CE_Weapon_GrenadeFirefoam.label>
+	<CE_Weapon_GrenadeFirefoam.description>Специальная противопожарная граната. Выпускает облако огнетушащей пены при срабатывании.</CE_Weapon_GrenadeFirefoam.description>
+	<CE_Weapon_GrenadeFirefoam.verbs.0.label>метнуть противопожарную гранату</CE_Weapon_GrenadeFirefoam.verbs.0.label>
 
 </LanguageData>

--- a/Languages/Spanish/DefInjected/ThingDef/Weapons_Grenades.xml
+++ b/Languages/Spanish/DefInjected/ThingDef/Weapons_Grenades.xml
@@ -3,35 +3,35 @@
 
 	<!-- Flashbang grenade -->
 
-	<Proj_GrenadeFlashbang.label>flashbang grenade</Proj_GrenadeFlashbang.label>
+	<CE_Proj_GrenadeFlashbang.label>flashbang grenade</CE_Proj_GrenadeFlashbang.label>
 
-	<Weapon_GrenadeFlashbang.label>flashbang grenade</Weapon_GrenadeFlashbang.label>
-	<Weapon_GrenadeFlashbang.description>Pyrotechnic charge designed to produce a blinding flash of light and loud noise, temporarily blinding and disorienting anyone nearby.</Weapon_GrenadeFlashbang.description>
-	<Weapon_GrenadeFlashbang.verbs.0.label>throw flashbang grenade</Weapon_GrenadeFlashbang.verbs.0.label>
+	<CE_Weapon_GrenadeFlashbang.label>flashbang grenade</CE_Weapon_GrenadeFlashbang.label>
+	<CE_Weapon_GrenadeFlashbang.description>Pyrotechnic charge designed to produce a blinding flash of light and loud noise, temporarily blinding and disorienting anyone nearby.</CE_Weapon_GrenadeFlashbang.description>
+	<CE_Weapon_GrenadeFlashbang.verbs.0.label>throw flashbang grenade</CE_Weapon_GrenadeFlashbang.verbs.0.label>
 
 	<!-- Stick bomb -->
 
-	<Proj_GrenadeStickBomb.label>bomba de palo</Proj_GrenadeStickBomb.label>
+	<CE_Proj_GrenadeStickBomb.label>bomba de palo</CE_Proj_GrenadeStickBomb.label>
 
-	<Weapon_GrenadeStickBomb.label>bomba de palo</Weapon_GrenadeStickBomb.label>
-	<Weapon_GrenadeStickBomb.description>Explosivo primitivo con fusibles. Un favorito de los tribales que utilizan estos para luchar contra los enemigos tecnológicamente avanzados con armadura pesada.</Weapon_GrenadeStickBomb.description>
-	<Weapon_GrenadeStickBomb.verbs.0.label>lanzar bomba de palo</Weapon_GrenadeStickBomb.verbs.0.label>
+	<CE_Weapon_GrenadeStickBomb.label>bomba de palo</CE_Weapon_GrenadeStickBomb.label>
+	<CE_Weapon_GrenadeStickBomb.description>Explosivo primitivo con fusibles. Un favorito de los tribales que utilizan estos para luchar contra los enemigos tecnológicamente avanzados con armadura pesada.</CE_Weapon_GrenadeStickBomb.description>
+	<CE_Weapon_GrenadeStickBomb.verbs.0.label>lanzar bomba de palo</CE_Weapon_GrenadeStickBomb.verbs.0.label>
 
 	<!-- Smoke grenade -->
 
-	<Proj_GrenadeSmoke.label>granada de humo</Proj_GrenadeSmoke.label>
+	<CE_Proj_GrenadeSmoke.label>granada de humo</CE_Proj_GrenadeSmoke.label>
 
-	<Weapon_GrenadeSmoke.label>granada de humo</Weapon_GrenadeSmoke.label>
-	<Weapon_GrenadeSmoke.description>Libera una gran nube de humo defensivo, proporcionando ocultamiento contra disparos.</Weapon_GrenadeSmoke.description>
-	<Weapon_GrenadeSmoke.verbs.0.label>lanzar granada de humo</Weapon_GrenadeSmoke.verbs.0.label>
+	<CE_Weapon_GrenadeSmoke.label>granada de humo</CE_Weapon_GrenadeSmoke.label>
+	<CE_Weapon_GrenadeSmoke.description>Libera una gran nube de humo defensivo, proporcionando ocultamiento contra disparos.</CE_Weapon_GrenadeSmoke.description>
+	<CE_Weapon_GrenadeSmoke.verbs.0.label>lanzar granada de humo</CE_Weapon_GrenadeSmoke.verbs.0.label>
 
 	<!-- Firefoam grenade -->
 
-	<Proj_GrenadeFirefoam.label>granada de espuma</Proj_GrenadeFirefoam.label>
+	<CE_Proj_GrenadeFirefoam.label>granada de espuma</CE_Proj_GrenadeFirefoam.label>
 
-	<Weapon_GrenadeFirefoam.label>granada de espuma</Weapon_GrenadeFirefoam.label>
-	<Weapon_GrenadeFirefoam.description>Granada especial contra incendios. Libera una nube de espuma contra incendios, sobre el impacto.</Weapon_GrenadeFirefoam.description>
-	<Weapon_GrenadeFirefoam.verbs.0.label>lanzar granada de espuma</Weapon_GrenadeFirefoam.verbs.0.label>
+	<CE_Weapon_GrenadeFirefoam.label>granada de espuma</CE_Weapon_GrenadeFirefoam.label>
+	<CE_Weapon_GrenadeFirefoam.description>Granada especial contra incendios. Libera una nube de espuma contra incendios, sobre el impacto.</CE_Weapon_GrenadeFirefoam.description>
+	<CE_Weapon_GrenadeFirefoam.verbs.0.label>lanzar granada de espuma</CE_Weapon_GrenadeFirefoam.verbs.0.label>
 
 	<!--<Proj_GrenadeFlashbang.label>Granada deslumbrante</Proj_GrenadeFlashbang.label>-->
 	<!--<Weapon_GrenadeFlashbang.label>Granada deslumbrante</Weapon_GrenadeFlashbang.label>-->

--- a/Languages/SpanishLatin/DefInjected/ThingDef/Weapons_Grenades.xml
+++ b/Languages/SpanishLatin/DefInjected/ThingDef/Weapons_Grenades.xml
@@ -3,35 +3,35 @@
 
 	<!-- Flashbang grenade -->
 
-	<Proj_GrenadeFlashbang.label>flashbang grenade</Proj_GrenadeFlashbang.label>
+	<CE_Proj_GrenadeFlashbang.label>flashbang grenade</CE_Proj_GrenadeFlashbang.label>
 
-	<Weapon_GrenadeFlashbang.label>flashbang grenade</Weapon_GrenadeFlashbang.label>
-	<Weapon_GrenadeFlashbang.description>Pyrotechnic charge designed to produce a blinding flash of light and loud noise, temporarily blinding and disorienting anyone nearby.</Weapon_GrenadeFlashbang.description>
-	<Weapon_GrenadeFlashbang.verbs.0.label>throw flashbang grenade</Weapon_GrenadeFlashbang.verbs.0.label>
+	<CE_Weapon_GrenadeFlashbang.label>flashbang grenade</CE_Weapon_GrenadeFlashbang.label>
+	<CE_Weapon_GrenadeFlashbang.description>Pyrotechnic charge designed to produce a blinding flash of light and loud noise, temporarily blinding and disorienting anyone nearby.</CE_Weapon_GrenadeFlashbang.description>
+	<CE_Weapon_GrenadeFlashbang.verbs.0.label>throw flashbang grenade</CE_Weapon_GrenadeFlashbang.verbs.0.label>
 
 	<!-- Stick bomb -->
 
-	<Proj_GrenadeStickBomb.label>bomba de palo</Proj_GrenadeStickBomb.label>
+	<CE_Proj_GrenadeStickBomb.label>bomba de palo</CE_Proj_GrenadeStickBomb.label>
 
-	<Weapon_GrenadeStickBomb.label>bomba de palo</Weapon_GrenadeStickBomb.label>
-	<Weapon_GrenadeStickBomb.description>Explosivo primitivo con fusibles. Un favorito de los tribales que utilizan estos para luchar contra los enemigos tecnológicamente avanzados con armadura pesada.</Weapon_GrenadeStickBomb.description>
-	<Weapon_GrenadeStickBomb.verbs.0.label>lanzar bomba de palo</Weapon_GrenadeStickBomb.verbs.0.label>
+	<CE_Weapon_GrenadeStickBomb.label>bomba de palo</CE_Weapon_GrenadeStickBomb.label>
+	<CE_Weapon_GrenadeStickBomb.description>Explosivo primitivo con fusibles. Un favorito de los tribales que utilizan estos para luchar contra los enemigos tecnológicamente avanzados con armadura pesada.</CE_Weapon_GrenadeStickBomb.description>
+	<CE_Weapon_GrenadeStickBomb.verbs.0.label>lanzar bomba de palo</CE_Weapon_GrenadeStickBomb.verbs.0.label>
 
 	<!-- Smoke grenade -->
 
-	<Proj_GrenadeSmoke.label>granada de humo</Proj_GrenadeSmoke.label>
+	<CE_Proj_GrenadeSmoke.label>granada de humo</CE_Proj_GrenadeSmoke.label>
 
-	<Weapon_GrenadeSmoke.label>granada de humo</Weapon_GrenadeSmoke.label>
-	<Weapon_GrenadeSmoke.description>Libera una gran nube de humo defensivo, proporcionando ocultamiento contra disparos.</Weapon_GrenadeSmoke.description>
-	<Weapon_GrenadeSmoke.verbs.0.label>lanzar granada de humo</Weapon_GrenadeSmoke.verbs.0.label>
+	<CE_Weapon_GrenadeSmoke.label>granada de humo</CE_Weapon_GrenadeSmoke.label>
+	<CE_Weapon_GrenadeSmoke.description>Libera una gran nube de humo defensivo, proporcionando ocultamiento contra disparos.</CE_Weapon_GrenadeSmoke.description>
+	<CE_Weapon_GrenadeSmoke.verbs.0.label>lanzar granada de humo</CE_Weapon_GrenadeSmoke.verbs.0.label>
 
 	<!-- Firefoam grenade -->
 
-	<Proj_GrenadeFirefoam.label>granada de espuma</Proj_GrenadeFirefoam.label>
+	<CE_Proj_GrenadeFirefoam.label>granada de espuma</CE_Proj_GrenadeFirefoam.label>
 
-	<Weapon_GrenadeFirefoam.label>granada de espuma</Weapon_GrenadeFirefoam.label>
-	<Weapon_GrenadeFirefoam.description>Granada especial contra incendios. Libera una nube de espuma contra incendios, sobre el impacto.</Weapon_GrenadeFirefoam.description>
-	<Weapon_GrenadeFirefoam.verbs.0.label>lanzar granada de espuma</Weapon_GrenadeFirefoam.verbs.0.label>
+	<CE_Weapon_GrenadeFirefoam.label>granada de espuma</CE_Weapon_GrenadeFirefoam.label>
+	<CE_Weapon_GrenadeFirefoam.description>Granada especial contra incendios. Libera una nube de espuma contra incendios, sobre el impacto.</CE_Weapon_GrenadeFirefoam.description>
+	<CE_Weapon_GrenadeFirefoam.verbs.0.label>lanzar granada de espuma</CE_Weapon_GrenadeFirefoam.verbs.0.label>
 
 	<!--<Proj_GrenadeFlashbang.label>Granada deslumbrante</Proj_GrenadeFlashbang.label>-->
 	<!--<Weapon_GrenadeFlashbang.label>Granada deslumbrante</Weapon_GrenadeFlashbang.label>-->

--- a/ModPatches/Rimsenal Enhanced Vanilla/Patches/Rimsenal Enhanced Vanilla/Weapons_Ranged_CE.xml
+++ b/ModPatches/Rimsenal Enhanced Vanilla/Patches/Rimsenal Enhanced Vanilla/Weapons_Ranged_CE.xml
@@ -3,7 +3,7 @@
 
 	<!-- ========== Remove Duplicate Rimsenal Smoke Grenade =========== -->
 	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="Proj_GrenadeSmoke" and graphicData/texPath="Things/Projectile/SmokeGrenade"]</xpath>
+		<xpath>Defs/ThingDef[defName="Proj_GrenadeSmoke" and graphicData/texPath="Things/Projectile/SmokeGrenade"]</xpath> <!-- TODO: Figure out if this also needs to be renamed-->
 	</Operation>
 
 	<Operation Class="PatchOperationRemove">

--- a/Patches/Core/ThingDefs_Misc/Apparel_Belts.xml
+++ b/Patches/Core/ThingDefs_Misc/Apparel_Belts.xml
@@ -38,7 +38,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_SmokepopBelt"]/comps/li[@Class="CompProperties_ApparelReloadable"]/ammoDef</xpath>
 		<value>
-			<ammoDef>Weapon_GrenadeSmoke</ammoDef>
+			<ammoDef>CE_Weapon_GrenadeSmoke</ammoDef>
 		</value>
 	</Operation>
 
@@ -62,7 +62,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_FirefoampopPack"]/comps/li[@Class="CompProperties_ApparelReloadable"]/ammoDef</xpath>
 		<value>
-			<ammoDef>Weapon_GrenadeFirefoam</ammoDef>
+			<ammoDef>CE_Weapon_GrenadeFirefoam</ammoDef>
 		</value>
 	</Operation>
 

--- a/Source/CombatExtended/Harmony/Harmony_BackCompatibility_1_5.cs
+++ b/Source/CombatExtended/Harmony/Harmony_BackCompatibility_1_5.cs
@@ -1,0 +1,243 @@
+﻿using System;
+using HarmonyLib;
+using Verse;
+
+namespace CombatExtended.HarmonyCE;
+
+[HarmonyPatch(typeof(BackCompatibilityConverter_1_5), nameof(BackCompatibilityConverter_1_5.BackCompatibleDefName))]
+public class Harmony_BackCompatibility_1_5
+{
+    public static void Postfix(BackCompatibilityConverter_1_5 __instance, ref string __result, Type defType, string defName)
+    {
+        if (defType == typeof(ThingDef))
+        {
+            switch (defName)
+            {
+                // Core
+                case "Proj_GrenadeConcussion":
+                    __result = "CE_Proj_GrenadeConcussion";
+                    break;
+                case "Weapon_GrenadeConcussion":
+                    __result = "CE_Weapon_GrenadeConcussion";
+                    break;
+                case "Proj_GrenadeFlashbang":
+                    __result = "CE_Proj_GrenadeFlashbang";
+                    break;
+                case "Weapon_GrenadeFlashbang":
+                    __result = "CE_Weapon_GrenadeFlashbang";
+                    break;
+                case "Proj_GrenadeStickBomb":
+                    __result = "CE_Proj_GrenadeStickBomb";
+                    break;
+                case "Weapon_GrenadeStickBomb":
+                    __result = "CE_Weapon_GrenadeStickBomb";
+                    break;
+                case "Proj_GrenadeSmoke":
+                    __result = "CE_Proj_GrenadeSmoke";
+                    break;
+                case "Weapon_GrenadeSmoke":
+                    __result = "CE_Weapon_GrenadeSmoke";
+                    break;
+                case "Proj_GrenadeFirefoam":
+                    __result = "CE_Proj_GrenadeFirefoam";
+                    break;
+                case "Weapon_GrenadeFirefoam":
+                    __result = "CE_Weapon_GrenadeFirefoam";
+                    break;
+
+                // Armory
+                case "Gun_TwelvePounder":
+                    __result = "CE_Gun_TwelvePounder";
+                    break;
+                case "Turret_TwelvePounder":
+                    __result = "CE_Turret_TwelvePounder";
+                    break;
+                case "Blueprint_Turret_TwelvePounder":
+                    __result = "Blueprint_CE_Turret_TwelvePounder";
+                    break;
+                case "Frame_Turret_TwelvePounder":
+                    __result = "Frame_CE_Turret_TwelvePounder";
+                    break;
+                case "Blueprint_Install_Turret_TwelvePounder":
+                    __result = "Blueprint_Install_CE_Turret_TwelvePounder";
+                    break;
+
+                case "Gun_12PounderBombard":
+                    __result = "CE_Gun_12PounderBombard";
+                    break;
+                case "Turret_12PounderBombard":
+                    __result = "CE_Turret_12PounderBombard";
+                    break;
+                case "Blueprint_Turret_12PounderBombard":
+                    __result = "Blueprint_CE_Turret_12PounderBombard";
+                    break;
+                case "Frame_Turret_12PounderBombard":
+                    __result = "Frame_CE_Turret_12PounderBombard";
+                    break;
+                case "Blueprint_Install_Turret_12PounderBombard":
+                    __result = "Blueprint_Install_CE_Turret_12PounderBombard";
+                    break;
+
+                case "Gun_GatlingGun":
+                    __result = "CE_Gun_GatlingGun";
+                    break;
+                case "Turret_GatlingGun":
+                    __result = "CE_Turret_GatlingGun";
+                    break;
+                case "Blueprint_Turret_GatlingGun":
+                    __result = "Blueprint_CE_Turret_GatlingGun";
+                    break;
+                case "Frame_Turret_GatlingGun":
+                    __result = "Frame_CE_Turret_GatlingGun";
+                    break;
+                case "Blueprint_Install_Turret_GatlingGun":
+                    __result = "Blueprint_Install_CE_Turret_GatlingGun";
+                    break;
+
+                case "Gun_M1919Browning":
+                    __result = "CE_Gun_M1919Browning";
+                    break;
+                case "Turret_M1919Browning":
+                    __result = "CE_Turret_M1919Browning";
+                    break;
+                case "Blueprint_Turret_M1919Browning":
+                    __result = "Blueprint_CE_Turret_M1919Browning";
+                    break;
+                case "Frame_Turret_M1919Browning":
+                    __result = "Frame_CE_Turret_M1919Browning";
+                    break;
+                case "Blueprint_Install_Turret_M1919Browning":
+                    __result = "Blueprint_Install_CE_Turret_M1919Browning";
+                    break;
+
+                case "Gun_M2HB":
+                    __result = "CE_Gun_M2HB";
+                    break;
+                case "Turret_M2HB":
+                    __result = "CE_Turret_M2HB";
+                    break;
+                case "Blueprint_Turret_M2HB":
+                    __result = "Blueprint_CE_Turret_M2HB";
+                    break;
+                case "Frame_Turret_M2HB":
+                    __result = "Frame_CE_Turret_M2HB";
+                    break;
+                case "Blueprint_Install_Turret_M2HB":
+                    __result = "Blueprint_Install_CE_Turret_M2HB";
+                    break;
+
+                case "Gun_MkNineteenGL":
+                    __result = "CE_Gun_MkNineteenGL";
+                    break;
+                case "Turret_MkNineteenGL":
+                    __result = "CE_Turret_MkNineteenGL";
+                    break;
+                case "Blueprint_Turret_MkNineteenGL":
+                    __result = "Blueprint_CE_Turret_MkNineteenGL";
+                    break;
+                case "Frame_Turret_MkNineteenGL":
+                    __result = "Frame_CE_Turret_MkNineteenGL";
+                    break;
+                case "Blueprint_Install_Turret_MkNineteenGL":
+                    __result = "Blueprint_Install_CE_Turret_MkNineteenGL";
+                    break;
+
+                case "Gun_OrganGun":
+                    __result = "CE_Gun_OrganGun";
+                    break;
+                case "Turret_OrganGun":
+                    __result = "CE_Turret_OrganGun";
+                    break;
+                case "Blueprint_Turret_OrganGun":
+                    __result = "Blueprint_CE_Turret_OrganGun";
+                    break;
+                case "Frame_Turret_OrganGun":
+                    __result = "Frame_CE_Turret_OrganGun";
+                    break;
+                case "Blueprint_Install_Turret_OrganGun":
+                    __result = "Blueprint_Install_CE_Turret_OrganGun";
+                    break;
+
+                case "Gun_PKM":
+                    __result = "CE_EmplacementGun_PKM";
+                    break;
+                case "Turret_PKM":
+                    __result = "CE_Turret_PKM";
+                    break;
+                case "Blueprint_Turret_PKM":
+                    __result = "Blueprint_CE_Turret_PKM";
+                    break;
+                case "Frame_Turret_PKM":
+                    __result = "Frame_CE_Turret_PKM";
+                    break;
+                case "Blueprint_Install_Turret_PKM":
+                    __result = "Blueprint_Install_CE_Turret_PKM";
+                    break;
+
+                case "Gun_PortabletMortar":
+                    __result = "CE_Gun_PortabletMortar";
+                    break;
+                case "Turret_PortabletMortar":
+                    __result = "CE_Turret_PortabletMortar";
+                    break;
+                case "Blueprint_Turret_PortabletMortar":
+                    __result = "Blueprint_CE_Turret_PortabletMortar";
+                    break;
+                case "Frame_Turret_PortabletMortar":
+                    __result = "Frame_CE_Turret_PortabletMortar";
+                    break;
+                case "Blueprint_Install_Turret_PortabletMortar":
+                    __result = "Blueprint_Install_CE_Turret_PortabletMortar";
+                    break;
+
+                case "Gun_SPGNine":
+                    __result = "CE_Gun_SPGNine";
+                    break;
+                case "Turret_SPGNine":
+                    __result = "CE_Turret_SPGNine";
+                    break;
+                case "Blueprint_Turret_SPGNine":
+                    __result = "Blueprint_CE_Turret_SPGNine";
+                    break;
+                case "Frame_Turret_SPGNine":
+                    __result = "Frame_CE_Turret_SPGNine";
+                    break;
+                case "Blueprint_Install_Turret_SPGNine":
+                    __result = "Blueprint_Install_CE_Turret_SPGNine";
+                    break;
+
+                case "Gun_ShotgunTurret":
+                    __result = "CE_Gun_ShotgunTurret";
+                    break;
+                case "Turret_ShotgunTurret":
+                    __result = "CE_Turret_ShotgunTurret";
+                    break;
+                case "Blueprint_Turret_ShotgunTurret":
+                    __result = "Blueprint_CE_Turret_ShotgunTurret";
+                    break;
+                case "Frame_Turret_ShotgunTurret":
+                    __result = "Frame_CE_Turret_ShotgunTurret";
+                    break;
+                case "Blueprint_Install_Turret_ShotgunTurret":
+                    __result = "Blueprint_Install_CE_Turret_ShotgunTurret";
+                    break;
+
+                case "Gun_Vickers":
+                    __result = "CE_Gun_Vickers";
+                    break;
+                case "Turret_Vickers":
+                    __result = "CE_Turret_Vickers";
+                    break;
+                case "Blueprint_Turret_Vickers":
+                    __result = "Blueprint_CE_Turret_Vickers";
+                    break;
+                case "Frame_Turret_Vickers":
+                    __result = "Frame_CE_Turret_Vickers";
+                    break;
+                case "Blueprint_Install_Turret_Vickers":
+                    __result = "Blueprint_Install_CE_Turret_Vickers";
+                    break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Changes

- Added a backCompat converter for 1.5 => 1.6, used to change the defNames in saves carried over between versions
  - Currently also includes changes to Armory turrets
- Added prefixes to the added grenade defNames

## Reasoning

- Even if other save-breaking changes end up being made, best to minimize the impact where we can

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)