### PR TITLE
Update Rimsenal Core Modular Helmets costlists

### DIFF
--- a/ModPatches/Rimsenal Core/Patches/Rimsenal Core/Apparel_RS_CE.xml
+++ b/ModPatches/Rimsenal Core/Patches/Rimsenal Core/Apparel_RS_CE.xml
@@ -384,15 +384,6 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Apparel_PioneerH"]/costList/Plasteel</xpath>
-		<value>
-			<Plasteel>40</Plasteel>
-			<DevilstrandCloth>10</DevilstrandCloth>
-			<ComponentSpacer>1</ComponentSpacer>
-		</value>
-	</Operation>
-
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_PioneerH"]/apparel/layers</xpath>
 		<value>
@@ -577,14 +568,6 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Apparel_NomadH"]/costList/Plasteel</xpath>
-		<value>
-			<Plasteel>40</Plasteel>
-			<DevilstrandCloth>10</DevilstrandCloth>
-			<ComponentSpacer>1</ComponentSpacer>
-		</value>
-	</Operation>
 
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_NomadH"]/apparel/layers</xpath>
@@ -728,14 +711,6 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Apparel_MedicH"]/costList/Plasteel</xpath>
-		<value>
-			<Plasteel>40</Plasteel>
-			<DevilstrandCloth>10</DevilstrandCloth>
-			<ComponentSpacer>1</ComponentSpacer>
-		</value>
-	</Operation>
 
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_MedicH"]/apparel/layers</xpath>


### PR DESCRIPTION
Problem: Rimsenal Core updated its modular helmet system to require security helmet precursor armor to craft, rather than plasteel directly. Since CE patched the costlist of these helmets, red errors appeared on startup. 

## Changes

Since the precursor helmets appear to have already been patched by CE, including costs, I just deleted  the part of the CE patch that messed with rimsenal's costs. 

## Reasoning

Precursor armors already patched by CE. Deleting the costlist patch seemed just reasonable. 

## Alternatives

Suffer, probably

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [X] (For compatibility patches) ...with and without patched mod loaded
- [X] Playtested a colony (specify how long)  (devmode quicktest and confirmed that pawns can build these helmets)
