### PR TITLE
Add blast marks and craters to big explosives

### DIFF
--- a/Defs/Ammo/Advanced/30x64mmFuelCell.xml
+++ b/Defs/Ammo/Advanced/30x64mmFuelCell.xml
@@ -108,6 +108,7 @@
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 			<ai_IsIncendiary>true</ai_IsIncendiary>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Advanced/66mmThermalBolt.xml
+++ b/Defs/Ammo/Advanced/66mmThermalBolt.xml
@@ -95,6 +95,7 @@
 			<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
 			<preExplosionSpawnChance>0.2</preExplosionSpawnChance>
 			<soundExplode>MortarIncendiary_Explode</soundExplode>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">

--- a/Defs/Ammo/Advanced/70mmMechanoidGrenade.xml
+++ b/Defs/Ammo/Advanced/70mmMechanoidGrenade.xml
@@ -87,6 +87,7 @@
 			<explosionRadius>2.5</explosionRadius>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">

--- a/Defs/Ammo/Advanced/80x256mmFuelCell.xml
+++ b/Defs/Ammo/Advanced/80x256mmFuelCell.xml
@@ -92,6 +92,7 @@
 				<tilesPerTick>0.05</tilesPerTick>
 				<range>40</range>
 			</shellingProps>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">

--- a/Defs/Ammo/Grenade/83mmPIATGrenade.xml
+++ b/Defs/Ammo/Grenade/83mmPIATGrenade.xml
@@ -121,6 +121,7 @@
 			<damageAmountBase>139</damageAmountBase>
 			<explosionRadius>2.5</explosionRadius>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">

--- a/Defs/Ammo/Medieval/CannonBall.xml
+++ b/Defs/Ammo/Medieval/CannonBall.xml
@@ -178,6 +178,7 @@
 			<explosionRadius>2.5</explosionRadius>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
@@ -282,6 +283,7 @@
 			<explosionRadius>2.5</explosionRadius>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">

--- a/Defs/Ammo/Modded/Warhammer 40k/PlasmaCannon.xml
+++ b/Defs/Ammo/Modded/Warhammer 40k/PlasmaCannon.xml
@@ -287,6 +287,7 @@
 				<explosiveRadius>2.9</explosiveRadius>
 				<explosionSound>MortarBomb_Explode</explosionSound>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+				<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 			</li>
 		</comps>
 		<modExtensions>

--- a/Defs/Ammo/Rocket/127mmJavelinMissile.xml
+++ b/Defs/Ammo/Rocket/127mmJavelinMissile.xml
@@ -26,6 +26,7 @@
 				<explosiveRadius>3</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 				<explosionSound>MortarBomb_Explode</explosionSound>
+				<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 			</li>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>

--- a/Defs/Ammo/Rocket/130mmType63.xml
+++ b/Defs/Ammo/Rocket/130mmType63.xml
@@ -117,6 +117,7 @@
 			<damageAmountBase>254</damageAmountBase>
 			<explosionRadius>3.5</explosionRadius>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">

--- a/Defs/Ammo/Rocket/132mmM13.xml
+++ b/Defs/Ammo/Rocket/132mmM13.xml
@@ -75,6 +75,7 @@
 				<range>20</range>
 				<damage>0.23</damage>
 			</shellingProps>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">

--- a/Defs/Ammo/Rocket/150mmMBTLAWMissile.xml
+++ b/Defs/Ammo/Rocket/150mmMBTLAWMissile.xml
@@ -26,6 +26,7 @@
 				<explosiveRadius>2.5</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 				<explosionSound>MortarBomb_Explode</explosionSound>
+				<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 			</li>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>

--- a/Defs/Ammo/Rocket/57mmS5Rocket.xml
+++ b/Defs/Ammo/Rocket/57mmS5Rocket.xml
@@ -246,6 +246,7 @@
 			<armorPenetrationBlunt>0</armorPenetrationBlunt>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 			<ai_IsIncendiary>true</ai_IsIncendiary>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rocket/83mmSMAW.xml
+++ b/Defs/Ammo/Rocket/83mmSMAW.xml
@@ -166,6 +166,7 @@
 			<explosionRadius>2.5</explosionRadius>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
@@ -191,6 +192,7 @@
 			<explosionRadius>5</explosionRadius>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rocket/84x246mmR.xml
+++ b/Defs/Ammo/Rocket/84x246mmR.xml
@@ -299,6 +299,7 @@
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 			<ai_IsIncendiary>true</ai_IsIncendiary>
 			<speed>48</speed>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 	</ThingDef>
 
@@ -315,6 +316,7 @@
 			<speed>51</speed>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
@@ -441,6 +443,7 @@
 			<speed>65</speed>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<ai_IsIncendiary>true</ai_IsIncendiary>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">

