### PR TITLE
Archon VPE patch

### DIFF
--- a/ModPatches/Vanilla Races Expanded - Archon/Patches/Vanilla Races Expanded - Archon/Abilities_Transcendent.xml
+++ b/ModPatches/Vanilla Races Expanded - Archon/Patches/Vanilla Races Expanded - Archon/Abilities_Transcendent.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Psycasts Expanded</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/VFECore.Abilities.AbilityDef[defName="VREA_PsychicWarp" or defName="VREA_PsychicThrow"]/range</xpath>
+					<value>
+						<range>28</range>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/VFECore.Abilities.AbilityDef[defName="VREA_PsychicLance"]/range</xpath>
+					<value>
+						<range>55</range>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VREA_PsychicThrow"]/projectile/armorPenetrationBase</xpath>
+					<value>
+						<armorPenetrationBase>10</armorPenetrationBase>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VREA_PsychicWarp"]/projectile/armorPenetrationBase</xpath>
+					<value>
+						<armorPenetrationBase>22</armorPenetrationBase>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Vanilla Races Expanded - Archon/Patches/Vanilla Races Expanded - Archon/Abilities_Transcendent.xml
+++ b/ModPatches/Vanilla Races Expanded - Archon/Patches/Vanilla Races Expanded - Archon/Abilities_Transcendent.xml
@@ -22,20 +22,6 @@
 					</value>
 				</li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VREA_PsychicThrow"]/projectile/armorPenetrationBase</xpath>
-					<value>
-						<armorPenetrationBase>10</armorPenetrationBase>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VREA_PsychicWarp"]/projectile/armorPenetrationBase</xpath>
-					<value>
-						<armorPenetrationBase>22</armorPenetrationBase>
-					</value>
-				</li>
-
 			</operations>
 		</match>
 	</Operation>

--- a/ModPatches/Vanilla Races Expanded - Archon/Patches/Vanilla Races Expanded - Archon/Abilities_Transcendent.xml
+++ b/ModPatches/Vanilla Races Expanded - Archon/Patches/Vanilla Races Expanded - Archon/Abilities_Transcendent.xml
@@ -9,14 +9,14 @@
 			<operations>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/VFECore.Abilities.AbilityDef[defName="VREA_PsychicWarp" or defName="VREA_PsychicThrow"]/range</xpath>
+					<xpath>Defs/VEF.Abilities.AbilityDef[defName="VREA_PsychicWarp" or defName="VREA_PsychicThrow"]/range</xpath>
 					<value>
 						<range>28</range>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/VFECore.Abilities.AbilityDef[defName="VREA_PsychicLance"]/range</xpath>
+					<xpath>Defs/VEF.Abilities.AbilityDef[defName="VREA_PsychicLance"]/range</xpath>
 					<value>
 						<range>55</range>
 					</value>


### PR DESCRIPTION
## Additions
Patched VPE for VRE Archon 
## Changes
increased range and armor pen of the combat Abilities and 
Edit projectiles seems to have full armor pen removing armor pen patch
## References

## Reasoning

## Alternatives

## Testing 
tests are done on 1.5, when VRE Archon is updated for 1.6 "VFECore.Abilities.AbilityDef" need to be replaced with "VEF.Abilities.AbilityDef"
Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
