### PR TITLE
RH-HD2 Super Firearms Fixes

### DIFF
--- a/ModPatches/RH2 Helldivers Super Firearms/Patches/RH2 Helldivers Super Firearms/HD2_Eruptor.xml
+++ b/ModPatches/RH2 Helldivers Super Firearms/Patches/RH2 Helldivers Super Firearms/HD2_Eruptor.xml
@@ -59,6 +59,9 @@
 				<canTargetLocations>true</canTargetLocations>
 			</targetParams>
 		</Properties>
+		<FireModes>
+			<aiAimMode>AimedShot</aiAimMode>
+		</FireModes>
 		<AmmoUser>
 			<magazineSize>5</magazineSize>
 			<reloadTime>4.7</reloadTime>

--- a/ModPatches/RH2 Helldivers Super Firearms/Patches/RH2 Helldivers Super Firearms/HD2_MachineGuns.xml
+++ b/ModPatches/RH2 Helldivers Super Firearms/Patches/RH2 Helldivers Super Firearms/HD2_MachineGuns.xml
@@ -121,6 +121,7 @@
 		</FireModes>
 		<weaponTags>
 			<li>CE_MachineGun</li>
+			<li>Bipod_LMG</li>
 		</weaponTags>
 	</Operation>
 

--- a/ModPatches/RH2 Helldivers Super Firearms/Patches/RH2 Helldivers Super Firearms/HD2_SniperRifles.xml
+++ b/ModPatches/RH2 Helldivers Super Firearms/Patches/RH2 Helldivers Super Firearms/HD2_SniperRifles.xml
@@ -68,8 +68,11 @@
 			<reloadTime>3</reloadTime>
 			<ammoSet>AmmoSet_9x70mmDiligent</ammoSet>
 		</AmmoUser>
+		<FireModes>
+			<aiAimMode>AimedShot</aiAimMode>
+		</FireModes>
 		<weaponTags>
-			<li>Bipod_DMR</li>
+			<li>CE_AI_SR</li>
 		</weaponTags>
 	</Operation>
 
@@ -105,8 +108,11 @@
 			<reloadTime>3</reloadTime>
 			<ammoSet>AmmoSet_9x70mmDiligent</ammoSet>
 		</AmmoUser>
+		<FireModes>
+			<aiAimMode>AimedShot</aiAimMode>
+		</FireModes>
 		<weaponTags>
-			<li>Bipod_DMR</li>
+			<li>CE_AI_SR</li>
 		</weaponTags>
 	</Operation>
 
@@ -142,6 +148,9 @@
 			<reloadTime>2.7</reloadTime>
 			<ammoSet>AmmoSet_125x100Justice</ammoSet>
 		</AmmoUser>
+		<FireModes>
+			<aiAimMode>AimedShot</aiAimMode>
+		</FireModes>
 		<weaponTags>
 			<li>Bipod_AMR</li>
 		</weaponTags>


### PR DESCRIPTION
## Changes

- Fixed bipod not working for AMR due to missing `FireModes` data
- Added missing `FireModes` data to Eruptor and Diligence DMRs
- Removed bipods from DMRs (they don't have them in source game)
- Added bipod to LMG (not represented on sprite, but present in source game)

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors