### PR TITLE
Fix: Stabilization expires too fast if Pawn is off-screen

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/HediffComp_Stabilize.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/HediffComp_Stabilize.cs
@@ -14,6 +14,7 @@ public class HediffComp_Stabilize : HediffComp
 
     private bool stabilized = false;
     private float bleedModifier = 1;
+    private int ticksUntilNextUpdate = 60;              // Once per second
 
     public HediffCompProperties_Stabilize Props
     {
@@ -83,20 +84,26 @@ public class HediffComp_Stabilize : HediffComp
 
     public override void CompPostTickInterval(ref float severityAdjustment, int delta)
     {
-        // Increase bleed modifier once per second
-        if (stabilized && bleedModifier < 1 && parent.pawn.IsHashIntervalTick(60, delta))
+        ticksUntilNextUpdate -= delta;
+        if (ticksUntilNextUpdate <= 0)     // Once in a second
         {
-            bleedModifier = bleedModifier + bleedIncreasePerSec * delta;
-            if (bleedModifier >= 1)
+            if (stabilized && bleedModifier < 1)
             {
-                bleedModifier = 1;
-                //stabilized = false;
+                float secondsPassed = (60 - ticksUntilNextUpdate) / 60f;
+                bleedModifier = bleedModifier + bleedIncreasePerSec * secondsPassed;
+                if (bleedModifier >= 1)
+                {
+                    bleedModifier = 1;
+                    //stabilized = false;
+                }
             }
-        }
-        else if (!stabilized && parent.pawn.Downed)
-        {
-            // Teach about stabilizing
-            LessonAutoActivator.TeachOpportunity(CE_ConceptDefOf.CE_Stabilizing, parent.pawn, OpportunityType.Important);
+            else if (!stabilized && parent.pawn.Downed)
+            {
+                // Teach about stabilizing
+                LessonAutoActivator.TeachOpportunity(CE_ConceptDefOf.CE_Stabilizing, parent.pawn, OpportunityType.Important);
+            }
+
+            ticksUntilNextUpdate = 60;
         }
     }
 


### PR DESCRIPTION
## Additions

Fix a bug, where stabilization expired too fast if Pawn was off-screen.
Introduced by new 1.6 RW performance improvement.
Bug's demonstration: https://www.youtube.com/watch?v=Rju1QUNHuLY

## Changes

Rewrite Method "CompPostTickInterval" in the way to avoid multiple execution in a second due to introduction of value "delta".
Method now receives the count of ticks it must evaluate ("delta") and proceed with them each second.

## References

N/A

## Reasoning

Stabilization is broken if Pawn is off-screen. It ticks ~6-10 times faster.

## Alternatives

N/A

## Testing

Check tests you have performed:
- [x ] Compiles without warnings
- [x ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [~] Playtested a colony: Performed controlled video-recorded tests before/after the change using the same starting conditions (same save file).

