### PR TITLE
Flying pawn height offsets, again

### DIFF
--- a/Source/CombatExtended/CombatExtended/CollisionVertical.cs
+++ b/Source/CombatExtended/CombatExtended/CollisionVertical.cs
@@ -82,6 +82,11 @@ public struct CollisionVertical
 
             shotHeightOffset = collisionHeight * (1 - BodyRegionMiddleHeight);
 
+            if (pawn.Flying)
+            {
+                heightAdjust += 0.5f * pawn.flight.PositionOffsetFactor;
+            }
+
             // Humanlikes in combat crouch to reduce their profile
             if (pawn.IsCrouching())
             {


### PR DESCRIPTION
## Additions

- A naive implementation of height offsets for pawns flying in-map (birds flying away from the map appear to no longer be spawned)
- Currently just adds 0.5 to the height, with light easing using the numbers from the flight tracker.

## Reasoning

- Probably best to not give it too large of a bonus, since it might make projectile visuals look wrong.

## Alternatives

- Use a separate value from the trench height offset.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] Playtested a colony (no clue how to test this)