### PR TITLE
Update references to AnimalBehaviours to target VEF.AnimalBehaviours

### DIFF
--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Atispec.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Atispec.xml
@@ -75,7 +75,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="AA_Atispec"]/comps</xpath>
 		<value>
-			<li Class="AnimalBehaviours.CompProperties_InitialHediff">
+			<li Class="VEF.AnimalBehaviours.CompProperties_InitialHediff">
 				<hediffname>AA_LowBleed</hediffname>
 				<hediffseverity>1</hediffseverity>
 			</li>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_EngorgedTentacularAberration.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_EngorgedTentacularAberration.xml
@@ -62,7 +62,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="AA_EngorgedTentacularAberration"]/comps</xpath>
 					<value>
-						<li Class="AnimalBehaviours.CompProperties_InitialHediff">
+						<li Class="VEF.AnimalBehaviours.CompProperties_InitialHediff">
 							<hediffname>AA_LowBleed</hediffname>
 							<hediffseverity>1</hediffseverity>
 						</li>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Gallatross.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Gallatross.xml
@@ -101,7 +101,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="AA_Gallatross"]/comps</xpath>
 		<value>
-			<li Class="AnimalBehaviours.CompProperties_InitialHediff">
+			<li Class="VEF.AnimalBehaviours.CompProperties_InitialHediff">
 				<hediffname>AA_LowBleed</hediffname>
 				<hediffseverity>1</hediffseverity>
 			</li>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_MoribundGallatross.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_MoribundGallatross.xml
@@ -101,7 +101,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="AA_GallatrossMoribund"]/comps</xpath>
 		<value>
-			<li Class="AnimalBehaviours.CompProperties_InitialHediff">
+			<li Class="VEF.AnimalBehaviours.CompProperties_InitialHediff">
 				<hediffname>AA_LowBleed</hediffname>
 				<hediffseverity>1</hediffseverity>
 			</li>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_UnblinkingEye.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_UnblinkingEye.xml
@@ -73,7 +73,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="AA_UnblinkingEye"]/comps</xpath>
 					<value>
-						<li Class="AnimalBehaviours.CompProperties_InitialHediff">
+						<li Class="VEF.AnimalBehaviours.CompProperties_InitialHediff">
 							<hediffname>AA_LowBleed</hediffname>
 							<hediffseverity>1</hediffseverity>
 						</li>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_PristineAssembler.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Races/Races_PristineAssembler.xml
@@ -41,7 +41,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="AM_Mech_PristineAssembler"]/comps/li[@Class ="AnimalBehaviours.CompProperties_AnimalProduct"]/randomItems</xpath>
+					<xpath>Defs/ThingDef[defName="AM_Mech_PristineAssembler"]/comps/li[@Class ="VEF.AnimalBehaviours.CompProperties_AnimalProduct"]/randomItems</xpath>
 					<value>
 						<li>FSX</li>
 						<li>Prometheum</li>

--- a/ModPatches/The Joris Experience/Patches/The Joris Experience/Unique_Joris_Extended.xml
+++ b/ModPatches/The Joris Experience/Patches/The Joris Experience/Unique_Joris_Extended.xml
@@ -211,7 +211,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="JE_BiblicallyAccurateJoris"]/comps</xpath>
 		<value>
-			<li Class="AnimalBehaviours.CompProperties_InitialHediff">
+			<li Class="VEF.AnimalBehaviours.CompProperties_InitialHediff">
 				<hediffname>JJ_LowBleed</hediffname>
 				<hediffseverity>1</hediffseverity>
 			</li>

--- a/ModPatches/The Joris Experience/Patches/The Joris Experience/Unique_Joris_Extended2.xml
+++ b/ModPatches/The Joris Experience/Patches/The Joris Experience/Unique_Joris_Extended2.xml
@@ -651,7 +651,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="JE_ZombieJoris"]/comps</xpath>
 		<value>
-			<li Class="AnimalBehaviours.CompProperties_InitialHediff">
+			<li Class="VEF.AnimalBehaviours.CompProperties_InitialHediff">
 				<hediffname>JJ_LowBleed</hediffname>
 				<hediffseverity>1</hediffseverity>
 			</li>

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Durapod.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Durapod.xml
@@ -78,7 +78,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="VFEI2_Durapod"]/comps/li[@Class="AnimalBehaviours.CompProperties_HediffAfterHealthLoss"]</xpath>
+		<xpath>Defs/ThingDef[defName="VFEI2_Durapod"]/comps/li[@Class="VEF.AnimalBehaviours.CompProperties_HediffAfterHealthLoss"]</xpath>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Ironclad.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Ironclad.xml
@@ -95,7 +95,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="VFEI2_Ironclad"]/comps/li[@Class="AnimalBehaviours.CompProperties_HediffAfterHealthLoss"]</xpath>
+		<xpath>Defs/ThingDef[defName="VFEI2_Ironclad"]/comps/li[@Class="VEF.AnimalBehaviours.CompProperties_HediffAfterHealthLoss"]</xpath>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Silverfish.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Silverfish.xml
@@ -101,7 +101,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="VFEI2_Silverfish"]/comps/li[@Class="AnimalBehaviours.CompProperties_HediffAfterHealthLoss"]</xpath>
+		<xpath>Defs/ThingDef[defName="VFEI2_Silverfish"]/comps/li[@Class="VEF.AnimalBehaviours.CompProperties_HediffAfterHealthLoss"]</xpath>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Tankroach.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Races/Races_Tankroach.xml
@@ -103,7 +103,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="VFEI2_Tankroach"]/comps/li[@Class="AnimalBehaviours.CompProperties_HediffAfterHealthLoss"]</xpath>
+		<xpath>Defs/ThingDef[defName="VFEI2_Tankroach"]/comps/li[@Class="VEF.AnimalBehaviours.CompProperties_HediffAfterHealthLoss"]</xpath>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">


### PR DESCRIPTION
This is not a full patch update of any of the involved mods, it is targeting one specific update across multiple mods' patches.

## Additions

N/A

## Changes

- Fix references to AnimalBehaviours to now reference VEF.AnimalBehaviours after VFECore restructured to VEF

## References

- Based on Discord bug report https://discord.com/channels/278818534069501953/324222101550661663/1390911920240066642

## Reasoning

- namespace has changed

## Alternatives

- wait for full 1.6 release of the mods involved before updating patches

## Testing

Check tests you have performed:
- [ X ] Compiles without warnings
- [ ] Game runs without errors - the rest of the patches are still broken
- [ X ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
