### PR TITLE
Fix and restore ally smoke throwing

### DIFF
--- a/Source/CombatExtended/CombatExtended/SuppressionUtility.cs
+++ b/Source/CombatExtended/CombatExtended/SuppressionUtility.cs
@@ -25,8 +25,7 @@ public static class SuppressionUtility
 
     public static bool TryRequestHelp(Pawn pawn)
     {
-        //TODO: 1.5
-        if (pawn != null)
+        if (pawn == null)
         {
             return false;
         }
@@ -35,6 +34,10 @@ public static class SuppressionUtility
         ThingWithComps grenade = null;
         foreach (Pawn other in pawn.Position.PawnsInRange(map, 8))
         {
+            if (other == null)
+            {
+                continue;
+            }
             if (other.Faction != pawn.Faction)
             {
                 continue;


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Re-introduces the behaviour of throwing smokes at allies.

## Reasoning

Why did you choose to implement things this way, e.g.
- In 1.4, CE had code that made npcs throw smoke at their suppressed allies. In 1.5 migration period, it started throwing NREs and got temporarily disabled. I fixed it up, turns out NREs were caused by allied pawns being null - from becoming dead or other reasons. Most noticeably, they happened when a rocket exploded in a middle of a swarm - someone is guaranteed to be dead and others heavily suppressed.
- To test this, go into `Royalty\Patches\PawnKindDefs_Royalty\PawnKinds_Royalty.xml`, set Cataphract's chance to carry smokes to 1.0, spawn an empire raid and shoot 7.62x54 AP - enough to suppress everyone except cataphracts. They will attempt to throw smokes at allies

## Alternatives

Describe alternative implementations you have considered, e.g.
- Keep it unused.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (a few devmode raid vs raid)
