### PR TITLE
Interrupt in-melee shooting

### DIFF
--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -1316,8 +1316,7 @@ public class Verb_LaunchProjectileCE : Verb
             return ReachabilityImmediate.CanReachImmediate(root, targ, caster.Map, PathEndMode.Touch, null);
         }
         CellRect cellRect = (!targ.HasThing) ? CellRect.SingleCell(targ.Cell) : targ.Thing.OccupiedRect();
-        float num = cellRect.ClosestDistSquaredTo(root);
-        if (num > EffectiveRange * EffectiveRange || num < verbProps.minRange * verbProps.minRange)
+        if (OutOfRange(root, targ, cellRect))
         {
             resultingLine = new ShootLine(root, targetPos.ToIntVec3());
             return false;


### PR DESCRIPTION
## Changes

- Changed `TryFindCEShootLineFromTo` to use the vanilla `OutOfRange` check, which correctly accounts for the pawn being in melee range.
- This interrupts a melee attack in warmup, as opposed to the current behavior of letting the pawn finish the burst.

## Reasoning

- Matches vanilla melee-locking.
- Pawns being able to get off a burst in melee is easily exploitable.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
