### PR TITLE
Misstall apparel

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -346,6 +346,7 @@
 		<li IfModActive="Haplo.Miscellaneous.MAI">ModPatches/Misc MAI</li>
 		<li IfModActive="Haplo.Miscellaneous.Robots">ModPatches/MiscRobots</li>
 		<li IfModActive="Haplo.Miscellaneous.TurretBaseAndObjects">ModPatches/MiscTurrets</li>
+		<li IfModActive="misstall.nisstallsoutfitszzz">ModPatches/Misstall's Armor and Uniforms</li>
 		<li IfModActive="dninemfive.moa">ModPatches/Moa</li>
 		<li IfModActive="Moonjelly.Race.Mod, zal.moonjelly">ModPatches/Moonjelly Race</li>
 		<li IfModActive="Taranchuk.MoreArchotechGarbageContinued">ModPatches/More Archotech Garbage Continued</li>

--- a/ModPatches/Misstall's Armor and Uniforms/Patches/Misstall's Armor and Uniforms/Misstall_Apparel.xml
+++ b/ModPatches/Misstall's Armor and Uniforms/Patches/Misstall's Armor and Uniforms/Misstall_Apparel.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!--Uniform-->
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[
+		defName="Apparel_MUO_01uniform" or 
+		defName="Apparel_MUOS_02uniform" or 
+		defName="Apparel_MUOV_03uniform"
+		]/statBases/StuffEffectMultiplierArmor</xpath>
+		<value>
+			<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+			<WornBulk>0</WornBulk>
+		</value>
+	</Operation>
+	
+	<!--Shell-->
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[
+		defName="Apparel_PKR_01uniform" or 
+		defName="Apparel_CAT_01uniform"]/statBases/StuffEffectMultiplierArmor</xpath>
+		<value>
+			<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+			<Bulk>7.5</Bulk>
+			<WornBulk>2</WornBulk>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_LabCoat"]/statBases/StuffEffectMultiplierArmor</xpath>
+		<value>
+			<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+			<Bulk>7.5</Bulk>
+			<WornBulk>1</WornBulk>
+		</value>
+	</Operation>
+	
+	<!--Shoes/Gloves (Civ)-->
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MUO_1KT"]/statBases/StuffEffectMultiplierArmor</xpath>
+		<value>
+			<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
+			<Bulk>3</Bulk>
+			<WornBulk>0</WornBulk>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MUO_1GL"]/statBases/StuffEffectMultiplierArmor</xpath>
+		<value>
+			<StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>
+			<Bulk>0.5</Bulk>
+			<WornBulk>0</WornBulk>
+		</value>
+	</Operation>
+	
+	<!--Melee Boot-->
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MUO_2KT"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>3</ArmorRating_Sharp>
+			<Bulk>5</Bulk>
+			<WornBulk>3</WornBulk>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MUO_2KT"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>1.5</ArmorRating_Blunt>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MUO_2KT"]/equippedStatOffsets/MeleeDodgeChance</xpath>
+		<value>
+			<MeleeDodgeChance>0.35</MeleeDodgeChance>
+		</value>
+	</Operation>
+	
+	<!--Light Boot-->
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MUO_3KT"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>2</ArmorRating_Sharp>
+			<Bulk>5</Bulk>
+			<WornBulk>1</WornBulk>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MUO_3KT"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>1</ArmorRating_Blunt>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MUO_3KT"]/equippedStatOffsets/MeleeDodgeChance</xpath>
+		<value>
+			<MeleeDodgeChance>0.25</MeleeDodgeChance>
+		</value>
+	</Operation>
+	
+	<!--Melee Glove-->
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MUO_2GL"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>2</ArmorRating_Sharp>
+			<Bulk>5</Bulk>
+			<WornBulk>1</WornBulk>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MUO_2GL"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>1</ArmorRating_Blunt>
+		</value>
+	</Operation>
+	
+	<!--Light Glove-->
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MUO_3GL"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>1</ArmorRating_Sharp>
+			<Bulk>1</Bulk>
+			<WornBulk>0</WornBulk>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MUO_3GL"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>0.5</ArmorRating_Blunt>
+		</value>
+	</Operation>
+	
+</Patch>

