### PR TITLE
Weapon proficiency C# patch w/o new project

### DIFF
--- a/Source/CombatExtended/Harmony/Compatibility/Harmony_WeaponProficiency.cs
+++ b/Source/CombatExtended/Harmony/Compatibility/Harmony_WeaponProficiency.cs
@@ -12,20 +12,20 @@ namespace CombatExtended.HarmonyCE.Compatibility;
 
 public static class Harmony_WeaponProficiency
 {
-    private static MethodInfo Verb_WeaponProficiency_Patch_HarmonyPatches
-    {
-        get
-        {
-            return AccessTools.Method("WeaponProficiency.Patches.Pawn_HealthTracker_Notify_UsedVerb_WeaponProficiencyPatch:IsValidVerb");
-        }
-    }
     [HarmonyPatch]
     public static class Harmony_WeaponProficiency_Apply
     {
+        static MethodInfo TargetMethod()
+        {
+            // Dynamically resolve the method at runtime without loading the assembly directly
+            return AccessTools.Method("WeaponProficiency.Patches.Pawn_HealthTracker_Notify_UsedVerb_WeaponProficiencyPatch:IsValidVerb");
+        }
+
         public static bool Prepare()
         {
-            return Verb_WeaponProficiency_Patch_HarmonyPatches != null;
+            return TargetMethod() != null;
         }
+
         // Correct postfix signature: use __result to modify the return value
         static void Postfix(Verb verb, ref bool __result)
         {

--- a/Source/CombatExtended/Harmony/Compatibility/Harmony_WeaponProficiency.cs
+++ b/Source/CombatExtended/Harmony/Compatibility/Harmony_WeaponProficiency.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using HarmonyLib;
+using RimWorld;
+using UnityEngine;
+using Verse;
+
+namespace CombatExtended.HarmonyCE.Compatibility;
+
+public static class Harmony_WeaponProficiency
+{
+    private static MethodInfo Verb_WeaponProficiency_Patch_HarmonyPatches
+    {
+        get
+        {
+            return AccessTools.Method("WeaponProficiency.Patches.Pawn_HealthTracker_Notify_UsedVerb_WeaponProficiencyPatch:IsValidVerb");
+        }
+    }
+    [HarmonyPatch]
+    public static class Harmony_WeaponProficiency_Apply
+    {
+        public static bool Prepare()
+        {
+            return Verb_WeaponProficiency_Patch_HarmonyPatches != null;
+        }
+        // Correct postfix signature: use __result to modify the return value
+        static void Postfix(Verb verb, ref bool __result)
+        {
+            if (verb is Verb_LaunchProjectileCE)
+            {
+                __result = true;
+            }
+        }
+
+    }
+
+}


### PR DESCRIPTION
## Additions
Weapon proficiency C# patch to patch in CE verbs on their end
move the old C# patch to /Harmony
## Changes
no more compat project
## References
- Closes #[#4109]
## Reasoning
Learnt that I didn't need to make a compat project to patch it
## Alternatives
not fix it?
## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
