### PR TITLE
Reduce advanced ammo spawn rate

### DIFF
--- a/Defs/Ammo/Advanced/5x50mmCaseless.xml
+++ b/Defs/Ammo/Advanced/5x50mmCaseless.xml
@@ -74,6 +74,7 @@
 			<MarketValue>0.05</MarketValue>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_5x50mmCaseless_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Generic/AntiMateriel.xml
+++ b/Defs/Ammo/Generic/AntiMateriel.xml
@@ -72,6 +72,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_50BMG_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -83,6 +84,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_50BMG_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -97,6 +99,7 @@
 			<Mass>0.099</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_50BMG_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Generic/Autocannon.xml
+++ b/Defs/Ammo/Generic/Autocannon.xml
@@ -60,7 +60,6 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
-		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_20x102mmNATO_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -72,7 +71,6 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
-		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_20x102mmNATO_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -87,7 +85,6 @@
 			<Mass>0.213</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
-		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_20x102mmNATO_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Generic/Autocannon.xml
+++ b/Defs/Ammo/Generic/Autocannon.xml
@@ -60,6 +60,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_20x102mmNATO_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -71,6 +72,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_20x102mmNATO_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -85,6 +87,7 @@
 			<Mass>0.213</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_20x102mmNATO_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Generic/Rifle.xml
+++ b/Defs/Ammo/Generic/Rifle.xml
@@ -83,6 +83,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_762x51mmNATO_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -94,6 +95,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_762x51mmNATO_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -108,6 +110,7 @@
 			<Mass>0.02</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_762x51mmNATO_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Generic/RifleIntermediate.xml
+++ b/Defs/Ammo/Generic/RifleIntermediate.xml
@@ -83,6 +83,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_556x45mmNATO_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -94,6 +95,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_556x45mmNATO_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -108,6 +110,7 @@
 			<Mass>0.011</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_556x45mmNATO_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Generic/RifleMagnum.xml
+++ b/Defs/Ammo/Generic/RifleMagnum.xml
@@ -71,6 +71,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_338Lapua_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -82,6 +83,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_338Lapua_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -96,6 +98,7 @@
 			<Mass>0.037</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_338Lapua_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Generic/Shell_Cannon.xml
+++ b/Defs/Ammo/Generic/Shell_Cannon.xml
@@ -111,7 +111,6 @@
 			<Mass>2.088</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
-		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_40x365mmBofors_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Generic/Shell_Cannon.xml
+++ b/Defs/Ammo/Generic/Shell_Cannon.xml
@@ -111,6 +111,7 @@
 			<Mass>2.088</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_40x365mmBofors_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Grenade/20x42mmGrenade.xml
+++ b/Defs/Ammo/Grenade/20x42mmGrenade.xml
@@ -83,6 +83,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<detonateProjectile>Bullet_20x42mm_Incendiary</detonateProjectile>
 	</ThingDef>
 
@@ -94,6 +95,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<detonateProjectile>Bullet_20x42mm_APHE</detonateProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Grenade/20x42mmGrenade.xml
+++ b/Defs/Ammo/Grenade/20x42mmGrenade.xml
@@ -83,7 +83,6 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
-		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<detonateProjectile>Bullet_20x42mm_Incendiary</detonateProjectile>
 	</ThingDef>
 
@@ -95,7 +94,6 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
-		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<detonateProjectile>Bullet_20x42mm_APHE</detonateProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/12.7x108mmSoviet.xml
+++ b/Defs/Ammo/HighCaliber/12.7x108mmSoviet.xml
@@ -71,6 +71,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_127x108mm_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -82,6 +83,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_127x108mm_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -96,6 +98,7 @@
 			<Mass>0.112</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_127x108mm_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/13.2x92mmSRTuF.xml
+++ b/Defs/Ammo/HighCaliber/13.2x92mmSRTuF.xml
@@ -70,6 +70,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_132x92mmSRTuF_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -81,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_132x92mmSRTuF_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -95,6 +97,7 @@
 			<Mass>0.12</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_132x92mmSRTuF_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/14.5x114mmSoviet.xml
+++ b/Defs/Ammo/HighCaliber/14.5x114mmSoviet.xml
@@ -71,6 +71,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_145x114mm_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -82,6 +83,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_145x114mm_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -96,6 +98,7 @@
 			<Mass>0.159</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_145x114mm_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/15.2x169mm.xml
+++ b/Defs/Ammo/HighCaliber/15.2x169mm.xml
@@ -45,6 +45,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_152x169mm_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/2-Bore.xml
+++ b/Defs/Ammo/HighCaliber/2-Bore.xml
@@ -71,6 +71,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_2Bore_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -82,6 +83,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_2Bore_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -96,6 +98,7 @@
 			<Mass>0.38</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_2Bore_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/20x102mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/20x102mmNATO.xml
