### PR TITLE
Fixed mortar aim

### DIFF
--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootMortarCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootMortarCE.cs
@@ -66,16 +66,16 @@ public class Verb_ShootMortarCE : Verb_ShootCE
         }
         return true;
     }
-	
-	public override ShiftVecReport ShiftVecReportFor(LocalTargetInfo target)
-	{
-		return ShiftVecReportFor(target, target.Cell);
-	}
 
-	public override ShiftVecReport ShiftVecReportFor(LocalTargetInfo target, IntVec3 targetCell)
-	{
-		ShiftVecReport report = base.ShiftVecReportFor(target, targetCell);
-		report.circularMissRadius = this.GetMissRadiusForDist(report.shotDist);
+    public override ShiftVecReport ShiftVecReportFor(LocalTargetInfo target)
+    {
+        return ShiftVecReportFor(target, target.Cell);
+    }
+
+    public override ShiftVecReport ShiftVecReportFor(LocalTargetInfo target, IntVec3 targetCell)
+    {
+        ShiftVecReport report = base.ShiftVecReportFor(target, targetCell);
+        report.circularMissRadius = this.GetMissRadiusForDist(report.shotDist);
 
         // Check for marker
         ArtilleryMarker marker = null;


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Fixed mortars having near perfect aim and ignoring indirect fire penalty

## References

Links to the associated issues or other related pull requests, e.g.

- Fixes bugs introduced from #3534 

## Reasoning

Why did you choose to implement things this way, e.g.
- Verb_LaunchProjectileCE.TryCastShot() shiftVecReport was changed from (Target) to (Target, Cell). Mortar does not override ShiftVecReport(Target,Cell) so was using original method. This caused Marker and Indirect aiming to still utilize direct aiming values.


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (Spawned some 81mm mortars and shot couple dozens of shots both direct and indirect and ensured that mortars no longer had pinpoint accuracy. Also made sure bino correctly removed indirect fire penalty)
