### PR TITLE
Weighted Ammo for Elite Pawnkinds

### DIFF
--- a/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -40,6 +40,12 @@
 					<min>10</min>
 					<max>30</max>
 				</primaryMagazineCount>
+				<weightedAmmoCategories>
+					<GrenadeHE>0.5</GrenadeHE>
+					<GrenadeHETF>0.25</GrenadeHETF>
+					<GrenadeHEDP>0.25</GrenadeHEDP>
+					<GrenadeEMP>0.1</GrenadeEMP>
+				</weightedAmmoCategories>
 				<forcedSidearm>
 					<sidearmMoney>
 						<min>170</min>
@@ -267,6 +273,14 @@
 					<min>3</min>
 					<max>5</max>
 				</primaryMagazineCount>
+				<weightedAmmoCategories>
+					<FullMetalJacket>0.2</FullMetalJacket>
+					<ArmorPiercing>0.2</ArmorPiercing>
+					<HollowPoint>0.1</HollowPoint>
+					<IncendiaryAP>0.33</IncendiaryAP>
+					<ExplosiveAP>0.33</ExplosiveAP>
+					<Sabot>0.25</Sabot>
+				</weightedAmmoCategories>
 				<shieldMoney>
 					<min>1000</min>
 					<max>1600</max>

--- a/Royalty/Patches/PawnKindDefs_Royalty/PawnKinds_Royalty.xml
+++ b/Royalty/Patches/PawnKindDefs_Royalty/PawnKinds_Royalty.xml
@@ -257,6 +257,12 @@
 					<min>4</min>
 					<max>6</max>
 				</primaryMagazineCount>
+				<weightedAmmoCategories>
+					<GrenadeHE>0.5</GrenadeHE>
+					<GrenadeHETF>0.25</GrenadeHETF>
+					<GrenadeHEDP>0.25</GrenadeHEDP>
+					<GrenadeEMP>0.1</GrenadeEMP>
+				</weightedAmmoCategories>				
 				<sidearms>
 					<li>
 						<generateChance>0.5</generateChance>
@@ -338,6 +344,14 @@
 					<min>4</min>
 					<max>6</max>
 				</primaryMagazineCount>
+				<weightedAmmoCategories>
+					<FullMetalJacket>0.2</FullMetalJacket>
+					<ArmorPiercing>0.2</ArmorPiercing>
+					<HollowPoint>0.1</HollowPoint>
+					<IncendiaryAP>0.33</IncendiaryAP>
+					<ExplosiveAP>0.33</ExplosiveAP>
+					<Sabot>0.25</Sabot>
+				</weightedAmmoCategories>				
 				<sidearms>
 					<li>
 						<generateChance>0.5</generateChance>
@@ -390,6 +404,14 @@
 					<min>4</min>
 					<max>6</max>
 				</primaryMagazineCount>
+				<weightedAmmoCategories>
+					<FullMetalJacket>0.2</FullMetalJacket>
+					<ArmorPiercing>0.2</ArmorPiercing>
+					<HollowPoint>0.1</HollowPoint>
+					<IncendiaryAP>0.33</IncendiaryAP>
+					<ExplosiveAP>0.33</ExplosiveAP>
+					<Sabot>0.25</Sabot>
+				</weightedAmmoCategories>				
 				<sidearms>
 					<li>
 						<generateChance>0.5</generateChance>


### PR DESCRIPTION
## Additions
- Use weighted ammo selection for grenadiers and elite pawnkinds.
  - Elite pawns have a proportionally higher chance of spawning with more advanced ammo types, such as AP-I and AP-HE. Same for Sabot, just at a lower rate. Hollow Points are arguably the least useful against the player, so spawn them less frequently.
  - Grenadiers will spawn with favor offensive ammo like HE, HEDP, and Airburst, and EMP will spawn at a lower rate. HE is more likely than HEDP or Airburst, since it's a comparatively more common.

## References
- Implements changes from #4045 

## Reasoning
- Makes sense for elite pawns to spawn with more effective ammo types, which make them a higher threat.
- Doesn't make sense to spawn grenadiers with EMP rounds at the same frequency as high-explosive types of ammo.

## Alternatives
- Could not add weighted ammo.
- Could change weights,

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
