### PR TITLE
Preliminary Odyssey support

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/BulletCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/BulletCE.cs
@@ -113,6 +113,16 @@ public class BulletCE : ProjectileCE
                         hitThing.TakeDamage(secDinfo).AssociateWithLog(logEntry);
                     }
                 }
+
+                foreach (ExtraDamage damage in base.ExtraDamages)
+                {
+                    if (Rand.Chance(damage.chance))
+                    {
+                        var extraDinfo = new DamageInfo(damage.def, damage.amount, damage.armorPenetration,
+                            angle: ExactRotation.eulerAngles.y, instigator: launcher, weapon: equipmentDef, intendedTarget: intendedTarget.Thing, instigatorGuilty: InstigatorGuilty);
+                        hitThing.TakeDamage(extraDinfo).AssociateWithLog(logEntry);
+                    }
+                }
             }
             catch (Exception e)
             {

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -68,7 +68,7 @@ public abstract class ProjectileCE : ThingWithComps
     protected bool InstigatorGuilty => !(launcher is Pawn launcherPawn && launcherPawn.Drafted);
 
     public DamageDef damageDefOverride;
-    
+
     public DamageDef DamageDef => damageDefOverride ?? def.projectile.damageDef;
 
     public Thing intendedTargetThing
@@ -164,9 +164,9 @@ public abstract class ProjectileCE : ThingWithComps
     protected Sustainer ambientSustainer;
 
     public virtual bool AnimalsFleeImpact => false;
-    
+
     public List<ExtraDamage> extraDamages = new List<ExtraDamage>();
-    
+
     public IEnumerable<ExtraDamage> ExtraDamages => extraDamages.Concat(def.projectile.extraDamages ?? Enumerable.Empty<ExtraDamage>());
 
     #endregion

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -638,7 +638,7 @@ public class Verb_LaunchProjectileCE : Verb
     public virtual ShiftVecReport ShiftVecReportFor(LocalTargetInfo target, IntVec3 targetCell)
     {
         ShiftVecReport report = new ShiftVecReport();
-        
+
         bool ignoreMalusesFlag = EquipmentSource != null && EquipmentSource.TryGetComp(out CompUniqueWeapon comp) && comp.IgnoreAccuracyMaluses;
 
         report.target = target;

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -638,6 +638,8 @@ public class Verb_LaunchProjectileCE : Verb
     public virtual ShiftVecReport ShiftVecReportFor(LocalTargetInfo target, IntVec3 targetCell)
     {
         ShiftVecReport report = new ShiftVecReport();
+        
+        bool ignoreMalusesFlag = EquipmentSource != null && EquipmentSource.TryGetComp(out CompUniqueWeapon comp) && comp.IgnoreAccuracyMaluses;
 
         report.target = target;
         report.aimingAccuracy = AimingAccuracy;
@@ -652,7 +654,7 @@ public class Verb_LaunchProjectileCE : Verb
         report.maxRange = EffectiveRange;
         report.lightingShift = CE_Utility.GetLightingShift(Shooter, LightingTracker.CombatGlowAtFor(caster.Position, targetCell));
 
-        if (!caster.Position.Roofed(caster.Map) || !targetCell.Roofed(caster.Map))  //Change to more accurate algorithm?
+        if (!ignoreMalusesFlag && (!caster.Position.Roofed(caster.Map) || !targetCell.Roofed(caster.Map)))  //Change to more accurate algorithm?
         {
             report.weatherShift = 1 - caster.Map.weatherManager.CurWeatherAccuracyMultiplier;
         }
@@ -666,7 +668,7 @@ public class Verb_LaunchProjectileCE : Verb
 
         GetHighestCoverAndSmokeForTarget(target, out cover, out smokeDensity, out roofed);
         report.cover = cover;
-        report.smokeDensity = smokeDensity;
+        report.smokeDensity = ignoreMalusesFlag ? 0 : smokeDensity;
         report.roofed = roofed;
         return report;
     }
@@ -1133,6 +1135,21 @@ public class Verb_LaunchProjectileCE : Verb
             projectile.intendedTarget = currentTarget;
             projectile.mount = caster.Position.GetThingList(caster.Map).FirstOrDefault(t => t is Pawn && t != caster);
             projectile.AccuracyFactor = report.accuracyFactor * report.swayDegrees * ((numShotsFired + 1) * 0.75f);
+
+            if (EquipmentSource.TryGetComp(out CompUniqueWeapon comp))
+            {
+                foreach (WeaponTraitDef trait in comp.TraitsListForReading)
+                {
+                    if (trait.damageDefOverride != null)
+                    {
+                        projectile.damageDefOverride = trait.damageDefOverride;
+                    }
+                    if (!trait.extraDamages.NullOrEmpty())
+                    {
+                        projectile.extraDamages.AddRange(trait.extraDamages);
+                    }
+                }
+            }
 
             if (instant)
             {


### PR DESCRIPTION
## Additions

- Support for ExtraDamages, DamageDefOverride and IgnoreAccuracyMaluses fields added in the unstable branch.

## Reasoning

- Even if we decide to not use the fields as part of Odyssey patching, those are still very likely to be used by other modders and this will let us make future patches easier.

## Alternatives

- Unify SecondaryDamage and ExtraDamage into a single system.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
