### PR TITLE
Loadout PostExpose Null Check

### DIFF
--- a/Source/CombatExtended/CombatExtended/Loadouts/Loadout.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/Loadout.cs
@@ -367,6 +367,10 @@ public class Loadout : IExposable, ILoadReferenceable, IComparable
         _parent = null;
         // slots
         Scribe_Collections.Look(ref _slots, "slots", LookMode.Deep);
+        if (Scribe.mode == LoadSaveMode.PostLoadInit)
+        {
+            _slots?.RemoveAll(slot => slot == null || (slot.thingDef == null && slot.genericDef == null));
+        }
     }
 
     public string GetUniqueLoadID()


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Adds null check for loadout slots

## Reasoning

Why did you choose to implement things this way, e.g.
- If a thingDef is removed between save and the next load of the save, it will generate a null def. Mainly due to users changing/removing mods between saves
- Null def in the save will cause the loadout dialog to self destruct
- Removes the slot if both thingDef and genericDef are null on a slot during loading process
- Adding null checks in the dialog box would not prevent the the continue saving of the slots with null things

## Alternatives

Describe alternative implementations you have considered, e.g.
- Send users who modify lists during play to the phantom zone

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