--- a/ModPatches/Misstall's Armor and Uniforms/Patches/Misstall's Armor and Uniforms/Misstall_Apparel.xml
+++ b/ModPatches/Misstall's Armor and Uniforms/Patches/Misstall's Armor and Uniforms/Misstall_Apparel.xml
@@ -130,7 +130,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_MUO_3GL"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
-			<ArmorRating_Sharp>1</ArmorRating_Sharp>
+			<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
 			<Bulk>1</Bulk>
 			<WornBulk>0</WornBulk>
 		</value>
@@ -139,7 +139,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_MUO_3GL"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
-			<ArmorRating_Blunt>0.5</ArmorRating_Blunt>
+			<ArmorRating_Blunt>0.25</ArmorRating_Blunt>
 		</value>
 	</Operation>
 	

--- a/ModPatches/Misstall's Armor and Uniforms/Patches/Misstall's Armor and Uniforms/Misstall_Armor.xml
+++ b/ModPatches/Misstall's Armor and Uniforms/Patches/Misstall's Armor and Uniforms/Misstall_Armor.xml
@@ -1,0 +1,327 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	
+	<!--Vest-->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_AML"]/statBases</xpath>
+		<value>
+			<Bulk>5</Bulk>
+			<WornBulk>1</WornBulk>
+			<StuffEffectMultiplierArmor>6.4</StuffEffectMultiplierArmor>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_AML"]/statBases/MaxHitPoints</xpath>
+		<value>
+			<MaxHitPoints>100</MaxHitPoints>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_AML"]/statBases/Mass</xpath>
+		<value>
+			<Mass>9</Mass>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_AML"]/statBases/ArmorRating_Sharp</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_AML"]/statBases/ArmorRating_Blunt</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_AML"]/statBases/ArmorRating_Heat</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_AML"]/equippedStatOffsets</xpath>
+		<value>
+			<equippedStatOffsets>
+				<CarryBulk>5</CarryBulk>
+				<ReloadSpeed>0.1</ReloadSpeed>
+			</equippedStatOffsets>
+		</value>
+	</Operation>
+
+	<!-- Change recipe to stuffed -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_AML"]</xpath>
+		<value>
+			<costStuffCount>70</costStuffCount>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_AML"]</xpath>
+		<value>
+			<stuffCategories>
+				<li>Steeled</li>
+			</stuffCategories>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_AML"]/recipeMaker/unfinishedThingDef</xpath>
+		<value>
+			<unfinishedThingDef>UnfinishedSteeledTechArmor</unfinishedThingDef>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_AML"]/costList/Steel</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_AML"]/costList/ComponentIndustrial</xpath>
+	</Operation>
+	
+	<!--Armor-->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_MAH"]/statBases</xpath>
+		<value>
+			<Bulk>25</Bulk>
+			<WornBulk>10</WornBulk>
+			<StuffEffectMultiplierArmor>6.4</StuffEffectMultiplierArmor>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_MAH"]/statBases/MaxHitPoints</xpath>
+		<value>
+			<MaxHitPoints>175</MaxHitPoints>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_MAH"]/statBases/Mass</xpath>
+		<value>
+			<Mass>12</Mass>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_MAH"]/statBases/ArmorRating_Sharp</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_MAH"]/statBases/ArmorRating_Blunt</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_MAH"]/statBases/ArmorRating_Heat</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_MAH"]/equippedStatOffsets</xpath>
+		<value>
+			<equippedStatOffsets>
+				<CarryBulk>5</CarryBulk>
+				<ReloadSpeed>0.1</ReloadSpeed>
+			</equippedStatOffsets>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_MAH"]</xpath>
+		<value>
+			<li Class="CombatExtended.PartialArmorExt">
+				<stats>
+					<li>
+						<ArmorRating_Sharp>0.70</ArmorRating_Sharp>
+						<parts>
+							<li>Neck</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.70</ArmorRating_Blunt>
+						<parts>
+							<li>Neck</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
+						<parts>
+							<li>Arm</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
+						<parts>
+							<li>Arm</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.70</ArmorRating_Sharp>
+						<parts>
+							<li>Leg</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.70</ArmorRating_Blunt>
+						<parts>
+							<li>Leg</li>
+						</parts>
+					</li>
+				</stats>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- Change recipe to stuffed -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_MAH"]</xpath>
+		<value>
+			<costStuffCount>85</costStuffCount>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_MAH"]</xpath>
+		<value>
+			<stuffCategories>
+				<li>Steeled</li>
+			</stuffCategories>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_MAH"]/recipeMaker/unfinishedThingDef</xpath>
+		<value>
+			<unfinishedThingDef>UnfinishedSteeledTechArmor</unfinishedThingDef>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_MAH"]/costList/Steel</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_MAH"]/costList/ComponentIndustrial</xpath>
+	</Operation>
+	
+	<!--Optional Armor-->
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_ZSK"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>7</ArmorRating_Sharp>
+			<Bulk>15</Bulk>
+			<WornBulk>10</WornBulk>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_ZSK"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>10.5</ArmorRating_Blunt>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_ZSK"]/equippedStatOffsets/MoveSpeed</xpath>
+	</Operation>
+	
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_ZSK"]</xpath>
+		<value>
+			<li Class="CombatExtended.PartialArmorExt">
+				<stats>
+					<li>
+						<ArmorRating_Sharp>0.70</ArmorRating_Sharp>
+						<parts>
+							<li>Neck</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.70</ArmorRating_Blunt>
+						<parts>
+							<li>Neck</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
+						<parts>
+							<li>Arm</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
+						<parts>
+							<li>Arm</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
+						<parts>
+							<li>Leg</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
+						<parts>
+							<li>Leg</li>
+						</parts>
+					</li>
+				</stats>
+			</li>
+		</value>
+	</Operation>
+	
+	<!--Optical Cloak-->
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_CamoCloak"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>2</ArmorRating_Sharp>
+			<Bulk>5</Bulk>
+			<WornBulk>2</WornBulk>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_CamoCloak"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>3</ArmorRating_Blunt>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_CamoCloak"]/equippedStatOffsets/MoveSpeed</xpath>
+	</Operation>
+	
+	<!--Exosuit-->
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_ExoS"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<Bulk>10</Bulk>
+			<WornBulk>5</WornBulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_ExoS"]/statBases/ArmorRating_Blunt</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_ExoS"]/statBases/ArmorRating_Heat</xpath>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_ExoS"]</xpath>
+		<value>
+			<equippedStatOffsets>
+				<CarryWeight>10</CarryWeight>
+			</equippedStatOffsets>
+		</value>
+	</Operation>
+	
+</Patch>

