### PR TITLE
Alpha biomes darts fix

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -49,6 +49,7 @@
 		<li>miho.fortifiedoutremer</li>
 		<li>co.uk.epicguru.whatsthatmod</li>
 		<li>sarg.alphagenes</li>
+		<li>sarg.alphabiomes</li>
 		<li>accurex.medievalempireoverhaul</li>
 		<li>BlackMarket420.Kerberos</li>		
 	</loadBefore>

--- a/ModPatches/Alpha Biomes/Defs/Alpha Biomes/Defs_Ammo.xml
+++ b/ModPatches/Alpha Biomes/Defs/Alpha Biomes/Defs_Ammo.xml
@@ -52,6 +52,8 @@
 			<damageAmountBase>4</damageAmountBase>
 			<armorPenetrationSharp>1.35</armorPenetrationSharp>
 			<armorPenetrationBlunt>1.50</armorPenetrationBlunt>
+			<preExplosionSpawnChance>0.25</preExplosionSpawnChance>
+			<preExplosionSpawnThingDef>AB_WeaponPoisonDart</preExplosionSpawnThingDef>
 		</projectile>
 	</ThingDef>
 

--- a/ModPatches/Alpha Biomes/Defs/Alpha Biomes/Defs_Ammo.xml
+++ b/ModPatches/Alpha Biomes/Defs/Alpha Biomes/Defs_Ammo.xml
@@ -1,81 +1,105 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Defs>
 
-    <CombatExtended.AmmoCategoryDef>
-        <defName>Tar</defName>
-        <label>Tar</label>
-        <description>Releases a splattering of thick, black substance.</description>
-    </CombatExtended.AmmoCategoryDef>
+	<CombatExtended.AmmoCategoryDef>
+		<defName>Tar</defName>
+		<label>Tar</label>
+		<description>Releases a splattering of thick, black substance.</description>
+	</CombatExtended.AmmoCategoryDef>
 
-    <!-- ======== Projectiles ======== -->
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_Blowdart_AB</defName>
+		<label>blowgun darts</label>
+		<ammoTypes>
+			<AB_WeaponPoisonDart>Projectile_Dart_Venom_AB</AB_WeaponPoisonDart>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
 
-    <ThingDef ParentName="Base81mmMortarShell">
-        <defName>Bullet_81mmMortarShell_Tar</defName>
-        <label>81mm mortar shell (Tar)</label>
-        <graphicData>
-            <texPath>Things/Projectile/ShellHighExplosive</texPath>
-            <graphicClass>Graphic_Single</graphicClass>
-        </graphicData>
-        <projectile Class="CombatExtended.ProjectilePropertiesCE">
-            <damageDef>AB_Tar</damageDef>
-            <damageAmountBase>40</damageAmountBase>
-            <explosionRadius>3.5</explosionRadius>
-            <flyOverhead>true</flyOverhead>
-            <soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
-            <soundExplode>Explosion_Smoke</soundExplode>
-            <soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
-            <soundAmbient>MortarRound_Ambient</soundAmbient>
-            <postExplosionSpawnThingDef>AB_Filth_Tar</postExplosionSpawnThingDef>
-            <postExplosionSpawnChance>0.8</postExplosionSpawnChance>
-            <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-        </projectile>
-    </ThingDef>            
+	<!-- ======== Projectiles ======== -->
 
-    <!-- ======== Recipes ======== -->
+	<ThingDef ParentName="Base81mmMortarShell">
+		<defName>Bullet_81mmMortarShell_Tar</defName>
+		<label>81mm mortar shell (Tar)</label>
+		<graphicData>
+			<texPath>Things/Projectile/ShellHighExplosive</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>AB_Tar</damageDef>
+			<damageAmountBase>40</damageAmountBase>
+			<explosionRadius>3.5</explosionRadius>
+			<flyOverhead>true</flyOverhead>
+			<soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
+			<soundExplode>Explosion_Smoke</soundExplode>
+			<soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
+			<soundAmbient>MortarRound_Ambient</soundAmbient>
+			<postExplosionSpawnThingDef>AB_Filth_Tar</postExplosionSpawnThingDef>
+			<postExplosionSpawnChance>0.8</postExplosionSpawnChance>
+			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+		</projectile>
+	</ThingDef>
 
