### PR TITLE
Add melee hit chance bonuses from Ideology

### DIFF
--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
@@ -184,7 +184,7 @@ public class Verb_MeleeAttackCE : Verb_MeleeAttack
         if (Rand.Chance(GetHitChance(targetThing)))
         {
             // Check for dodge
-            if (!targetImmobile && !surpriseAttack && Rand.Chance(defender.GetStatValue(StatDefOf.MeleeDodgeChance)))
+            if (!targetImmobile && !surpriseAttack && Rand.Chance(GetDodgeChance((defender))))
             {
                 // Attack is evaded
                 result = false;
@@ -542,6 +542,26 @@ public class Verb_MeleeAttackCE : Verb_MeleeAttack
         {
             float chance = CasterPawn.GetStatValue(StatDefOf.MeleeHitChance, true);
 
+            if (ModsConfig.IdeologyActive && target.HasThing)
+            {
+                if (DarknessCombatUtility.IsOutdoorsAndLit(target.Thing))
+                {
+                    chance += caster.GetStatValue(StatDefOf.MeleeHitChanceOutdoorsLitOffset);
+                }
+                else if (DarknessCombatUtility.IsOutdoorsAndDark(target.Thing))
+                {
+                    chance += caster.GetStatValue(StatDefOf.MeleeHitChanceOutdoorsDarkOffset);
+                }
+                else if (DarknessCombatUtility.IsIndoorsAndDark(target.Thing))
+                {
+                    chance += caster.GetStatValue(StatDefOf.MeleeHitChanceIndoorsDarkOffset);
+                }
+                else if (DarknessCombatUtility.IsIndoorsAndLit(target.Thing))
+                {
+                    chance += caster.GetStatValue(StatDefOf.MeleeHitChanceIndoorsLitOffset);
+                }
+            }
+
             switch (GetAttackedPartHeightCE())
             {
                 case BodyPartHeight.Bottom:
@@ -559,6 +579,34 @@ public class Verb_MeleeAttackCE : Verb_MeleeAttack
             return chance;
         }
         return DefaultHitChance;
+    }
+
+    private float GetDodgeChance(Pawn defender)
+    {
+        float chance = defender.GetStatValue(StatDefOf.MeleeDodgeChance);
+
+        if (!ModsConfig.IdeologyActive)
+        {
+            return chance;
+        }
+
+        if (DarknessCombatUtility.IsOutdoorsAndLit(defender))
+        {
+            chance += defender.GetStatValue(StatDefOf.MeleeDodgeChanceOutdoorsLitOffset);
+        }
+        else if (DarknessCombatUtility.IsOutdoorsAndDark(defender))
+        {
+            chance += defender.GetStatValue(StatDefOf.MeleeDodgeChanceOutdoorsDarkOffset);
+        }
+        else if (DarknessCombatUtility.IsIndoorsAndDark(defender))
+        {
+            chance += defender.GetStatValue(StatDefOf.MeleeDodgeChanceIndoorsDarkOffset);
+        }
+        else if (DarknessCombatUtility.IsIndoorsAndLit(defender))
+        {
+            chance += defender.GetStatValue(StatDefOf.MeleeDodgeChanceIndoorsLitOffset);
+        }
+        return chance;
     }
 
     /// <summary>


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Adds hit and dodge chance bonuses granted by ideology (i.e. Combat in darkness: preferred) to melee hit chance calculations.

## References

Links to the associated issues or other related pull requests, e.g.

## Reasoning

Why did you choose to implement things this way, e.g.
- It seems like this part of code was forgotten during patching of Ideology and bonuses never applied.
- Our calculations use different methods so it was easier to copy the code instead of rerouting to use vanilla methods.
- Code mostly copied from vanilla, i am not to be bullied for that horrible if else block.

## Alternatives

Describe alternative implementations you have considered, e.g.
- Use vanilla methods

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
Tested pawn vs raider, pawn vs animal, pawn vs wall.
