### PR TITLE
Increase ion component costs

### DIFF
--- a/Defs/Ammo/Advanced/12GaugeCharged.xml
+++ b/Defs/Ammo/Advanced/12GaugeCharged.xml
@@ -259,7 +259,7 @@
 						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
-				<count>10</count>
+				<count>12</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -272,7 +272,7 @@
 		<products>
 			<Ammo_12GaugeCharged_Ion>200</Ammo_12GaugeCharged_Ion>
 		</products>
-		<workAmount>15000</workAmount>
+		<workAmount>16200</workAmount>
 	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Advanced/12x72mmCharged.xml
+++ b/Defs/Ammo/Advanced/12x72mmCharged.xml
@@ -251,7 +251,7 @@
 						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
-				<count>14</count>
+				<count>17</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -264,7 +264,7 @@
 		<products>
 			<Ammo_12x72mmCharged_Ion>200</Ammo_12x72mmCharged_Ion>
 		</products>
-		<workAmount>22000</workAmount>
+		<workAmount>23800</workAmount>
 	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Advanced/20x105mmCharged.xml
+++ b/Defs/Ammo/Advanced/20x105mmCharged.xml
@@ -251,7 +251,7 @@
 						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
-				<count>16</count>
+				<count>20</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -264,7 +264,7 @@
 		<products>
 			<Ammo_20x105mmCharged_Ion>100</Ammo_20x105mmCharged_Ion>
 		</products>
-		<workAmount>26200</workAmount>
+		<workAmount>28600</workAmount>
 	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Advanced/6x18mmCharged.xml
+++ b/Defs/Ammo/Advanced/6x18mmCharged.xml
@@ -250,7 +250,7 @@
 						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
-				<count>5</count>
+				<count>6</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -263,7 +263,7 @@
 		<products>
 			<Ammo_6x18mmCharged_Ion>500</Ammo_6x18mmCharged_Ion>
 		</products>
-		<workAmount>6600</workAmount>
+		<workAmount>7200</workAmount>
 	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Advanced/6x24mmCharged.xml
+++ b/Defs/Ammo/Advanced/6x24mmCharged.xml
@@ -250,7 +250,7 @@
 						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
-				<count>5</count>
+				<count>6</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -263,7 +263,7 @@
 		<products>
 			<Ammo_6x24mmCharged_Ion>500</Ammo_6x24mmCharged_Ion>
 		</products>
-		<workAmount>6800</workAmount>
+		<workAmount>7200</workAmount>
 	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Advanced/8x35mmCharged.xml
+++ b/Defs/Ammo/Advanced/8x35mmCharged.xml
@@ -270,7 +270,7 @@
 						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
-				<count>9</count>
+				<count>11</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -283,7 +283,7 @@
 		<products>
 			<Ammo_8x35mmCharged_Ion>500</Ammo_8x35mmCharged_Ion>
 		</products>
-		<workAmount>13600</workAmount>
+		<workAmount>14800</workAmount>
 	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Advanced/8x50mmCharged.xml
+++ b/Defs/Ammo/Advanced/8x50mmCharged.xml
@@ -251,7 +251,7 @@
 						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
-				<count>11</count>
+				<count>14</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -264,7 +264,7 @@
 		<products>
 			<Ammo_8x50mmCharged_Ion>500</Ammo_8x50mmCharged_Ion>
 		</products>
-		<workAmount>17800</workAmount>
+		<workAmount>19600</workAmount>
 	</RecipeDef>
 
 </Defs>


### PR DESCRIPTION
## Changes

- Increased the component costs of Ion charge rounds by 20% and increased the work amount to match.

## References

- Reference sheets link: https://docs.google.com/spreadsheets/d/14XthkzHEXnN4N_xZoF8B3Zx1v4D_hreky-BHTyhQJvM/edit?usp=sharing

## Reasoning

- Ion rounds retain an effective pen/damage ratio of the other charged rounds and gain an extra EMP utility on top, the change is primarily to add an extra cost to said utility.

## Alternatives

- Decrease Ion effectiveness against fleshbags.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] Playtested a colony (specify how long)