--- a/ModPatches/Misstall's Armor and Uniforms/Patches/Misstall's Armor and Uniforms/Misstall_Head.xml
+++ b/ModPatches/Misstall's Armor and Uniforms/Patches/Misstall's Armor and Uniforms/Misstall_Head.xml
@@ -1,0 +1,348 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	
+	<!--Eyewear-->
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[
+		defName="Apparel_MAU_Eye" or 
+		defName="Apparel_MAU_2Mega" or 
+		defName="Apparel_MAU_2Mega"
+		]/statBases</xpath>
+		<value>
+			<WornBulk>0</WornBulk>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_Eye"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>6</ArmorRating_Sharp>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_Eye"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>12</ArmorRating_Blunt>
+		</value>
+	</Operation>
+	
+	<!--Glases-->
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[
+		defName="Apparel_MAU_2Mega" or 
+		defName="Apparel_MAU_2Mega"
+		]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>3</ArmorRating_Sharp>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[
+		defName="Apparel_MAU_2Mega" or 
+		defName="Apparel_MAU_2Mega"
+		]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>3</ArmorRating_Blunt>
+		</value>
+	</Operation>
+	
+	<!--Mask-->
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_Mask"]/statBases</xpath>
+		<value>
+			<WornBulk>0</WornBulk>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_Mask"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>3</ArmorRating_Sharp>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_Mask"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>3</ArmorRating_Blunt>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_Mask"]/equippedStatOffsets</xpath>
+		<value>
+			<SmokeSensitivity>-1</SmokeSensitivity>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[
+		defName="Apparel_MAU_Mask" 
+		]/apparel/layers</xpath>
+		<value>
+			<li>StrappedHead</li>
+		</value>
+	</Operation>
+	
+	<!--Hat-->
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[
+		defName="Apparel_MUH_01Beret" or 
+		defName="Apparel_MUG_01Beret"
+		]/statBases/StuffEffectMultiplierArmor</xpath>
+		<value>
+			<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
+			<WornBulk>0</WornBulk>
+		</value>
+	</Operation>
+	
+	<!--Headguards-->
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[
+		defName="Apparel_MAU_Rimk" or 
+		defName="Apparel_MAU_MortarRimk" or 
+		defName="Apparel_MAU_MKNTRimk"
+		]/statBases/MaxHitPoints</xpath>
+		<value>
+			<MaxHitPoints>100</MaxHitPoints>
+			<WornBulk>0</WornBulk>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[
+		defName="Apparel_MAU_Rimk" or 
+		defName="Apparel_MAU_MortarRimk" or 
+		defName="Apparel_MAU_MKNTRimk"
+		]/statBases/Mass</xpath>
+		<value>
+			<Mass>2</Mass>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[
+		defName="Apparel_MAU_Rimk" or 
+		defName="Apparel_MAU_MortarRimk" or 
+		defName="Apparel_MAU_MKNTRimk"
+		]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>8</ArmorRating_Sharp>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[
+		defName="Apparel_MAU_Rimk" or 
+		defName="Apparel_MAU_MortarRimk" or 
+		defName="Apparel_MAU_MKNTRimk"
+		]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>16</ArmorRating_Blunt>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[
+			defName="Apparel_MAU_Rimk" or 
+			defName="Apparel_MAU_MortarRimk" or 
+			defName="Apparel_MAU_MKNTRimk"]</xpath>
+		<value>
+			<li Class="CombatExtended.ApparelDefExtension">
+				<isRadioPack>true</isRadioPack>
+			</li>
+		</value>
+	</Operation>
+	
+	<!--NV-->
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_Rimk"]/statBases</xpath>
+		<value>
+			<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_Rimk"]/equippedStatOffsets</xpath>
+		<value>
+			<equippedStatOffsets>
+				<AimingAccuracy>0.3</AimingAccuracy>
+				<ShootingAccuracyPawn>0.75</ShootingAccuracyPawn>
+			</equippedStatOffsets>
+		</value>
+	</Operation>
+	
+	<!--Spotter-->
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_MortarRimk"]/statBases</xpath>
+		<value>
+			<NightVisionEfficiency_Apparel>0.3</NightVisionEfficiency_Apparel>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_MortarRimk"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
+		<value>
+			<AimingAccuracy>0.9</AimingAccuracy>
+		</value>
+	</Operation>
+	
+	<!--Mechinator-->
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_MKNTRimk"]/statBases</xpath>
+		<value>
+			<NightVisionEfficiency_Apparel>0.3</NightVisionEfficiency_Apparel>
+		</value>
+	</Operation>
+	
+	<!--Adv. Headset-->
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_Nekomimi"]/statBases/MaxHitPoints</xpath>
+		<value>
+			<MaxHitPoints>125</MaxHitPoints>
+			<WornBulk>0</WornBulk>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_Nekomimi"]/statBases/Mass</xpath>
+		<value>
+			<Mass>2</Mass>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_Nekomimi"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>10</ArmorRating_Sharp>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_Nekomimi"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>16</ArmorRating_Blunt>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_Nekomimi"]</xpath>
+		<value>
+			<li Class="CombatExtended.ApparelDefExtension">
+				<isRadioPack>true</isRadioPack>
+			</li>
+		</value>
+	</Operation>
+	
+	<!--NV-->
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_Nekomimi"]/statBases</xpath>
+		<value>
+			<NightVisionEfficiency_Apparel>0.8</NightVisionEfficiency_Apparel>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_Nekomimi"]/equippedStatOffsets</xpath>
+		<value>
+			<equippedStatOffsets>
+				<AimingAccuracy>0.6</AimingAccuracy>
+				<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
+			</equippedStatOffsets>
+		</value>
+	</Operation>
+	
+	<!--Helmet-->
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_HelInds"]/statBases/MaxHitPoints</xpath>
+		<value>
+			<MaxHitPoints>125</MaxHitPoints>
+			<WornBulk>1</WornBulk>
+			<Bulk>3</Bulk>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_HelInds"]/statBases/Mass</xpath>
+		<value>
+			<Mass>3</Mass>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_HelInds"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>8</ArmorRating_Sharp>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_HelInds"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>12</ArmorRating_Blunt>
+		</value>
+	</Operation>
+	
+	<!--Adv. Helmet-->
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_Helmet"]/statBases/MaxHitPoints</xpath>
+		<value>
+			<MaxHitPoints>150</MaxHitPoints>
+			<WornBulk>2</WornBulk>
+			<Bulk>3</Bulk>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_Helmet"]/statBases/Mass</xpath>
+		<value>
+			<Mass>4</Mass>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_Helmet"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>12</ArmorRating_Sharp>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_Helmet"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>18</ArmorRating_Blunt>
+		</value>
+	</Operation>
+	
+	<!--NV-->
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_Helmet"]/statBases</xpath>
+		<value>
+			<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_Helmet"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
+		<value>
+			<AimingAccuracy>0.3</AimingAccuracy>
+			<ShootingAccuracyPawn>0.75</ShootingAccuracyPawn>
+		</value>
+	</Operation>
+	
+</Patch>

