### PR TITLE
Building Instruction for VS 2022. Related Nuget package. 

### DIFF
--- a/Building.md
+++ b/Building.md
@@ -26,6 +26,14 @@ $ start CombatExtended/Source/CombatExtended.sln
 
 After this, building is just building the solution, references will be pulled from Nuget, and the assemblies should be automatically publicised by the msbuild task. The resulting assembly will be in `$(root)/Assemblies/CombatExtended.dll`.
 
+> **Note:**
+> If you open the NuGet Package Manager and don’t see any packages (e.g. Harmony), it usually means no package sources are configured.  
+> Go to **Tools → NuGet Package Manager → Package Manager Settings → Package Sources**
+> Ensure **nuget.org (https://api.nuget.org/v3/index.json)** is enabled or add the nuget repository.
+> Then reload the NuGet UI so dependencies can be restored.
+>
+> Check `Manage Nuget packages for solution` dialog and able to find `Lib.Harmony`
+
 ### Dotnet Build
 
 If you want to compile without an IDE, you can clone the repo as usual, and then manually call `dotnet build CombatExtended.sln` from the `Source` directory.  

--- a/Building.md
+++ b/Building.md
@@ -1,13 +1,16 @@
 # Building Instructions
+
 If you want to build CE yourself, pick your platform and preferred build system and follow the instructions.
 
 ## Linux
+
 ### Make.py
+
 This is the build system used for the CI system on github.  It does not execute arbitrary code from `.csproj` files, which makes it suitable for building PRs with repository secrets.  
 It requires `python3.6` or later, `wget`, and `mono` (a recent enough version to have the Roslyn (`csc`) compiler).  
 
 You can get the full usage string via `python3 Make.py --help`.  
-If you want to use it to generate publicized assemblies (required starting with CE for RW 1.3), you need to check out the AssemblyPublicizer ( https://github.com/CombatExtended-Continued/AssemblyPublicizer )
+If you want to use it to generate publicized assemblies (required starting with CE for RW 1.3), you need to check out the AssemblyPublicizer ( <https://github.com/CombatExtended-Continued/AssemblyPublicizer> )
 and tell Make.py where to find it.
 
 The invocation used by CI is about as simple as it gets.
@@ -17,20 +20,23 @@ The invocation used by CI is about as simple as it gets.
 ## Windows
 
 ### Rider or Visual Studio
+
 To install and open in either Rider or Visual Studio.
-```
+
+```bash
 $ git clone https://github.com/CombatExtended-Continued/CombatExtended
 $ start CombatExtended/Source/CombatExtended.sln 
 ```
+
 `start` will open the sln file with whatever IDE you have set to open .sln files by default. You can also just open the sln file normally.
 
 After this, building is just building the solution, references will be pulled from Nuget, and the assemblies should be automatically publicised by the msbuild task. The resulting assembly will be in `$(root)/Assemblies/CombatExtended.dll`.
 
 > **Note:**
 > If you open the NuGet Package Manager and don’t see any packages (e.g. Harmony), it usually means no package sources are configured.  
-> Go to **Tools → NuGet Package Manager → Package Manager Settings → Package Sources**
-> Ensure **nuget.org (https://api.nuget.org/v3/index.json)** is enabled or add the nuget repository.
-> Then reload the NuGet UI so dependencies can be restored.
+> Go to **Tools → NuGet Package Manager → Package Manager Settings → Package Sources**.
+>
+> Ensure **nuget.org (<https://api.nuget.org/v3/index.json>)** is enabled or add the nuget repository.
 >
 > Check `Manage Nuget packages for solution` dialog and able to find `Lib.Harmony`
 
@@ -43,9 +49,8 @@ Simply download the file to your Rimworld/Mods directory and run it.  Running it
 
 This assumes you have `git` and `dotnet` configured to be available from windows batch files.  See the readme file included in its repository for details.
 
-The repository for it is https://github.com/CombatExtended-Continued/CE-AutoInstaller-Updater-Builder 
+The repository for it is <https://github.com/CombatExtended-Continued/CE-AutoInstaller-Updater-Builder>
 
 ## Other options
-
 
 If you have a build system not listed here, please document how to use it.


### PR DESCRIPTION
## Additions

- add markdown explanation for Visual Studio 

## Changes

- check the following markdown
- <https://github.com/choi4624/CombatExtended/blob/250805-Building-instruction-for-VS/Building.md> 

<img width="1990" height="309" alt="image" src="https://github.com/user-attachments/assets/c392f786-7fbb-4d36-98ae-ca85617b38ce" />

## References

- Myself

<img width="1243" height="839" alt="2025-08-05_040000" src="https://github.com/user-attachments/assets/a73a5b3b-d828-472e-bdfc-c0ec2989d64a" />

## Reasoning

- I'm able to find why my project is not build. And check package manager setting is something wrong in my VS.
- Actually, I'm not using C# with package manager So I'm not configured like that. 
 - Is it not default setting in VS installed? Project doesn't configure link nuget package (unlike spring)

## Alternatives

- May be Skilled C# programmer or Rimworld modder don't require that 
- My Native language is not English so Something wired explanation is exist. 

## Testing

Check tests you have performed:
- [x] Compiles without warnings  
- [x] Game runs without errors - only markdown edit
- [ ] (For compatibility patches) ...with and without patched mod loaded - no
- [ ] Playtested a colony (specify how long) - no
