### PR TITLE
Fix AI GasMask Wearing

### DIFF
--- a/Source/CombatExtended/CombatExtended/AI/Comps/CompGasMask.cs
+++ b/Source/CombatExtended/CombatExtended/AI/Comps/CompGasMask.cs
@@ -8,6 +8,7 @@ namespace CombatExtended.AI
         private const string GASMASK_TAG = "GasMask";
 
         private const int SMOKE_TICKS_OFFSET = 800;
+        private const int LONG_GAS_TICKS_OFFSET = 3500; // Just over the check interval of 3451 in Vanilla
 
         private int lastSmokeTick = -1;
 
@@ -51,18 +52,27 @@ namespace CombatExtended.AI
             }
         }
 
-        public void Notify_ShouldEquipGasMask()
+        public void Notify_ShouldEquipGasMask(bool longOffset = false)
         {
-            if (lastSmokeTick < GenTicks.TicksGame
-                    && !SelPawn.Faction.IsPlayerSafe()
-                    && !SelPawn.Downed
-                    && SelPawn.apparel?.wornApparel != null)
+            if (SelPawn.Faction.IsPlayerSafe() || SelPawn.Downed || SelPawn.apparel?.wornApparel == null)
             {
-                if (!maskEquiped)
+                return;
+            }
+            if (lastSmokeTick < GenTicks.TicksGame && !maskEquiped)
+            {
+                WearMask();
+            }
+            if (maskEquiped)
+            {
+                int newTick = GenTicks.TicksGame + (longOffset ? LONG_GAS_TICKS_OFFSET : SMOKE_TICKS_OFFSET);
+                if (longOffset || newTick > lastSmokeTick)
                 {
-                    WearMask();
+                    lastSmokeTick = newTick;
                 }
-                lastSmokeTick = GenTicks.TicksGame + SMOKE_TICKS_OFFSET;
+            }
+            else
+            {
+                lastSmokeTick = -1;
             }
         }
 
@@ -82,7 +92,7 @@ namespace CombatExtended.AI
                     SelPawn.inventory.innerContainer.Remove(apparel);
                     SelPawn.apparel.Wear(apparel);
                     maskEquiped = true;
-                    break;
+                    return;
                 }
             }
         }

--- a/Source/CombatExtended/CombatExtended/AI/Comps/CompGasMask.cs
+++ b/Source/CombatExtended/CombatExtended/AI/Comps/CompGasMask.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using RimWorld;
+﻿using RimWorld;
 using Verse;
 
 namespace CombatExtended.AI
@@ -30,7 +27,7 @@ namespace CombatExtended.AI
             ticks++;
         }
 
-        public void UpdateGasMask()
+        private void UpdateGasMask()
         {
             if (SelPawn.Faction.IsPlayerSafe())
             {
@@ -61,7 +58,10 @@ namespace CombatExtended.AI
                     && !SelPawn.Downed
                     && SelPawn.apparel?.wornApparel != null)
             {
-                WearMask();
+                if (!maskEquiped)
+                {
+                    WearMask();
+                }
                 lastSmokeTick = GenTicks.TicksGame + SMOKE_TICKS_OFFSET;
             }
         }
@@ -75,53 +75,43 @@ namespace CombatExtended.AI
 
         private void WearMask()
         {
-
-            Apparel mask = null;
-            foreach (Apparel apparel in CompInventory.container.Where(t => t is Apparel).Cast<Apparel>())
+            foreach (Thing thing in CompInventory.container)
             {
-                if (apparel.def.apparel?.tags?.Contains(GASMASK_TAG) ?? false)
+                if (thing is Apparel apparel && (apparel.def.apparel.tags?.Contains(GASMASK_TAG) ?? false))
                 {
-                    mask = apparel;
+                    SelPawn.inventory.innerContainer.Remove(apparel);
+                    SelPawn.apparel.Wear(apparel);
+                    maskEquiped = true;
                     break;
                 }
-            }
-            if (mask != null)
-            {
-                SelPawn.inventory.innerContainer.Remove(mask);
-                SelPawn.apparel.Wear(mask);
             }
         }
 
         private void RemoveMask()
         {
-            Apparel mask = null;
             foreach (Apparel apparel in SelPawn.apparel.wornApparel)
             {
-                if (apparel.def.apparel?.tags?.Contains(GASMASK_TAG) ?? false)
+                if (apparel.def.apparel.tags?.Contains(GASMASK_TAG) ?? false)
                 {
-                    mask = apparel;
+                    SelPawn.apparel.Remove(apparel);
+                    SelPawn.inventory.innerContainer.TryAddOrTransfer(apparel);
                     break;
                 }
-            }
-            if (mask != null)
-            {
-                SelPawn.apparel.Remove(mask);
-                SelPawn.inventory.innerContainer.TryAddOrTransfer(mask);
             }
             maskEquiped = false;
         }
 
         private void CheckForMask()
         {
-            maskEquiped = false;
             foreach (Apparel apparel in SelPawn.apparel.wornApparel)
             {
-                if (apparel.def.apparel?.tags?.Contains(GASMASK_TAG) ?? false)
+                if (apparel.def.apparel.tags?.Contains(GASMASK_TAG) ?? false)
                 {
                     maskEquiped = true;
                     return;
                 }
             }
+            maskEquiped = false;
         }
     }
 }

