### PR TITLE
alpha mech enable the chaining effect

### DIFF
--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Misc/Weapons.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Misc/Weapons.xml
@@ -427,16 +427,9 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="AM_Bullet_Tesla"]/modExtensions/li[@Class="VEF.Weapons.TeslaChainingProps"]/bounceRange</xpath>
-					<value>
-						<bounceRange>6</bounceRange>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="AM_Bullet_Tesla"]/modExtensions/li[@Class="VEF.Weapons.TeslaChainingProps"]/maxBounceCount</xpath>
 					<value>
-						<maxBounceCount>2</maxBounceCount>
+						<maxBounceCount>1</maxBounceCount>
 					</value>
 				</li>
 

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Misc/Weapons.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Misc/Weapons.xml
@@ -408,35 +408,28 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="AM_Bullet_Tesla"]/projectile/damageAmountBase</xpath>
 					<value>
-						<damageAmountBase>10</damageAmountBase>
+						<damageAmountBase>1</damageAmountBase>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="AM_Bullet_Tesla"]/modExtensions/li[@Class="VEF.Weapons.TeslaChainingProps"]/damageDef</xpath>
 					<value>
-						<damageDef>EMP</damageDef>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="AM_Bullet_Tesla"]/modExtensions/li[@Class="VEF.Weapons.TeslaChainingProps"]/explosionDamageDef</xpath>
-					<value>
-						<explosionDamageDef>Smoke</explosionDamageDef>
+						<damageDef>Smoke</damageDef>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="AM_Bullet_Tesla"]/modExtensions/li[@Class="VEF.Weapons.TeslaChainingProps"]/maxLifetime</xpath>
 					<value>
-						<maxLifetime>10</maxLifetime>
+						<maxLifetime>15</maxLifetime>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="AM_Bullet_Tesla"]/modExtensions/li[@Class="VEF.Weapons.TeslaChainingProps"]/maxBounceCount</xpath>
 					<value>
-						<maxBounceCount>1</maxBounceCount>
+						<maxBounceCount>2</maxBounceCount>
 					</value>
 				</li>
 

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Misc/Weapons.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Misc/Weapons.xml
@@ -415,7 +415,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="AM_Bullet_Tesla"]/modExtensions/li[@Class="VEF.Weapons.TeslaChainingProps"]/damageDef</xpath>
 					<value>
-						<damageDef>EMP</damageDef>
+						<damageDef>Smoke</damageDef>
 					</value>
 				</li>
 

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Misc/Weapons.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Misc/Weapons.xml
@@ -422,7 +422,21 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="AM_Bullet_Tesla"]/modExtensions/li[@Class="VFEMech.TeslaChainingProps"]/maxLifetime</xpath>
 					<value>
-						<maxLifetime>6</maxLifetime>
+						<maxLifetime>30</maxLifetime>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="AM_Bullet_Tesla"]/modExtensions/li[@Class="VFEMech.TeslaChainingProps"]/bounceRange</xpath>
+					<value>
+						<bounceRange>4</bounceRange>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="AM_Bullet_Tesla"]/modExtensions/li[@Class="VFEMech.TeslaChainingProps"]/maxBounceCount</xpath>
+					<value>
+						<maxBounceCount>3</maxBounceCount>
 					</value>
 				</li>
 

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Misc/Weapons.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Misc/Weapons.xml
@@ -422,21 +422,21 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="AM_Bullet_Tesla"]/modExtensions/li[@Class="VEF.Weapons.TeslaChainingProps"]/maxLifetime</xpath>
 					<value>
-						<maxLifetime>30</maxLifetime>
+						<maxLifetime>15</maxLifetime>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="AM_Bullet_Tesla"]/modExtensions/li[@Class="VEF.Weapons.TeslaChainingProps"]/bounceRange</xpath>
 					<value>
-						<bounceRange>4</bounceRange>
+						<bounceRange>6</bounceRange>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="AM_Bullet_Tesla"]/modExtensions/li[@Class="VEF.Weapons.TeslaChainingProps"]/maxBounceCount</xpath>
 					<value>
-						<maxBounceCount>3</maxBounceCount>
+						<maxBounceCount>2</maxBounceCount>
 					</value>
 				</li>
 

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Misc/Weapons.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Misc/Weapons.xml
@@ -427,14 +427,14 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="AM_Bullet_Tesla"]/modExtensions/li[@Class="VFEMech.TeslaChainingProps"]/bounceRange</xpath>
+					<xpath>Defs/ThingDef[defName="AM_Bullet_Tesla"]/modExtensions/li[@Class="VEF.Weapons.TeslaChainingProps"]/bounceRange</xpath>
 					<value>
 						<bounceRange>4</bounceRange>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="AM_Bullet_Tesla"]/modExtensions/li[@Class="VFEMech.TeslaChainingProps"]/maxBounceCount</xpath>
+					<xpath>Defs/ThingDef[defName="AM_Bullet_Tesla"]/modExtensions/li[@Class="VEF.Weapons.TeslaChainingProps"]/maxBounceCount</xpath>
 					<value>
 						<maxBounceCount>3</maxBounceCount>
 					</value>

--- a/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Misc/Weapons.xml
+++ b/ModPatches/Alpha Mechs/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Misc/Weapons.xml
@@ -415,14 +415,21 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="AM_Bullet_Tesla"]/modExtensions/li[@Class="VEF.Weapons.TeslaChainingProps"]/damageDef</xpath>
 					<value>
-						<damageDef>Smoke</damageDef>
+						<damageDef>EMP</damageDef>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="AM_Bullet_Tesla"]/modExtensions/li[@Class="VEF.Weapons.TeslaChainingProps"]/explosionDamageDef</xpath>
+					<value>
+						<explosionDamageDef>Smoke</explosionDamageDef>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="AM_Bullet_Tesla"]/modExtensions/li[@Class="VEF.Weapons.TeslaChainingProps"]/maxLifetime</xpath>
 					<value>
-						<maxLifetime>15</maxLifetime>
+						<maxLifetime>10</maxLifetime>
 					</value>
 				</li>
 


### PR DESCRIPTION
## Additions
none
## Changes
enabled the chaining effect on tesla gun, changed the chain projectile damage to smoke, nerfed all the chain stats and damage, to not one shot mechs( still does a lot of damages to mechs that doesn't have high health pool)
## References
discord patch channel
## Reasoning
Would be nice if the chain worked, and not one shot every mech
## Alternatives
not have chaining effect
## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
