### PR TITLE
Re-add Nerfs and change inheritance/layers

### DIFF
--- a/Biotech/Patches/ThingDefs_Misc/Apparel_BiotechHeadgear.xml
+++ b/Biotech/Patches/ThingDefs_Misc/Apparel_BiotechHeadgear.xml
@@ -18,6 +18,25 @@
 			</layers>
 		</value>
 	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_Gunlink"]/equippedStatOffsets</xpath>
+		<value>
+			<equippedStatOffsets Inherit="False">
+				<MechBandwidth>9</MechBandwidth>
+				<VacuumResistance MayRequire="Ludeon.RimWorld.Odyssey">0</VacuumResistance>
+			</equippedStatOffsets>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_IntegratorHeadset"]/apparel</xpath>
+		<value>
+			<layers Inherit="False">
+				<li>StrappedHead</li>
+			</layers>
+		</value>
+	</Operation>
 
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="Apparel_AirwireHeadset" or defName="Apparel_ArrayHeadset" or defName="Apparel_IntegratorHeadset"]</xpath>
@@ -32,8 +51,6 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[@Name="ApparelArmorHelmetMechanitorBase"]</xpath>
 		<value>
-			<equippedStatOffsets Inherit="False">
-			</equippedStatOffsets>
 			<statBases Inherit="False">
 				<WorkToMake>15750</WorkToMake>
 				<MaxHitPoints>120</MaxHitPoints>
@@ -95,11 +112,9 @@
 		<value>
 			<ToxicEnvironmentResistance>0.50</ToxicEnvironmentResistance>
 			<SmokeSensitivity>-1</SmokeSensitivity>
+			<AimingAccuracy>-0.25</AimingAccuracy>
+			<ShootingAccuracyPawn>-1.25</ShootingAccuracyPawn>
 		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="Apparel_ArmorHelmetMechlordHelmet"]/equippedStatOffsets/MeleeHitChance</xpath>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">

--- a/Biotech/Patches/ThingDefs_Misc/Apparel_BiotechHeadgear.xml
+++ b/Biotech/Patches/ThingDefs_Misc/Apparel_BiotechHeadgear.xml
@@ -20,7 +20,7 @@
 	</Operation>
 	
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Apparel_Gunlink"]/equippedStatOffsets</xpath>
+		<xpath>Defs/ThingDef[defName="Apparel_IntegratorHeadset"]/equippedStatOffsets</xpath>
 		<value>
 			<equippedStatOffsets Inherit="False">
 				<MechBandwidth>9</MechBandwidth>

--- a/Biotech/Patches/ThingDefs_Misc/Apparel_BiotechVarious.xml
+++ b/Biotech/Patches/ThingDefs_Misc/Apparel_BiotechVarious.xml
@@ -39,11 +39,9 @@
 		<value>
 			<CarryWeight>65</CarryWeight>
 			<CarryBulk>10</CarryBulk>
+			<AimingAccuracy>-0.25</AimingAccuracy>
+			<ShootingAccuracyPawn>-1.25</ShootingAccuracyPawn>
 		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="Apparel_MechlordSuit"]/equippedStatOffsets/MeleeHitChance</xpath>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">


### PR DESCRIPTION

## Changes

Re-added penalties to Mechlord armor.
Change intergrator headset to work like other headsets layering wise.

## Reasoning

Mechlord armor in vanilla does the equivalent of smashing 10 levels of melee and shooting off of the user to compensate for the fact that it provides such a significant number of additional mech control slots + acceptable armor at the time.
There's not really any apparent reason why it shouldn't do the same in CE.

Specific scaling is so that the full set causes the combatant to lose roughly 10 levels worth of shooting and melee hit capacity.

## Alternatives

Change specifics of the offsets or leave as is.

## Testing

Check tests you have performed:
- [x] Game runs without errors
- [ ] Playtested a colony (specify how long)