@@ -60,6 +60,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_20x102mmNATO_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -71,6 +72,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_20x102mmNATO_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -85,6 +87,7 @@
 			<Mass>0.213</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_20x102mmNATO_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/20x110mmHispano.xml
+++ b/Defs/Ammo/HighCaliber/20x110mmHispano.xml
@@ -59,6 +59,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_20x110mmHispano_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -70,6 +71,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_20x110mmHispano_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -84,6 +86,7 @@
 			<Mass>0.205</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_20x110mmHispano_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/20x128mmOerlikon.xml
+++ b/Defs/Ammo/HighCaliber/20x128mmOerlikon.xml
@@ -59,6 +59,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_20x128mmOerlikon_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -70,6 +71,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_20x128mmOerlikon_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -84,6 +86,7 @@
 			<Mass>0.302</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_20x128mmOerlikon_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/20x138mmB.xml
+++ b/Defs/Ammo/HighCaliber/20x138mmB.xml
@@ -59,6 +59,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_20x138mmB_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -70,6 +71,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_20x138mmB_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -84,6 +86,7 @@
 			<Mass>0.249</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_20x138mmB_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/20x139mm.xml
+++ b/Defs/Ammo/HighCaliber/20x139mm.xml
@@ -59,6 +59,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_20x139mm_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -70,6 +71,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_20x139mm_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -84,6 +86,7 @@
 			<Mass>0.25</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_20x139mm_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/20x82mmMauser.xml
+++ b/Defs/Ammo/HighCaliber/20x82mmMauser.xml
@@ -59,6 +59,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_20x82mmMauser_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -70,6 +71,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_20x82mmMauser_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -84,6 +86,7 @@
 			<Mass>0.158</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_20x82mmMauser_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/20x99mmShVAK.xml
+++ b/Defs/Ammo/HighCaliber/20x99mmShVAK.xml
@@ -59,6 +59,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_20x99mmRShVAK_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -70,6 +71,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_20x99mmRShVAK_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -84,6 +86,7 @@
 			<Mass>0.175</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_20x99mmRShVAK_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/23x115mm.xml
+++ b/Defs/Ammo/HighCaliber/23x115mm.xml
@@ -59,6 +59,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_23x115mm_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -70,6 +71,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_23x115mm_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -84,6 +86,7 @@
 			<Mass>0.257</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_23x115mm_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/23x152mmB.xml
+++ b/Defs/Ammo/HighCaliber/23x152mmB.xml
@@ -59,6 +59,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_23x152mmB_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -70,6 +71,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_23x152mmB_APHE</cookOffProjectile>
 	</ThingDef>
 
@@ -84,6 +86,7 @@
 			<Mass>0.368</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_23x152mmB_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/25x137mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/25x137mmNATO.xml
@@ -59,6 +59,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_25x137mmNATO_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -70,6 +71,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_25x137mmNATO_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -84,6 +86,7 @@
 			<Mass>0.422</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_25x137mmNATO_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/27x145mmMauser.xml
+++ b/Defs/Ammo/HighCaliber/27x145mmMauser.xml
@@ -59,6 +59,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_27x145mmMauser_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -70,6 +71,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_27x145mmMauser_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -84,6 +86,7 @@
 			<Mass>0.403</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_27x145mmMauser_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/300WinchesterMagnum.xml
+++ b/Defs/Ammo/HighCaliber/300WinchesterMagnum.xml
@@ -70,6 +70,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_300WinchesterMagnum_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -81,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_300WinchesterMagnum_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -95,6 +97,7 @@
 			<Mass>0.028</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_300WinchesterMagnum_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/30x113mmB.xml
+++ b/Defs/Ammo/HighCaliber/30x113mmB.xml
@@ -59,6 +59,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_30x113mmB_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -70,6 +71,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_30x113mmB_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -84,6 +86,7 @@
 			<Mass>0.373</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_30x113mmB_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/30x165mm.xml
+++ b/Defs/Ammo/HighCaliber/30x165mm.xml
@@ -59,6 +59,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_30x165mm_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -70,6 +71,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_30x165mm_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -84,6 +86,7 @@
 			<Mass>0.665</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_30x165mm_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/30x170mm.xml
+++ b/Defs/Ammo/HighCaliber/30x170mm.xml
@@ -59,6 +59,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_30x170mm_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -70,6 +71,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_30x170mm_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -84,6 +86,7 @@
 			<Mass>0.656</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_30x170mm_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/30x173mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/30x173mmNATO.xml
@@ -59,6 +59,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_30x173mmNATO_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -70,6 +71,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_30x173mmNATO_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -84,6 +86,7 @@
 			<Mass>0.678</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_30x173mmNATO_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/338LapuaMagnum.xml
+++ b/Defs/Ammo/HighCaliber/338LapuaMagnum.xml
@@ -70,6 +70,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_338Lapua_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -81,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_338Lapua_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -95,6 +97,7 @@
 			<Mass>0.037</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_338Lapua_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/338NormaMagnum.xml
