### PR TITLE
Store default explosion falloff curve in a GameSetupStepDef

### DIFF
--- a/Defs/GameSetupSteps/ExplosiveCurveSetup.xml
+++ b/Defs/GameSetupSteps/ExplosiveCurveSetup.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Defs>
+
+  <GameSetupStepDef>
+    <defName>CE_ExplosionFalloffCurve</defName>
+    <order>1000</order>
+    <setupStep Class="CombatExtended.GameSetupStep_ExplosionCurve">
+      <defaultExplosionFalloffCurve>
+        <points>
+          <li>(1.5, 1)</li>
+          <li>(2.5, 0.5)</li>
+          <li>(5, 0.25)</li>
+          <li>(8, 0.1)</li>
+          <li>(12, 0.05)</li>
+        </points>
+      </defaultExplosionFalloffCurve>
+    </setupStep>
+  </GameSetupStepDef>
+</Defs>

--- a/Source/CombatExtended/CombatExtended/ExplosionCE.cs
+++ b/Source/CombatExtended/CombatExtended/ExplosionCE.cs
@@ -424,7 +424,6 @@ namespace CombatExtended
             }
             var distFromCenter = c.DistanceTo(Position) * Controller.settings.ExplosionFalloffFactor;
             return Mathf.Max(GenMath.RoundRandom(damAmount * FalloffCurve.Evaluate(distFromCenter) * Controller.settings.ExplosionPenMultiplier), 1);
-            
         }
         public float GetArmorPenetrationAtCE(IntVec3 c)
         {

--- a/Source/CombatExtended/CombatExtended/ExplosionCE.cs
+++ b/Source/CombatExtended/CombatExtended/ExplosionCE.cs
@@ -20,14 +20,7 @@ namespace CombatExtended
         public const float MaxMergeRange = 3f;           //merge within 3 tiles
         public const bool MergeExplosions = false;
 
-        private readonly SimpleCurve defaultCurve = new SimpleCurve
-        {
-            {1.5f, 1f},
-            {2.5f, 0.5f},
-            {5f, 0.25f},
-            {8f, 0.1f},
-            {12f, 0.05f}
-        };
+        internal static SimpleCurve defaultCurve = new SimpleCurve(); // Populated on game start from a SetupStepDef
         private SimpleCurve _falloffCurve;
 
         public SimpleCurve FalloffCurve
@@ -431,6 +424,7 @@ namespace CombatExtended
             }
             var distFromCenter = c.DistanceTo(Position) * Controller.settings.ExplosionFalloffFactor;
             return Mathf.Max(GenMath.RoundRandom(damAmount * FalloffCurve.Evaluate(distFromCenter) * Controller.settings.ExplosionPenMultiplier), 1);
+            
         }
         public float GetArmorPenetrationAtCE(IntVec3 c)
         {

--- a/Source/CombatExtended/CombatExtended/GameSetupSteps/GameSetupStep_ExplosionCurve.cs
+++ b/Source/CombatExtended/CombatExtended/GameSetupSteps/GameSetupStep_ExplosionCurve.cs
@@ -5,7 +5,7 @@ namespace CombatExtended;
 public class GameSetupStep_ExplosionCurve : GameSetupStep
 {
     public SimpleCurve defaultExplosionFalloffCurve;
-    
+
     public override int SeedPart => 58224852; // unused, but required
 
     public override void GenerateFresh()

--- a/Source/CombatExtended/CombatExtended/GameSetupSteps/GameSetupStep_ExplosionCurve.cs
+++ b/Source/CombatExtended/CombatExtended/GameSetupSteps/GameSetupStep_ExplosionCurve.cs
@@ -1,0 +1,20 @@
+﻿using Verse;
+
+namespace CombatExtended;
+
+public class GameSetupStep_ExplosionCurve : GameSetupStep
+{
+    public SimpleCurve defaultExplosionFalloffCurve;
+    
+    public override int SeedPart => 58224852; // unused, but required
+
+    public override void GenerateFresh()
+    {
+        ExplosionCE.defaultCurve = defaultExplosionFalloffCurve;
+    }
+
+    public override void GenerateFromScribe()
+    {
+        ExplosionCE.defaultCurve = defaultExplosionFalloffCurve;
+    }
+}

--- a/Source/CombatExtended/CombatExtended/GenExplosionCE.cs
+++ b/Source/CombatExtended/CombatExtended/GenExplosionCE.cs
@@ -54,7 +54,7 @@ namespace CombatExtended
             ThingDef preExplosionSpawnSingleThingDef = null,
 
             // CE parameters
-            float height = 0f, float scaleFactor = 1f, bool destroyAfterwards = false, ThingWithComps explosionParentToDestroy = null)
+            float height = 0f, float scaleFactor = 1f, bool destroyAfterwards = false, ThingWithComps explosionParentToDestroy = null, SimpleCurve falloffCurve = null)
         {
             // Allows destroyed things to be exploded with appropriate scaleFactor
             if (scaleFactor <= 0f)
@@ -134,6 +134,10 @@ namespace CombatExtended
             explosion.overrideCells = overrideCells;
             explosion.postExplosionSpawnSingleThingDef = postExplosionSpawnSingleThingDef;
             explosion.preExplosionSpawnSingleThingDef = preExplosionSpawnSingleThingDef;
+            if (falloffCurve != null)
+            {
+                explosion.FalloffCurve = falloffCurve;
+            }
             explosion.StartExplosionCE(explosionSound, ignoredThings);
 
             // Needed to allow CompExplosive to use stackCount

--- a/Source/CombatExtended/Harmony/Harmony_CompExplosive.cs
+++ b/Source/CombatExtended/Harmony/Harmony_CompExplosive.cs
@@ -77,6 +77,7 @@ namespace CombatExtended.HarmonyCE
                     yield return new CodeInstruction(OpCodes.Ldfld, AccessTools.Field(typeof(CompExplosive), nameof(CompExplosive.destroyedThroughDetonation)));    //Send along whether the thing should be destroyed
                     yield return new CodeInstruction(OpCodes.Ldarg_0);
                     yield return new CodeInstruction(OpCodes.Ldfld, AccessTools.Field(typeof(ThingComp), nameof(ThingComp.parent)));                //Send along parent, e.g the thing that should be destroyed
+                    yield return new CodeInstruction(OpCodes.Ldnull);
                     yield return new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(GenExplosionCE), nameof(GenExplosionCE.DoExplosion)));
 
                     // Fragment part


### PR DESCRIPTION
## Additions

- Added a GameSetupStepDef that initializes the default explosion curve.

## Changes

- Added an argument to GenExplosionCE.DoExplosion to override the falloff curve used.

## Reasoning

- Allows the default falloff curve to be patched using xpath.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] Playtested a colony (specify how long)