--- a/ModPatches/Misstall's Armor and Uniforms/Patches/Misstall's Armor and Uniforms/Misstall_Head.xml
+++ b/ModPatches/Misstall's Armor and Uniforms/Patches/Misstall's Armor and Uniforms/Misstall_Head.xml
@@ -2,15 +2,21 @@
 <Patch>
 	
 	<!--Eyewear-->
-	
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[
-		defName="Apparel_MAU_Eye" or 
 		defName="Apparel_MAU_2Mega" or 
 		defName="Apparel_MAU_2Mega"
 		]/statBases</xpath>
 		<value>
 			<WornBulk>0</WornBulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_Eye"]/statBases</xpath>
+		<value>
+			<WornBulk>0.5</WornBulk>
 		</value>
 	</Operation>
 	

--- a/ModPatches/Misstall's Armor and Uniforms/Patches/Misstall's Armor and Uniforms/Misstall_HeavyTurretpack.xml
+++ b/ModPatches/Misstall's Armor and Uniforms/Patches/Misstall's Armor and Uniforms/Misstall_HeavyTurretpack.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
-
-	<!--Light-->
 	
 	<!--Pack-->
 

--- a/ModPatches/Misstall's Armor and Uniforms/Patches/Misstall's Armor and Uniforms/Misstall_HeavyTurretpack.xml
+++ b/ModPatches/Misstall's Armor and Uniforms/Patches/Misstall's Armor and Uniforms/Misstall_HeavyTurretpack.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!--Light-->
+	
+	<!--Pack-->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_2PackTurret"]/statBases</xpath>
+		<value>
+			<Bulk>10</Bulk>
+			<WornBulk>2</WornBulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_2PackTurret"]/verbs</xpath>
+		<value>
+			<verbs>
+				<li Class="CombatExtended.VerbPropertiesCE">
+					<label>deploy turret</label>
+					<verbClass>CombatExtended.Verb_ShootCEOneUseStatic</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<onlyManualCast>True</onlyManualCast>
+					<warmupTime>1</warmupTime>
+					<range>25</range>
+					<soundCast>ThrowGrenade</soundCast>
+					<targetParams>
+						<canTargetPawns>false</canTargetPawns>
+						<canTargetBuildings>false</canTargetBuildings>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+					<defaultProjectile>Grenade_MAU_2TurretPack</defaultProjectile>
+					<rangedFireRulepack>Combat_RangedFire_Thrown</rangedFireRulepack>
+				</li>
+			</verbs>
+		</value>
+	</Operation>
+	
+	<!--Projectile-->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Grenade_MAU_2TurretPack"]/thingClass</xpath>
+		<value>
+			<thingClass>CombatExtended.ProjectileCE_SpawnsThing</thingClass>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Grenade_MAU_2TurretPack"]/projectile</xpath>
+		<value>
+			<projectile Class="CombatExtended.ProjectilePropertiesCE">
+				<dropsCasings>false</dropsCasings>
+				<dangerFactor>0</dangerFactor>
+				<airborneSuppressionFactor>0</airborneSuppressionFactor>
+				<speed>12</speed>
+				<spawnsThingDef>Turret_MAU_2TacticalTurret</spawnsThingDef>
+			</projectile>
+		</value>
+	</Operation>
+	
+	<!--Building-->
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Turret_MAU_2TacticalTurret"]/thingClass</xpath>
+		<value>
+			<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Turret_MAU_2TacticalTurret"]/statBases</xpath>
+		<value>
+			<AimingAccuracy>0.25</AimingAccuracy>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Turret_MAU_2TacticalTurret"]/statBases/ShootingAccuracyTurret</xpath>
+		<value>
+			<ShootingAccuracyTurret>0.6</ShootingAccuracyTurret>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Turret_MAU_2TacticalTurret"]/statBases/Mass</xpath>
+		<value>
+			<Mass>25</Mass>
+			<Bulk>15</Bulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Turret_MAU_2TacticalTurret"]/fillPercent</xpath>
+		<value>
+			<fillPercent>0.85</fillPercent>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Turret_MAU_2TacticalTurret"]/building/turretBurstCooldownTime</xpath>
+		<value>
+			<turretBurstCooldownTime>1.0</turretBurstCooldownTime>
+		</value>
+	</Operation>
+	
+	<!--Gun-->
+	
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Gun_MAU_2TacticalTurret</defName>
+		<statBases>
+			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+			<SightsEfficiency>1</SightsEfficiency>
+			<ShotSpread>0.08</ShotSpread>
+			<SwayFactor>0.75</SwayFactor>
+		</statBases>
+		<Properties>
+			<recoilAmount>1.40</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_8x35mmCharged</defaultProjectile>
+			<warmupTime>1.3</warmupTime>
+			<range>51</range>
+			<ticksBetweenBurstShots>7</ticksBetweenBurstShots>
+			<burstShotCount>3</burstShotCount>
+			<soundCast>MU_Shot_CTH</soundCast>
+			<soundCastTail>GunTail_Medium</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+			<recoilPattern>Mounted</recoilPattern>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>36</magazineSize>
+			<reloadTime>7.8</reloadTime>
+			<ammoSet>AmmoSet_8x35mmCharged</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aiAimMode>AimedShot</aiAimMode>
+			<noSnapshot>true</noSnapshot>
+			<noSingleShot>true</noSingleShot>
+		</FireModes>
+	</Operation>
+	
+</Patch>

