### PR TITLE
VFEM teslafix

### DIFF
--- a/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Security_Turrets.xml
+++ b/ModPatches/Vanilla Factions Expanded - Mechanoids/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Security_Turrets.xml
@@ -533,9 +533,23 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VFE_Bullet_TeslaProjectile"]/modExtensions/li[@Class="VFEMech.TeslaChainingProps"]/explosionDamageDef</xpath>
+		<value>
+			<explosionDamageDef>EMP</explosionDamageDef>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VFE_Bullet_TeslaProjectile"]/modExtensions/li[@Class="VFEMech.TeslaChainingProps"]/bounceRange</xpath>
+		<value>
+			<bounceRange>6</bounceRange>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="VFE_Bullet_TeslaProjectile"]/modExtensions/li[@Class="VFEMech.TeslaChainingProps"]/maxLifetime</xpath>
 		<value>
-			<maxLifetime>10</maxLifetime>
+			<maxLifetime>50</maxLifetime>
 		</value>
 	</Operation>
 


### PR DESCRIPTION
removed base damage change since it's stun damage, aoe changed to emp, re enabled chain lighting thing with higher maxLifetime

## Additions
none
## Changes
removed stun damage buff
## References

Links to the associated issues or other related pull requests, e.g.

## Reasoning
the beam is meant to stun the targets and the bounce and aoe are there to damage the mechs (turret only targets mechs) before with chain lighting bounce being disabled it does no damage just stuns
## Alternatives
didn't thought of any..
## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
