### PR TITLE
Fix MO Trebuchet Siege

### DIFF
--- a/ModPatches/Medieval Overhaul/Patches/Medieval Overhaul/ThingDefs_Buildings/MO_Siege_Trebuchet.xml
+++ b/ModPatches/Medieval Overhaul/Patches/Medieval Overhaul/ThingDefs_Buildings/MO_Siege_Trebuchet.xml
@@ -44,6 +44,20 @@
 			</li>
 		</value>
 	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="DankPyon_Artillery_Trebuchet"]/building/fixedStorageSettings/filter/categories/li</xpath>
+		<value>
+			<li>AmmoCatapult</li>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="DankPyon_Artillery_Trebuchet"]/building/defaultStorageSettings/filter/categories/li</xpath>
+		<value>
+			<li>AmmoCatapult</li>
+		</value>
+	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="DankPyon_Artillery_Trebuchet"]/verbs</xpath>


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Patch Trebuchet to account for CE's catapult ammo's thingCategory

## Reasoning

Why did you choose to implement things this way, e.g.
- Breaking siege raid worker due not having an ammo that can be utilized for the siege

## Alternatives

Describe alternative implementations you have considered, e.g.
- Suffer

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
