### PR TITLE
Implemented new weightedAmmoCategories field for LoadoutPropertiesExtension

### DIFF
--- a/Source/CombatExtended/CombatExtended/Defs/WeightedAmmoCategory.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/WeightedAmmoCategory.cs
@@ -1,0 +1,26 @@
+﻿using RimWorld;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using Verse;
+using System.Xml;
+
+namespace CombatExtended;
+public class WeightedAmmoCategory
+{
+    public AmmoCategoryDef ammoCategory;
+
+    public float chance;
+
+    public void LoadDataFromXmlCustom(XmlNode xmlRoot)
+    {
+        {
+            DirectXmlCrossRefLoader.RegisterObjectWantsCrossRef(this, "ammoCategory", xmlRoot.Name);
+
+            chance = ParseHelper.FromString<float>(xmlRoot.InnerText);
+        }
+    }
+}


### PR DESCRIPTION

## Additions

New field public List<WeightedAmmoCategory> weightedAmmoCategories
New class WeightedAmmoCategory

## Changes

Changed ammo selection logic in LoadWeaponWithRandAmmo(ThingWithComps gun)

## References

Longstanding modder request

## Reasoning

- Added as new field so that existing defs do not need to be rewritten, function the same as before

Old system was limited in the following ways:
- Can only define one forcedAmmoCategory
    - unable to force ammo category for different weapon types, e.g. if a PawnKind can use a shotgun or a rifle, can only force ammo category on one or the other
    - unable to force a subset of ammo categories, e.g. a PawnKind that can use any of the three advanced rifle ammos, but not the basic ones
    - if not using forcedAmmoCategory, have to rely on the global generateAllowChance of the ammos

New system enables the following improvements:
- Can now define multiple ammo categories for a PawnKindDef, e.g. a PawnKind that can spawn with only AP-I or AP-HE ammos
- This also allows including ammo categories meant for multiple primary and sidearm options, e.g. force select Slug for shotgun, Sabot for rifle
- Can weight ammo categories on a per-PawnKindDef basis, instead of having to rely on the global generateAllowChance of that ammo, e.g. a PawnKindDef with 75% chance to use AP and 25% to use AP-HE, another with 50%-50% chances

## Alternatives

- Leave in current state
- Rewrite to address one currently known limitation: if two weapons' AmmoSets share any AmmoCategoryDefs, there is no way to define if a given WeightedAmmoCategory is meant for one or the other i.e. no way to force primary rifle to use AP and sidearm pistol to use FMJ since they share both options.

## Testing

Check tests you have performed:
- [ X ] Compiles without warnings
- [ X ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ X ] Playtested a colony (specify how long) - generated multiple 10000 point raids without error, including PawnKinds that use forcedAmmoCategory, weightedAmmoCategories, and neither. Didn't seem to have a significant performance impact.