### PR TITLE
Interim genRadial fix

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_GenRadial.cs
+++ b/Source/CombatExtended/Harmony/Harmony_GenRadial.cs
@@ -118,13 +118,13 @@ internal static class Harmony_GenRadial
             }
         }
 #endif
+        float searchRadius = radius + float.Epsilon;
         float start = radialPatternRadii[count];
-        while (start <= radius)
+        while (start <= searchRadius)
         {
             start = radialPatternRadii[count++];
         }
-        __result = count - 1;
+        __result = count;
         return false;
-
     }
 }


### PR DESCRIPTION
## Changes

- A temporary fix for the shaved off corner cell in the radial patch, until a more proper solution is ready to be merged, such as #4029 

## Reasoning

- Even Ludeon is having to deal with bug reports about this error, better to do at least *something* about it.
- The changes made to more closely mimic how the original code handles the linear search.

## Alternatives

- Wait for an undetermined amount of time for a proper fix.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] Playtested a colony (specify how long)