+++ b/Defs/Ammo/HighCaliber/338NormaMagnum.xml
@@ -70,6 +70,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_338Norma_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -81,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_338Norma_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -95,6 +97,7 @@
 			<Mass>0.039</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_338Norma_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/35x228mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/35x228mmNATO.xml
@@ -59,6 +59,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_35x228mmNATO_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -70,6 +71,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_35x228mmNATO_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -84,6 +86,7 @@
 			<Mass>1.336</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_35x228mmNATO_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/408CheyenneTactical.xml
+++ b/Defs/Ammo/HighCaliber/408CheyenneTactical.xml
@@ -70,6 +70,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_408CheyenneTactical_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -81,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_408CheyenneTactical_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -95,6 +97,7 @@
 			<Mass>0.071</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_408CheyenneTactical_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/40x311mmR.xml
+++ b/Defs/Ammo/HighCaliber/40x311mmR.xml
@@ -59,6 +59,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_40x311mmR_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -70,6 +71,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_40x311mmR_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -84,6 +86,7 @@
 			<Mass>1.763</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_40x311mmR_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/470NitroExpress.xml
+++ b/Defs/Ammo/HighCaliber/470NitroExpress.xml
@@ -70,6 +70,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_470NitroExpress_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -81,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_470NitroExpress_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -95,6 +97,7 @@
 			<Mass>0.046</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_470NitroExpress_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/50BMG.xml
+++ b/Defs/Ammo/HighCaliber/50BMG.xml
@@ -71,6 +71,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_50BMG_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -82,6 +83,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_50BMG_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -96,6 +98,7 @@
 			<Mass>0.099</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_50BMG_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/55Boys.xml
+++ b/Defs/Ammo/HighCaliber/55Boys.xml
@@ -70,6 +70,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_55Boys_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -81,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_55Boys_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -95,6 +97,7 @@
 			<Mass>0.107</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_55Boys_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/600NitroExpress.xml
+++ b/Defs/Ammo/HighCaliber/600NitroExpress.xml
@@ -70,6 +70,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_600NitroExpress_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -81,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_600NitroExpress_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -95,6 +97,7 @@
 			<Mass>0.079</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_600NitroExpress_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/7.92x94mm Patronen.xml
+++ b/Defs/Ammo/HighCaliber/7.92x94mm Patronen.xml
@@ -71,6 +71,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_792x94mmPatronen_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -82,6 +83,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_792x94mmPatronen_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -96,6 +98,7 @@
 			<Mass>0.119</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_792x94mmPatronen_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/950JDJ.xml
+++ b/Defs/Ammo/HighCaliber/950JDJ.xml
@@ -70,6 +70,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_50JDJ_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -81,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_50JDJ_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -95,6 +97,7 @@
 			<Mass>0.219</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_50JDJ_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Modded/Halo/12.7x99mm.xml
+++ b/Defs/Ammo/Modded/Halo/12.7x99mm.xml
@@ -61,6 +61,7 @@
 			<Mass>0.112</Mass>
 		</statBases>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_127x99mm_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -72,6 +73,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_127x99mm_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -86,6 +88,7 @@
 			<Mass>0.095</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_127x99mm_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Modded/Halo/14.5x114mmUNSC.xml
+++ b/Defs/Ammo/Modded/Halo/14.5x114mmUNSC.xml
@@ -59,6 +59,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<generateAllowChance>0.15</generateAllowChance>
 		<cookOffProjectile>Bullet_145x114mmUNSC_Incendiary</cookOffProjectile>
 	</ThingDef>
@@ -71,6 +72,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<generateAllowChance>0.15</generateAllowChance>
 		<cookOffProjectile>Bullet_145x114mmUNSC_HE</cookOffProjectile>
 	</ThingDef>
@@ -86,6 +88,7 @@
 			<Mass>0.159</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<generateAllowChance>0.1</generateAllowChance>
 		<cookOffProjectile>Bullet_145x114mmUNSC_Sabot</cookOffProjectile>
 	</ThingDef>

--- a/Defs/Ammo/Modded/Halo/16x65mm.xml
+++ b/Defs/Ammo/Modded/Halo/16x65mm.xml
@@ -44,6 +44,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_16x65mm_HE</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Modded/Halo/7.62x51mmUNSC.xml
+++ b/Defs/Ammo/Modded/Halo/7.62x51mmUNSC.xml
@@ -131,6 +131,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<generateAllowChance>0.2</generateAllowChance>
 		<cookOffProjectile>Bullet_762x51mmUNSC_Incendiary</cookOffProjectile>
 	</ThingDef>
@@ -143,6 +144,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<generateAllowChance>0.2</generateAllowChance>
 		<cookOffProjectile>Bullet_762x51mmUNSC_HE</cookOffProjectile>
 	</ThingDef>
