### PR TITLE
Gate retargeting behind mod option in case something breaks

### DIFF
--- a/Languages/English/Keyed/ModMenu.xml
+++ b/Languages/English/Keyed/ModMenu.xml
@@ -86,13 +86,13 @@
 	<CE_Settings_ShowExtraStats_Desc>Enables extra (internal, redundant, or confusing) stats in some info cards.</CE_Settings_ShowExtraStats_Desc>
 	<CE_Settings_ShowExtraStats_Title>Show extra stats</CE_Settings_ShowExtraStats_Title>
 
-	<CE_Settings_FragmentsFromWalls_Desc>If true, damaging walls can generate fragments</CE_Settings_FragmentsFromWalls_Desc>
+	<CE_Settings_FragmentsFromWalls_Desc>When enabled, damaging walls can generate fragments.</CE_Settings_FragmentsFromWalls_Desc>
 	<CE_Settings_FragmentsFromWalls_Title>Fragments from walls</CE_Settings_FragmentsFromWalls_Title>
 
-	<CE_Settings_FasterRepeatShots_Desc>If true, subsequent shots at the same, or nearby, targets are faster.</CE_Settings_FasterRepeatShots_Desc>
+	<CE_Settings_FasterRepeatShots_Desc>When enabled, subsequent shots at the same, or nearby, targets are faster.</CE_Settings_FasterRepeatShots_Desc>
 	<CE_Settings_FasterRepeatShots_Title>Faster subsequent shots</CE_Settings_FasterRepeatShots_Title>
 
-	<CE_Settings_MidBurstRetarget_Desc>If true, shooters will switch to a new target when their primary target is downed mid-burst.</CE_Settings_MidBurstRetarget_Desc>
+	<CE_Settings_MidBurstRetarget_Desc>When enabled, shooters will switch to a new target when their primary target is downed mid-burst.</CE_Settings_MidBurstRetarget_Desc>
 	<CE_Settings_MidBurstRetarget_Title>Retarget mid burst</CE_Settings_MidBurstRetarget_Title>
 
 	<CE_Settings_EnableExtraEffects_Title>Show additional projectile visual effects</CE_Settings_EnableExtraEffects_Title>

--- a/Languages/English/Keyed/ModMenu.xml
+++ b/Languages/English/Keyed/ModMenu.xml
@@ -92,8 +92,8 @@
 	<CE_Settings_FasterRepeatShots_Desc>If true, subsequent shots at the same, or nearby, targets are faster.</CE_Settings_FasterRepeatShots_Desc>
 	<CE_Settings_FasterRepeatShots_Title>Faster subsequent shots</CE_Settings_FasterRepeatShots_Title>
 
-        <CE_Settings_MidBurstRetarget_Desc>If true, shooters will switch to a new target when their primary target is downed mid-burst.</CE_Settings_MidBurstRetarget_Desc>
-	<CE_Settings_MidBurstRetarget_Title>Retarget Mid Burst</CE_Settings_MidBurstRetarget_Title>
+	<CE_Settings_MidBurstRetarget_Desc>If true, shooters will switch to a new target when their primary target is downed mid-burst.</CE_Settings_MidBurstRetarget_Desc>
+	<CE_Settings_MidBurstRetarget_Title>Retarget mid burst</CE_Settings_MidBurstRetarget_Title>
 
 	<CE_Settings_EnableExtraEffects_Title>Show additional projectile visual effects</CE_Settings_EnableExtraEffects_Title>
 	<CE_Settings_EnableExtraEffects_Desc>Bullets and other projectiles will display additional effects, such as bullets kicking up dust or incendiaries throwing sparks. Cosmetic only, does not affect gameplay.</CE_Settings_EnableExtraEffects_Desc>

--- a/Languages/English/Keyed/ModMenu.xml
+++ b/Languages/English/Keyed/ModMenu.xml
@@ -92,6 +92,9 @@
 	<CE_Settings_FasterRepeatShots_Desc>If true, subsequent shots at the same, or nearby, targets are faster.</CE_Settings_FasterRepeatShots_Desc>
 	<CE_Settings_FasterRepeatShots_Title>Faster subsequent shots</CE_Settings_FasterRepeatShots_Title>
 