--- a/Source/CombatExtended/CombatExtended/Things/Smoke.cs
+++ b/Source/CombatExtended/CombatExtended/Things/Smoke.cs
@@ -126,7 +126,7 @@ namespace CombatExtended
                 }
                 if (pawn.RaceProps.Humanlike && !pawn.IsSubhuman)
                 {
-                    pawn.TryGetComp<CompTacticalManager>()?.GetTacticalComp<CompGasMask>()?.Notify_ShouldEquipGasMask();
+                    pawn.TryGetComp<CompTacticalManager>()?.GetTacticalComp<CompGasMask>()?.Notify_ShouldEquipGasMask(false);
                 }
                 var sensitivity = pawn.GetStatValue(CE_StatDefOf.SmokeSensitivity);
                 var breathing = PawnCapacityUtility.CalculateCapacityLevel(pawn.health.hediffSet, PawnCapacityDefOf.Breathing);

--- a/Source/CombatExtended/CombatExtended/Things/Smoke.cs
+++ b/Source/CombatExtended/CombatExtended/Things/Smoke.cs
@@ -124,7 +124,10 @@ namespace CombatExtended
                     }
                     continue;
                 }
-                pawn.TryGetComp<CompTacticalManager>()?.GetTacticalComp<CompGasMask>()?.Notify_ShouldEquipGasMask();
+                if (pawn.RaceProps.Humanlike && !pawn.IsSubhuman)
+                {
+                    pawn.TryGetComp<CompTacticalManager>()?.GetTacticalComp<CompGasMask>()?.Notify_ShouldEquipGasMask();
+                }
                 var sensitivity = pawn.GetStatValue(CE_StatDefOf.SmokeSensitivity);
                 var breathing = PawnCapacityUtility.CalculateCapacityLevel(pawn.health.hediffSet, PawnCapacityDefOf.Breathing);
                 float curSeverity = pawn.health.hediffSet.GetFirstHediffOfDef(CE_HediffDefOf.SmokeInhalation, false)?.Severity ?? 0f;

--- a/Source/CombatExtended/Harmony/Harmony_GameCondition_ToxicFallout.cs
+++ b/Source/CombatExtended/Harmony/Harmony_GameCondition_ToxicFallout.cs
@@ -26,14 +26,15 @@ namespace CombatExtended.HarmonyCE
                 MethodInfo additionalMethod = AccessTools.Method(typeof(Harmony_ToxicUtility), nameof(Harmony_ToxicUtility.TryNotify_ShouldEquipGasMask));
                 for (int i = 0; i < codes.Count; i++)
                 {
-                    yield return codes[i];
 
                     if (codes[i].opcode == OpCodes.Call && codes[i].operand as MethodInfo == targetMethod)
                     {
-                        yield return new CodeInstruction(OpCodes.Ldarg_0);
-                        yield return new CodeInstruction(OpCodes.Call, additionalMethod);
+                        codes.Insert(i, new CodeInstruction(OpCodes.Call, additionalMethod));
+                        codes.Insert(i, new CodeInstruction(OpCodes.Dup));
+                        break;
                     }
                 }
+                return codes;
             }
         }
         /// <summary>