@@ -158,6 +160,7 @@
 			<Mass>0.02</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<generateAllowChance>0.2</generateAllowChance>
 		<cookOffProjectile>Bullet_762x51mmUNSC_Sabot</cookOffProjectile>
 	</ThingDef>

--- a/Defs/Ammo/Modded/Halo/8 Gauge.xml
+++ b/Defs/Ammo/Modded/Halo/8 Gauge.xml
@@ -58,7 +58,6 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>Sabot</ammoClass>
-		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_8Gauge_Flechette</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Modded/Halo/8 Gauge.xml
+++ b/Defs/Ammo/Modded/Halo/8 Gauge.xml
@@ -58,6 +58,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_8Gauge_Flechette</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Modded/Halo/9.5x40mm.xml
+++ b/Defs/Ammo/Modded/Halo/9.5x40mm.xml
@@ -84,6 +84,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<generateAllowChance>0.2</generateAllowChance>
 		<cookOffProjectile>Bullet_95x40mmUNSC_Incendiary</cookOffProjectile>
 	</ThingDef>
@@ -96,6 +97,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<generateAllowChance>0.2</generateAllowChance>
 		<cookOffProjectile>Bullet_95x40mmUNSC_HE</cookOffProjectile>
 	</ThingDef>
@@ -111,6 +113,7 @@
 			<Mass>0.02</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<generateAllowChance>0.2</generateAllowChance>
 		<cookOffProjectile>Bullet_95x40mmUNSC_Sabot</cookOffProjectile>
 	</ThingDef>

--- a/Defs/Ammo/Modded/Warhammer 40k/Autoguns.xml
+++ b/Defs/Ammo/Modded/Warhammer 40k/Autoguns.xml
@@ -83,6 +83,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_825mmLong_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -94,6 +95,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_825mmLong_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -108,6 +110,7 @@
 			<Mass>0.023</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_825mmLong_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/127x55mm.xml
+++ b/Defs/Ammo/Rifle/127x55mm.xml
@@ -83,6 +83,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_127x55mm_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -94,6 +95,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_127x55mm_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -108,6 +110,7 @@
 			<Mass>0.054</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_127x55mm_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/243Winchester.xml
+++ b/Defs/Ammo/Rifle/243Winchester.xml
@@ -82,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_243Winchester_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -93,6 +94,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_243Winchester_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -107,6 +109,7 @@
 			<Mass>0.016</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_243Winchester_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/277Fury.xml
+++ b/Defs/Ammo/Rifle/277Fury.xml
@@ -82,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_277Fury_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -93,6 +94,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_277Fury_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -107,6 +109,7 @@
 			<Mass>0.02</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_277Fury_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/280British.xml
+++ b/Defs/Ammo/Rifle/280British.xml
@@ -82,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_280British_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -93,6 +94,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_280British_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -107,6 +109,7 @@
 			<Mass>0.019</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_280British_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/30-30Winchester.xml
+++ b/Defs/Ammo/Rifle/30-30Winchester.xml
@@ -82,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_3030Winchester_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -93,6 +94,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_3030Winchester_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -107,6 +109,7 @@
 			<Mass>0.021</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_3030Winchester_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/3006Springfield.xml
+++ b/Defs/Ammo/Rifle/3006Springfield.xml
@@ -83,6 +83,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_3006Springfield_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -94,6 +95,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_3006Springfield_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -108,6 +110,7 @@
 			<Mass>0.023</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_3006Springfield_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/300AACBlackout.xml
+++ b/Defs/Ammo/Rifle/300AACBlackout.xml
@@ -82,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_300AACBlackout_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -93,6 +94,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_300AACBlackout_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -107,6 +109,7 @@
 			<Mass>0.011</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_300AACBlackout_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/303British.xml
+++ b/Defs/Ammo/Rifle/303British.xml
@@ -82,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_303British_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -93,6 +94,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_303British_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -107,6 +109,7 @@
 			<Mass>0.022</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_303British_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/30Carbine.xml
+++ b/Defs/Ammo/Rifle/30Carbine.xml
@@ -82,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_30Carbine_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -93,6 +94,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_30Carbine_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -107,6 +109,7 @@
 			<Mass>0.01</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_30Carbine_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/38-55Winchester.xml
+++ b/Defs/Ammo/Rifle/38-55Winchester.xml
@@ -82,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_3855Winchester_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -93,6 +94,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_3855Winchester_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -107,6 +109,7 @@
 			<Mass>0.026</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_3855Winchester_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/44-40Winchester.xml
+++ b/Defs/Ammo/Rifle/44-40Winchester.xml
@@ -82,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_44-40Winchester_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -93,6 +94,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_44-40Winchester_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -107,6 +109,7 @@
 			<Mass>0.018</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_44-40Winchester_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/4570Gov.xml
