### PR TITLE
Convert comps to interval ticks

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoResupplyOnWakeup.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoResupplyOnWakeup.cs
@@ -128,9 +128,9 @@ namespace CombatExtended
             return false;
         }
 
-        public override void CompTick()
+        public override void CompTickInterval(int delta)
         {
-            if (parent.IsHashIntervalTick(ticksBetweenChecks))
+            if (parent.IsHashIntervalTick(ticksBetweenChecks, delta))
             {
                 TickRareWorker();
             }

--- a/Source/CombatExtended/CombatExtended/Comps/CompArmorDurability.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompArmorDurability.cs
@@ -112,7 +112,7 @@ namespace CombatExtended
 
         public int timer;
 
-        public override void CompTick()
+        public override void CompTickInterval(int delta)
         {
             if (durabilityProps.Regenerates)
             {
@@ -120,13 +120,13 @@ namespace CombatExtended
                 {
                     if (curDurability < maxDurability)
                     {
-                        curDurability += Math.Min(durabilityProps.RegenValue, maxDurability - curDurability);
+                        curDurability += Math.Min(durabilityProps.RegenValue * delta, maxDurability - curDurability);
                     }
                     timer = 0;
                 }
-                timer++;
+                timer += delta;
             }
-            base.CompTick();
+            base.CompTickInterval(delta);
         }
 
         public override void PostPostMake()

--- a/Source/CombatExtended/CombatExtended/Comps/CompInventory.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompInventory.cs
@@ -621,21 +621,21 @@ namespace CombatExtended
             }
         }
 