--- a/Defs/Ammo/Rocket/M6A3.xml
+++ b/Defs/Ammo/Rocket/M6A3.xml
@@ -151,6 +151,7 @@
 			<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
 			<preExplosionSpawnChance>0.5</preExplosionSpawnChance>
 			<soundExplode>MortarBomb_Explode</soundExplode>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rocket/M74.xml
+++ b/Defs/Ammo/Rocket/M74.xml
@@ -106,6 +106,7 @@
 			<preExplosionSpawnChance>0.5</preExplosionSpawnChance>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<ai_IsIncendiary>true</ai_IsIncendiary>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 		<!-- <comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">

--- a/Defs/Ammo/Rocket/RPG7.xml
+++ b/Defs/Ammo/Rocket/RPG7.xml
@@ -174,6 +174,7 @@
 			<armorPenetrationBlunt>0</armorPenetrationBlunt>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 			<ai_IsIncendiary>true</ai_IsIncendiary>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 			<!-- <fuze_delay>2</fuze_delay>
       		<HP_penetration>true</HP_penetration>
      		<HP_penetration_ratio>300</HP_penetration_ratio> -->

--- a/Defs/Ammo/Rocket/RPO.xml
+++ b/Defs/Ammo/Rocket/RPO.xml
@@ -73,6 +73,7 @@
 			<preExplosionSpawnChance>0.5</preExplosionSpawnChance>
 			<soundExplode>MortarIncendiary_Explode</soundExplode>
 			<ai_IsIncendiary>true</ai_IsIncendiary>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rocket/SPG9.xml
+++ b/Defs/Ammo/Rocket/SPG9.xml
@@ -185,6 +185,7 @@
 			<armorPenetrationBlunt>0</armorPenetrationBlunt>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 			<ai_IsIncendiary>true</ai_IsIncendiary>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rocket/TomahawkLAM.xml
+++ b/Defs/Ammo/Rocket/TomahawkLAM.xml
@@ -112,6 +112,7 @@
 			<damageAmountBase>5653</damageAmountBase>
 			<soundExplode>Explosion_GiantBomb</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			<preExplosionSpawnSingleThingDef>CraterLarge</preExplosionSpawnSingleThingDef>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">

--- a/Defs/Ammo/Shell/100x695mmR.xml
+++ b/Defs/Ammo/Shell/100x695mmR.xml
@@ -127,6 +127,7 @@
 			<explosionRadius>3</explosionRadius>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">

--- a/Defs/Ammo/Shell/105mmHowitzer.xml
+++ b/Defs/Ammo/Shell/105mmHowitzer.xml
@@ -169,6 +169,7 @@
 			<explosionRadius>3</explosionRadius>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
@@ -225,6 +226,7 @@
 			<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
 			<preExplosionSpawnChance>0.15</preExplosionSpawnChance>
 			<soundExplode>MortarIncendiary_Explode</soundExplode>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
@@ -337,6 +339,7 @@
 			<explosionRadius>3</explosionRadius>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
@@ -362,6 +365,7 @@
 			<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
 			<preExplosionSpawnChance>0.25</preExplosionSpawnChance>
 			<soundExplode>MortarIncendiary_Explode</soundExplode>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">

--- a/Defs/Ammo/Shell/105x607mmR.xml
+++ b/Defs/Ammo/Shell/105x607mmR.xml
@@ -123,6 +123,7 @@
 			<explosionRadius>4</explosionRadius>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">

--- a/Defs/Ammo/Shell/105x617mmR.xml
+++ b/Defs/Ammo/Shell/105x617mmR.xml
@@ -129,6 +129,7 @@
 			<explosionRadius>3</explosionRadius>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">

--- a/Defs/Ammo/Shell/120mmCannon.xml
+++ b/Defs/Ammo/Shell/120mmCannon.xml
@@ -122,6 +122,7 @@
 			<explosionRadius>4</explosionRadius>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">

--- a/Defs/Ammo/Shell/120mmMortar.xml
+++ b/Defs/Ammo/Shell/120mmMortar.xml
@@ -153,6 +153,7 @@
 			<explosionRadius>3.5</explosionRadius>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
@@ -215,6 +216,7 @@
 			<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
 			<preExplosionSpawnChance>0.2</preExplosionSpawnChance>
 			<soundExplode>MortarIncendiary_Explode</soundExplode>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Shell/152mmHowitzer.xml
+++ b/Defs/Ammo/Shell/152mmHowitzer.xml
@@ -165,6 +165,7 @@
 			<shellingProps>
 				<damage>0.36</damage>
 			</shellingProps>
+			<preExplosionSpawnSingleThingDef>CraterMedium</preExplosionSpawnSingleThingDef>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
@@ -224,6 +225,7 @@
 			<shellingProps>
 				<damage>0.32</damage>
 			</shellingProps>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