+++ b/Defs/Ammo/Rifle/4570Gov.xml
@@ -82,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_4570Gov_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -93,6 +94,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_4570Gov_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -107,6 +109,7 @@
 			<Mass>0.029</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_4570Gov_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/458SOCOM.xml
+++ b/Defs/Ammo/Rifle/458SOCOM.xml
@@ -82,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_458SOCOM_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -93,6 +94,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_458SOCOM_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -107,6 +109,7 @@
 			<Mass>0.024</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_458SOCOM_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/473x33mmCaseless.xml
+++ b/Defs/Ammo/Rifle/473x33mmCaseless.xml
@@ -82,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_473x33mmCaseless_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -93,6 +94,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_473x33mmCaseless_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -107,6 +109,7 @@
 			<Mass>0.008</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_473x33mmCaseless_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/485x49mm.xml
+++ b/Defs/Ammo/Rifle/485x49mm.xml
@@ -82,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_485x49mm_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -93,6 +94,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_485x49mm_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -107,6 +109,7 @@
 			<Mass>0.01</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_485x49mm_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/50Beowulf.xml
+++ b/Defs/Ammo/Rifle/50Beowulf.xml
@@ -82,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_50Beowulf_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -93,6 +94,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_50Beowulf_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -107,6 +109,7 @@
 			<Mass>0.027</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_50Beowulf_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/545x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/545x39mmSoviet.xml
@@ -96,6 +96,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_545x39mmSoviet_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -107,6 +108,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_545x39mmSoviet_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -121,6 +123,7 @@
 			<Mass>0.01</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_545x39mmSoviet_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/556x45mmNATO.xml
+++ b/Defs/Ammo/Rifle/556x45mmNATO.xml
@@ -96,6 +96,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_556x45mmNATO_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -107,6 +108,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_556x45mmNATO_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -121,6 +123,7 @@
 			<Mass>0.011</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_556x45mmNATO_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/56-56Spencer.xml
+++ b/Defs/Ammo/Rifle/56-56Spencer.xml
@@ -82,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_5656Spencer_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -93,6 +94,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_5656Spencer_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -107,6 +109,7 @@
 			<Mass>0.023</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_5656Spencer_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/58x42mmDBP10.xml
+++ b/Defs/Ammo/Rifle/58x42mmDBP10.xml
@@ -82,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_58x42mmDBP10_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -93,6 +94,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_58x42mmDBP10_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -107,6 +109,7 @@
 			<Mass>0.013</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_58x42mmDBP10_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/6.5Creedmoor.xml
+++ b/Defs/Ammo/Rifle/6.5Creedmoor.xml
@@ -82,6 +82,8 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_65x48mmCreedmoor_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -93,6 +95,8 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_65x48mmCreedmoor_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -107,6 +111,8 @@
 			<Mass>0.019</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_65x48mmCreedmoor_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/6.5x52mm Carcano.xml
+++ b/Defs/Ammo/Rifle/6.5x52mm Carcano.xml
@@ -82,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_65x52mmCarcano_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -93,6 +94,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_65x52mmCarcano_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -107,6 +109,7 @@
 			<Mass>0.02</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_65x52mmCarcano_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/65x50mmSRArisaka.xml
+++ b/Defs/Ammo/Rifle/65x50mmSRArisaka.xml
@@ -82,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_65x50mmSRArisaka_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -93,6 +94,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_65x50mmSRArisaka_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -107,6 +109,7 @@
 			<Mass>0.019</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_65x50mmSRArisaka_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/7.92x57mmMauser.xml
+++ b/Defs/Ammo/Rifle/7.92x57mmMauser.xml
@@ -82,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_792x57mmMauser_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -93,6 +94,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_792x57mmMauser_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -107,6 +109,7 @@
 			<Mass>0.023</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_792x57mmMauser_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/75x54mmFrench.xml
+++ b/Defs/Ammo/Rifle/75x54mmFrench.xml
@@ -82,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_75x54mmFrench_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -93,6 +94,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_75x54mmFrench_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -107,6 +109,7 @@
 			<Mass>0.021</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_75x54mmFrench_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/762x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/762x39mmSoviet.xml
@@ -96,6 +96,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_762x39mmSoviet_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -107,6 +108,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_762x39mmSoviet_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -121,6 +123,7 @@
 			<Mass>0.013</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_762x39mmSoviet_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/762x51mmNATO.xml
+++ b/Defs/Ammo/Rifle/762x51mmNATO.xml
@@ -82,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_762x51mmNATO_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -93,6 +94,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_762x51mmNATO_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -107,6 +109,7 @@
 			<Mass>0.02</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_762x51mmNATO_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/762x54mmR.xml
+++ b/Defs/Ammo/Rifle/762x54mmR.xml
@@ -82,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_762x54mmR_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -93,6 +94,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_762x54mmR_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -107,6 +109,7 @@
 			<Mass>0.022</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_762x54mmR_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/77x58mmArisaka.xml
