### PR TITLE
Change debug builds to embedded symbols

### DIFF
--- a/Source/BetterTurretsCompat/BetterTurretsCompat.csproj
+++ b/Source/BetterTurretsCompat/BetterTurretsCompat.csproj
@@ -13,7 +13,7 @@
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
 		<OutputPath>..\..\ModPatches\BetterTurrets\Assemblies\</OutputPath>
-		<DebugType>portable</DebugType>
+		<DebugType>embedded</DebugType>
 		<DebugSymbols>true</DebugSymbols>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<LangVersion>12.0</LangVersion>

--- a/Source/CombatExtended/CombatExtended.csproj
+++ b/Source/CombatExtended/CombatExtended.csproj
@@ -13,7 +13,7 @@
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
 		<OutputPath>..\..\Assemblies\</OutputPath>
-		<DebugType>portable</DebugType>
+		<DebugType>embedded</DebugType>
 		<DebugSymbols>true</DebugSymbols>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<LangVersion>12.0</LangVersion>

--- a/Source/MiscTurretsCompat/MiscTurretsCompat.csproj
+++ b/Source/MiscTurretsCompat/MiscTurretsCompat.csproj
@@ -13,7 +13,7 @@
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
 		<OutputPath>..\..\ModPatches\MiscTurrets\Assemblies\</OutputPath>
-		<DebugType>portable</DebugType>
+		<DebugType>embedded</DebugType>
 		<DebugSymbols>true</DebugSymbols>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<LangVersion>12.0</LangVersion>

--- a/Source/MultiplayerCompat/MultiplayerCompat.csproj
+++ b/Source/MultiplayerCompat/MultiplayerCompat.csproj
@@ -13,7 +13,7 @@
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
 		<OutputPath>..\..\ModPatches\Multiplayer\Assemblies\</OutputPath>
-		<DebugType>portable</DebugType>
+		<DebugType>embedded</DebugType>
 		<DebugSymbols>true</DebugSymbols>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<LangVersion>12.0</LangVersion>

--- a/Source/PsyblastersCompat/PsyblastersCompat.csproj
+++ b/Source/PsyblastersCompat/PsyblastersCompat.csproj
@@ -13,7 +13,7 @@
     </PropertyGroup>
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
         <OutputPath>..\..\ModPatches\PsychicAmmo\Assemblies</OutputPath>
-        <DebugType>portable</DebugType>
+        <DebugType>embedded</DebugType>
         <DebugSymbols>true</DebugSymbols>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <LangVersion>latest</LangVersion>

--- a/Source/SOS2Compat/SOS2Compat.csproj
+++ b/Source/SOS2Compat/SOS2Compat.csproj
@@ -13,7 +13,7 @@
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
 		<OutputPath>..\..\ModPatches\Save Our Ship 2\Assemblies</OutputPath>
-		<DebugType>portable</DebugType>
+		<DebugType>embedded</DebugType>
 		<DebugSymbols>true</DebugSymbols>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<LangVersion>12.0</LangVersion>

--- a/Source/SRTSCompat/SRTSCompat.csproj
+++ b/Source/SRTSCompat/SRTSCompat.csproj
@@ -13,7 +13,7 @@
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
 		<OutputPath>..\..\ModPatches\SRTS\Assemblies\</OutputPath>
-		<DebugType>portable</DebugType>
+		<DebugType>embedded</DebugType>
 		<DebugSymbols>true</DebugSymbols>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<LangVersion>12.0</LangVersion>

--- a/Source/VehiclesCompat/VehiclesCompat.csproj
+++ b/Source/VehiclesCompat/VehiclesCompat.csproj
@@ -13,7 +13,7 @@
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
 		<OutputPath>..\..\ModPatches\VehicleFramework\Assemblies\</OutputPath>
-		<DebugType>portable</DebugType>
+		<DebugType>embedded</DebugType>
 		<DebugSymbols>true</DebugSymbols>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<LangVersion>12.0</LangVersion>


### PR DESCRIPTION
## Changes

- Changed the debug type on debug builds to use embedded symbols.

## Reasoning

- The game can now load and use embedded symbols without any external tools like Doorstop, which should help when reproducing bugs locally.
- This does not affect the output of our build system, since it's not building in debug mode.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