--- a/ModPatches/Misstall's Armor and Uniforms/Patches/Misstall's Armor and Uniforms/Misstall_Loadbearing.xml
+++ b/ModPatches/Misstall's Armor and Uniforms/Patches/Misstall's Armor and Uniforms/Misstall_Loadbearing.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!--Loadbearing Vests-->
+	
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[
+		defName="Apparel_MAU_SOG" or 
+		defName="Apparel_MAU_2SOG" or 
+		defName="Apparel_MAU_3SOG"
+		]/statBases/ArmorRating_Sharp</xpath>
+	</Operation>
+	
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[
+		defName="Apparel_MAU_SOG" or 
+		defName="Apparel_MAU_2SOG" or 
+		defName="Apparel_MAU_3SOG"
+		]/statBases/ArmorRating_Blunt</xpath>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[
+		defName="Apparel_MAU_SOG" or 
+		defName="Apparel_MAU_2SOG" or 
+		defName="Apparel_MAU_3SOG"
+		]/apparel/layers</xpath>
+		<value>
+			<layers>
+				<li>Webbing</li>
+			</layers>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[
+		defName="Apparel_MAU_SOG" or 
+		defName="Apparel_MAU_2SOG" or 
+		defName="Apparel_MAU_3SOG"
+		]/apparel/bodyPartGroups</xpath>
+		<value>
+			<bodyPartGroups>
+				<li>Shoulders</li>
+			</bodyPartGroups>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_SOG"]/equippedStatOffsets</xpath>
+		<value>
+			<equippedStatOffsets>
+				<CarryBulk>15</CarryBulk>
+				<ReloadSpeed>0.1</ReloadSpeed>
+			</equippedStatOffsets>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[
+		defName="Apparel_MAU_2SOG" or 
+		defName="Apparel_MAU_3SOG"
+		]/equippedStatOffsets</xpath>
+		<value>
+			<equippedStatOffsets>
+				<CarryBulk>30</CarryBulk>
+				<ReloadSpeed>0.1</ReloadSpeed>
+			</equippedStatOffsets>
+		</value>
+	</Operation>
+	
+	<!--Backpacks-->
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[
+		defName="Apparel_MUO_BK" or 
+		defName="Apparel_MUO_2BK"]/apparel/layers</xpath>
+		<value>
+			<layers>
+				<li>Backpack</li>
+			</layers>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[
+		defName="Apparel_MUO_BK" or 
+		defName="Apparel_MUO_2BK"]/apparel/bodyPartGroups</xpath>
+		<value>
+			<bodyPartGroups>
+				<li>Shoulders</li>
+			</bodyPartGroups>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MUO_BK"]/equippedStatOffsets</xpath>
+		<value>
+			<equippedStatOffsets>
+				<CarryBulk>30</CarryBulk>
+			</equippedStatOffsets>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MUO_2BK"]/equippedStatOffsets</xpath>
+		<value>
+			<equippedStatOffsets>
+				<CarryBulk>50</CarryBulk>
+			</equippedStatOffsets>
+		</value>
+	</Operation>
+	
+</Patch>

