### PR TITLE
Add Fail Message For Transpilers

### DIFF
--- a/Source/CombatExtended/Harmony/Compatibility/Harmony_AlphaGenes.cs
+++ b/Source/CombatExtended/Harmony/Compatibility/Harmony_AlphaGenes.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using HarmonyLib;
-using UnityEngine;
 using Verse;
 
 namespace CombatExtended.HarmonyCE.Compatibility
@@ -41,20 +39,32 @@ namespace CombatExtended.HarmonyCE.Compatibility
 
             public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
             {
+                bool foundInjection = false;
+                bool secondInjection = false;
                 foreach (var instruction in instructions)
                 {
                     if (instruction.opcode == OpCodes.Ldc_R4 && ((float)instruction.operand) == 1225f)
                     {
                         yield return new CodeInstruction(OpCodes.Ldc_R4, 3469.21f); //Your value here
+                        foundInjection = true;
                     }
                     else if (instruction.opcode == OpCodes.Ldc_R4 && ((float)instruction.operand) == 225f)
                     {
                         yield return new CodeInstruction(OpCodes.Ldc_R4, 835.21f); //Your value here
+                        secondInjection = true;
                     }
                     else
                     {
                         yield return instruction;
                     }
+                }
+                if (!foundInjection)
+                {
+                    Log.Error($"Combat Extended :: Failed to find first injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
+                }
+                if (!secondInjection)
+                {
+                    Log.Error($"Combat Extended :: Failed to find second injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
                 }
             }
         }
@@ -74,20 +84,32 @@ namespace CombatExtended.HarmonyCE.Compatibility
 
             public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
             {
+                bool foundInjection = false;
+                bool secondInjection = false;
                 foreach (var instruction in instructions)
                 {
                     if (instruction.opcode == OpCodes.Ldc_R4 && ((float)instruction.operand) == 35f)
                     {
                         yield return new CodeInstruction(OpCodes.Ldc_R4, 58.9f); //Your value here
+                        foundInjection = true;
                     }
                     else if (instruction.opcode == OpCodes.Ldc_R4 && ((float)instruction.operand) == 15f)
                     {
                         yield return new CodeInstruction(OpCodes.Ldc_R4, 28.9f); //Your value here
+                        secondInjection = true;
                     }
                     else
                     {
                         yield return instruction;
                     }
+                }
+                if (!foundInjection)
+                {
+                    Log.Error($"Combat Extended :: Failed to find first injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
+                }
+                if (!secondInjection)
+                {
+                    Log.Error($"Combat Extended :: Failed to find second injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
                 }
             }
         }

--- a/Source/CombatExtended/Harmony/Compatibility/Harmony_BBBodySupport.cs
+++ b/Source/CombatExtended/Harmony/Compatibility/Harmony_BBBodySupport.cs
@@ -53,8 +53,8 @@ namespace CombatExtended.HarmonyCE.Compatibility
 
         static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {
-            bool patched = false;
             bool ready = false;
+            bool foundInjection = false;
 
             List<CodeInstruction> patch = new List<CodeInstruction>
             {
@@ -70,7 +70,7 @@ namespace CombatExtended.HarmonyCE.Compatibility
             foreach (var code in instructions)
             {
                 yield return code;
-                if (!patched)
+                if (!foundInjection)
                 {
                     if (code.opcode == OpCodes.Ldsfld)
                     {
@@ -83,9 +83,13 @@ namespace CombatExtended.HarmonyCE.Compatibility
                         {
                             yield return c;
                         }
-                        patched = true;
+                        foundInjection = true;
                     }
                 }
+            }
+            if (!foundInjection)
+            {
+                Log.Error($"Combat Extended :: Failed to find injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
             }
         }
     }

--- a/Source/CombatExtended/Harmony/Compatibility/Harmony_RunAndGun.cs
+++ b/Source/CombatExtended/Harmony/Compatibility/Harmony_RunAndGun.cs
@@ -55,7 +55,7 @@ namespace CombatExtended.HarmonyCE.Compatibility
 
         internal static IEnumerable<CodeInstruction> Transpiler(ILGenerator gen, IEnumerable<CodeInstruction> instructions)
         {
-            bool patched = false;
+            bool foundInjection = false;
             bool ready = false;
 
             List<CodeInstruction> patch = new List<CodeInstruction>
@@ -68,7 +68,7 @@ namespace CombatExtended.HarmonyCE.Compatibility
             foreach (var code in instructions)
             {
                 yield return code;
-                if (!patched)
+                if (!foundInjection)
                 {
                     if (code.opcode == OpCodes.Isinst && ReferenceEquals(code.operand, Stance_RunAndGun))
                     {
@@ -81,9 +81,13 @@ namespace CombatExtended.HarmonyCE.Compatibility
                         {
                             yield return c;
                         }
-                        patched = true;
+                        foundInjection = true;
                     }
                 }
+            }
+            if (!foundInjection)
+            {
+                Log.Error($"Combat Extended :: Failed to find injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
             }
         }
 

--- a/Source/CombatExtended/Harmony/Compatibility/Harmony_VanillaEventExpanded.cs
+++ b/Source/CombatExtended/Harmony/Compatibility/Harmony_VanillaEventExpanded.cs
@@ -34,6 +34,7 @@ namespace CombatExtended.HarmonyCE.Compatibility
             {
                 var list = instructions.ToList();
                 MethodInfo overrideMethod = typeof(Harmony_WeaponPod_Patch).GetMethod("InsertMethod", BindingFlags.Static | BindingFlags.Public);
+                bool foundInjection = false;
                 for (int i = list.Count - 1; i >= 0; --i)
                 {
                     if (list[i].opcode == OpCodes.Brtrue_S)
@@ -43,8 +44,13 @@ namespace CombatExtended.HarmonyCE.Compatibility
                             new CodeInstruction(OpCodes.Ldloc_S, 6),
                             new CodeInstruction(OpCodes.Call, overrideMethod),
                         });
+                        foundInjection = true;
                         break;
                     }
+                }
+                if (!foundInjection)
+                {
+                    Log.Error($"Combat Extended :: Failed to find injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
                 }
                 return list;
             }

--- a/Source/CombatExtended/Harmony/HarmonyBase.cs
+++ b/Source/CombatExtended/Harmony/HarmonyBase.cs
@@ -362,6 +362,17 @@ namespace CombatExtended.HarmonyCE
             }
             return -1;
         }
