### PR TITLE
Tweak skill xp gain

### DIFF
--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_MarkForArtilleryCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_MarkForArtilleryCE.cs
@@ -27,14 +27,6 @@ namespace CombatExtended
         {
             _lastConditionsCheckedAt = -1;
         }
-        public override void WarmupComplete()
-        {
-            base.WarmupComplete();
-            if (ShooterPawn != null && ShooterPawn.skills != null)
-            {
-                ShooterPawn.skills.Learn(SkillDefOf.Shooting, 200);
-            }
-        }
 
         public override bool TryCastShot()
         {

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
@@ -168,7 +168,7 @@ namespace CombatExtended
 
             // Award XP as per vanilla
             bool targetImmobile = IsTargetImmobile(currentTarget);
-            if (!targetImmobile && casterPawn.skills != null && currentTarget.Pawn == null || !currentTarget.Pawn.IsColonyMech)
+            if (!targetImmobile && casterPawn.skills != null && (currentTarget.Pawn == null || !currentTarget.Pawn.IsColonyMech))
             {
                 casterPawn.skills.Learn(SkillDefOf.Melee, HitXP * verbProps.AdjustedFullCycleTime(this, casterPawn), false);
             }

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
@@ -168,7 +168,7 @@ namespace CombatExtended
 
             // Award XP as per vanilla
             bool targetImmobile = IsTargetImmobile(currentTarget);
-            if (!targetImmobile && casterPawn.skills != null)
+            if (!targetImmobile && casterPawn.skills != null && currentTarget.Pawn == null || !currentTarget.Pawn.IsColonyMech)
             {
                 casterPawn.skills.Learn(SkillDefOf.Melee, HitXP * verbProps.AdjustedFullCycleTime(this, casterPawn), false);
             }
@@ -260,7 +260,10 @@ namespace CombatExtended
                             isCrit = true;
                             damageResult = ApplyMeleeDamageToTarget(currentTarget);
                             moteText = casterPawn.def.race.Animal ? null : "CE_TextMote_CriticalHit".Translate();
-                            casterPawn.skills?.Learn(SkillDefOf.Melee, CritXP * verbProps.AdjustedFullCycleTime(this, casterPawn), false);
+                            if (!defender.IsColonyMech)
+                            {
+                                casterPawn.skills?.Learn(SkillDefOf.Melee, CritXP * verbProps.AdjustedFullCycleTime(this, casterPawn), false);
+                            }
                         }
                         else
                         {

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -233,7 +233,7 @@ namespace CombatExtended
             _isAiming = false;
 
             // Award XP
-            if (ShooterPawn?.skills != null && currentTarget.Thing is Pawn)
+            if (ShooterPawn?.skills != null && currentTarget.Thing is Pawn { Downed: false, IsColonyMech: false} )
             {
                 var time = verbProps.AdjustedFullCycleTime(this, ShooterPawn);
                 time += aimTicks.TicksToSeconds();

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -233,7 +233,7 @@ namespace CombatExtended
             _isAiming = false;
 
             // Award XP
-            if (ShooterPawn?.skills != null && currentTarget.Thing is Pawn { Downed: false, IsColonyMech: false} )
+            if (ShooterPawn?.skills != null && currentTarget.Thing is Pawn { Downed: false, IsColonyMech: false })
             {
                 var time = verbProps.AdjustedFullCycleTime(this, ShooterPawn);
                 time += aimTicks.TicksToSeconds();


### PR DESCRIPTION
## Changes

- Added checks for downed and colony mech pawns to closer match vanilla skill gain conditions.
- Removed skill gain from binoculars to prevent free skill farming.

## Reasoning

- Matches vanilla behavior and prevents farming skill levels by attacking colony mechs using low-pen attacks.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
