### PR TITLE
30mm label fix

### DIFF
--- a/Defs/Ammo/HighCaliber/30x113mmB.xml
+++ b/Defs/Ammo/HighCaliber/30x113mmB.xml
@@ -160,9 +160,9 @@
 
 	<RecipeDef ParentName="AmmoRecipeBase">
 		<defName>MakeAmmo_30x113mmB_AP</defName>
-		<label>make 30x113mmB (AP) cartridge x100</label>
-		<description>Craft 100 .30x113mmB (AP) cartridges.</description>
-		<jobString>Making .30x113mmB (AP) cartridges.</jobString>
+		<label>make 30x113mmB (AP) cartridge x150</label>
+		<description>Craft 150 30x113mmB (AP) cartridges.</description>
+		<jobString>Making 30x113mmB (AP) cartridges.</jobString>
 		<ingredients>
 			<li>
 				<filter>
@@ -186,9 +186,9 @@
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
 		<defName>MakeAmmo_30x113mmB_Incendiary</defName>
-		<label>make 30x113mmB (AP-I) cartridge x100</label>
-		<description>Craft 100 .30x113mmB (AP-I) cartridges.</description>
-		<jobString>Making .30x113mmB (AP-I) cartridges.</jobString>
+		<label>make 30x113mmB (AP-I) cartridge x150</label>
+		<description>Craft 150 30x113mmB (AP-I) cartridges.</description>
+		<jobString>Making 30x113mmB (AP-I) cartridges.</jobString>
 		<ingredients>
 			<li>
 				<filter>
@@ -221,9 +221,9 @@
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
 		<defName>MakeAmmo_30x113mmB_HE</defName>
-		<label>make 30x113mmB (AP-HE) cartridge x100</label>
-		<description>Craft 100 .30x113mmB (AP-HE) cartridges.</description>
-		<jobString>Making .30x113mmB (AP-HE) cartridges.</jobString>
+		<label>make 30x113mmB (AP-HE) cartridge x150</label>
+		<description>Craft 150 30x113mmB (AP-HE) cartridges.</description>
+		<jobString>Making 30x113mmB (AP-HE) cartridges.</jobString>
 		<ingredients>
 			<li>
 				<filter>
@@ -256,9 +256,9 @@
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
 		<defName>MakeAmmo_30x113mmB_Sabot</defName>
-		<label>make 30x113mmB (Sabot) cartridge x100</label>
-		<description>Craft 100 .30x113mmB (Sabot) cartridges.</description>
-		<jobString>Making .30x113mmB (Sabot) cartridges.</jobString>
+		<label>make 30x113mmB (Sabot) cartridge x150</label>
+		<description>Craft 150 30x113mmB (Sabot) cartridges.</description>
+		<jobString>Making 30x113mmB (Sabot) cartridges.</jobString>
 		<ingredients>
 			<li>
 				<filter>

--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -348,7 +348,7 @@
 		<li IfModActive="dninemfive.moa">ModPatches/Moa</li>
 		<li IfModActive="Moonjelly.Race.Mod, zal.moonjelly">ModPatches/Moonjelly Race</li>
 		<li IfModActive="Taranchuk.MoreArchotechGarbageContinued">ModPatches/More Archotech Garbage Continued</li>
-    <li IfModActive="wekk.mamap">ModPatches/More Armory! Midworld Arms Pack</li>
+		<li IfModActive="wekk.mamap">ModPatches/More Armory! Midworld Arms Pack</li>
 		<li IfModActive="Meltup.MoreConsumablesAndMutagens.Reworked">ModPatches/More Consumables And Mutagens</li>
 		<li IfModActive="Domi.MoreMedievalHelms">ModPatches/More Medieval Helms and Armor</li>
 		<li IfModActive="Arquebus.MorePersonaTraits">ModPatches/More Persona Traits</li>


### PR DESCRIPTION
## Changes
- Fix typo in 30x113mmB recipe label.
- Whitespace housekeeping

## Reasoning
- Had the wrong quantity in the label.

## Alternatives
- Suffer.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