+
+        // This gets the clean class name without trailing +Transpiler..etc
+        public static string GetClassName(Type declaringType)
+        {
+            while (declaringType?.DeclaringType != null)
+            {
+                declaringType = declaringType.DeclaringType;
+            }
+
+            return declaringType?.Name ?? "UnknownClass";
+        }
         #endregion Utility_Methods
     }
 }

--- a/Source/CombatExtended/Harmony/Harmony_ApparelGraphicRecordGetter.cs
+++ b/Source/CombatExtended/Harmony/Harmony_ApparelGraphicRecordGetter.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
 using HarmonyLib;
@@ -33,6 +34,7 @@ namespace CombatExtended.HarmonyCE
         internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {
             var write = false;
+            bool foundInjection = false;
 
             foreach (var code in instructions)
             {
@@ -46,11 +48,17 @@ namespace CombatExtended.HarmonyCE
                 {
                     write = true;
                     yield return new CodeInstruction(OpCodes.Callvirt, AccessTools.Method(typeof(Harmony_ApparelGraphicRecordGetter), nameof(IsHeadwear)));
+                    foundInjection = true;
+
                 }
                 else
                 {
                     yield return code;
                 }
+            }
+            if (!foundInjection)
+            {
+                Log.Error($"Combat Extended :: Failed to find injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
             }
         }
     }

--- a/Source/CombatExtended/Harmony/Harmony_AttackTargetFinder.cs
+++ b/Source/CombatExtended/Harmony/Harmony_AttackTargetFinder.cs
@@ -1,10 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Reflection.Emit;
-using System.Text;
 using CombatExtended.AI;
-using CombatExtended.Utilities;
 using HarmonyLib;
 using RimWorld;
 using UnityEngine;
