### PR TITLE
Fix Bipod NRE

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/BipodComp.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/BipodComp.cs
@@ -12,6 +12,7 @@ namespace CombatExtended
         #region Fields
         public bool ShouldSetUpint;
         private bool _missingComp;
+        private CompFireModes compFireMode;
 
         public bool IsSetUpRn;
 
@@ -24,14 +25,8 @@ namespace CombatExtended
         {
             get
             {
-                if (Controller.settings.AutoSetUp)
+                if (Controller.settings.AutoSetUp && !_missingComp)
                 {
-                    CompFireModes compFireMode = this.parent.TryGetComp<CompFireModes>();
-                    if (compFireMode == null)
-                    {
-                        _missingComp = true;
-                        return ShouldSetUpint && !IsSetUpRn;
-                    }
                     Pawn pawn = ((Pawn_EquipmentTracker)this.ParentHolder).pawn;
                     return (((compFireMode.CurrentAimMode == Props.catDef.autosetMode) | (!Props.catDef.useAutoSetMode && compFireMode.CurrentAimMode != AimMode.Snapshot)) && !IsSetUpRn && !pawn.IsCarryingPawn());
                 }
@@ -41,6 +36,16 @@ namespace CombatExtended
         #endregion
 
         #region Methods
+        public override void PostSpawnSetup(bool respawningAfterLoad)
+        {
+            base.PostSpawnSetup(respawningAfterLoad);
+            compFireMode = this.parent.TryGetComp<CompFireModes>();
+            if (compFireMode == null)
+            {
+                _missingComp = true;
+            }
+
+        }
         public override void PostExposeData()
         {
             Scribe_Values.Look(ref IsSetUpRn, "isBipodSetUp");


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Adds null check for compFireMode
- Refactors CompGetGizmosExtra due to even more duplicate code. Was becoming a mess to read
- Removes unneeded null check as pawn is always true 

## References

Links to the associated issues or other related pull requests, e.g.
- Exception ticking Kelas (at (65, 0, 79)): System.NullReferenceException: Object reference not set to an instance of an object
[Ref E3EA01BC]
 at CombatExtended.BipodComp.get_ShouldSetUp () [0x0002f] in <061d7558c7d04349973dcd3abd1d7509>:0 

## Reasoning

Why did you choose to implement things this way, e.g.
- Was becoming utter mess to read

## Alternatives

Describe alternative implementations you have considered, e.g.
- Enforce proper XML with a heavy hand
 
## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)