### PR TITLE
Add Shield Damage Multiplier

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -746,13 +746,14 @@ namespace CombatExtended
             // and break it if we manage to decrease its hitpoints to zero or lower.
             if (interceptorComp.currentHitPoints > 0)
             {
-                interceptorComp.currentHitPoints -= Mathf.FloorToInt(this.DamageAmount);
+                float shieldDamage = this.DamageAmount * Props.shieldDamageMultiplier;
+                interceptorComp.currentHitPoints -= Mathf.FloorToInt(shieldDamage);
 
                 if (interceptorComp.currentHitPoints <= 0)
                 {
                     interceptorComp.currentHitPoints = 0;
                     interceptorComp.startedChargingTick = Find.TickManager.TicksGame;
-                    interceptorComp.BreakShieldHitpoints(new DamageInfo(projectileProperties.damageDef, this.DamageAmount));
+                    interceptorComp.BreakShieldHitpoints(new DamageInfo(projectileProperties.damageDef, shieldDamage));
                     return true;
                 }
             }

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectilePropertiesCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectilePropertiesCE.cs
@@ -64,6 +64,7 @@ namespace CombatExtended
         public float aimHeightOffset = 0;
 
         public float empShieldBreakChance = 1f;
+        public float shieldDamageMultiplier = 1f;
         public float collideDistance = 1f;
         public float impactChance = 1f;
 

--- a/Source/CombatExtended/Harmony/Harmony_CompShield.cs
+++ b/Source/CombatExtended/Harmony/Harmony_CompShield.cs
@@ -1,7 +1,6 @@
 ﻿using HarmonyLib;
 using Verse;
 using RimWorld;
-using System.Linq;
 
 namespace CombatExtended.HarmonyCE
 {
@@ -41,10 +40,12 @@ namespace CombatExtended.HarmonyCE
             }
             float bc = 1.0f;
             bool isEMP = dinfo.Def == DamageDefOf.EMP;
+            float shieldDamageMultiplier = 1f;
             if (dinfo.Weapon?.projectile is ProjectilePropertiesCE pce)
             {
                 bc = pce.empShieldBreakChance;
                 isEMP = isEMP || pce.secondaryDamage?.FirstOrDefault(sd => sd.def == DamageDefOf.EMP) != null;
+                shieldDamageMultiplier = pce.shieldDamageMultiplier;
             }
             if (isEMP && Rand.Chance(bc))
             {
@@ -56,7 +57,7 @@ namespace CombatExtended.HarmonyCE
             if (dinfo.Def.isRanged || dinfo.Def.isExplosive)
             {
                 absorbed = true;
-                __instance.energy -= dinfo.Amount * __instance.Props.energyLossPerDamage * (isEMP ? (1 + bc) : 1);
+                __instance.energy -= dinfo.Amount * __instance.Props.energyLossPerDamage * shieldDamageMultiplier;
                 if (__instance.energy < 0f)
                 {
                     __instance.Break();


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Adds shield damage multiplier to shields
- Adds shield damage multiplier to interceptors
- Adds shield damage multiplier to CE's projectile properties

## Reasoning

Why did you choose to implement things this way, e.g.
- EMP's RNG of instakilling shields regardless of size makes little sense. Same round will take out a shield with HP value of float.MaxValue the same as a 300hp shield belt. This still gives the ability to tailor EMP to be extremely effective against shields, but also the ability to make other projectiles not great at all against them.

## Alternatives

Describe alternative implementations you have considered, e.g.
- Completely remove instant shield breaking code

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