@@ -34,6 +33,7 @@ namespace CombatExtended.HarmonyCE
             internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
             {
                 var codes = instructions.ToList();
+                bool foundInjection = false;
                 for (int i = 0; i < instructions.Count(); i++)
                 {
                     if (codes[i].opcode == OpCodes.Call && ReferenceEquals(codes[i].operand, AccessTools.Method(typeof(VerbUtility), nameof(VerbUtility.IsEMP))))
@@ -85,9 +85,14 @@ namespace CombatExtended.HarmonyCE
                         codes.InsertRange(blockStart, instructionsToInsert);
 
                         blockStartInstr.MoveLabelsTo(codes[blockStart]);
+                        foundInjection = true;
 
                         break;
                     }
+                }
+                if (!foundInjection)
+                {
+                    Log.Error($"Combat Extended :: Failed to find injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
                 }
 
                 return codes;

--- a/Source/CombatExtended/Harmony/Harmony_AvoidGrid.cs
+++ b/Source/CombatExtended/Harmony/Harmony_AvoidGrid.cs
@@ -1,7 +1,8 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.Reflection;
 using System.Reflection.Emit;
 using HarmonyLib;
+using Verse;
 using Verse.AI;
 
 namespace CombatExtended.HarmonyCE
@@ -11,13 +12,19 @@ namespace CombatExtended.HarmonyCE
     {
         private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {
+            bool foundInjection = false;
             foreach (var code in instructions)
             {
                 if (code.opcode == OpCodes.Ldc_I4_S && (sbyte)code.operand == 45)
                 {
                     code.operand = 8;
+                    foundInjection = true;
                 }
                 yield return code;
+            }
+            if (!foundInjection)
+            {
+                Log.Error($"Combat Extended :: Failed to find injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
             }
         }
     }

--- a/Source/CombatExtended/Harmony/Harmony_Bombardment.cs
+++ b/Source/CombatExtended/Harmony/Harmony_Bombardment.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
+using System.Reflection;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
 using HarmonyLib;
 using RimWorld;
 using Verse;
@@ -15,20 +12,32 @@ namespace CombatExtended.HarmonyCE
     {
         static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
         {
+            bool foundInjection = false;
+            bool secondInjection = false;
             foreach (var instruction in instructions)
             {  // Replaces the default damage and armor pen values of -1
                 if (instruction.opcode == OpCodes.Ldc_I4_M1)
                 {
                     yield return new CodeInstruction(OpCodes.Ldc_I4, 546); // new damage
+                    foundInjection = true;
                 }
                 else if (instruction.opcode == OpCodes.Ldc_R4 && (float)instruction.operand == -1f)
                 {
                     yield return new CodeInstruction(OpCodes.Ldc_R4, 180f); // new pen
+                    secondInjection = true;
                 }
                 else
                 {
                     yield return instruction;
                 }
+            }
+            if (!foundInjection)
+            {
+                Log.Error($"Combat Extended :: Failed to find first injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
+            }
+            if (!secondInjection)
+            {
+                Log.Error($"Combat Extended :: Failed to find second injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
             }
         }
     }

--- a/Source/CombatExtended/Harmony/Harmony_CompressibilityDecider.cs
+++ b/Source/CombatExtended/Harmony/Harmony_CompressibilityDecider.cs
@@ -1,14 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
-using System.Text;
 using HarmonyLib;
-using RimWorld;
 using Verse;
-using Verse.AI;
-using Verse.AI.Group;
 
 namespace CombatExtended.HarmonyCE
 {
@@ -20,6 +15,7 @@ namespace CombatExtended.HarmonyCE
         {
             var instructionsList = instructions.ToList();
             var notProjectileLabel = generator.DefineLabel();
+            bool foundInjection = false;
 
             for (int i = 0; i < instructionsList.Count(); i++)
             {
@@ -44,9 +40,14 @@ namespace CombatExtended.HarmonyCE
                     yield return instructionsList[i - 3].Clone(); // ldloc
                     yield return instructionsList[i - 2].Clone(); // ldloc
                     yield return instructionsList[i - 1].Clone(); // callvirt
+                    foundInjection = true;
                 }
 
                 yield return instructionsList[i];
+            }
+            if (!foundInjection)
+            {
+                Log.Error($"Combat Extended :: Failed to find injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
             }
         }
     }

--- a/Source/CombatExtended/Harmony/Harmony_DamageWorker_AddInjury.cs
+++ b/Source/CombatExtended/Harmony/Harmony_DamageWorker_AddInjury.cs
@@ -151,6 +151,7 @@ namespace CombatExtended.HarmonyCE
                 var getItem = AccessTools.PropertyGetter(typeof(List<BodyPartRecord>), "Item");
                 var setHitPart = AccessTools.Method(typeof(DamageInfo), "SetHitPart");
                 var callHelper = AccessTools.Method(typeof(Patch_DamageWorker_Cut), "ApplyCECleavedDamage");
+                bool foundInjection = false;
 
                 for (int i = 0; i < code.Count - 12; i++)
                 {
@@ -176,8 +177,13 @@ namespace CombatExtended.HarmonyCE
                             new CodeInstruction(OpCodes.Call, callHelper)
                         };
                         code.InsertRange(i, injected);
+                        foundInjection = true;
                         break;
                     }
+                }
+                if (!foundInjection)
+                {
+                    Log.Error($"Combat Extended :: Failed to find injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
                 }
                 return code;
             }
@@ -225,6 +231,7 @@ namespace CombatExtended.HarmonyCE
                 });
                 var setHitPart = AccessTools.Method(typeof(DamageInfo), nameof(DamageInfo.SetHitPart));
                 var callHelper = AccessTools.Method(typeof(Patch_DamageWorker_Scratch), "ApplyCEScratchedDamage");
+                bool foundInjection = false;
                 for (int i = 0; i < code.Count - 15; i++)
                 {
                     if (code[i].opcode == OpCodes.Ldloc_0 &&
@@ -255,9 +262,14 @@ namespace CombatExtended.HarmonyCE
                                 new CodeInstruction(OpCodes.Call, callHelper)
                             };
                             code.InsertRange(i, injected);
+                            foundInjection = true;
                             break;
                         }
                     }
