### PR TITLE
Fix melee shooting exploit

### DIFF
--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -282,7 +282,6 @@ namespace CombatExtended
                     return false;
                 }
             }
-            
             return Projectile != null && !VerbPropsCE.disallowedProjectileDefs.Contains(Projectile);
         }
 


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Added a check to projectile launching order to see if pawn is currently engaged in melee. If true, pawn won't be able to shoot anyone.
- Added a check to AI proj launching to see if verb allows ignoring melee (copied from vanilla)

## Reasoning

Why did you choose to implement things this way, e.g.
- It was possible to exploit a bug, where you can shoot in melee by targetting someone far away with your gun. This allowed to use any gun or grenade despite being attacked in melee.
- Vanilla added the `verbProps.ai_ProjectileLaunchingIgnoresMeleeThreats` bool for hellsphere cannon to make it non-melee-blockable, but our code was outdated and didn't do that.
- Most of the code changes were copied from decompiled vanilla.
- This PR doesn't fix the issue where if a defending pawn was shooting at a target, and someone else attacked them in melee, the defending pawn does not stop shooting.

## Alternatives

Describe alternative implementations you have considered, e.g.
- Add some way to stop shooting warmup when getting attacked.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
tested player pawn getting attacked in melee
tested player pawn shooting without melee
tested raider shooting and getting attacked in melee
tested manned turret shooting
