### PR TITLE
1.6 Rimsenal Spacer

### DIFF
--- a/ModPatches/Rimsenal - Spacer Faction Pack/Patches/Rimsenal - Spacer Faction Pack/Apparel_Spacer_CE.xml
+++ b/ModPatches/Rimsenal - Spacer Faction Pack/Patches/Rimsenal - Spacer Faction Pack/Apparel_Spacer_CE.xml
@@ -94,5 +94,108 @@
 			</layers>
 		</value>
 	</Operation>
+	
+	<!-- ========== Data Glasses =========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_DataGlasses"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>0.01</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_DataGlasses"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>0.01</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAttributeAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_DataGlasses"]/costList</xpath>
+		<attribute>Inherit</attribute>
+		<value>false</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_DataGlasses"]/equippedStatOffsets</xpath>
+		<value>
+			<equippedStatOffsets Inherit="False">
+				<ResearchSpeed>0.25</ResearchSpeed>
+				<SocialImpact>0.25</SocialImpact>
+			</equippedStatOffsets>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_DataGlasses"]/apparel</xpath>
+		<value>
+			<layers Inherit="False">
+				<li>StrappedHead</li>
+			</layers>
+		</value>
+	</Operation>
+	
+	<!-- ========== Foam Pack ========== -->
+
+	<Operation Class="PatchOperationAdd" MayRequire="rimsenal.EVP">
+		<xpath>Defs/ThingDef[defName="Apparel_OmnifoamPack"]/statBases</xpath>
+		<value>
+			<Bulk>10</Bulk>
+			<WornBulk>2</WornBulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace" MayRequire="rimsenal.EVP">
+		<xpath>Defs/ThingDef[defName="Apparel_OmnifoamPack"]/verbs</xpath>
+		<value>
+			<verbs>
+				<li Class="CombatExtended.VerbPropertiesCE">
+					<label>deploy omnifoam</label>
+					<verbClass>CombatExtended.Verb_LaunchProjectileStaticCE</verbClass>
+					<warmupTime>0.5</warmupTime>
+					<range>8</range>
+					<burstShotCount>1</burstShotCount>
+					<onlyManualCast>true</onlyManualCast>
+					<hasStandardCommand>true</hasStandardCommand>
+					<targetable>true</targetable>
+					<violent>false</violent>
+					<range>25</range>
+					<soundCast>Shot_IncendiaryLauncher</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>14</muzzleFlashScale>
+					<targetParams>
+						<canTargetPawns>false</canTargetPawns>
+						<canTargetBuildings>false</canTargetBuildings>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+					<defaultProjectile>Proj_Omnifoam</defaultProjectile>
+					<rangedFireRulepack>Combat_RangedFire_Thrown</rangedFireRulepack>
+					<canGoWild>false</canGoWild>
+				</li>
+			</verbs>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace" MayRequire="rimsenal.EVP">
+		<xpath>Defs/ThingDef[defName="Proj_Omnifoam"]/thingClass</xpath>
+		<value>
+			<thingClass>CombatExtended.ProjectileCE_SpawnsThing</thingClass>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace" MayRequire="rimsenal.EVP">
+		<xpath>Defs/ThingDef[defName="Proj_Omnifoam"]/projectile</xpath>
+		<value>
+			<projectile Class="CombatExtended.ProjectilePropertiesCE">
+				<dropsCasings>false</dropsCasings>
+				<dangerFactor>0</dangerFactor>
+				<airborneSuppressionFactor>0</airborneSuppressionFactor>
+				<speed>12</speed>
+				<spawnsThingDef>Omnifoam_chunk</spawnsThingDef>
+				<tryAdjacentFreeSpaces>true</tryAdjacentFreeSpaces>
+			</projectile>
+		</value>
+	</Operation>
 
 </Patch>

