### PR TITLE
Det's Half-Foot Initial Compatibility Patch

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -135,7 +135,7 @@
 		<li IfModActive="Pal5k.DeployableTurret">ModPatches/Deployable Turret</li>
 		<li IfModActive="DetVisor.EnergyWeapons">ModPatches/Det's Energy Weapons</li>
 		<li IfModActive="det.boglegs">ModPatches/Det's Xenotypes - Boglegs</li>
-    <li IfModActive="det.halffoot">ModPatches/Det's Xenotypes - Half-foot</li>
+		<li IfModActive="det.halffoot">ModPatches/Det's Xenotypes - Half-foot</li>
 		<li IfModActive="det.keshig">ModPatches/Det's Xenotypes - Keshig</li>
 		<li IfModActive="det.venators">ModPatches/Det's Xenotypes - Venators</li>
 		<li IfModActive="ATK.DevilstrandAnimals">ModPatches/Devilstrand Animals</li>

--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -135,6 +135,7 @@
 		<li IfModActive="Pal5k.DeployableTurret">ModPatches/Deployable Turret</li>
 		<li IfModActive="DetVisor.EnergyWeapons">ModPatches/Det's Energy Weapons</li>
 		<li IfModActive="det.boglegs">ModPatches/Det's Xenotypes - Boglegs</li>
+    <li IfModActive="det.halffoot">ModPatches/Det's Xenotypes - Half-foot</li>
 		<li IfModActive="det.keshig">ModPatches/Det's Xenotypes - Keshig</li>
 		<li IfModActive="det.venators">ModPatches/Det's Xenotypes - Venators</li>
 		<li IfModActive="ATK.DevilstrandAnimals">ModPatches/Devilstrand Animals</li>

--- a/ModPatches/Det's Xenotypes - Half-foot/Patches/Det's Xenotypes - Half-foot/Apparel_Headgear.xml
+++ b/ModPatches/Det's Xenotypes - Half-foot/Patches/Det's Xenotypes - Half-foot/Apparel_Headgear.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- DV_Apparel_ServiceHeadset  -->
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="DV_Apparel_ServiceHeadset"]/statBases</xpath>
+		<value>
+			<Bulk>1</Bulk>
+			<WornBulk>1</WornBulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="DV_Apparel_ServiceHeadset"]/apparel/layers</xpath>
+		<value>
+			<layers>
+				<li>StrappedHead</li>
+			</layers>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="DV_Apparel_ServiceHeadset"]</xpath>
+		<value>
+			<li Class="CombatExtended.ApparelDefExtension">
+				<isRadioPack>true</isRadioPack>
+			</li>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Det's Xenotypes - Half-foot/Patches/Det's Xenotypes - Half-foot/Weapon_Melee_Spacer.xml
+++ b/ModPatches/Det's Xenotypes - Half-foot/Patches/Det's Xenotypes - Half-foot/Weapon_Melee_Spacer.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+    <!-- Arc Wrench -->
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="DV_MeleeWeapon_ArcWrench"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>handle</label>
+					<capacities>
+						<li>Poke</li>
+					</capacities>
+					<power>2</power>
+					<cooldownTime>1.59</cooldownTime>
+					<armorPenetrationBlunt>2.00</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>15</power>
+					<extraMeleeDamages>
+						<li>
+							<def>Stun</def>
+							<amount>8</amount>
+							<chance>0.20</chance>
+						</li>
+					</extraMeleeDamages>
+					<cooldownTime>1.68</cooldownTime>
+					<chanceFactor>1.33</chanceFactor>
+					<armorPenetrationBlunt>14</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="DV_MeleeWeapon_ArcWrench"]/statBases</xpath>
+		<value>
+			<Bulk>3.5</Bulk>
+			<MeleeCounterParryBonus>0.2</MeleeCounterParryBonus>
+		</value>
+	</Operation>
+
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="DV_MeleeWeapon_ArcWrench"] </xpath>
+		<value>
+			<equippedStatOffsets>
+				<MeleeCritChance>0.5</MeleeCritChance>
+				<MeleeParryChance>0.15</MeleeParryChance>
+				<MeleeDodgeChance>0.05</MeleeDodgeChance>
+			</equippedStatOffsets>
+		</value>
+	</Operation>
+	
+
+</Patch>

--- a/ModPatches/Det's Xenotypes - Half-foot/Patches/Det's Xenotypes - Half-foot/Weapon_Melee_Spacer.xml
+++ b/ModPatches/Det's Xenotypes - Half-foot/Patches/Det's Xenotypes - Half-foot/Weapon_Melee_Spacer.xml
@@ -32,7 +32,7 @@
 					</extraMeleeDamages>
 					<cooldownTime>1.68</cooldownTime>
 					<chanceFactor>1.33</chanceFactor>
-					<armorPenetrationBlunt>14</armorPenetrationBlunt>
+					<armorPenetrationBlunt>12</armorPenetrationBlunt>
 					<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
 				</li>
 			</tools>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -183,6 +183,7 @@ Darkest Rim: Apparel	|
 Deployable Turret   |
 Det's Energy Weapons    |
 Det's Xenotypes - Boglegs   |
+Det's Xenotypes - Half-foot   |
 Det's Xenotypes - Keshig   |
 Det's Xenotypes - Venators   |
 Devilstrand Animals |


### PR DESCRIPTION
## Additions

Added compatibility patch for the headset and wrench introduced in the new xenotype mod. 

## Changes

Xenotype itself largely did not appear to need patching. Strangely, I see no way for this xenotype to spawn naturally in the game at least from the xml files itself. (no pawnkinds)

Wrench is comparable to an entrenching shovel, but since it is electrified, I gave it a small stun capability. 

The new headset appears to be comparable to an integrator headset except instead of giving mech bandwidth, it speeds up repair process. I largely copied over the stats given to integrator headsets.

## Alternatives

Could've given increased suppression vulnerability to a gene. Could've given bulk penalty to the gene.

However, as the mod itself does not appear to actually change the pawn's bodysize nor mess with carry weight in any way (the bodysize change seems more or less cosmetic), I didn't feel like changing it on our side either. 
## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [X] (For compatibility patches) ...with and without patched mod loaded
- [X] Playtested a colony (specify how long)  (pawn set to the xenotype seems to function more or less as intended. Weapons can be constructed. Compiles without error.)
