### PR TITLE
fix pawns jobdriver freezing due to jobs being null

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompTacticalManager.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompTacticalManager.cs
@@ -243,8 +243,7 @@ public class CompTacticalManager : ThingComp
         }
 
         ICompTactics failedComp = null;
-
-        if (!CompSuppressable.IsHunkering && (SelPawn.jobs.curDriver is IJobDriver_Tactical || AllChecksPassed(verb, castTarg, destTarg, out failedComp)))
+        if (!CompSuppressable.IsHunkering && (SelPawn.jobs?.curDriver is IJobDriver_Tactical || AllChecksPassed(verb, castTarg, destTarg, out failedComp)))
         {
             foreach (ICompTactics comp in TacticalComps)
             {


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- adds a null check in tactical manager

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #4076
- [Discussion](https://discord.com/channels/278818534069501953/324222101550661663/1402633872742809621)

## Reasoning

Why did you choose to implement things this way, e.g.
- Caused a game breaking bug, making pawns stand still in combat unresponsively
- Difficult to reproduce, basically you have to spawn a 10k vs 10k raid with humans and just wait for it to happen. I managed to reproduce it with only CE and dlcs, have a save where it often happens that i can share if needed. While i'm not 100% sure why and when it happens, this fix seems to stop errors from occurring in the test case i have.

## Alternatives

Describe alternative implementations you have considered, e.g.
- Investigate deeper?

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