@@ -51,14 +52,15 @@ namespace CombatExtended.HarmonyCE
                 MethodInfo additionalMethod = AccessTools.Method(typeof(Harmony_ToxicUtility), nameof(Harmony_ToxicUtility.TryNotify_ShouldEquipGasMask));
                 for (int i = 0; i < codes.Count; i++)
                 {
-                    yield return codes[i];
 
                     if (codes[i].opcode == OpCodes.Call && codes[i].operand as MethodInfo == targetMethod)
                     {
-                        yield return new CodeInstruction(OpCodes.Ldarg_0);
-                        yield return new CodeInstruction(OpCodes.Call, additionalMethod);
+                        codes.Insert(i, new CodeInstruction(OpCodes.Call, additionalMethod));
+                        codes.Insert(i, new CodeInstruction(OpCodes.Dup));
+                        break;
                     }
                 }
+                return codes;
             }
         }
         public static void TryNotify_ShouldEquipGasMask(Pawn pawn)

--- a/Source/CombatExtended/Harmony/Harmony_GameCondition_ToxicFallout.cs
+++ b/Source/CombatExtended/Harmony/Harmony_GameCondition_ToxicFallout.cs
@@ -65,7 +65,7 @@ namespace CombatExtended.HarmonyCE
         {
             if (pawn.RaceProps.Humanlike && !pawn.IsSubhuman)
             {
-                pawn.TryGetComp<CompTacticalManager>()?.GetTacticalComp<CompGasMask>()?.Notify_ShouldEquipGasMask();
+                pawn.TryGetComp<CompTacticalManager>()?.GetTacticalComp<CompGasMask>()?.Notify_ShouldEquipGasMask(true);
             }
         }
     }

--- a/Source/CombatExtended/Harmony/Harmony_GameCondition_ToxicFallout.cs
+++ b/Source/CombatExtended/Harmony/Harmony_GameCondition_ToxicFallout.cs
@@ -1,0 +1,72 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using CombatExtended.AI;
+using HarmonyLib;
+using Verse;
+
+namespace CombatExtended.HarmonyCE
+{
+    internal static class Harmony_ToxicUtility
+    {
+        /// <summary>
+        /// Transpile <see cref="ToxicUtility.DoAirbornePawnToxicDamage"/> to tell AI pawns to wear mask
+        /// used when outside during Toxic Fallout
+        /// </summary>
+        [HarmonyPatch(typeof(ToxicUtility), nameof(ToxicUtility.DoAirbornePawnToxicDamage))]
+        static class Patch_DoAirbornePawnToxicDamage
+        {
+
+            public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+            {
+                List<CodeInstruction> codes = instructions.ToList();
+
+                MethodInfo targetMethod = AccessTools.Method(typeof(ToxicUtility), nameof(ToxicUtility.DoPawnToxicDamage));
+                MethodInfo additionalMethod = AccessTools.Method(typeof(Harmony_ToxicUtility), nameof(Harmony_ToxicUtility.TryNotify_ShouldEquipGasMask));
+                for (int i = 0; i < codes.Count; i++)
+                {
+                    yield return codes[i];
+
+                    if (codes[i].opcode == OpCodes.Call && codes[i].operand as MethodInfo == targetMethod)
+                    {
+                        yield return new CodeInstruction(OpCodes.Ldarg_0);
+                        yield return new CodeInstruction(OpCodes.Call, additionalMethod);
+                    }
+                }
+            }
+        }
+        /// <summary>
+        /// Transpile <see cref="ToxicUtility.PawnToxicTickInterval"/> to tell AI pawns to wear mask
+        /// used when standing on polluted terrain
+        /// </summary>
+        [HarmonyPatch(typeof(ToxicUtility), nameof(ToxicUtility.PawnToxicTickInterval))]
+        static class Patch_PawnToxicTickInterval
+        {
+            public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+            {
+                List<CodeInstruction> codes = instructions.ToList();
+
+                MethodInfo targetMethod = AccessTools.Method(typeof(ToxicUtility), nameof(ToxicUtility.DoPawnToxicDamage));
+                MethodInfo additionalMethod = AccessTools.Method(typeof(Harmony_ToxicUtility), nameof(Harmony_ToxicUtility.TryNotify_ShouldEquipGasMask));
+                for (int i = 0; i < codes.Count; i++)
+                {
+                    yield return codes[i];
+
+                    if (codes[i].opcode == OpCodes.Call && codes[i].operand as MethodInfo == targetMethod)
+                    {
+                        yield return new CodeInstruction(OpCodes.Ldarg_0);
+                        yield return new CodeInstruction(OpCodes.Call, additionalMethod);
+                    }
+                }
+            }
+        }
+        public static void TryNotify_ShouldEquipGasMask(Pawn pawn)
+        {
+            if (pawn.RaceProps.Humanlike && !pawn.IsSubhuman)
+            {
+                pawn.TryGetComp<CompTacticalManager>()?.GetTacticalComp<CompGasMask>()?.Notify_ShouldEquipGasMask();
+            }
+        }
+    }
+}