-    <RecipeDef ParentName="AmmoRecipeBase">
-        <defName>MakeAB_Shell_Tar</defName>
-        <label>make 81mm tar mortar shell x2</label>
-        <description>Craft 2 tar shells.</description>
-        <jobString>Making 81mm tar shells.</jobString>
-        <ingredients>
-            <li>
-                <filter>
-                    <thingDefs>
-                        <li>Steel</li>
-                    </thingDefs>
-                </filter>
-                <count>25</count>
-            </li>
-            <li>
-                <filter>
-                    <thingDefs>
-                        <li>ComponentIndustrial</li>
-                    </thingDefs>
-                </filter>
-                <count>2</count>
-            </li>
-            <li>
-                <filter>
-                    <thingDefs>
-                        <li>AB_AsphaltBucket</li>
-                    </thingDefs>
-                </filter>
-                <count>10</count>
-            </li>
-        </ingredients>
-        <fixedIngredientFilter>
-            <thingDefs>
-                <li>Steel</li>
-                <li>ComponentIndustrial</li>
-                <li>AB_AsphaltBucket</li>
-            </thingDefs>
-        </fixedIngredientFilter>
-        <products>
-            <AB_Shell_Tar>2</AB_Shell_Tar>
-        </products>
-        <workAmount>3000</workAmount>
-        <researchPrerequisite>Mortars</researchPrerequisite>
-    </RecipeDef>
+	<ThingDef ParentName="BaseArrowProjectile">
+		<defName>Projectile_Dart_Venom_AB</defName>
+		<label>poison dart</label>
+		<graphicData>
+			<texPath>Things/Item/Resource/AB_PoisonDart</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<speed>16</speed>
+			<damageDef>AB_ParalysingSting</damageDef>
+			<damageAmountBase>4</damageAmountBase>
+			<armorPenetrationSharp>1.35</armorPenetrationSharp>
+			<armorPenetrationBlunt>1.50</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<!-- ======== Recipes ======== -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAB_Shell_Tar</defName>
+		<label>make 81mm tar mortar shell x2</label>
+		<description>Craft 2 tar shells.</description>
+		<jobString>Making 81mm tar shells.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>25</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>2</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>AB_AsphaltBucket</li>
+					</thingDefs>
+				</filter>
+				<count>10</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>ComponentIndustrial</li>
+				<li>AB_AsphaltBucket</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<AB_Shell_Tar>2</AB_Shell_Tar>
+		</products>
+		<workAmount>3000</workAmount>
+		<researchPrerequisite>Mortars</researchPrerequisite>
+	</RecipeDef>
 
 </Defs>

--- a/ModPatches/Alpha Biomes/Patches/Alpha Biomes/RangedIndustrialGrenades.xml
+++ b/ModPatches/Alpha Biomes/Patches/Alpha Biomes/RangedIndustrialGrenades.xml
@@ -3,68 +3,78 @@
 
 	<!-- ========== Poison Dart ========== -->
 
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>AB_WeaponPoisonDart</defName>
-		<statBases>
-			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-			<SightsEfficiency>0.7</SightsEfficiency>
-			<ShotSpread>0.07</ShotSpread>
-			<SwayFactor>1</SwayFactor>
-			<Bulk>1</Bulk>
-		</statBases>
-		<Properties>
-			<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>AB_WeaponPoisonDartProjectile</defaultProjectile>
-			<warmupTime>1</warmupTime>
-			<range>14</range>
-			<soundCast>ThrowGrenade</soundCast>
-			<muzzleFlashScale>0</muzzleFlashScale>
-		</Properties>
-		<FireModes>
-			<aiAimMode>AimedShot</aiAimMode>
-		</FireModes>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
+	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="AB_WeaponPoisonDart"]</xpath>
 		<value>
