### PR TITLE
GenRadial Patch

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_GenRadial.cs
+++ b/Source/CombatExtended/Harmony/Harmony_GenRadial.cs
@@ -116,7 +116,8 @@ namespace CombatExtended.HarmonyCE
                 idx = RadialPatternCount - 6;
             }
 
-            /* Since a circle has 8-way symmetry (axis + diagonals, forming the 8 octants)
+            /* 
+             * Since a circle has 8-way symmetry (axis + diagonals, forming the 8 octants)
              *   the final answers are always the sum of the following:
              * - 1, for the center cell
              * - 4*a, where "a = floor(radius)" is the number of cells on the +x axis
@@ -127,15 +128,12 @@ namespace CombatExtended.HarmonyCE
              * We can determine the last three bits of the answer as 1 or 5 (0b101)
              *   and skip every 8 cells when searching
              */
-            {
-                const float SqrtHalf = 0.707106781f;
-                int a = (int)radius;
-                int d = (int)(radius * SqrtHalf);
-                idx = (idx & -7) | (((a + d) % 2 == 0) ? 1 : 5);
-            }
+            const float SqrtHalf = 0.707106781f;
+            int a = (int)radius;
+            int d = (int)(radius * SqrtHalf);
+            idx = (idx & -7) | (((a + d) % 2 == 0) ? 1 : 5);
             
             // Linear search every 8 cells starting from the middle of estimation
-            // Bound check needed to avoid IndexOutOfRangeError
             if (RadialPatternRadii[idx] <= radius)
             {
                 do


### PR DESCRIPTION
## Changes

~~Removed a "-1" at the end of the patch before returning the result.
Added a index range check in the final look.~~

Replaced GenRadial.NumCellsInRadius with my implementation to fix errors within specific ranges of inputs.

## References

See "Reasoning"

## Reasoning

~~I suspect [this line](https://github.com/CombatExtended-Continued/CombatExtended/blob/0b84986f55e854bb24253bcfca7c517ef2877632/Source/CombatExtended/Harmony/Harmony_GenRadial.cs#L127) causes an off-by-one error and the -1 shouldn't be there, here are the reasoning:
Say I am requesting NumCellsInRadius(1.0f), then the answer should trivially be 5 (there are 5 cells within a radius of 1, them being the center cell and the immediately neighboring 4 cell), and the array RadialPatternRadii would begin with [0f,1f,1f,1f,1f,...].
The method would find [in these lines](https://github.com/CombatExtended-Continued/CombatExtended/blob/0b84986f55e854bb24253bcfca7c517ef2877632/Source/CombatExtended/Harmony/Harmony_GenRadial.cs#L123-L126) that 1.0f = RadialPatternRadii[4] <= 1.0f < RadialPatternRadii[5] = 1.414f, and ``count`` would end at 5.
But because of the -1, instead of returning 5, it returns 4, missing one cell.
Another example: Say I am requesting NumCellsInRadius(119f), this should return 44469 (all the cells), but this is impossible because we'd see a IndexOutOfRange exception when [this line](https://github.com/CombatExtended-Continued/CombatExtended/blob/0b84986f55e854bb24253bcfca7c517ef2877632/Source/CombatExtended/Harmony/Harmony_GenRadial.cs#L125) tries to access RadialPatternRadii[44469].~~  

For ``NumCellsInRadius(radius)``, consider any float32 number ``radius`` between ``sqrt(3f) <= radius < 2f``, the answer should be ``9`` but current implementation returns ``8`` instead:

1. [These lines](https://github.com/CombatExtended-Continued/CombatExtended/blob/0b84986f55e854bb24253bcfca7c517ef2877632/Source/CombatExtended/Harmony/Harmony_GenRadial.cs#L98-L100) would resolve that ``3f <= radsq < 4f``, ``r == (int)radsq == 3``, and ``count == radialPatternNumCells[r - 1] == radialPatternNumCells[2] == 9``.
2. The ``9``th cell is indeed a cell guaranteed to be within the specified distance, in fact it is that last cell. And ``count = 9`` would be the correct answer if it just returned.
3. The initial ``start = radialPatternRadii[count]`` accesses ``radialPatternRadii[9]``, which is the ``10``th cell in ``radialPatternRadii``, which returns ``2f``.
4. Since ``start > radius``, [the while loop](https://github.com/CombatExtended-Continued/CombatExtended/blob/0b84986f55e854bb24253bcfca7c517ef2877632/Source/CombatExtended/Harmony/Harmony_GenRadial.cs#L123-L126) is skipped.
5. ``__result = count - 1`` [at the end](https://github.com/CombatExtended-Continued/CombatExtended/blob/0b84986f55e854bb24253bcfca7c517ef2877632/Source/CombatExtended/Harmony/Harmony_GenRadial.cs#L127) causes an off-by-one error, returning ``8``.  

This also occurs at ``sqrt(6) <= radius < sqrt(8)``, ``sqrt(11) <= radius < sqrt(13)``, ``sqrt(14) <= radius < 4``...

## Alternatives

Just in case this is interesting to you all:
I wrote a patch mod for GenRadial that's somewhat different to CE's implementation: https://github.com/AmCh-Q/RimWorldMod_GenRadial_Increase/blob/main/Source/Main.cs

~~IDK how to benchmark the performance, but my solution involves more math hacks, no division/sqrt/pow, doesn't use a RadialPatternNumCells helper array or buckets, and only iterates over 1/8 of the circle. So it could be faster and more space efficient.~~
[I have benchmarked and showed the performance difference](https://github.com/CombatExtended-Continued/CombatExtended/pull/4029#issuecomment-3046081379), but this is probably secondary to fixing the wrong results.

## Testing

- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] Playtested a colony (specify how long)
