### PR TITLE
Fix Bipod NRE On Load

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/BipodComp.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/BipodComp.cs
@@ -11,7 +11,6 @@ namespace CombatExtended
     {
         #region Fields
         public bool ShouldSetUpint;
-        private bool _missingComp;
         private CompFireModes compFireMode;
 
         public bool IsSetUpRn;
@@ -25,7 +24,7 @@ namespace CombatExtended
         {
             get
             {
-                if (Controller.settings.AutoSetUp && !_missingComp)
+                if (Controller.settings.AutoSetUp && compFireMode != null)
                 {
                     Pawn pawn = ((Pawn_EquipmentTracker)this.ParentHolder).pawn;
                     return (((compFireMode.CurrentAimMode == Props.catDef.autosetMode) | (!Props.catDef.useAutoSetMode && compFireMode.CurrentAimMode != AimMode.Snapshot)) && !IsSetUpRn && !pawn.IsCarryingPawn());
@@ -36,19 +35,19 @@ namespace CombatExtended
         #endregion
 
         #region Methods
+
         public override void PostSpawnSetup(bool respawningAfterLoad)
         {
             base.PostSpawnSetup(respawningAfterLoad);
             compFireMode = this.parent.TryGetComp<CompFireModes>();
-            if (compFireMode == null)
-            {
-                _missingComp = true;
-            }
-
         }
         public override void PostExposeData()
         {
             Scribe_Values.Look(ref IsSetUpRn, "isBipodSetUp");
+            if (Scribe.mode == LoadSaveMode.PostLoadInit)
+            {
+                compFireMode = this.parent.TryGetComp<CompFireModes>();
+            }
             base.PostExposeData();
         }
 
@@ -76,7 +75,7 @@ namespace CombatExtended
             }
             if (Controller.settings.AutoSetUp)
             {
-                if (_missingComp)
+                if (compFireMode == null)
                 {
                     yield return new Command_Action
                     {

--- a/Source/CombatExtended/CombatExtended/ModSettings/Settings.cs
+++ b/Source/CombatExtended/CombatExtended/ModSettings/Settings.cs
@@ -259,7 +259,7 @@ namespace CombatExtended
         private void DoSettingsWindowContents_Mechanics(Listing_Standard list)
         {
 
-            Rect fullRect = list.GetRect(300f);
+            Rect fullRect = list.GetRect(500f);
             const float columnPadding = 16f;
             float columnWidth = (fullRect.width - columnPadding) / 2f;
 


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Fixes NRE in bipod setup when loading from save
- Changes bool check to just straight comp null check
- Fixes menu size for mechanics, as settings were getting cut off


## Reasoning

Why did you choose to implement things this way, e.g.
- NRE needs fixing
- Menu needs to be manually adjusted

## Alternatives

Describe alternative implementations you have considered, e.g.
- Suffer
- Most likely also needs pushed to Master and hotfix released for workshop so 1.5's last vestiges aren't left broken

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (Load save to fix issue)