+                }
+                if (!foundInjection)
+                {
+                    Log.Error($"Combat Extended :: Failed to find injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
                 }
                 return code;
             }
@@ -287,6 +299,7 @@ namespace CombatExtended.HarmonyCE
                 var callHelper = AccessTools.Method(typeof(Patch_DamageWorker_Blunt), "ApplyCEBluntDamage");
                 var type = typeof(DamageWorker_Blunt).GetNestedType("<>c__DisplayClass1_0", BindingFlags.NonPublic);
                 var lastInfo = AccessTools.Field(type, "lastInfo");
+                bool foundInjection = false;
 
                 for (int i = 0; i < code.Count - 10; i++)
                 {
@@ -310,10 +323,14 @@ namespace CombatExtended.HarmonyCE
                             new CodeInstruction(OpCodes.Sub),
                             new CodeInstruction(OpCodes.Stloc_3),
                         };
-
+                        foundInjection = true;
                         code.InsertRange(i, injected);
                         break;
                     }
+                }
+                if (!foundInjection)
+                {
+                    Log.Error($"Combat Extended :: Failed to find injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
                 }
                 return code;
             }

--- a/Source/CombatExtended/Harmony/Harmony_ExpandableWorldObjectsUtility.cs
+++ b/Source/CombatExtended/Harmony/Harmony_ExpandableWorldObjectsUtility.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using RimWorld.Planet;
+﻿using RimWorld.Planet;
 using HarmonyLib;
 using Verse;
 using System.Collections.Generic;
 using System.Linq;
-using RimWorld;
 using System.Reflection;
 using System.Reflection.Emit;
 
@@ -51,20 +49,24 @@ namespace CombatExtended.HarmonyCE
             public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
             {
                 var codes = instructions.ToList();
-                var finished = false;
+                bool foundInjection = false;
                 for (int i = 0; i < codes.Count; i++)
                 {
-                    if (!finished)
+                    if (!foundInjection)
                     {
                         if (codes[i].opcode == OpCodes.Callvirt && codes[i].OperandIs(allWorldObjectGetter))
                         {
-                            finished = true;
                             yield return codes[i];
                             yield return new CodeInstruction(OpCodes.Call, getAllWorldObjectCE);
+                            foundInjection = true;
                             continue;
                         }
                     }
                     yield return codes[i];
+                }
+                if (!foundInjection)
+                {
+                    Log.Error($"Combat Extended :: Failed to find injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
                 }
             }
 

--- a/Source/CombatExtended/Harmony/Harmony_Fire.cs
+++ b/Source/CombatExtended/Harmony/Harmony_Fire.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.Reflection;
-using System.Text;
 using System.Reflection.Emit;
 using HarmonyLib;
 using Verse;
@@ -21,6 +18,7 @@ namespace CombatExtended.HarmonyCE
 
         internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {
+            bool foundInjection = false;
             foreach (CodeInstruction code in instructions)
             {
                 if (code.opcode == OpCodes.Ldc_R4 && code.operand is float && (float)code.operand == 150f)
@@ -33,8 +31,12 @@ namespace CombatExtended.HarmonyCE
                     yield return new CodeInstruction(OpCodes.Ldloca, 0);
                     yield return new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(Harmony_Fire_DoFireDamage), nameof(ApplySizeMult)));
                     yield return new CodeInstruction(OpCodes.Ldloc_1);
+                    foundInjection = true;
                 }
-
+                if (!foundInjection)
+                {
+                    Log.Error($"Combat Extended :: Failed to find injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
+                }
                 yield return code;
             }
         }
