### PR TITLE
Melee effects update

### DIFF
--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
@@ -188,7 +188,7 @@ public class Verb_MeleeAttackCE : Verb_MeleeAttack
             {
                 // Attack is evaded
                 result = false;
-                soundDef = SoundMiss();
+                soundDef = SoundDodge(defender);
                 CreateCombatLog((ManeuverDef maneuver) => maneuver.combatLogRulesDodge, false);
 
                 moteText = "TextMote_Dodge".Translate();

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
@@ -192,6 +192,7 @@ public class Verb_MeleeAttackCE : Verb_MeleeAttack
                 CreateCombatLog((ManeuverDef maneuver) => maneuver.combatLogRulesDodge, false);
 
                 moteText = "TextMote_Dodge".Translate();
+                defender.drawer.jitterer.AddOffset(1.5f, (defender.Position - casterPawn.Position).AngleFlat + Rand.Range(-90f, 90));
                 defender.skills?.Learn(SkillDefOf.Melee, DodgeXP * verbProps.AdjustedFullCycleTime(this, casterPawn), false);
             }
             else
@@ -226,6 +227,7 @@ public class Verb_MeleeAttackCE : Verb_MeleeAttack
                         // Do a riposte
                         DoParry(defender, parryThing, true, deflected);
                         moteText = "CE_TextMote_Riposted".Translate();
+                        defender.drawer.Notify_MeleeAttackOn(casterPawn);
                         CreateCombatLog((ManeuverDef maneuver) => maneuver.combatLogRulesDeflect, false); //placeholder
 
                         defender.skills?.Learn(SkillDefOf.Melee, (CritXP + ParryXP) * verbProps.AdjustedFullCycleTime(this, casterPawn), false);
@@ -239,6 +241,18 @@ public class Verb_MeleeAttackCE : Verb_MeleeAttack
                         {
                             moteText = "CE_TextMote_Parried".Translate();
                         }
+                        else
+                        {
+                            //play hit received jitter animation
+                            defender.drawer.jitterer.AddOffset(0.1f, (defender.Position - casterPawn.Position).AngleFlat);
+                        }
+
+                        if (parryThing.Stuff != null && parryThing.Stuff.stuffProps.soundMeleeHitSharp != null)
+                        {
+                            parryThing.Stuff.stuffProps.soundMeleeHitSharp.PlayOneShot(new TargetInfo(defender.Position,
+                                defender.Map, false));
+                        }
+
                         CreateCombatLog((ManeuverDef maneuver) => maneuver.combatLogRulesMiss, false); //placeholder
 
                         defender.skills?.Learn(SkillDefOf.Melee, ParryXP * verbProps.AdjustedFullCycleTime(this, casterPawn), false);


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Dodge now uses vanilla's dodge sounds instead of miss sounds.
- Adds subtle animations to blocking and dodging. Uses the same jitterer as the vanilla's forward lean when doing a melee attack. 
- Now, dodge similarly leans backwards or to the side, and blocking does a slight shake like taking a hit does. Riposte does a lean forward like an attack, parry does nothing.
- Blocking/parrying also plays weapon's/shield's stuff sharp hit sound, if it has stuff

## Reasoning

Why did you choose to implement things this way, e.g.
- We forgot to add dodge sounds when vanilla added them.
- Dodging animations makes melee a little bit more visually engaging and less awkward looking,
- Blocking sounds let you know that a hit occurred and shield took damage.

## Alternatives

Describe alternative implementations you have considered, e.g.
- Keep pawns staring awkwardly at each other.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
