### PR TITLE
Fix post and pre single thing spawning

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoExploder.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoExploder.cs
@@ -60,8 +60,9 @@ public class CompAmmoExploder : ThingComp
                             postExplosionSpawnThingDef: proj.postExplosionSpawnThingDef,
                             preExplosionSpawnChance: proj.preExplosionSpawnChance,
                             preExplosionSpawnThingCount: proj.preExplosionSpawnThingCount,
-                            preExplosionSpawnThingDef: proj.preExplosionSpawnThingDef
-
+                            preExplosionSpawnThingDef: proj.preExplosionSpawnThingDef,
+                            preExplosionSpawnSingleThingDef: proj.preExplosionSpawnSingleThingDef,
+                            postExplosionSpawnSingleThingDef: proj.postExplosionSpawnSingleThingDef
                         );
                     }
                 }

--- a/Source/CombatExtended/CombatExtended/Comps/CompExplosiveCE.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompExplosiveCE.cs
@@ -68,7 +68,9 @@ public class CompExplosiveCE : ThingComp
                 ignoredThings,
                 screenShakeFactor: Props.screenShakeFactor,
                 height: pos.y,
-                scaleFactor: scaleFactor);
+                scaleFactor: scaleFactor,
+                preExplosionSpawnSingleThingDef: Props.preExplosionSpawnSingleThingDef,
+                postExplosionSpawnSingleThingDef: Props.postExplosionSpawnSingleThingDef);
         }
     }
 }

--- a/Source/CombatExtended/CombatExtended/Comps/CompProperties_ExplosiveCE.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompProperties_ExplosiveCE.cs
@@ -30,6 +30,8 @@ public class CompProperties_ExplosiveCE : CompProperties
     public ThingDef preExplosionSpawnThingDef = null;
     public float preExplosionSpawnChance = 0;
     public int preExplosionSpawnThingCount = 1;
+    public ThingDef preExplosionSpawnSingleThingDef;
+    public ThingDef postExplosionSpawnSingleThingDef;
     public bool damageFalloff = true;
     public float chanceToStartFire;
     public float screenShakeFactor;

--- a/Source/CombatExtended/CombatExtended/ExplosionCE.cs
+++ b/Source/CombatExtended/CombatExtended/ExplosionCE.cs
@@ -373,6 +373,7 @@ public class ExplosionCE : Verse.Explosion
             }
             return false;
         }, 25, RegionType.Set_Passable);
+        this.TrySpawnSingleThing(this.preExplosionSpawnSingleThingDef);
     }
 
     public override void Tick()
@@ -400,6 +401,7 @@ public class ExplosionCE : Verse.Explosion
         }
         if (toBeMerged || !this.cellsToAffect.Any<IntVec3>())
         {
+            this.ExplosionEnded();
             this.Destroy(DestroyMode.Vanish);
         }
     }

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -1532,7 +1532,9 @@ public abstract class ProjectileCE : ThingWithComps
                     ignoredThings,
                     postExplosionSpawnThingDefWater: def.projectile.postExplosionSpawnThingDefWater,
                     screenShakeFactor: def.projectile.screenShakeFactor,
-                    height: explodePos.y);
+                    height: explodePos.y,
+                    preExplosionSpawnSingleThingDef: Props.preExplosionSpawnSingleThingDef,
+                    postExplosionSpawnSingleThingDef: Props.postExplosionSpawnSingleThingDef);
 
                 dangerAmount = def.projectile.damageAmountBase;
 

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_BunkerBuster.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_BunkerBuster.cs
@@ -40,7 +40,9 @@ public class ProjectileCE_BunkerBuster : ProjectileCE_Explosive
                                        preExplosionSpawnThingDef: props.preExplosionSpawnThingDef,
                                        preExplosionSpawnChance: props.preExplosionSpawnChance,
                                        preExplosionSpawnThingCount: props.preExplosionSpawnThingCount,
-                                       postExplosionGasType: props.postExplosionGasType
+                                       postExplosionGasType: props.postExplosionGasType,
+                                       preExplosionSpawnSingleThingDef: Props.preExplosionSpawnSingleThingDef,
+                                       postExplosionSpawnSingleThingDef: Props.postExplosionSpawnSingleThingDef
                                       );
 
             foreach (var comp in GetComps<CompFragments>())


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Added 1.6 code to handle new postExplosionSpawnSingleThingDef and preExplosionSpawnThingDef fields in explosions

## Reasoning

Why did you choose to implement things this way, e.g.
- 1.6 added it
- Use antimatter IED trap for testing - it will start spawning a crater from its XML with this pr

## Alternatives

Describe alternative implementations you have considered, e.g.
- Reject technology

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
