### PR TITLE
Minor startup housekeeping

### DIFF
--- a/Source/CombatExtended/CombatExtended/AmmoGeneralizer.cs
+++ b/Source/CombatExtended/CombatExtended/AmmoGeneralizer.cs
@@ -6,10 +6,10 @@ using RimWorld;
 using Verse;
 using UnityEngine;
 namespace CombatExtended;
-[StaticConstructorOnStartup]
+
 public class AmmoGeneralizer
 {
-    static AmmoGeneralizer()
+    public static void GeneralizeAmmo()
     {
         /*
          * Generic ammosetdefs need projectiles for the code to work, but what the projectiles are doesn't matter

--- a/Source/CombatExtended/CombatExtended/DefUtility.cs
+++ b/Source/CombatExtended/CombatExtended/DefUtility.cs
@@ -206,9 +206,9 @@ public static class DefUtility
              * wether this apparel is a radio pack
              */
             isRadioArray[def.index] = extension.isRadioPack;
-            if (Prefs.DevMode && extension.isRadioPack)
+            if (Controller.settings.DebuggingMode && extension.isRadioPack)
             {
-                Log.Message($"{def}");
+                Log.Message($"{def} - Radio pack enabled");
             }
         }
     }

--- a/Source/CombatExtended/CombatExtended/ModSettings/Controller.cs
+++ b/Source/CombatExtended/CombatExtended/ModSettings/Controller.cs
@@ -133,8 +133,6 @@ public class Controller : Mod
         LongEventHandler.QueueLongEvent(patches.Install, "CE_LongEvent_CompatibilityPatches", false, null);
 
         genericState = settings.GenericAmmo;
-
-
     }
 
 

--- a/Source/CombatExtended/CombatExtended/ModSettings/Controller.cs
+++ b/Source/CombatExtended/CombatExtended/ModSettings/Controller.cs
@@ -112,6 +112,9 @@ public class Controller : Mod
 
         // Initialize loadout generator
         LongEventHandler.QueueLongEvent(LoadoutPropertiesExtension.Reset, "CE_LongEvent_LoadoutProperties", false, null);
+        
+        // Apply generic mode
+        LongEventHandler.QueueLongEvent(AmmoGeneralizer.GeneralizeAmmo, "CE_LongEvent_AmmoGeneralizer", false, null);
 
         // Inject ammo
         LongEventHandler.QueueLongEvent(AmmoInjector.Inject, "CE_LongEvent_AmmoInjector", false, null);
@@ -120,7 +123,7 @@ public class Controller : Mod
         LongEventHandler.QueueLongEvent(BoundsInjector.Inject, "CE_LongEvent_BoundingBoxes", false, null);
 
         // Initialize the DefUtility (a caching system for common checks on defs)
-        LongEventHandler.QueueLongEvent(DefUtility.Initialize, "CE_LongEvent_BoundingBoxes", false, null);
+        LongEventHandler.QueueLongEvent(DefUtility.Initialize, "CE_LongEvent_DefUtility", false, null);
 
         Log.Message("Combat Extended :: initialized");
 

--- a/Source/CombatExtended/Compatibility/Multiplayer.cs
+++ b/Source/CombatExtended/Compatibility/Multiplayer.cs
@@ -12,7 +12,7 @@ public class Multiplayer : IPatch
 
     public bool CanInstall()
     {
-        Log.Message("Checking Multiplayer Compat");
+        Log.Message("Combat Extended :: Checking Multiplayer Compat");
         return ModLister.HasActiveModWithName("Multiplayer");
     }
 

--- a/Source/CombatExtended/Compatibility/VanillaPsycastExpanded.cs
+++ b/Source/CombatExtended/Compatibility/VanillaPsycastExpanded.cs
@@ -15,7 +15,7 @@ public class VanillaPsycastExpanded : IPatch
     const string ModName = "Vanilla Psycasts Expanded";
     public bool CanInstall()
     {
-        Log.Message("Vanilla Psycasts Expanded loaded: " + ModLister.HasActiveModWithName(ModName));
+        Log.Message("Combat Extended :: Vanilla Psycasts Expanded loaded: " + ModLister.HasActiveModWithName(ModName));
         return ModLister.HasActiveModWithName(ModName);
     }
 


### PR DESCRIPTION
## Changes

- Moved radio pack logging on startup behind a debugging mode setting.
- Added a prefix to a few startup log messages.
- Moved ammo generalizer from a SCOS to a synchronous long event.

## Reasoning

- Reduces some logging spam and makes certain messages more readable.
- Generalizer was moved to more rigidly define its order prior to the injector, and this lets us give it a loading message.

## Alternatives

- Exist as is.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