@@ -338,6 +340,7 @@
 			<explosionRadius>5.5</explosionRadius>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			<preExplosionSpawnSingleThingDef>CraterMedium</preExplosionSpawnSingleThingDef>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
@@ -363,6 +366,7 @@
 			<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
 			<preExplosionSpawnChance>0.20</preExplosionSpawnChance>
 			<soundExplode>MortarIncendiary_Explode</soundExplode>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">

--- a/Defs/Ammo/Shell/155mmHowitzer.xml
+++ b/Defs/Ammo/Shell/155mmHowitzer.xml
@@ -153,6 +153,7 @@
 			<shellingProps>
 				<damage>0.33</damage>
 			</shellingProps>
+			<preExplosionSpawnSingleThingDef>CraterMedium</preExplosionSpawnSingleThingDef>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
@@ -212,6 +213,7 @@
 			<shellingProps>
 				<damage>0.33</damage>
 			</shellingProps>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
@@ -294,6 +296,7 @@
 			<explosionRadius>5.5</explosionRadius>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			<preExplosionSpawnSingleThingDef>CraterMedium</preExplosionSpawnSingleThingDef>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
@@ -319,6 +322,7 @@
 			<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
 			<preExplosionSpawnChance>0.20</preExplosionSpawnChance>
 			<soundExplode>MortarIncendiary_Explode</soundExplode>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">

--- a/Defs/Ammo/Shell/15cmNebelwerfer.xml
+++ b/Defs/Ammo/Shell/15cmNebelwerfer.xml
@@ -74,6 +74,7 @@
 				<range>16</range>
 				<damage>0.045</damage>
 			</shellingProps>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">

--- a/Defs/Ammo/Shell/28cmSpgr.xml
+++ b/Defs/Ammo/Shell/28cmSpgr.xml
@@ -85,6 +85,7 @@
 			<explosionRadius>7</explosionRadius>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			<preExplosionSpawnSingleThingDef>CraterMedium</preExplosionSpawnSingleThingDef>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">

--- a/Defs/Ammo/Shell/60mmMortar.xml
+++ b/Defs/Ammo/Shell/60mmMortar.xml
@@ -167,6 +167,7 @@
 			<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
 			<preExplosionSpawnChance>0.15</preExplosionSpawnChance>
 			<soundExplode>MortarIncendiary_Explode</soundExplode>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Shell/81mmMortar.xml
+++ b/Defs/Ammo/Shell/81mmMortar.xml
@@ -211,6 +211,7 @@
 				<damageFalloff>true</damageFalloff>
 				<explosionEffect>GiantExplosion</explosionEffect>
 				<explosionSound>Explosion_GiantBomb</explosionSound>
+				<preExplosionSpawnSingleThingDef>CraterMedium</preExplosionSpawnSingleThingDef>
 				<wickTicks>60~120</wickTicks>
 				<explodeOnKilled>True</explodeOnKilled>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
@@ -302,6 +303,7 @@
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 			<ai_IsIncendiary>true</ai_IsIncendiary>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
@@ -370,6 +372,7 @@
 			<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
 			<preExplosionSpawnChance>0.15</preExplosionSpawnChance>
 			<soundExplode>MortarIncendiary_Explode</soundExplode>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 		<modExtensions>
 			<li Class="CombatExtended.GenericLabelExtension">
@@ -479,6 +482,7 @@
 			<soundExplode>Explosion_GiantBomb</soundExplode>
 			<soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
 			<soundAmbient>MortarRound_Ambient</soundAmbient>
+			<preExplosionSpawnSingleThingDef>CraterMedium</preExplosionSpawnSingleThingDef>
 			<shellingProps>
 				<damage>0.85</damage>
 			</shellingProps>

--- a/Defs/Ammo/Shell/90mmCannon.xml
+++ b/Defs/Ammo/Shell/90mmCannon.xml
@@ -191,6 +191,7 @@
 			<explosionRadius>2.5</explosionRadius>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">

--- a/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
@@ -636,6 +636,7 @@
 					<min>5</min>
 					<max>30</max>
 				</wickTicks>
+				<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 			</li>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
@@ -664,6 +665,7 @@
 					<min>5</min>
 					<max>20</max>
 				</wickTicks>
+				<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
 			</li>
 		</value>
 	</Operation>


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Adds xml for spawning blast marks filth and craters by explosives. I tried to follow vanilla's logic as close as possible, so added blast marks to all HE and Incendiary explosives with 2.5 or more radius (marks are 3x3), and craters to a few big explosions with >5 radius and >500 damage.

## References

Links to the associated issues or other related pull requests, e.g.
- Requires #4128 

## Reasoning

Why did you choose to implement things this way, e.g.
- Keep up with vanilla's visuals
- I might have missed a few explosives

## Alternatives

Describe alternative implementations you have considered, e.g.
- Automate this

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
tested mortar and 90mm flak
- [ ] Playtested a colony (specify how long)