+++ b/Defs/Ammo/Rifle/77x58mmArisaka.xml
@@ -82,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_77x58mmArisaka_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -93,6 +94,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_77x58mmArisaka_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -107,6 +109,7 @@
 			<Mass>0.023</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_77x58mmArisaka_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/792x33mmKurz.xml
+++ b/Defs/Ammo/Rifle/792x33mmKurz.xml
@@ -82,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_792x33mmKurz_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -93,6 +94,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_792x33mmKurz_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -107,6 +109,7 @@
 			<Mass>0.015</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_792x33mmKurz_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/8.6mmBlackout.xml
+++ b/Defs/Ammo/Rifle/8.6mmBlackout.xml
@@ -82,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_86x43mmBlackout_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -93,6 +94,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_86x43mmBlackout_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -107,6 +109,7 @@
 			<Mass>0.021</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_86x43mmBlackout_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/8x50mmRLebel.xml
+++ b/Defs/Ammo/Rifle/8x50mmRLebel.xml
@@ -82,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_8x50mmRLebel_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -93,6 +94,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_8x50mmRLebel_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -107,6 +109,7 @@
 			<Mass>0.023</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_8x50mmRLebel_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/8x50mmRMannlicher.xml
+++ b/Defs/Ammo/Rifle/8x50mmRMannlicher.xml
@@ -82,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_8x50mmRMannlicher_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -93,6 +94,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_8x50mmRMannlicher_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -107,6 +109,7 @@
 			<Mass>0.025</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_8x50mmRMannlicher_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/9x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/9x39mmSoviet.xml
@@ -82,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_9x39mmSoviet_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -93,6 +94,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_9x39mmSoviet_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -107,6 +109,7 @@
 			<Mass>0.02</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_9x39mmSoviet_Sabot</cookOffProjectile>
 	</ThingDef>
 	<!-- ================== Projectiles ================== -->

--- a/ModPatches/Call of Duty - Zombies Pack/Defs/Call of Duty - Zombies Pack/Ammo/Rayguns/Raygun.xml
+++ b/ModPatches/Call of Duty - Zombies Pack/Defs/Call of Duty - Zombies Pack/Ammo/Rayguns/Raygun.xml
@@ -38,6 +38,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_Raygun</cookOffProjectile>
 	</ThingDef>
 	<!-- ==================== Projectiles ========================== -->

--- a/ModPatches/Call of Duty - Zombies Pack/Defs/Call of Duty - Zombies Pack/Ammo/Rayguns/Raygun2Y.xml
+++ b/ModPatches/Call of Duty - Zombies Pack/Defs/Call of Duty - Zombies Pack/Ammo/Rayguns/Raygun2Y.xml
@@ -38,6 +38,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_Raygun_two_y</cookOffProjectile>
 	</ThingDef>
 	<!-- ==================== Projectiles ========================== -->

--- a/ModPatches/Call of Duty - Zombies Pack/Defs/Call of Duty - Zombies Pack/Ammo/Rayguns/Raygun2Y_Punched.xml
+++ b/ModPatches/Call of Duty - Zombies Pack/Defs/Call of Duty - Zombies Pack/Ammo/Rayguns/Raygun2Y_Punched.xml
@@ -37,6 +37,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_Raygun_two_y_Punched</cookOffProjectile>
 	</ThingDef>
 	<!-- ==================== Projectiles ========================== -->

--- a/ModPatches/Call of Duty - Zombies Pack/Defs/Call of Duty - Zombies Pack/Ammo/Rayguns/Raygun3GKZ.xml
+++ b/ModPatches/Call of Duty - Zombies Pack/Defs/Call of Duty - Zombies Pack/Ammo/Rayguns/Raygun3GKZ.xml
@@ -38,6 +38,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_Raygun_three_GKZ</cookOffProjectile>
 	</ThingDef>
 	<!-- ==================== Projectiles ========================== -->

--- a/ModPatches/Call of Duty - Zombies Pack/Defs/Call of Duty - Zombies Pack/Ammo/Rayguns/Raygun3GKZ_Punched.xml
+++ b/ModPatches/Call of Duty - Zombies Pack/Defs/Call of Duty - Zombies Pack/Ammo/Rayguns/Raygun3GKZ_Punched.xml
@@ -38,6 +38,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_Raygun_three_GKZ_Punched</cookOffProjectile>
 	</ThingDef>
 	<!-- ==================== Projectiles ========================== -->

--- a/ModPatches/Call of Duty - Zombies Pack/Defs/Call of Duty - Zombies Pack/Ammo/Rayguns/Raygun_Punched.xml
+++ b/ModPatches/Call of Duty - Zombies Pack/Defs/Call of Duty - Zombies Pack/Ammo/Rayguns/Raygun_Punched.xml
@@ -38,6 +38,7 @@
 			<color>(200,200,200)</color>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_Raygun_Punched</cookOffProjectile>
 	</ThingDef>
 	<!-- ==================== Projectiles ========================== -->