--- a/ModPatches/Misstall's Armor and Uniforms/Patches/Misstall's Armor and Uniforms/Misstall_Loadbearing.xml
+++ b/ModPatches/Misstall's Armor and Uniforms/Patches/Misstall's Armor and Uniforms/Misstall_Loadbearing.xml
@@ -62,7 +62,7 @@
 		]/equippedStatOffsets</xpath>
 		<value>
 			<equippedStatOffsets>
-				<CarryBulk>30</CarryBulk>
+				<CarryBulk>25</CarryBulk>
 				<ReloadSpeed>0.1</ReloadSpeed>
 			</equippedStatOffsets>
 		</value>

--- a/ModPatches/Misstall's Armor and Uniforms/Patches/Misstall's Armor and Uniforms/Misstall_Turretpack.xml
+++ b/ModPatches/Misstall's Armor and Uniforms/Patches/Misstall's Armor and Uniforms/Misstall_Turretpack.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!--Light-->
+	
+	<!--Pack-->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_PackTurret"]/statBases</xpath>
+		<value>
+			<Bulk>10</Bulk>
+			<WornBulk>2</WornBulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_PackTurret"]/verbs</xpath>
+		<value>
+			<verbs>
+				<li Class="CombatExtended.VerbPropertiesCE">
+					<label>deploy turret</label>
+					<verbClass>CombatExtended.Verb_ShootCEOneUseStatic</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<onlyManualCast>True</onlyManualCast>
+					<warmupTime>1</warmupTime>
+					<range>25</range>
+					<soundCast>ThrowGrenade</soundCast>
+					<targetParams>
+						<canTargetPawns>false</canTargetPawns>
+						<canTargetBuildings>false</canTargetBuildings>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+					<defaultProjectile>Grenade_MAU_TurretPack</defaultProjectile>
+					<rangedFireRulepack>Combat_RangedFire_Thrown</rangedFireRulepack>
+				</li>
+			</verbs>
+		</value>
+	</Operation>
+	
+	<!--Projectile-->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Grenade_MAU_TurretPack"]/thingClass</xpath>
+		<value>
+			<thingClass>CombatExtended.ProjectileCE_SpawnsThing</thingClass>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Grenade_MAU_TurretPack"]/projectile</xpath>
+		<value>
+			<projectile Class="CombatExtended.ProjectilePropertiesCE">
+				<dropsCasings>false</dropsCasings>
+				<dangerFactor>0</dangerFactor>
+				<airborneSuppressionFactor>0</airborneSuppressionFactor>
+				<speed>12</speed>
+				<spawnsThingDef>Turret_MAU_TacticalTurret</spawnsThingDef>
+			</projectile>
+		</value>
+	</Operation>
+	
+	<!--Building-->
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Turret_MAU_TacticalTurret"]/thingClass</xpath>
+		<value>
+			<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Turret_MAU_TacticalTurret"]/statBases</xpath>
+		<value>
+			<AimingAccuracy>0.25</AimingAccuracy>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Turret_MAU_TacticalTurret"]/statBases/ShootingAccuracyTurret</xpath>
+		<value>
+			<ShootingAccuracyTurret>0.5</ShootingAccuracyTurret>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Turret_TacticalTurret"]/statBases/Mass</xpath>
+		<value>
+			<Mass>25</Mass>
+			<Bulk>15</Bulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Turret_MAU_TacticalTurret"]/comps/li[@Class="CompProperties_Explosive"]</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Turret_MAU_TacticalTurret"]/fillPercent</xpath>
+		<value>
+			<fillPercent>0.85</fillPercent>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Turret_MAU_TacticalTurret"]/building/turretBurstCooldownTime</xpath>
+		<value>
+			<turretBurstCooldownTime>1.0</turretBurstCooldownTime>
+		</value>
+	</Operation>
+	
+	<!--Gun-->
+	
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Gun_MAU_TacticalTurret</defName>
+		<statBases>
+			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+			<SightsEfficiency>1</SightsEfficiency>
+			<ShotSpread>0.11</ShotSpread>
+			<SwayFactor>0.75</SwayFactor>
+		</statBases>
+		<Properties>
+			<recoilAmount>1.39</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_6x18mmCharged</defaultProjectile>
+			<warmupTime>0.8</warmupTime>
+			<range>31</range>
+			<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+			<burstShotCount>10</burstShotCount>
+			<soundCast>MU_Shot_CTL</soundCast>
+			<soundCastTail>GunTail_Medium</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+			<recoilPattern>Mounted</recoilPattern>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>120</magazineSize>
+			<reloadTime>7.8</reloadTime>
+			<ammoSet>AmmoSet_6x18mmCharged</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aiAimMode>AimedShot</aiAimMode>
+			<noSnapshot>true</noSnapshot>
+			<noSingleShot>true</noSingleShot>
+		</FireModes>
+	</Operation>
+	
+</Patch>