--- a/Source/CombatExtended/Harmony/Harmony_GameCondition_ToxicFallout.cs
+++ b/Source/CombatExtended/Harmony/Harmony_GameCondition_ToxicFallout.cs
@@ -26,11 +26,10 @@ namespace CombatExtended.HarmonyCE
                 MethodInfo additionalMethod = AccessTools.Method(typeof(Harmony_ToxicUtility), nameof(Harmony_ToxicUtility.TryNotify_ShouldEquipGasMask));
                 for (int i = 0; i < codes.Count; i++)
                 {
-
-                    if (codes[i].opcode == OpCodes.Call && codes[i].operand as MethodInfo == targetMethod)
+                    if (codes[i].Calls(targetMethod))
                     {
-                        codes.Insert(i, new CodeInstruction(OpCodes.Call, additionalMethod));
-                        codes.Insert(i, new CodeInstruction(OpCodes.Dup));
+                        codes.Insert(i - 1, new CodeInstruction(OpCodes.Call, additionalMethod));
+                        codes.Insert(i - 1, new CodeInstruction(OpCodes.Dup));
                         break;
                     }
                 }
@@ -52,11 +51,10 @@ namespace CombatExtended.HarmonyCE
                 MethodInfo additionalMethod = AccessTools.Method(typeof(Harmony_ToxicUtility), nameof(Harmony_ToxicUtility.TryNotify_ShouldEquipGasMask));
                 for (int i = 0; i < codes.Count; i++)
                 {
-
-                    if (codes[i].opcode == OpCodes.Call && codes[i].operand as MethodInfo == targetMethod)
+                    if (codes[i].Calls(targetMethod))
                     {
-                        codes.Insert(i, new CodeInstruction(OpCodes.Call, additionalMethod));
-                        codes.Insert(i, new CodeInstruction(OpCodes.Dup));
+                        codes.Insert(i - 1, new CodeInstruction(OpCodes.Call, additionalMethod));
+                        codes.Insert(i - 1, new CodeInstruction(OpCodes.Dup));
                         break;
                     }
                 }

--- a/Source/CombatExtended/Harmony/Harmony_GasUtility_PawnGasEffectsTickInterval.cs
+++ b/Source/CombatExtended/Harmony/Harmony_GasUtility_PawnGasEffectsTickInterval.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using CombatExtended.AI;
+using HarmonyLib;
+using Verse;
+
+namespace CombatExtended.HarmonyCE
+{
+    internal static class Harmony_GasUtility
+    {
+        /// <summary>
+        /// Transpile <see cref="GasUtility.DoAirbornePawnToxicDamage"/> to tell AI pawns to wear mask
+        /// when exposed to toxic gas
+        /// </summary>
+        [HarmonyPatch(typeof(GasUtility), nameof(GasUtility.PawnGasEffectsTickInterval))]
+        static class Patch_PawnGasEffectsTickInterval
+        {
+
+            public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+            {
+                List<CodeInstruction> codes = instructions.ToList();
+
+                MethodInfo targetMethod = AccessTools.Method(typeof(GasUtility), nameof(GasUtility.ShouldGetGasExposureHediff));
+                MethodInfo additionalMethod = AccessTools.Method(typeof(Harmony_GasUtility), nameof(Harmony_GasUtility.TryNotify_ShouldEquipGasMask));
+                for (int i = 0; i < codes.Count; i++)
+                {
+                    // Injecting this before the target method, so that pawns can put the gas mask on to avoid the debilitating exposure hediff.
+                    if (codes[i].opcode == OpCodes.Call && codes[i].operand as MethodInfo == targetMethod)
+                    {
+                        codes.Insert(i, new CodeInstruction(OpCodes.Call, additionalMethod));
+                        codes.Insert(i, new CodeInstruction(OpCodes.Dup));
+                        break;
+                    }
+                }
+                return codes;
+            }
+        }
+
+        public static void TryNotify_ShouldEquipGasMask(Pawn pawn)
+        {
+            if (pawn.RaceProps.Humanlike && !pawn.IsSubhuman)
+            {
+                pawn.TryGetComp<CompTacticalManager>()?.GetTacticalComp<CompGasMask>()?.Notify_ShouldEquipGasMask();
+            }
+        }
+    }
+}