@@ -45,17 +47,23 @@ namespace CombatExtended.HarmonyCE
     {
         internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {
+            bool foundInjection = false;
             foreach (CodeInstruction code in instructions)
             {
                 //Log.Message($"OpCode {code.opcode}, operand {code.operand}, type {code.operand.GetType()}");
                 if (code.opcode == OpCodes.Ldc_I4_S && code.operand is sbyte && (sbyte)code.operand == 15)
                 {
                     yield return new CodeInstruction(OpCodes.Ldc_I4, 1500);
+                    foundInjection = true;
                 }
                 else
                 {
                     yield return code;
                 }
+            }
+            if (!foundInjection)
+            {
+                Log.Error($"Combat Extended :: Failed to find injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
             }
         }
 
@@ -71,13 +79,19 @@ namespace CombatExtended.HarmonyCE
 
         internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {
+            bool foundInjection = false;
             foreach (CodeInstruction code in instructions)
             {
                 if (code.opcode == OpCodes.Ldc_R4 && code.operand is float && (float)code.operand == 1f)
                 {
                     code.operand = 0.6f;
+                    foundInjection = true;
                 }
                 yield return code;
+            }
+            if (!foundInjection)
+            {
+                Log.Error($"Combat Extended :: Failed to find injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
             }
         }
 
@@ -112,17 +126,23 @@ namespace CombatExtended.HarmonyCE
 
         internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {
+            bool foundInjection = false;
             foreach (CodeInstruction code in instructions)
             {
                 if (code.opcode == OpCodes.Ldc_R4 && code.operand is float && (float)code.operand == 0.00055f)
                 {
                     yield return new CodeInstruction(OpCodes.Ldarg_0);
                     yield return new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(Harmony_Fire_DoComplexCalcs), nameof(GetWindGrowthAdjust)));
+                    foundInjection = true;
                 }
                 else
                 {
                     yield return code;
                 }
+            }
+            if (!foundInjection)
+            {
+                Log.Error($"Combat Extended :: Failed to find injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
             }
         }
         internal static void Postfix(Fire __instance)
@@ -221,6 +241,7 @@ namespace CombatExtended.HarmonyCE
             var delete = false;
             var passedRadPattern = false;
             var codes = new List<CodeInstruction>();
+            bool foundInjection = false;
 
             foreach (var code in instructions)
             {
@@ -255,12 +276,16 @@ namespace CombatExtended.HarmonyCE
                     codes.Add(new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(Harmony_Fire_TrySpread), nameof(GetWindMult))));
 
                     codes.Add(new CodeInstruction(OpCodes.Sub));
+                    foundInjection = true;
                     continue;
                 }
 
                 codes.Add(code);
             }
-
+            if (!foundInjection)
+            {
+                Log.Error($"Combat Extended :: Failed to find injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
+            }
             return codes;
         }
     }

--- a/Source/CombatExtended/Harmony/Harmony_Fire.cs
+++ b/Source/CombatExtended/Harmony/Harmony_Fire.cs
@@ -33,11 +33,11 @@ namespace CombatExtended.HarmonyCE
                     yield return new CodeInstruction(OpCodes.Ldloc_1);
                     foundInjection = true;
                 }
-                if (!foundInjection)
-                {
-                    Log.Error($"Combat Extended :: Failed to find injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
-                }
                 yield return code;
+            }
+            if (!foundInjection)
+            {
+                Log.Error($"Combat Extended :: Failed to find injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
             }
         }
     }

--- a/Source/CombatExtended/Harmony/Harmony_FireUtility.cs
+++ b/Source/CombatExtended/Harmony/Harmony_FireUtility.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Reflection;
 using System.Reflection.Emit;
 using HarmonyLib;
 using RimWorld;
@@ -12,6 +13,7 @@ namespace CombatExtended.HarmonyCE
         internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {
             var write = false;
+            bool foundInjection = false;
             foreach (CodeInstruction code in instructions)
             {
                 if (write)
@@ -19,6 +21,7 @@ namespace CombatExtended.HarmonyCE
                     if (code.opcode == OpCodes.Ldc_I4_1)
                     {
                         code.opcode = OpCodes.Ldc_I4_M1;
+                        foundInjection = true;
                     }
 
                     write = false;
@@ -28,6 +31,10 @@ namespace CombatExtended.HarmonyCE
                     write = true;
                 }
                 yield return code;
+            }
+            if (!foundInjection)
+            {
+                Log.Error($"Combat Extended :: Failed to find injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
             }
         }
     }

--- a/Source/CombatExtended/Harmony/Harmony_HediffComp_TendDuration.cs
+++ b/Source/CombatExtended/Harmony/Harmony_HediffComp_TendDuration.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Reflection.Emit;
 using HarmonyLib;
 using Verse;
@@ -19,14 +20,20 @@ namespace CombatExtended.HarmonyCE
         static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {
             int countReplace = 0;
+            bool foundInjection = false;
             foreach (CodeInstruction instruction in instructions)
             {
                 if (countReplace < 2 && instruction.opcode == OpCodes.Ldc_R4 && (instruction.OperandIs(-0.25f) || instruction.OperandIs(0.25f)))
                 {
                     instruction.operand = countReplace == 0 ? -0.15f : 0.15f;
+                    foundInjection = true;
                     countReplace++;
                 }
                 yield return instruction;
+            }
+            if (!foundInjection)
+            {
+                Log.Error($"Combat Extended :: Failed to find injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
             }
         }
     }

--- a/Source/CombatExtended/Harmony/Harmony_Hediff_Injury.cs
+++ b/Source/CombatExtended/Harmony/Harmony_Hediff_Injury.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Reflection;
 using System.Reflection.Emit;
 using HarmonyLib;
 using Verse;
