### PR TITLE
reload when mag has less ammo than required for UB

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
@@ -392,14 +392,21 @@ public class CompAmmoUser : CompRangedGizmoGiver
     /// available in the inventory.
     /// </remarks>
     /// <returns></returns>
-    public bool TryPrepareShot()
+    public bool TryPrepareShot(int ammoConsumedPerShot = 1)
     {
         if (HasMagazine)
         {
+            ammoConsumedPerShot = (ammoConsumedPerShot > 0) ? ammoConsumedPerShot : 1;
             // If magazine is empty, return false
             if (curMagCountInt <= 0)
             {
                 CurMagCount = 0;
+                return false;
+            }
+
+            if (curMagCountInt - ammoConsumedPerShot < 0)
+            {
+                TryStartReload();
                 return false;
             }
 
@@ -639,7 +646,7 @@ public class CompAmmoUser : CompRangedGizmoGiver
 
     private void DoOutOfAmmoAction()
     {
-        //Don't stow weapon for player pawns when in god mode, can be ammoying when testing single shot weapons.
+        //Don't stow weapon for player pawns when in god mode, can be annoying when testing single shot weapons.
         if (this.parent.def.weaponTags.Contains("NoSwitch") || (DebugSettings.godMode && Wielder != null && (Wielder.IsColonistPlayerControlled || Wielder.IsColonyMech)))
         {
             return;

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -357,7 +357,8 @@ public class Verb_ShootCE : Verb_LaunchProjectileCE
 
     public override bool TryCastShot()
     {
-        if (!CompAmmo?.TryPrepareShot() ?? false)
+        int ammoConsumedPerShot = (CompAmmo.Props.ammoSet?.ammoConsumedPerShot ?? 1) * VerbPropsCE.ammoConsumedPerShotCount;
+        if (!CompAmmo?.TryPrepareShot(ammoConsumedPerShot) ?? false)
         {
             return false;
         }
@@ -392,7 +393,7 @@ public class Verb_ShootCE : Verb_LaunchProjectileCE
         int ammoConsumedPerShot = (CompAmmo.Props.ammoSet?.ammoConsumedPerShot ?? 1) * VerbPropsCE.ammoConsumedPerShotCount;
         CompAmmo.Notify_ShotFired(ammoConsumedPerShot);
 
-        if (ShooterPawn != null && !CompAmmo.CanBeFiredNow)
+        if (ShooterPawn != null && (!CompAmmo.CanBeFiredNow || ammoConsumedPerShot > CompAmmo.CurMagCount))
         {
             CompAmmo.TryStartReload();
             resetRetarget();


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Check if curMagCount is enough to fire alternate modes that have ammoConsumedPerShotCount > 1

## Changes

Describe adjustments to existing features made in this merge, e.g.

## References

Links to the associated issues or other related pull requests, e.g.
- Contributes towards #[3994]

## Reasoning

Why did you choose to implement things this way, e.g.
- Insuficcient ammo should force a gun reload instead of allowing to fire while spending less ammo then required for the fire mode

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x ] Outer Rim - Core
- [x] Playtested a colony (specify how long)