-			<equippedAngleOffset>60</equippedAngleOffset>
+			<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseWeaponAndAmmoNeolithic">
+				<defName>AB_WeaponPoisonDart</defName>
+				<label>dribbling cap poison dart</label>
+				<description>This small poison dart has been filled with the pungent resin flowing from a dribbling cap fungus. It is an extremely potent neurotoxin, causing immediate paralysis, and eventually, death.</description>
+				<graphicData>
+					<texPath>Things/Item/Resource/AB_PoisonDart</texPath>
+					<graphicClass>Graphic_Single</graphicClass>
+					<onGroundRandomRotateAngle>0</onGroundRandomRotateAngle>
+				</graphicData>
+				<soundInteract>Interact_Grenade</soundInteract>
+				<statBases>
+					<SightsEfficiency>1.0</SightsEfficiency>
+					<ShotSpread>1.5</ShotSpread>
+					<SwayFactor>2.5</SwayFactor>
+					<Mass>0.014</Mass>
+					<Bulk>0.04</Bulk>
+					<Flammability>1</Flammability>
+					<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+					<MeleeCounterParryBonus>0.06</MeleeCounterParryBonus>
+				</statBases>
+				<equippedStatOffsets>
+					<MeleeCritChance>0.10</MeleeCritChance>
+					<MeleeParryChance>0.10</MeleeParryChance>
+					<MeleeDodgeChance>0.57</MeleeDodgeChance>
+				</equippedStatOffsets>
+				<equippedAngleOffset>60</equippedAngleOffset>
+				<stackLimit>50</stackLimit>
+				<weaponTags>
+					<li>NeolithicRangedBasic</li>
+					<li>CE_OneHandedWeapon</li>
+				</weaponTags>
+				<weaponClasses>
+					<li>Ranged</li>
+				</weaponClasses>
+				<tradeability>Sellable</tradeability>
+				<verbs>
+					<li Class="CombatExtended.VerbPropertiesCE">
+						<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Projectile_Dart_Venom_AB</defaultProjectile>
+						<warmupTime>0.8</warmupTime>
+						<range>10</range>
+						<!--<soundCast>Interact_BeatFire</soundCast>-->
+					</li>
+				</verbs>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>point</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<extraMeleeDamages>
+							<li>
+								<def>AB_ParalysingSting</def>
+								<amount>2</amount>
+								<chance>1</chance>
+							</li>
+						</extraMeleeDamages>
+						<power>4</power>
+						<cooldownTime>1.49</cooldownTime>
+						<chanceFactor>1.5</chanceFactor>
+						<armorPenetrationSharp>1</armorPenetrationSharp>
+						<armorPenetrationBlunt>0.75</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+					</li>
+				</tools>
+				<ammoClass>VenomArrow</ammoClass>
+			</ThingDef>
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationAttributeSet">
-		<xpath>Defs/ThingDef[defName="AB_WeaponPoisonDartProjectile"]/projectile</xpath>
-		<attribute>Class</attribute>
-		<value>CombatExtended.ProjectilePropertiesCE</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="AB_WeaponPoisonDartProjectile"]</xpath>
-		<value>
-			<thingClass>CombatExtended.BulletCE</thingClass>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="AB_WeaponPoisonDartProjectile"]/projectile</xpath>
-		<value>
-			<armorPenetrationSharp>1.5</armorPenetrationSharp>
-			<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="AB_WeaponPoisonDartProjectile"]/projectile/speed</xpath>
-		<value>
-			<speed>12</speed>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="AB_WeaponPoisonDartProjectile"]/projectile/damageAmountBase</xpath>
-		<value>
-			<damageAmountBase>5</damageAmountBase>
-		</value>
-	</Operation>
 </Patch>

--- a/ModPatches/Alpha Biomes/Patches/Alpha Biomes/RangedIndustrialGrenades.xml
+++ b/ModPatches/Alpha Biomes/Patches/Alpha Biomes/RangedIndustrialGrenades.xml
@@ -3,77 +3,58 @@
 
 	<!-- ========== Poison Dart ========== -->
 
+	<Operation Class="PatchOperationAttributeSet">
+		<xpath>Defs/ThingDef[defName="AB_WeaponPoisonDart"]</xpath>
+		<attribute>ParentName</attribute>
+		<value>BaseWeaponAndAmmoNeolithic</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAttributeSet">
+		<xpath>Defs/ThingDef[defName="AB_WeaponPoisonDart"]</xpath>
+		<attribute>Class</attribute>
+		<value>CombatExtended.AmmoDef</value>
+	</Operation>
+
 	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AB_WeaponPoisonDart"]/statBases/Mass</xpath>
+		<value>
+			<Mass>0.014</Mass>
+			<SightsEfficiency>1</SightsEfficiency>
+			<ShotSpread>1.5</ShotSpread>
+			<SwayFactor>2.5</SwayFactor>
+			<Bulk>0.04</Bulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AB_WeaponPoisonDart"]/verbs</xpath>
+		<value>
+			<verbs>
+				<li Class="CombatExtended.VerbPropertiesCE">
+					<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Projectile_Dart_Venom_AB</defaultProjectile>
+					<warmupTime>0.8</warmupTime>
+					<range>10</range>
+					<!--<soundCast>Interact_BeatFire</soundCast>-->
+				</li>
+			</verbs>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="AB_WeaponPoisonDart"]</xpath>
 		<value>