@@ -18,6 +19,7 @@ namespace CombatExtended.HarmonyCE
             {
                 var patchPhase = 0;
                 var emitOriginal = true;
+                bool foundInjection = false;
 
                 foreach (var instruction in instructions)
                 {
@@ -42,6 +44,7 @@ namespace CombatExtended.HarmonyCE
                                 patchPhase = 2;
                                 yield return instruction;
                                 yield return new CodeInstruction(OpCodes.Nop);
+                                foundInjection = true;
                             }
 
                             break;
@@ -59,6 +62,10 @@ namespace CombatExtended.HarmonyCE
                     {
                         yield return instruction;
                     }
+                }
+                if (!foundInjection)
+                {
+                    Log.Error($"Combat Extended :: Failed to find injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
                 }
             }
         }

--- a/Source/CombatExtended/Harmony/Harmony_JobGiver_AIBreaching.cs
+++ b/Source/CombatExtended/Harmony/Harmony_JobGiver_AIBreaching.cs
@@ -24,6 +24,7 @@ namespace CombatExtended.HarmonyCE
             MethodInfo pIsMechanoid = AccessTools.DeclaredPropertyGetter(typeof(RaceProperties), nameof(RaceProperties.IsMechanoid));
 
             Label checkNoDesignatedSoloAttackerExistsLabel = generator.DefineLabel();
+            bool foundInjection = false;
 
             for (int i = 0; i < instructionsList.Count; i++)
             {
@@ -39,11 +40,16 @@ namespace CombatExtended.HarmonyCE
                     yield return new CodeInstruction(OpCodes.Callvirt, pRaceProps);
                     yield return new CodeInstruction(OpCodes.Callvirt, pIsMechanoid);
                     yield return new CodeInstruction(OpCodes.Brfalse_S, (Label)checkPawnIsSoloAttackerLabel);
+                    foundInjection = true;
                 }
                 else
                 {
                     yield return instructionsList[i];
                 }
+            }
+            if (!foundInjection)
+            {
+                Log.Error($"Combat Extended :: Failed to find injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
             }
         }
     }

--- a/Source/CombatExtended/Harmony/Harmony_PawnColumnWorkers.cs
+++ b/Source/CombatExtended/Harmony/Harmony_PawnColumnWorkers.cs
@@ -7,7 +7,6 @@ using HarmonyLib;
 using Verse;
 using RimWorld;
 using UnityEngine;
-using Verse.AI;
 
 namespace CombatExtended.HarmonyCE
 {
@@ -55,11 +54,17 @@ namespace CombatExtended.HarmonyCE
         [HarmonyTranspiler]
         static IEnumerable<CodeInstruction> MinWidth(IEnumerable<CodeInstruction> instructions)
         {
+            bool foundInjection = false;
             foreach (CodeInstruction instruction in instructions)
             {
                 if (instruction.opcode == OpCodes.Ldc_R4 && (instruction.operand as float?).HasValue && (instruction.operand as float?).Value.Equals(orgMinWidth))
                 {
                     instruction.operand = PawnColumnWorker_Loadout._MinWidth;
+                    foundInjection = true;
+                }
+                if (!foundInjection)
+                {
+                    Log.Error($"Combat Extended :: Failed to find injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
                 }
                 yield return instruction;
             }
@@ -71,13 +76,19 @@ namespace CombatExtended.HarmonyCE
         [HarmonyTranspiler]
         static IEnumerable<CodeInstruction> OptWidth(IEnumerable<CodeInstruction> instructions)
         {
+            bool foundInjection = false;
             foreach (CodeInstruction instruction in instructions)
             {
                 if (instruction.opcode == OpCodes.Ldc_R4 && (instruction.operand as float?).HasValue && (instruction.operand as float?).Value.Equals(orgOptimalWidth))
                 {
                     instruction.operand = PawnColumnWorker_Loadout._OptimalWidth;
+                    foundInjection = true;
                 }
                 yield return instruction;
+            }
+            if (!foundInjection)
+            {
+                Log.Error($"Combat Extended :: Failed to find injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
             }
         }
     }

--- a/Source/CombatExtended/Harmony/Harmony_PawnColumnWorkers.cs
+++ b/Source/CombatExtended/Harmony/Harmony_PawnColumnWorkers.cs
@@ -62,11 +62,11 @@ namespace CombatExtended.HarmonyCE
                     instruction.operand = PawnColumnWorker_Loadout._MinWidth;
                     foundInjection = true;
                 }
-                if (!foundInjection)
-                {
-                    Log.Error($"Combat Extended :: Failed to find injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
-                }
                 yield return instruction;
+            }
+            if (!foundInjection)
+            {
+                Log.Error($"Combat Extended :: Failed to find injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
             }
         }
 

--- a/Source/CombatExtended/Harmony/Harmony_PawnGraphicSet.cs
+++ b/Source/CombatExtended/Harmony/Harmony_PawnGraphicSet.cs
@@ -1,10 +1,8 @@
 ﻿using HarmonyLib;
 using RimWorld;
-using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Reflection;
 using System.Reflection.Emit;
-using System.Text;
 using Verse;
 
 namespace CombatExtended.HarmonyCE
@@ -20,6 +18,7 @@ namespace CombatExtended.HarmonyCE
         internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {
             var write = false;
+            bool foundInjection = false;
 
             foreach (var code in instructions)
             {
@@ -32,12 +31,17 @@ namespace CombatExtended.HarmonyCE
                 if (code.opcode == OpCodes.Ldsfld && ReferenceEquals(code.operand, AccessTools.Field(typeof(ApparelLayerDefOf), nameof(ApparelLayerDefOf.Overhead))))
                 {
                     write = true;
+                    foundInjection = true;
                     yield return new CodeInstruction(OpCodes.Callvirt, AccessTools.Method(typeof(Harmony_PawnGraphicSet), nameof(RenderSpecial)));
                 }
                 else
                 {
                     yield return code;
                 }
+            }
+            if (!foundInjection)
+            {
+                Log.Error($"Combat Extended :: Failed to find injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
             }
         }
     }

--- a/Source/CombatExtended/Harmony/Harmony_PawnRenderer.cs
+++ b/Source/CombatExtended/Harmony/Harmony_PawnRenderer.cs
@@ -1,11 +1,7 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Reflection;
 using System.Reflection.Emit;
-using System.Runtime.CompilerServices;
 using HarmonyLib;
 using RimWorld;
 using UnityEngine;
@@ -94,20 +90,24 @@ namespace CombatExtended.HarmonyCE
                                     new CodeInstruction(OpCodes.Ldloc_2),
                                     new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(Harmony_PawnRenderer_DrawEquipmentAiming), nameof(RecoilCE)))
             };
