### PR TITLE
No subsequent shots bonus for weapons without magazines

### DIFF
--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -314,7 +314,7 @@ public class Verb_ShootCE : Verb_LaunchProjectileCE
 
     public override void RecalculateWarmupTicks()
     {
-        if (!Controller.settings.FasterRepeatShots)
+        if (!Controller.settings.FasterRepeatShots || compAmmo?.HasMagazine == false)
         {
             return;
         }


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Disallows weapons that don't have a magazine from benefiting from Subsequent Shot system.

## References

Links to the associated issues or other related pull requests, e.g.
- As per Serina's request
https://discord.com/channels/278818534069501953/303988654492090370/1397901456513695795

## Reasoning

Why did you choose to implement things this way, e.g.
- Weapons that require you to fiddle with something after each shot should not reacquire targets fast.

## Alternatives

Describe alternative implementations you have considered, e.g.
- Not do it, i don't particularly care, responding to serina's complaint

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
