### PR TITLE
Add 57x348mmSR Shell

### DIFF
--- a/Defs/Ammo/Shell/57x348mmSR.xml
+++ b/Defs/Ammo/Shell/57x348mmSR.xml
@@ -1,0 +1,344 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+	<ThingCategoryDef>
+		<defName>Ammo57x348mmSR</defName>
+		<label>57x348mmSR</label>
+		<parent>AmmoShells</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberAutocannonLarge</iconPath>
+	</ThingCategoryDef>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_57x348mmSR</defName>
+		<label>57x348mmSR</label>
+		<ammoTypes>
+			<Ammo_57x348mmSR_AP>Bullet_57x348mmSR_AP</Ammo_57x348mmSR_AP>
+			<Ammo_57x348mmSR_HE>Bullet_57x348mmSR_HE</Ammo_57x348mmSR_HE>
+			<Ammo_57x348mmSR_HE_TFuzed>Bullet_57x348mmSR_HE_TFuzed</Ammo_57x348mmSR_HE_TFuzed>
+			<Ammo_57x348mmSR_Sabot>Bullet_57x348mmSR_Sabot</Ammo_57x348mmSR_Sabot>
+		</ammoTypes>
+		<similarTo>AmmoSet_LightCannon</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo57x348mmSRBase" ParentName="HeavyAmmoBase" Abstract="True">
+		<description>Large caliber cartridge used by autocannons.</description>
+		<statBases>
+			<Mass>6.7</Mass>
+			<Bulk>12.79</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
+		<thingCategories>
+			<li>Ammo57x348mmSR</li>
+		</thingCategories>
+		<stackLimit>25</stackLimit>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo57x348mmSRBase">
+		<defName>Ammo_57x348mmSR_AP</defName>
+		<label>57x348mmSR cartridge (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_57x348mmSR_AP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo57x348mmSRBase">
+		<defName>Ammo_57x348mmSR_HE</defName>
+		<label>57x348mmSR cartridge (HE)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<ammoClass>GrenadeHE</ammoClass>
+		<cookOffProjectile>Bullet_57x348mmSR_HE</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo57x348mmSRBase">
+		<defName>Ammo_57x348mmSR_HE_TFuzed</defName>
+		<label>57x348mmsr cartridge (HE Time-Fuzed)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<ammoClass>GrenadeHETF</ammoClass>
+		<cookOffProjectile>Bullet_57x348mmSR_HE</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo57x348mmSRBase">
+		<defName>Ammo_57x348mmSR_Sabot</defName>
+		<label>57x348mmSR cartridge (Sabot)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<Mass>5.5</Mass>
+		</statBases>
+		<ammoClass>Sabot</ammoClass>
+		<cookOffProjectile>Bullet_57x348mmSR_Sabot</cookOffProjectile>
+	</ThingDef>
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef Name="Base57x348mmSRBullet" ParentName="BaseExplosiveBullet" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_Big</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<speed>178</speed>
+			<flyOverhead>false</flyOverhead>
+			<dropsCasings>true</dropsCasings>
+			<casingMoteDefname>Fleck_BigShell</casingMoteDefname>
+			<casingFilthDefname>Filth_CannonAmmoCasings</casingFilthDefname>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base57x348mmSRBullet">
+		<defName>Bullet_57x348mmSR_AP</defName>
+		<label>57x348mmSR bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<damageAmountBase>198</damageAmountBase>
+			<armorPenetrationSharp>147</armorPenetrationSharp>
+			<armorPenetrationBlunt>28000</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base57x348mmSRBullet">
+		<defName>Bullet_57x348mmSR_HE</defName>
+		<label>57x348mmSR bullet (HE)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bomb</damageDef>
+			<damageAmountBase>55</damageAmountBase>
+			<explosionRadius>1.5</explosionRadius>
+			<soundExplode>MortarBomb_Explode</soundExplode>
+			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+		</projectile>
+		<comps>
+			<li Class="CombatExtended.CompProperties_Fragments">
+				<fragments>
+					<Fragment_Large>7</Fragment_Large>
+					<Fragment_Small>14</Fragment_Small>
+				</fragments>
+			</li>
+		</comps>
+	</ThingDef>
+
+	<ThingDef ParentName="Base57x348mmSRBullet">
+		<defName>Bullet_57x348mmSR_HE_TFuzed</defName>
+		<label>57x348mmSR bullet (HE Time-Fuzed)</label>
+		<thingClass>CombatExtended.ProjectileCE_Bursting</thingClass>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bomb</damageDef>
+			<damageAmountBase>55</damageAmountBase>
+			<explosionRadius>1.5</explosionRadius>
+			<soundExplode>MortarBomb_Explode</soundExplode>
+			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			<aimHeightOffset>2</aimHeightOffset>
+			<armingDelay>2</armingDelay>
+		</projectile>
+		<comps>
+			<li Class="CombatExtended.CompProperties_Fragments">
+				<fragments>
+					<Fragment_Large>7</Fragment_Large>
+					<Fragment_Small>14</Fragment_Small>
+				</fragments>
+				<fragAngleRange>-89~-5</fragAngleRange>
+			</li>
+		</comps>
+	</ThingDef>
+
+	<ThingDef ParentName="Base57x348mmSRBullet">
+		<defName>Bullet_57x348mmSR_Sabot</defName>
+		<label>57x348mmSR bullet (Sabot)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<damageAmountBase>189</damageAmountBase>
+			<armorPenetrationSharp>221</armorPenetrationSharp>
+			<armorPenetrationBlunt>36000</armorPenetrationBlunt>
+			<speed>242</speed>
+		</projectile>
+	</ThingDef>
+
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="CannonAmmoRecipeBase">
+		<defName>MakeAmmo_57x348mmSR_AP</defName>
+		<label>make 57x348mmSR (AP) cartridge x10</label>
+		<description>Craft 10 57x348mmSR (AP) cartridges.</description>
+		<jobString>Making 57x348mmSR (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>122</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_57x348mmSR_AP>10</Ammo_57x348mmSR_AP>
+		</products>
+		<workAmount>14640</workAmount>
+	</RecipeDef>
+
+
+	<RecipeDef ParentName="CannonAmmoRecipeBase">
+		<defName>MakeAmmo_57x348mmSR_HE</defName>
+		<label>make 57x348mmSR (HE) cartridge x10</label>
+		<description>Craft 10 57x348mmSR (HE) cartridges.</description>
+		<jobString>Making 57x348mmSR (HE) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>122</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>2</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>FSX</li>
+					</thingDefs>
+				</filter>
+				<count>4</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>ComponentIndustrial</li>
+				<li>FSX</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_57x348mmSR_HE>10</Ammo_57x348mmSR_HE>
+		</products>
+		<workAmount>17800</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="CannonAmmoRecipeBase">
+		<defName>MakeAmmo_57x348mmSR_HE_TFuzed</defName>
+		<label>make 57x348mmSR (Time-Fuzed) cartridge x10</label>
+		<description>Craft 10 57x348mmSR (Time-Fuzed) cartridges.</description>
+		<jobString>Making 57x348mmSR (Time-Fuzed) cartridges.</jobString>
+		<researchPrerequisite Inherit="False" />
+		<researchPrerequisites>
+			<li>CE_TurretHeavyWeapons</li>
+			<li>CE_AdvancedLaunchers</li>
+		</researchPrerequisites>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>122</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>5</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>FSX</li>
+					</thingDefs>
+				</filter>
+				<count>4</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>ComponentIndustrial</li>
+				<li>FSX</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_57x348mmSR_HE_TFuzed>10</Ammo_57x348mmSR_HE_TFuzed>
+		</products>
+		<workAmount>19600</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="CannonAmmoRecipeBase">
+		<defName>MakeAmmo_57x348mmSR_Sabot</defName>
+		<label>make 57x348mmSR (Sabot) cartridge x10</label>
+		<description>Craft 10 57x348mmSR (Sabot) cartridges.</description>
+		<jobString>Making 57x348mmSR (Sabot) cartridges.</jobString>
+		<researchPrerequisite Inherit="False" />
+		<researchPrerequisites>
+			<li>CE_TurretHeavyWeapons</li>
+			<li>CE_AdvancedAmmo</li>
+		</researchPrerequisites>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>74</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Uranium</li>
+					</thingDefs>
+				</filter>
+				<count>14</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Chemfuel</li>
+					</thingDefs>
+				</filter>
+				<count>14</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Uranium</li>
+				<li>Chemfuel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_57x348mmSR_Sabot>10</Ammo_57x348mmSR_Sabot>
+		</products>
+		<workAmount>15800</workAmount>
+	</RecipeDef>
+
+</Defs>

--- a/Defs/Ammo/Shell/57x348mmSR.xml
+++ b/Defs/Ammo/Shell/57x348mmSR.xml
@@ -198,7 +198,6 @@
 		<workAmount>14640</workAmount>
 	</RecipeDef>
 
-
 	<RecipeDef ParentName="CannonAmmoRecipeBase">
 		<defName>MakeAmmo_57x348mmSR_HE</defName>
 		<label>make 57x348mmSR (HE) cartridge x10</label>


### PR DESCRIPTION
## Additions

Added 57x348mmSR shell.

## References

AmmoStat Sheet:  
https://docs.google.com/spreadsheets/d/1Y0tK7uN85p9nzm0X3rce8MsiN2-wSWrYBEmmP3GOaCk/edit?gid=746529518#gid=746529518

## Reasoning

Adding this real-world ammunition caliber will allow everyone to use items with a unified defName for ammunition, reducing management complexity.

In reality, this round is used by:

57mm guns:   S60, S68, 2A90

Related weapon platforms: 
2S38 (and other vehicles equipped with the AU-220M turret)

ZSU-57-2

Various vehicles armed with the S60 anti-aircraft gun

These are all highly renowned systems.