--- a/ModPatches/Call of Duty - Zombies Pack/Defs/Call of Duty - Zombies Pack/Ammo/Recipe/303British-Punched.xml
+++ b/ModPatches/Call of Duty - Zombies Pack/Defs/Call of Duty - Zombies Pack/Ammo/Recipe/303British-Punched.xml
@@ -76,6 +76,7 @@
 			<color>(255,200,200)</color>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_303British_Incendiary_Punched</cookOffProjectile>
 	</ThingDef>
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="303BritishPunched">
@@ -87,6 +88,7 @@
 			<color>(255,200,200)</color>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_303British_HE_Punched</cookOffProjectile>
 	</ThingDef>
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="303BritishPunched">
@@ -101,6 +103,7 @@
 			<Mass>0.022</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_303British_Sabot_Punched</cookOffProjectile>
 	</ThingDef>
 	<!-- ==================== Projectiles ==================== -->

--- a/ModPatches/Call of Duty - Zombies Pack/Defs/Call of Duty - Zombies Pack/Ammo/Recipe/556x45mmNATO-Punched.xml
+++ b/ModPatches/Call of Duty - Zombies Pack/Defs/Call of Duty - Zombies Pack/Ammo/Recipe/556x45mmNATO-Punched.xml
@@ -76,6 +76,7 @@
 			<color>(255,200,200)</color>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_556x45mmNATO_Incendiary_Punched</cookOffProjectile>
 	</ThingDef>
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="556x45mmNATOPunched">
@@ -87,6 +88,7 @@
 			<color>(255,200,200)</color>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_556x45mmNATO_HE_Punched</cookOffProjectile>
 	</ThingDef>
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="556x45mmNATOPunched">
@@ -101,6 +103,7 @@
 			<Mass>0.011</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_556x45mmNATO_Sabot_Punched</cookOffProjectile>
 	</ThingDef>
 	<!-- ==================== Projectiles ==================== -->

--- a/ModPatches/Call of Duty - Zombies Pack/Defs/Call of Duty - Zombies Pack/Ammo/Recipe/762x51mmNATO-Punched.xml
+++ b/ModPatches/Call of Duty - Zombies Pack/Defs/Call of Duty - Zombies Pack/Ammo/Recipe/762x51mmNATO-Punched.xml
@@ -76,6 +76,7 @@
 			<color>(255,200,200)</color>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_762x51mmNATO_Incendiary_Punched</cookOffProjectile>
 	</ThingDef>
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x51mmNATOPunched">
@@ -87,6 +88,7 @@
 			<color>(255,200,200)</color>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_762x51mmNATO_HE_Punched</cookOffProjectile>
 	</ThingDef>
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x51mmNATOPunched">
@@ -101,6 +103,7 @@
 			<Mass>0.02</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_762x51mmNATO_Sabot_Punched</cookOffProjectile>
 	</ThingDef>
 	<!-- ==================== Projectiles ==================== -->

--- a/ModPatches/Call of Duty - Zombies Pack/Defs/Call of Duty - Zombies Pack/Ammo/Recipe/762x54mmR-Punched.xml
+++ b/ModPatches/Call of Duty - Zombies Pack/Defs/Call of Duty - Zombies Pack/Ammo/Recipe/762x54mmR-Punched.xml
@@ -76,6 +76,7 @@
 			<color>(255,200,200)</color>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_762x54mmR_Incendiary_Punched</cookOffProjectile>
 	</ThingDef>
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x54mmRPunched">
@@ -87,6 +88,7 @@
 			<color>(255,200,200)</color>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_762x54mmR_HE_Punched</cookOffProjectile>
 	</ThingDef>
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x54mmRPunched">
@@ -101,6 +103,7 @@
 			<Mass>0.022</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_762x54mmR_Sabot_Punched</cookOffProjectile>
 	</ThingDef>
 	<!-- ==================== Projectiles ==================== -->

--- a/ModPatches/Call of Duty - Zombies Pack/Defs/Call of Duty - Zombies Pack/Ammo/Wunders/WundersS.xml
+++ b/ModPatches/Call of Duty - Zombies Pack/Defs/Call of Duty - Zombies Pack/Ammo/Wunders/WundersS.xml
@@ -33,6 +33,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_Wunder_s</cookOffProjectile>
 		<thingCategories>
 			<li>AmmoWunder_s</li>