-            bool foundRecoil = false;
             int index = 0;
+            bool foundInjection = false;
             for (int i = 0; i < codes.Count; i++)
             {
                 CodeInstruction code = codes[i];
-                if (foundRecoil && code.opcode == OpCodes.Stloc_1)
+                if (foundInjection && code.opcode == OpCodes.Stloc_1)
                 {
                     index = i + 1;
                     break;
                 }
                 else if (code.opcode == OpCodes.Call && ReferenceEquals(code.operand, typeof(EquipmentUtility).GetMethod(nameof(EquipmentUtility.Recoil))))
                 {
-                    foundRecoil = true;
+                    foundInjection = true;
                 }
+            }
+            if (!foundInjection)
+            {
+                Log.Error($"Combat Extended :: Failed to find injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
             }
             codes.InsertRange(index, recoil_opcodes);
             codes[codes.Count - 2].operand =

--- a/Source/CombatExtended/Harmony/Harmony_Pawn_HealthTracker.cs
+++ b/Source/CombatExtended/Harmony/Harmony_Pawn_HealthTracker.cs
@@ -25,6 +25,7 @@ namespace CombatExtended.HarmonyCE
             Label deathOnDownLabel = generator.DefineLabel();
 
             bool flag = false;
+            bool foundInjection = false;
 
             List<CodeInstruction> codes = instructions.ToList();
             for (int i = 0; i < codes.Count; i++)
@@ -48,13 +49,19 @@ namespace CombatExtended.HarmonyCE
                         {
                             deathOnDownLabel
                         };
+                    foundInjection = true;
                 }
+            }
+            if (!foundInjection)
+            {
+                Log.Error($"Combat Extended :: Failed to find injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
             }
             return Transpilers.MethodReplacer(
                        codes,
                        AccessTools.Method(typeof(Rand), nameof(Rand.Chance)),
                        AccessTools.Method(typeof(Harmony_Pawn_HealthTracker_CheckForStateChange), nameof(Harmony_Pawn_HealthTracker_CheckForStateChange.NoChance))
                    );
+
         }
 
         static bool NoChance(float unusedChance)

--- a/Source/CombatExtended/Harmony/Harmony_TradeUtility.cs
+++ b/Source/CombatExtended/Harmony/Harmony_TradeUtility.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.Reflection;
 using System.Reflection.Emit;
 using HarmonyLib;
 using Verse;
