### PR TITLE
Revert delta-ticks for fleck comp

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompThrownFleckEmitterSmooth.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompThrownFleckEmitterSmooth.cs
@@ -40,7 +40,7 @@ namespace CombatExtended
             }
         }
 
-        public override void CompTickInterval(int delta)
+        public override void CompTick()
         {
             if (!IsOn)
             {


### PR DESCRIPTION
## Changes

- Reverts projectile fleck comp back to regular tick method

## Reasoning

- Staggered visuals don't look as good
- Initially thought the interval would only matter on offscreen projectiles, where flecks don't spawn, however the rate is also slowed down depending on zoom levels.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] Playtested a colony (specify how long)