--- a/ModPatches/Call of Duty - Zombies Pack/Defs/Call of Duty - Zombies Pack/Ammo/Wunders/WundersS_Punched.xml
+++ b/ModPatches/Call of Duty - Zombies Pack/Defs/Call of Duty - Zombies Pack/Ammo/Wunders/WundersS_Punched.xml
@@ -32,6 +32,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_Wunder_s_Punched</cookOffProjectile>
 		<thingCategories>
 			<li>AmmoWunder_s_Punched</li>

--- a/ModPatches/Call of Duty - Zombies Pack/Defs/Call of Duty - Zombies Pack/Ammo/Zaps/Waveguns.xml
+++ b/ModPatches/Call of Duty - Zombies Pack/Defs/Call of Duty - Zombies Pack/Ammo/Zaps/Waveguns.xml
@@ -38,6 +38,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_Wavegun</cookOffProjectile>
 	</ThingDef>
 	<!-- ==================== Projectiles ========================== -->

--- a/ModPatches/Call of Duty - Zombies Pack/Defs/Call of Duty - Zombies Pack/Ammo/Zaps/Waveguns_Punched.xml
+++ b/ModPatches/Call of Duty - Zombies Pack/Defs/Call of Duty - Zombies Pack/Ammo/Zaps/Waveguns_Punched.xml
@@ -37,6 +37,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_Wavegun_Punched</cookOffProjectile>
 	</ThingDef>
 	<!-- ==================== Projectiles ========================== -->

--- a/ModPatches/Censored Armory/Defs/Censored Armory/37x249mmR.xml
+++ b/ModPatches/Censored Armory/Defs/Censored Armory/37x249mmR.xml
@@ -47,6 +47,7 @@
 			<drawSize>1.50</drawSize>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_37x249mmR_HE</cookOffProjectile>
 	</ThingDef>
 

--- a/ModPatches/Censored Armory/Defs/Censored Armory/37x249mmR.xml
+++ b/ModPatches/Censored Armory/Defs/Censored Armory/37x249mmR.xml
@@ -47,7 +47,6 @@
 			<drawSize>1.50</drawSize>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
-		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_37x249mmR_HE</cookOffProjectile>
 	</ThingDef>
 

--- a/ModPatches/RH2 Helldivers Super Firearms/Defs/RH2 Helldivers Super Firearms/125x100_Justice.xml
+++ b/ModPatches/RH2 Helldivers Super Firearms/Defs/RH2 Helldivers Super Firearms/125x100_Justice.xml
@@ -71,6 +71,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_125x100_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -82,6 +83,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_125x100_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -96,6 +98,7 @@
 			<Mass>0.099</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_125x100_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/ModPatches/RH2 Helldivers Super Firearms/Defs/RH2 Helldivers Super Firearms/55x50_Liberty.xml
+++ b/ModPatches/RH2 Helldivers Super Firearms/Defs/RH2 Helldivers Super Firearms/55x50_Liberty.xml
@@ -82,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_55x50mmLiberty_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -93,6 +94,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_55x50mmLiberty_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -107,6 +109,7 @@
 			<Mass>0.011</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_55x50mmLiberty_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/ModPatches/RH2 Helldivers Super Firearms/Defs/RH2 Helldivers Super Firearms/8x60_Constitution.xml
+++ b/ModPatches/RH2 Helldivers Super Firearms/Defs/RH2 Helldivers Super Firearms/8x60_Constitution.xml
@@ -82,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_8x60mmConstitution_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -93,6 +94,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_8x60mmConstitution_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -107,6 +109,7 @@
 			<Mass>0.023</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_8x60mmConstitution_Sabot</cookOffProjectile>
 	</ThingDef>
 

--- a/ModPatches/RH2 Helldivers Super Firearms/Defs/RH2 Helldivers Super Firearms/9x70_Diligent.xml
+++ b/ModPatches/RH2 Helldivers Super Firearms/Defs/RH2 Helldivers Super Firearms/9x70_Diligent.xml
@@ -82,6 +82,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_9x70mmDiligent_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -93,6 +94,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_9x70mmDiligent_HE</cookOffProjectile>
 	</ThingDef>
 
@@ -107,6 +109,7 @@
 			<Mass>0.023</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
+		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_9x70mmDiligent_Sabot</cookOffProjectile>
 	</ThingDef>
 


### PR DESCRIPTION
## Changes
- Make sabot, AP-HE, and AP-I spawn on NPCs less frequently for rifle and high caliber ammosets.
 - Spawn rate reduced to 0.65.

## References
- Complements #4092

## Reasoning
As suggested by @Breadbox2k19 on #4092, doesn't necessarily make sense for advanced ammo types to spawn as frequently as 'basic' ammo types like FMJ, AP, and HP. This makes the advanced ammo types spawn less frequently, but hopefully doesn't reduce the overall threat presented by these pawnkinds during raid.

Left a comment in the xml so that these are easy to find and replace in the future, if we want to adjust these values in the future.

## Alternatives
- Could reduce the ammo commonality further, potentially creating a more aggressive balance shift.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