@@ -11,14 +11,20 @@ namespace CombatExtended.HarmonyCE
     {
         internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {
+            bool foundInjection = false;
             foreach (var instruction in instructions)
             {
                 if (instruction.opcode == OpCodes.Ldc_R4 && (instruction.operand?.Equals(0.5f) ?? false))
                 {
                     instruction.operand = 0.01f;
+                    foundInjection = true;
                 }
 
                 yield return instruction;
+            }
+            if (!foundInjection)
+            {
+                Log.Error($"Combat Extended :: Failed to find injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
             }
         }
     }

--- a/Source/CombatExtended/Harmony/Harmony_Verb.cs
+++ b/Source/CombatExtended/Harmony/Harmony_Verb.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using HarmonyLib;
 using Verse;
 using RimWorld;
@@ -39,6 +37,7 @@ namespace CombatExtended.HarmonyCE
             MethodInfo pnonInterruptingSelfCast = AccessTools.PropertyGetter(typeof(Verb), nameof(Verb.NonInterruptingSelfCast));
             MethodInfo pCasterPawn = AccessTools.PropertyGetter(typeof(Verb), nameof(Verb.CasterPawn));
             MethodInfo pSpawned = AccessTools.PropertyGetter(typeof(Pawn), nameof(Pawn.Spawned));
+            bool foundInjection = false;
 
             bool ticksBetweenBurstShotsFinished = false;
 
@@ -65,9 +64,14 @@ namespace CombatExtended.HarmonyCE
                     yield return new CodeInstruction(OpCodes.Callvirt, pCasterPawn);
                     yield return new CodeInstruction(OpCodes.Callvirt, pSpawned);
                     yield return new CodeInstruction(OpCodes.Brfalse_S, blockEndLabel);
+                    foundInjection = true;
                     continue;
                 }
                 yield return codes[i];
+            }
+            if (!foundInjection)
+            {
+                Log.Error($"Combat Extended :: Failed to find injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
             }
         }
 

--- a/Source/CombatExtended/Harmony/Harmony_VerbTracker.cs
+++ b/Source/CombatExtended/Harmony/Harmony_VerbTracker.cs
@@ -59,6 +59,8 @@ namespace CombatExtended.HarmonyCE
             var verb = il.DeclareLocal(typeof(VerbTracker));
             var verbCE = il.DeclareLocal(typeof(Verb_LaunchProjectileCE));
             var failBranch = il.DefineLabel();
+            bool foundInjection = false;
+            bool secondInjection = false;
 
             foreach (CodeInstruction instruction in instructions)
             {
@@ -83,6 +85,7 @@ namespace CombatExtended.HarmonyCE
 
                     // modify the current instruction (should be ldloc.0) to have the label for fail condition.
                     instruction.labels.Add(failBranch);
+                    foundInjection = true;
 
                     // done
                     patchPhase = 2;
@@ -95,11 +98,20 @@ namespace CombatExtended.HarmonyCE
                     yield return new CodeInstruction(OpCodes.Stloc, verb);
                     // push the JUST stored local variable back onto the stack for use by the next instruction.
                     yield return new CodeInstruction(OpCodes.Ldloc, verb);
+                    secondInjection = true;
                     patchPhase = 1;
                 }
 
 
                 yield return instruction;
+            }
+            if (!foundInjection)
+            {
+                Log.Error($"Combat Extended :: Failed to find first injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
+            }
+            if (!secondInjection)
+            {
+                Log.Error($"Combat Extended :: Failed to find second injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
             }
         }
     }

--- a/Source/CombatExtended/Harmony/Harmony_Verb_BeatFire.cs
+++ b/Source/CombatExtended/Harmony/Harmony_Verb_BeatFire.cs
@@ -1,10 +1,8 @@
 ﻿using HarmonyLib;
 using RimWorld;
-using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Reflection;
 using System.Reflection.Emit;
-using System.Text;
 using Verse;
 
 namespace CombatExtended.HarmonyCE
@@ -16,13 +14,19 @@ namespace CombatExtended.HarmonyCE
         {
             internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
             {
+                bool foundInjection = false;
                 foreach (var instruction in instructions)
                 {
                     if (instruction.opcode == OpCodes.Ldc_R4 && instruction.operand is float amount && amount == 32f)
                     {
                         instruction.operand = 48f;
+                        foundInjection = true;
                     }
                     yield return instruction;
+                }
+                if (!foundInjection)
+                {
+                    Log.Error($"Combat Extended :: Failed to find injection point when applying Patch: {HarmonyBase.GetClassName(MethodBase.GetCurrentMethod()?.DeclaringType)}");
                 }
             }
         }

--- a/Source/CombatExtended/Utilities/TranspilerCE.cs
+++ b/Source/CombatExtended/Utilities/TranspilerCE.cs
@@ -84,7 +84,5 @@ namespace CombatExtended.Utilities
                 yield return iterInstructions.Current;
             }
         }
-
-
     }
 }

--- a/Source/CombatExtended/Utilities/TranspilerCE.cs
+++ b/Source/CombatExtended/Utilities/TranspilerCE.cs
@@ -84,5 +84,7 @@ namespace CombatExtended.Utilities
                 yield return iterInstructions.Current;
             }
         }
+
+
     }
 }


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Adds fail error message for transpiler patches

## Reasoning

Why did you choose to implement things this way, e.g.
- Allows us to know when a transpiler is failing.
- Silent fail had a patch broken for entire time of 1.5 #4014

## Alternatives

Describe alternative implementations you have considered, e.g.
- Silent failures

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