-        public override void CompTick()
+        public override void CompTickInterval(int delta)
         {
             /*
              * Need to update this to avoid calling IsColonist too soon after spawning
              */
-            age++;
+            age += delta;
             /*
              * Routin cleanup
              */
-            if ((parentPawn.thingIDNumber + GenTicks.TicksGame) % CLEANUPTICKINTERVAL == 0)
+            if (parentPawn.IsHashIntervalTick(CLEANUPTICKINTERVAL, delta))
             {
                 // Ask HoldTracker to clean itself up...
                 parentPawn.HoldTrackerCleanUp();
             }
-            base.CompTick();
+            base.CompTickInterval(delta);
             // Remove items from inventory if we're over the bulk limit
             /*
             while (availableBulk < 0 && container.Count > 0)

--- a/Source/CombatExtended/CombatExtended/Comps/CompSuppressable.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompSuppressable.cs
@@ -249,9 +249,9 @@ namespace CombatExtended
             return BlockerRegistry.PawnUnsuppressableFromCallback(parent as Pawn, origin) || SuppressionUtility.InterceptorZonesFor((Pawn)parent).Where(x => x.Contains(parent.Position)).Any(x => !x.Contains(origin));
         }
 
-        public override void CompTick()
+        public override void CompTickInterval(int delta)
         {
-            base.CompTick();
+            base.CompTickInterval(delta);
 
             // Update suppressed tick counter and check for mental breaks
             if (!isSuppressed)
@@ -260,7 +260,7 @@ namespace CombatExtended
             }
             else if (IsHunkering)
             {
-                ticksHunkered++;
+                ticksHunkered += delta;
             }
 
             if (ticksHunkered > MinTicksUntilMentalBreak && Rand.Chance(ChanceBreakPerTick))
@@ -279,7 +279,7 @@ namespace CombatExtended
             //Apply decay once per second
             if (ticksUntilDecay > 0)
             {
-                ticksUntilDecay--;
+                ticksUntilDecay -= delta;
             }
             else if (currentSuppression > 0)
             {
@@ -288,7 +288,7 @@ namespace CombatExtended
                 {
                     MoteMakerCE.ThrowText(parent.DrawPos, parent.Map, "-" + (SuppressionDecayRate * 30), Color.red);
                 }
-                currentSuppression -= Mathf.Min(SuppressionDecayRate, currentSuppression);
+                currentSuppression -= Mathf.Min(SuppressionDecayRate * delta, currentSuppression);
                 isSuppressed = currentSuppression > 0;
 
                 // Clear crouch-walking
@@ -298,11 +298,11 @@ namespace CombatExtended
                 }
 
                 //Decay location suppression
-                locSuppressionAmount -= Mathf.Min(SuppressionDecayRate, locSuppressionAmount);
+                locSuppressionAmount -= Mathf.Min(SuppressionDecayRate * delta, locSuppressionAmount);
             }
 
             // Throw mote at set interval
-            if (parent.IsHashIntervalTick(TicksPerMote) && CanReactToSuppression)
+            if (parent.IsHashIntervalTick(TicksPerMote, delta) && CanReactToSuppression)
             {
                 if (this.IsHunkering)
                 {
@@ -314,7 +314,7 @@ namespace CombatExtended
                 }
             }
             if (!parent.Faction.IsPlayerSafe()
-                    && parent.IsHashIntervalTick(120)
+                    && parent.IsHashIntervalTick(120, delta)
                     && isSuppressed
                     && GenTicks.TicksGame - lastHelpRequestAt > HelpRequestCooldown)
             {

--- a/Source/CombatExtended/CombatExtended/Comps/CompTacticalManager.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompTacticalManager.cs
@@ -115,10 +115,10 @@ namespace CombatExtended
             TargetIndex.C,
         };
 
-        public override void CompTick()
+        public override void CompTickInterval(int delta)
         {
-            base.CompTick();
-            if (parent.IsHashIntervalTick(120) && Active)
+            base.CompTickInterval(delta);
+            if (parent.IsHashIntervalTick(120, delta) && Active)
             {
                 /*
                  * Clear the cache if it's very outdated to allow GC to take over

--- a/Source/CombatExtended/CombatExtended/Comps/CompThrownFleckEmitterSmooth.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompThrownFleckEmitterSmooth.cs
@@ -40,7 +40,7 @@ namespace CombatExtended
             }
         }
 
-        public override void CompTick()
+        public override void CompTickInterval(int delta)
         {
             if (!IsOn)
             {

--- a/Source/CombatExtended/CombatExtended/Comps/HediffComp_InfecterCE.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/HediffComp_InfecterCE.cs
@@ -97,17 +97,17 @@ namespace CombatExtended
             }
         }
 
-        public override void CompPostTick(ref float severityAdjustment)
+        public override void CompPostTickInterval(ref float severityAdjustment, int delta)
         {
             if (!(_tendedOutside && IsInternal) && parent.TryGetComp<HediffComp_TendDuration>().IsTended)
             {
-                _ticksTended++;
+                _ticksTended += delta;
             }
 
             if (!_alreadyCausedInfection && _ticksUntilInfect > 0)
             {
-                _ticksUntilInfect--;
-                if (_ticksUntilInfect == 0)
+                _ticksUntilInfect -= delta;
+                if (_ticksUntilInfect <= 0)
                 {
                     CheckMakeInfection();
                 }

--- a/Source/CombatExtended/CombatExtended/Comps/HediffComp_Prometheum.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/HediffComp_Prometheum.cs
@@ -12,11 +12,11 @@ namespace CombatExtended
     {
         private const float InternalFireDamage = 2;
 
-        public override void CompPostTick(ref float severityAdjustment)
+        public override void CompPostTickInterval(ref float severityAdjustment, int delta)
         {
-            base.CompPostTick(ref severityAdjustment);
+            base.CompPostTickInterval(ref severityAdjustment, delta);
 
-            if (Pawn.IsHashIntervalTick(GenTicks.TicksPerRealSecond))
+            if (Pawn.IsHashIntervalTick(GenTicks.TicksPerRealSecond, delta))
             {
                 if (Pawn.Position.GetThingList(Pawn.Map).Any(x => x.def == ThingDefOf.Filth_FireFoam))
                 {
@@ -27,11 +27,11 @@ namespace CombatExtended
                 Fire fire = Pawn.GetAttachment(ThingDefOf.Fire) as Fire;
                 if (fire == null && Pawn.Spawned)
                 {
-                    Pawn.TryAttachFire(parent.Severity * 0.5f, null);
+                    Pawn.TryAttachFire(parent.Severity * 0.5f * delta, null);
                 }
                 else if (fire != null)
                 {
-                    fire.fireSize = Mathf.Min(fire.fireSize + parent.Severity * 0.5f, 1.75f);  // Clamped at max fire size
+                    fire.fireSize = Mathf.Min(fire.fireSize + parent.Severity * 0.5f * delta, 1.75f);  // Clamped at max fire size
                 }
 
                 // Apply to internal parts
@@ -42,7 +42,7 @@ namespace CombatExtended
                     {
                         return;
                     }
-                    Pawn.TakeDamage(new DamageInfo(CE_DamageDefOf.Flame_Secondary, InternalFireDamage * Pawn.BodySize * parent.Severity, 0, -1, null,
+                    Pawn.TakeDamage(new DamageInfo(CE_DamageDefOf.Flame_Secondary, InternalFireDamage * Pawn.BodySize * parent.Severity * delta, 0, -1, null,
                                                    internalPart));
                 }
             }

--- a/Source/CombatExtended/CombatExtended/Comps/HediffComp_Stabilize.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/HediffComp_Stabilize.cs
@@ -82,12 +82,12 @@ namespace CombatExtended
             Scribe_Values.Look(ref bleedModifier, "bleedModifier", 1);
         }
 
-        public override void CompPostTick(ref float severityAdjustment)
+        public override void CompPostTickInterval(ref float severityAdjustment, int delta)
         {
             // Increase bleed modifier once per second
-            if (stabilized && bleedModifier < 1 && parent.ageTicks % 60 == 0)
+            if (stabilized && bleedModifier < 1 && parent.pawn.IsHashIntervalTick(60, delta))
             {
-                bleedModifier = bleedModifier + bleedIncreasePerSec;
+                bleedModifier = bleedModifier + bleedIncreasePerSec * delta;
                 if (bleedModifier >= 1)
                 {
                     bleedModifier = 1;

--- a/Source/CombatExtended/CombatExtended/Comps/HediffComp_Venom.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/HediffComp_Venom.cs
@@ -20,14 +20,14 @@ namespace CombatExtended
             _lifetime = Rand.Range(Props.MinTicks, Props.MaxTicks);
         }
 
-        public override void CompPostTick(ref float severityAdjustment)
+        public override void CompPostTickInterval(ref float severityAdjustment, int delta)
         {
             _isPermanent ??= parent.IsPermanent();
 
-            base.CompPostTick(ref severityAdjustment);
+            base.CompPostTickInterval(ref severityAdjustment, delta);
             if (parent.ageTicks < _lifetime && !_isPermanent.Value)
             {
-                HealthUtility.AdjustSeverity(parent.pawn, CE_HediffDefOf.VenomBuildup, _venomPerTick);
+                HealthUtility.AdjustSeverity(parent.pawn, CE_HediffDefOf.VenomBuildup, _venomPerTick * delta);
             }
         }
 

--- a/Source/CombatExtended/CombatExtended/Projectiles/ArtilleryMarker.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ArtilleryMarker.cs
@@ -56,9 +56,9 @@ namespace CombatExtended
             Scribe_Values.Look(ref this.lifetimeTicks, "lifetimeTicks");
         }
 
-        public override void Tick()
+        public override void TickInterval(int delta)
         {
-            lifetimeTicks--;
+            lifetimeTicks -= delta;
             if (lifetimeTicks <= 0)
             {
                 this.Destroy();

--- a/Source/CombatExtended/CombatExtended/Things/AmmoThing.cs
+++ b/Source/CombatExtended/CombatExtended/Things/AmmoThing.cs
@@ -54,7 +54,7 @@ namespace CombatExtended
             }
         }
 
-        public override void Tick()
+        public override void TickInterval(int delta)
         {
             // Self-destruct if ammo is disabled
             if (ShouldDestroy)
@@ -66,20 +66,23 @@ namespace CombatExtended
             base.Tick();
 
             // Cook off ammo based on how much damage we've taken so far
-            if (numToCookOff > 0 && Rand.Chance((float)numToCookOff / def.stackLimit))
+            for (int i = 0; i < delta; i++) // Might feel weird in practice, could be reverted to regular ticks
             {
-                if (TryLaunchCookOffProjectile() || TryDetonate())
+                if (numToCookOff > 0 && Rand.Chance((float)numToCookOff / def.stackLimit))
                 {
-                    // Reduce stack count
-                    if (stackCount > 1)
+                    if (TryLaunchCookOffProjectile() || TryDetonate())
                     {
-                        numToCookOff--;
-                        stackCount--;
-                    }
-                    else
-                    {
-                        numToCookOff = 0;
-                        Destroy(DestroyMode.KillFinalize);
+                        // Reduce stack count
+                        if (stackCount > 1)
+                        {
+                            numToCookOff--;
+                            stackCount--;
+                        }
+                        else
+                        {
+                            numToCookOff = 0;
+                            Destroy(DestroyMode.KillFinalize);
+                        }
                     }
                 }
             }

--- a/Source/CombatExtended/CombatExtended/Things/AmmoThing.cs
+++ b/Source/CombatExtended/CombatExtended/Things/AmmoThing.cs
@@ -63,7 +63,7 @@ namespace CombatExtended
             }
 
             //Calls CompExplosive _first_
-            base.Tick();
+            base.TickInterval(delta);
 
             // Cook off ammo based on how much damage we've taken so far
             for (int i = 0; i < delta; i++) // Might feel weird in practice, could be reverted to regular ticks

--- a/Source/CombatExtended/CombatExtended/Things/Flare.cs
+++ b/Source/CombatExtended/CombatExtended/Things/Flare.cs
@@ -256,9 +256,9 @@ namespace CombatExtended
 
         private static readonly Vector3 _moteDrawOffset = new Vector3(0, 0, -0.5f);
 
-        public override void Tick()
+        public override void TickInterval(int delta)
         {
-            base.Tick();
+            base.TickInterval(delta);
             if (nextSmokePuff <= 0)
             {
                 /*
@@ -316,7 +316,7 @@ namespace CombatExtended
 
                 nextSmokePuff = Rand.Range(SMOKE_MIN_INTERVAL, SMOKE_MAX_INTERVAL);
             }
-            nextSmokePuff--;
+            nextSmokePuff -= delta;
             if (Progress >= 0.99f)
             {
                 Destroy();

--- a/Source/CombatExtended/CombatExtended/Things/IncendiaryFuel.cs
+++ b/Source/CombatExtended/CombatExtended/Things/IncendiaryFuel.cs
@@ -39,7 +39,7 @@ namespace CombatExtended
             }
         }
 
-        public override void Tick()
+        public override void TickInterval(int delta)
         {
             if (Position.GetThingList(base.Map).Any(x => x.def == ThingDefOf.Filth_FireFoam) || Position.GetTerrain(base.Map).IsWater)
             {

--- a/Source/CombatExtended/CombatExtended/WorldObjects/TravelingThing.cs
+++ b/Source/CombatExtended/CombatExtended/WorldObjects/TravelingThing.cs
@@ -69,12 +69,12 @@ namespace CombatExtended
 
         protected abstract void Arrived();
 
-        public override void Tick()
+        public override void TickInterval(int delta)
         {
             try
             {
-                base.Tick();
-                distanceTraveled += this.tilesPerTick;
+                base.TickInterval(delta);
+                distanceTraveled += this.tilesPerTick * delta;
                 if (TraveledPtc >= 1.0f)
                 {
                     Tile = destinationTile;

--- a/Source/CombatExtended/Contrib/MechTakeAmmoCE/Core/CompMechAmmo.cs
+++ b/Source/CombatExtended/Contrib/MechTakeAmmoCE/Core/CompMechAmmo.cs
@@ -143,9 +143,9 @@ namespace CombatExtended
             yield break;
         }
 
-        public override void CompTick()
+        public override void CompTickInterval(int delta)
         {
-            if (!parent.IsHashIntervalTick(REFRESH_INTERVAL))
+            if (!parent.IsHashIntervalTick(REFRESH_INTERVAL, delta))
             {
                 return;
             }


### PR DESCRIPTION
## Changes

- Converted existing ThingComp and HediffComp and some regular ticks to use the new interval ticks system.

## Reasoning

- Passed `delta` argument is the number of ticks since last call, so it was used to scale the effects the ticks had.
- This is still largely a blind conversion, so might be missing certain details.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