-			<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseWeaponAndAmmoNeolithic">
-				<defName>AB_WeaponPoisonDart</defName>
-				<label>dribbling cap poison dart</label>
-				<description>This small poison dart has been filled with the pungent resin flowing from a dribbling cap fungus. It is an extremely potent neurotoxin, causing immediate paralysis, and eventually, death.</description>
-				<graphicData>
-					<texPath>Things/Item/Resource/AB_PoisonDart</texPath>
-					<graphicClass>Graphic_Single</graphicClass>
-					<onGroundRandomRotateAngle>0</onGroundRandomRotateAngle>
-				</graphicData>
-				<soundInteract>Interact_Grenade</soundInteract>
-				<statBases>
-					<SightsEfficiency>1.0</SightsEfficiency>
-					<ShotSpread>1.5</ShotSpread>
-					<SwayFactor>2.5</SwayFactor>
-					<Mass>0.014</Mass>
-					<Bulk>0.04</Bulk>
-					<Flammability>1</Flammability>
-					<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-					<MeleeCounterParryBonus>0.06</MeleeCounterParryBonus>
-				</statBases>
-				<equippedStatOffsets>
-					<MeleeCritChance>0.10</MeleeCritChance>
-					<MeleeParryChance>0.10</MeleeParryChance>
-					<MeleeDodgeChance>0.57</MeleeDodgeChance>
-				</equippedStatOffsets>
-				<equippedAngleOffset>60</equippedAngleOffset>
-				<stackLimit>50</stackLimit>
-				<weaponTags>
-					<li>NeolithicRangedBasic</li>
-					<li>CE_OneHandedWeapon</li>
-				</weaponTags>
-				<weaponClasses>
-					<li>Ranged</li>
-				</weaponClasses>
-				<tradeability>Sellable</tradeability>
-				<verbs>
-					<li Class="CombatExtended.VerbPropertiesCE">
-						<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
-						<hasStandardCommand>true</hasStandardCommand>
-						<defaultProjectile>Projectile_Dart_Venom_AB</defaultProjectile>
-						<warmupTime>0.8</warmupTime>
-						<range>10</range>
-						<!--<soundCast>Interact_BeatFire</soundCast>-->
-					</li>
-				</verbs>
-				<tools>
-					<li Class="CombatExtended.ToolCE">
-						<label>point</label>
-						<capacities>
-							<li>Stab</li>
-						</capacities>
-						<extraMeleeDamages>
-							<li>
-								<def>AB_ParalysingSting</def>
-								<amount>2</amount>
-								<chance>1</chance>
-							</li>
-						</extraMeleeDamages>
-						<power>4</power>
-						<cooldownTime>1.49</cooldownTime>
-						<chanceFactor>1.5</chanceFactor>
-						<armorPenetrationSharp>1</armorPenetrationSharp>
-						<armorPenetrationBlunt>0.75</armorPenetrationBlunt>
-						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
-					</li>
-				</tools>
-				<ammoClass>VenomArrow</ammoClass>
-			</ThingDef>
+			<ammoClass>VenomArrow</ammoClass>
+			<equippedAngleOffset>60</equippedAngleOffset>
+			<stackLimit>50</stackLimit>			
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="AB_WeaponPoisonDart"]/weaponTags</xpath>
+		<value>
+			<li>CE_OneHandedWeapon</li>
 		</value>
 	</Operation>
 

--- a/ModPatches/Alpha Biomes/Patches/Alpha Biomes/Tar_IED.xml
+++ b/ModPatches/Alpha Biomes/Patches/Alpha Biomes/Tar_IED.xml
@@ -7,6 +7,7 @@
 			<costList>
 				<Steel>10</Steel>
 				<ComponentIndustrial>1</ComponentIndustrial>
+				<AB_AsphaltBucket>5</AB_AsphaltBucket>
 			</costList>
 		</value>
 	</Operation>

--- a/ModPatches/Alpha Biomes/Patches/Alpha Biomes/Tar_IED.xml
+++ b/ModPatches/Alpha Biomes/Patches/Alpha Biomes/Tar_IED.xml
@@ -7,7 +7,6 @@
 			<costList>
 				<Steel>10</Steel>
 				<ComponentIndustrial>1</ComponentIndustrial>
-				<AB_ProcessedResin>1</AB_ProcessedResin>
 			</costList>
 		</value>
 	</Operation>


### PR DESCRIPTION
## Additions
none
## Changes
change the alpha biome darts to ammo
fix the darts don't stack
and removed AB_ProcessedResin from a recipe
## References
none
## Reasoning
it didn't stack before
## Alternatives
not fixing it?
## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