--- a/ModPatches/Misstall's Armor and Uniforms/Patches/Misstall's Armor and Uniforms/Misstall_Turretpack.xml
+++ b/ModPatches/Misstall's Armor and Uniforms/Patches/Misstall's Armor and Uniforms/Misstall_Turretpack.xml
@@ -122,20 +122,20 @@
 			<recoilAmount>1.39</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_6x18mmCharged</defaultProjectile>
+			<defaultProjectile>Bullet_6x24mmCharged</defaultProjectile>
 			<warmupTime>0.8</warmupTime>
 			<range>31</range>
 			<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
-			<burstShotCount>10</burstShotCount>
+			<burstShotCount>6</burstShotCount>
 			<soundCast>MU_Shot_CTL</soundCast>
 			<soundCastTail>GunTail_Medium</soundCastTail>
 			<muzzleFlashScale>9</muzzleFlashScale>
 			<recoilPattern>Mounted</recoilPattern>
 		</Properties>
 		<AmmoUser>
-			<magazineSize>120</magazineSize>
+			<magazineSize>60</magazineSize>
 			<reloadTime>7.8</reloadTime>
-			<ammoSet>AmmoSet_6x18mmCharged</ammoSet>
+			<ammoSet>AmmoSet_6x24mmCharged</ammoSet>
 		</AmmoUser>
 		<FireModes>
 			<aiAimMode>AimedShot</aiAimMode>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -365,6 +365,7 @@ Misc. Core	|
 Misc. MAI |
 Misc. Robots	|
 Misc. Turrets   |
+Misstall's Armor and Uniforms   |
 Moa |
 Moonjelly Race  |
 More Archotech Garbage Continued  |


### PR DESCRIPTION
## Additions

Patches apparel.
Charge backpack turrets patched with 6x24 and 8x35.

## Reasoning

Some apparel has been adjusted to use CE layers since tacvests kind of suck as middle layer option, and to prevent doubling up on gas masks. Industrial armor sets have been patched to work like vanilla vest with stuffability instead of just flat stat.

## Alternatives

Leave tacvest type things on middle where they're functionally useless really.

## Testing

Check tests you have performed:
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