--- a/Source/CombatExtended/Harmony/Harmony_GasUtility_PawnGasEffectsTickInterval.cs
+++ b/Source/CombatExtended/Harmony/Harmony_GasUtility_PawnGasEffectsTickInterval.cs
@@ -40,8 +40,8 @@ namespace CombatExtended.HarmonyCE
                     }
                     if (codes[i].opcode == OpCodes.Ldarg_0 && codes[i + 2].operand is FieldInfo fieldInfo && fieldInfo == secondInjectionSite && !secondInjectionFound)
                     {
-                        codes.Insert(i + 1 , new CodeInstruction(OpCodes.Call, additionalMethod));
-                        codes.Insert(i + 1 , new CodeInstruction(OpCodes.Dup));
+                        codes.Insert(i + 1, new CodeInstruction(OpCodes.Call, additionalMethod));
+                        codes.Insert(i + 1, new CodeInstruction(OpCodes.Dup));
                         secondInjectionFound = true;
                     }
                 }

--- a/Source/CombatExtended/Harmony/Harmony_GasUtility_PawnGasEffectsTickInterval.cs
+++ b/Source/CombatExtended/Harmony/Harmony_GasUtility_PawnGasEffectsTickInterval.cs
@@ -27,7 +27,7 @@ namespace CombatExtended.HarmonyCE
                 for (int i = 0; i < codes.Count; i++)
                 {
                     // Injecting this before the target method, so that pawns can put the gas mask on to avoid the debilitating exposure hediff.
-                    if (codes[i].opcode == OpCodes.Call && codes[i].operand as MethodInfo == targetMethod)
+                    if (codes[i].Calls(targetMethod))
                     {
                         codes.Insert(i, new CodeInstruction(OpCodes.Call, additionalMethod));
                         codes.Insert(i, new CodeInstruction(OpCodes.Dup));

--- a/Source/CombatExtended/Harmony/Harmony_GasUtility_PawnGasEffectsTickInterval.cs
+++ b/Source/CombatExtended/Harmony/Harmony_GasUtility_PawnGasEffectsTickInterval.cs
@@ -53,7 +53,7 @@ namespace CombatExtended.HarmonyCE
         {
             if (pawn.RaceProps.Humanlike && !pawn.IsSubhuman)
             {
-                pawn.TryGetComp<CompTacticalManager>()?.GetTacticalComp<CompGasMask>()?.Notify_ShouldEquipGasMask();
+                pawn.TryGetComp<CompTacticalManager>()?.GetTacticalComp<CompGasMask>()?.Notify_ShouldEquipGasMask(false);
             }
         }
     }


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Tweaks AI of non-colonists to don gas masks when exposed to Toxic Gas
- Tweaks AI of non-colonists to don gas masks when exposed to Toxic Fallout
- Tweaks AI of non-colonists to don gas masks when exposed to Polluted Terrain

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Refactor CompGasMask for minor performance improvements and readability
- Smoke checks for if pawn is Humanlike and not Subhuman. Prevents TryGetComp unnecessarily

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #3982 

## Reasoning

Why did you choose to implement things this way, e.g.
- Harmony patches before their target method to mimic Smoke and prevent ill effects
- Removing LINQ prevents unnecessary allocations
- Removes unnecessary null checks on apparel.def
- Consolidates checks to prevent unnecessary assignments of variables
- AI pawns will take off gas masks if they have them when spawning into map, but will put them back on if they are exposed. Would have to add additional checks to prevent this, but should not take them back off once donned by the new patches.

## Alternatives

Describe alternative implementations you have considered, e.g. 
- Allow player colonists to automatically wear gas masks if they have one
- Pawns utilize apparel wearing JobDriver

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