--- a/ModPatches/Rimsenal - Spacer Faction Pack/Patches/Rimsenal - Spacer Faction Pack/Weapons_EVSmart_CE.xml
+++ b/ModPatches/Rimsenal - Spacer Faction Pack/Patches/Rimsenal - Spacer Faction Pack/Weapons_EVSmart_CE.xml
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- ========== Melee Tools =========== -->
+	<Operation Class="PatchOperationReplace" MayRequire="rimsenal.EVP">
+		<xpath>Defs/ThingDef[defName="Gun_SmartHeavyPistol"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>grip</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>2</power>
+					<cooldownTime>1.54</cooldownTime>
+					<chanceFactor>1.5</chanceFactor>
+					<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>muzzle</label>
+					<capacities>
+						<li>Poke</li>
+					</capacities>
+					<power>2</power>
+					<cooldownTime>1.54</cooldownTime>
+					<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace" MayRequire="rimsenal.EVP">
+		<xpath>Defs/ThingDef[
+			defName="Gun_SmartCarbine" or
+			defName="Gun_SmartBattleRifle"
+			]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>stock</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>8</power>
+					<cooldownTime>1.55</cooldownTime>
+					<chanceFactor>1.5</chanceFactor>
+					<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>barrel</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>5</power>
+					<cooldownTime>2.02</cooldownTime>
+					<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>muzzle</label>
+					<capacities>
+						<li>Poke</li>
+					</capacities>
+					<power>8</power>
+					<cooldownTime>1.55</cooldownTime>
+					<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<!-- ========== Stats =========== -->
+	<Operation Class="PatchOperationAdd" MayRequire="rimsenal.EVP">
+		<xpath>Defs/ThingDef[
+			defName="Gun_SmartHeavyPistol" or
+			defName="Gun_SmartCarbine" or
+			defName="Gun_SmartBattleRifle"
+			]/statBases </xpath>
+		<value>
+			<NightVisionEfficiency_Weapon>0.50</NightVisionEfficiency_Weapon>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd" MayRequire="rimsenal.EVP">
+		<xpath>Defs/ThingDef[
+			defName="Gun_SmartHeavyPistol" or
+			defName="Gun_SmartCarbine" or
+			defName="Gun_SmartBattleRifle"
+			]/equippedStatOffsets </xpath>
+		<value>
+			<AimingAccuracy>0.5</AimingAccuracy>
+		</value>
+	</Operation>
+
+	<!-- ========== Smart Heavy =========== -->
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible" MayRequire="rimsenal.EVP">
+		<defName>Gun_SmartHeavyPistol</defName>
+		<statBases>
+			<SightsEfficiency>0.9</SightsEfficiency>
+			<ShotSpread>0.135</ShotSpread><!--25% reduction-->
+			<SwayFactor>1.29</SwayFactor><!--25% reduction-->
+			<Bulk>3.21</Bulk>
+			<Mass>1.95</Mass>
+			<RangedWeapon_Cooldown>0.41</RangedWeapon_Cooldown>
+		</statBases>
+		<Properties>
+			<recoilAmount>1.65</recoilAmount><!--50% reduction-->
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_500SWMagnum_FMJ</defaultProjectile>
+			<warmupTime>0.4</warmupTime>
+			<range>21</range>
+			<soundCast>Shot_Revolver</soundCast>
+			<soundCastTail>GunTail_Light</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>5</magazineSize>
+			<reloadTime>3.6</reloadTime>
+			<ammoSet>AmmoSet_500SWMagnum</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aiAimMode>Snapshot</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>CE_Sidearm</li>
+			<li>CE_AI_Pistol</li>
+			<li>CE_OneHandedWeapon</li>
+			<li>AdvancedGun</li>
+		</weaponTags>
+	</Operation>
+
+
+	<!-- ========== Smart Carbine =========== -->
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible" MayRequire="rimsenal.EVP">
+		<defName>Gun_SmartCarbine</defName>
+		<statBases>
+			<WorkToMake>39500</WorkToMake>
+			<SightsEfficiency>1.20</SightsEfficiency>
+			<ShotSpread>0.11</ShotSpread>
+			<SwayFactor>0.77</SwayFactor>
+			<Bulk>4.65</Bulk>
+			<Mass>2.85</Mass>
+			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+		</statBases>
+		<Properties>
+			<recoilAmount>0.72</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_556x45mmNATO_FMJ_SB</defaultProjectile>
+			<warmupTime>0.7</warmupTime>
+			<range>51</range>
+			<burstShotCount>6</burstShotCount>
+			<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+			<soundCast>Shot_AssaultRifle</soundCast>
+			<soundCastTail>GunTail_Medium</soundCastTail>
+			<muzzleFlashScale>8</muzzleFlashScale>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>30</magazineSize>
+			<reloadTime>3.0</reloadTime>
+			<ammoSet>AmmoSet_556x45mmNATO_SB</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aimedBurstShotCount>3</aimedBurstShotCount>
+			<aiUseBurstMode>TRUE</aiUseBurstMode>
+			<aiAimMode>AimedShot</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>CE_Rifle</li>
+			<li>CE_AI_AssaultWeapon</li>
+			<li>AdvancedGun</li>
+		</weaponTags>
+	</Operation>
+	
+	<!-- ========== Smart BR =========== -->
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible" MayRequire="rimsenal.EVP">
+		<defName>Gun_SmartBattleRifle</defName>
+		<statBases>
+			<WorkToMake>39500</WorkToMake>
+			<SightsEfficiency>1.20</SightsEfficiency>
+			<ShotSpread>0.06</ShotSpread>
+			<SwayFactor>1.25</SwayFactor>
+			<Bulk>9.00</Bulk>
+			<Mass>4.80</Mass>
+			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+		</statBases>
+		<Properties>
+			<recoilAmount>0.92</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_277Fury_FMJ</defaultProjectile>
+			<warmupTime>0.9</warmupTime>
+			<range>62</range>
+			<burstShotCount>6</burstShotCount>
+			<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+			<soundCast>Shot_AssaultRifle</soundCast>
+			<soundCastTail>GunTail_Medium</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>20</magazineSize>
+			<reloadTime>3.0</reloadTime>
+			<ammoSet>AmmoSet_277Fury</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aimedBurstShotCount>3</aimedBurstShotCount>
+			<aiUseBurstMode>TRUE</aiUseBurstMode>
+			<aiAimMode>AimedShot</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>CE_Rifle</li>
+			<li>CE_AI_AssaultWeapon</li>
+			<li>AdvancedGun</li>
+		</weaponTags>
+	</Operation>
+	
+
+
+</Patch>

--- a/ModPatches/Rimsenal - Spacer Faction Pack/Patches/Rimsenal - Spacer Faction Pack/Weapons_Smart_CE.xml
+++ b/ModPatches/Rimsenal - Spacer Faction Pack/Patches/Rimsenal - Spacer Faction Pack/Weapons_Smart_CE.xml
@@ -472,10 +472,10 @@
 			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 		</statBases>
 		<Properties>
-			<recoilAmount>1.11</recoilAmount>
+			<recoilAmount>0.78</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_277Fury_FMJ</defaultProjectile>
+			<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
 			<warmupTime>0.9</warmupTime>
 			<range>62</range>
 			<burstShotCount>6</burstShotCount>
@@ -487,7 +487,7 @@
 		<AmmoUser>
 			<magazineSize>30</magazineSize>
 			<reloadTime>3.0</reloadTime>
-			<ammoSet>AmmoSet_277Fury</ammoSet>
+			<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
 		</AmmoUser>
 		<FireModes>
 			<aimedBurstShotCount>3</aimedBurstShotCount>


### PR DESCRIPTION

## Additions

New Apparel
Content w/ Rimsenal Enhanced Vanilla patches added.

## Changes

 AR stats changed and downcalibered to 5.56 to squeeze in BR and facilitate carbine.

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Easier to move the AR back to 5.56 than figure out what to do with the battle rifle. Also saves having to make a LV 277 fury for the carbine.

## Alternatives

Re-do all ammo back to general competitors.
Give the BR like, automatic lapmag which is probably a bit excessive.

## Testing

Check tests you have performed:
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