+        <CE_Settings_MidBurstRetarget_Desc>If true, shooters will switch to a new target when their primary target is downed mid-burst.</CE_Settings_MidBurstRetarget_Desc>
+	<CE_Settings_MidBurstRetarget_Title>Retarget Mid Burst</CE_Settings_MidBurstRetarget_Title>
+
 	<CE_Settings_EnableExtraEffects_Title>Show additional projectile visual effects</CE_Settings_EnableExtraEffects_Title>
 	<CE_Settings_EnableExtraEffects_Desc>Bullets and other projectiles will display additional effects, such as bullets kicking up dust or incendiaries throwing sparks. Cosmetic only, does not affect gameplay.</CE_Settings_EnableExtraEffects_Desc>
 

--- a/Source/CombatExtended/CombatExtended/ModSettings/Settings.cs
+++ b/Source/CombatExtended/CombatExtended/ModSettings/Settings.cs
@@ -37,6 +37,7 @@ namespace CombatExtended
 
         private bool fragmentsFromWalls = false;
 
+        private bool midBurstRetarget = true;
         private bool fasterRepeatShots = true;
 
         private float explosionPenMultiplier = 1.0f;
@@ -140,6 +141,7 @@ namespace CombatExtended
         public bool FragmentsFromWalls => fragmentsFromWalls;
 
         public bool FasterRepeatShots => fasterRepeatShots;
+        public bool MidBurstRetarget => midBurstRetarget;
 
         public float ExplosionPenMultiplier => explosionPenMultiplier;
         public float ExplosionFalloffFactor => explosionFalloffFactor;
@@ -224,6 +226,7 @@ namespace CombatExtended
 
             Scribe_Values.Look(ref fragmentsFromWalls, "fragmentsFromWalls", false);
             Scribe_Values.Look(ref fasterRepeatShots, "fasterRepeatShots", false);
+            Scribe_Values.Look(ref midBurstRetarget, "midBurstRetarget", true);
             Scribe_Values.Look(ref explosionPenMultiplier, "explosionPenMultiplier", 1.0f);
             Scribe_Values.Look(ref explosionFalloffFactor, "explosionFalloffFactor", 1.0f);
 
@@ -273,6 +276,7 @@ namespace CombatExtended
             left.CheckboxLabeled("CE_Settings_SmokeEffects_Title".Translate(), ref smokeEffects, "CE_Settings_SmokeEffects_Desc".Translate());
             left.CheckboxLabeled("CE_Settings_TurretsBreakShields_Title".Translate(), ref turretsBreakShields, "CE_Settings_TurretsBreakShields_Desc".Translate());
             left.CheckboxLabeled("CE_Settings_FasterRepeatShots_Title".Translate(), ref fasterRepeatShots, "CE_Settings_FasterRepeatShots_Desc".Translate());
+            left.CheckboxLabeled("CE_Settings_MidBurstRetarget_Title".Translate(), ref midBurstRetarget, "CE_Settings_MidBurstRetarget_Desc".Translate());
             left.CheckboxLabeled("CE_Settings_EnableArcOfFire_Title".Translate(), ref enableArcOfFire, "CE_Settings_EnableArcOfFire_Desc".Translate());
             left.CheckboxLabeled("CE_Settings_EnableCIWS".Translate(), ref enableCIWS, "CE_Settings_EnableCIWS_Desc".Translate());
             left.CheckboxLabeled("CE_Settings_FragmentsFromWalls_Title".Translate(), ref fragmentsFromWalls, "CE_Settings_FragmentsFromWalls_Desc".Translate());
@@ -453,6 +457,7 @@ namespace CombatExtended
             smokeEffects = true;
             turretsBreakShields = true;
             fasterRepeatShots = true;
+            midBurstRetarget = true;
             enableCIWS = true;
             fragmentsFromWalls = false;
             mergeExplosions = true;

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -953,7 +953,7 @@ namespace CombatExtended
 
         protected bool Retarget()
         {
-            if (!doRetarget)
+            if (!Controller.settings.MidBurstRetarget || !doRetarget)
             {
                 return false;
             }


### PR DESCRIPTION
## Changes

- Mid burst retargeting can be disabled via mod-option menu.

## Reasoning

There are several subsystems that interlock in a poor way, but it's too late in 1.5's release cycle to fix them.
This makes working on any of them prone to breaking the others. So while the retargeting is fixed, this adds
a reasonable failsafe in the event it breaks in an akward way after we move to working on 1.6.

## Alternatives

Leave it always on and be willing to backport fixes for it for a couple months.
disable it for 1.5
default it to disabled but with a mod option to enable it - it *was* on all the time previously though.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
