### PR TITLE
Add grenades to pawnkinds inventories

### DIFF
--- a/Defs/PawnKindDefs/PawnKinds_CE.xml
+++ b/Defs/PawnKindDefs/PawnKinds_CE.xml
@@ -45,7 +45,7 @@
 						</magazineCount>
 					</li>
 					<li>
-						<generateChance>0.1</generateChance>
+						<generateChance>0.25</generateChance>
 						<sidearmMoney>
 							<min>10</min>
 							<max>100</max>
@@ -109,6 +109,22 @@
 						<li>CE_Sidearm_Tribal</li>
 					</weaponTags>
 				</forcedSidearm>
+				<sidearms>
+					<li>
+						<generateChance>0.4</generateChance>
+						<sidearmMoney>
+							<min>80</min>
+							<max>160</max>
+						</sidearmMoney>
+						<weaponTags>
+							<li>CE_GrenadeNeolithic_Smoke</li>
+						</weaponTags>
+						<magazineCount>
+							<min>0</min>
+							<max>1</max>
+						</magazineCount>
+					</li>
+				</sidearms>
 			</li>
 		</modExtensions>
 	</PawnKindDef>
@@ -167,6 +183,22 @@
 						<weaponTags>
 							<li>CE_Sidearm_Tribal</li>
 						</weaponTags>
+					</li>
+					<li>
+						<generateChance>0.1</generateChance>
+						<sidearmMoney>
+							<min>80</min>
+							<max>160</max>
+						</sidearmMoney>
+						<weaponTags>
+							<li>CE_GrenadeNeolithic_Smoke</li>
+							<li>CE_GrenadeNeolithic_Incendiary</li>
+							<li>CE_GrenadeNeolithic</li>
+						</weaponTags>
+						<magazineCount>
+							<min>0</min>
+							<max>0</max>
+						</magazineCount>
 					</li>
 				</sidearms>
 			</li>

--- a/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -28,6 +28,22 @@
 						<li>CE_Sidearm_Melee</li>
 					</weaponTags>
 				</forcedSidearm>
+				<sidearms>
+					<li>
+						<generateChance>0.2</generateChance>
+						<sidearmMoney>
+							<min>80</min>
+							<max>160</max>
+						</sidearmMoney>
+						<weaponTags>
+							<li>GrenadeSmoke</li>
+						</weaponTags>
+						<magazineCount>
+							<min>0</min>
+							<max>1</max>
+						</magazineCount>
+					</li>
+				</sidearms>
 			</li>
 		</value>
 	</Operation>
@@ -122,6 +138,22 @@
 							<max>3</max>
 						</magazineCount>
 					</li>
+					<li>
+						<generateChance>0.1</generateChance>
+						<sidearmMoney>
+							<min>80</min>
+							<max>160</max>
+						</sidearmMoney>
+						<weaponTags>
+							<li>CE_GrenadeFlashbang</li>
+							<li>GrenadeSmoke</li>
+							<li>GrenadeDestructive</li>
+						</weaponTags>
+						<magazineCount>
+							<min>0</min>
+							<max>1</max>
+						</magazineCount>
+					</li>
 				</sidearms>
 			</li>
 		</value>
@@ -163,6 +195,20 @@
 							<li>CE_Sidearm</li>
 						</weaponTags>
 					</li>
+					<li>
+						<generateChance>0.15</generateChance>
+						<sidearmMoney>
+							<min>80</min>
+							<max>160</max>
+						</sidearmMoney>
+						<weaponTags>
+							<li>GrenadeSmoke</li>
+						</weaponTags>
+						<magazineCount>
+							<min>0</min>
+							<max>0</max>
+						</magazineCount>
+					</li>
 				</sidearms>
 			</li>
 		</value>
@@ -199,6 +245,20 @@
 						<weaponTags>
 							<li>CE_Sidearm_Melee</li>
 						</weaponTags>
+					</li>
+					<li>
+						<generateChance>0.15</generateChance>
+						<sidearmMoney>
+							<min>80</min>
+							<max>160</max>
+						</sidearmMoney>
+						<weaponTags>
+							<li>GrenadeSmoke</li>
+						</weaponTags>
+						<magazineCount>
+							<min>0</min>
+							<max>0</max>
+						</magazineCount>
 					</li>
 				</sidearms>
 			</li>
@@ -298,7 +358,36 @@
 							<min>1</min>
 							<max>3</max>
 						</magazineCount>
-					</li>					
+					</li>
+					<li>
+						<generateChance>0.5</generateChance>
+						<sidearmMoney>
+							<min>160</min>
+							<max>320</max>
+						</sidearmMoney>
+						<weaponTags>
+							<li>GrenadeDestructive</li>
+						</weaponTags>
+						<magazineCount>
+							<min>0</min>
+							<max>2</max>
+						</magazineCount>
+					</li>
+					<li>
+						<generateChance>0.5</generateChance>
+						<sidearmMoney>
+							<min>160</min>
+							<max>320</max>
+						</sidearmMoney>
+						<weaponTags>
+							<li>CE_GrenadeFlashbang</li>
+							<li>GrenadeSmoke</li>
+						</weaponTags>
+						<magazineCount>
+							<min>0</min>
+							<max>1</max>
+						</magazineCount>
+					</li>
 				</sidearms>
 			</li>
 		</value>
@@ -362,7 +451,7 @@
 							<min>1</min>
 							<max>3</max>
 						</magazineCount>
-					</li>					
+					</li>
 				</sidearms>
 			</li>
 		</value>
@@ -437,6 +526,22 @@
 							<max>5</max>
 						</magazineCount>
 					</li>
+					<li>
+						<generateChance>0.1</generateChance>
+						<sidearmMoney>
+							<min>80</min>
+							<max>160</max>
+						</sidearmMoney>
+						<weaponTags>
+							<li>CE_GrenadeFlashbang</li>
+							<li>GrenadeSmoke</li>
+							<li>GrenadeDestructive</li>
+						</weaponTags>
+						<magazineCount>
+							<min>0</min>
+							<max>0</max>
+						</magazineCount>
+					</li>
 				</sidearms>
 			</li>
 		</value>
@@ -491,7 +596,7 @@
 						</weaponTags>
 					</li>
 					<li>
-						<generateChance>0.1</generateChance>
+						<generateChance>0.4</generateChance>
 						<sidearmMoney>
 							<min>10</min>
 							<max>100</max>
@@ -500,8 +605,8 @@
 							<li>GrenadeSmoke</li>
 						</weaponTags>
 						<magazineCount>
-							<min>1</min>
-							<max>2</max>
+							<min>0</min>
+							<max>1</max>
 						</magazineCount>
 					</li>
 					<li>
@@ -656,6 +761,20 @@
 						<weaponTags>
 							<li>CE_Sidearm_Tribal</li>
 						</weaponTags>
+					</li>
+					<li>
+						<generateChance>0.1</generateChance>
+						<sidearmMoney>
+							<min>80</min>
+							<max>160</max>
+						</sidearmMoney>
+						<weaponTags>
+							<li>CE_GrenadeNeolithic_Incendiary</li>
+						</weaponTags>
+						<magazineCount>
+							<min>0</min>
+							<max>0</max>
+						</magazineCount>
 					</li>
 				</sidearms>
 			</li>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
@@ -350,6 +350,7 @@
 			<li>CE_AI_Grenade</li>
 			<li>CE_AI_AOE</li>
 			<li>CE_OneHandedWeapon</li>
+			<li>CE_GrenadeNeolithic_Incendiary</li>
 		</weaponTags>
 	</Operation>
 

--- a/Royalty/Patches/PawnKindDefs_Royalty/PawnKinds_Royalty.xml
+++ b/Royalty/Patches/PawnKindDefs_Royalty/PawnKinds_Royalty.xml
@@ -65,7 +65,7 @@
 						</magazineCount>
 					</li>
 					<li>
-						<generateChance>0.1</generateChance>
+						<generateChance>0.25</generateChance>
 						<sidearmMoney>
 							<min>10</min>
 							<max>100</max>
@@ -74,8 +74,22 @@
 							<li>GrenadeSmoke</li>
 						</weaponTags>
 						<magazineCount>
-							<min>1</min>
-							<max>2</max>
+							<min>0</min>
+							<max>1</max>
+						</magazineCount>
+					</li>
+					<li>
+						<generateChance>0.15</generateChance>
+						<sidearmMoney>
+							<min>10</min>
+							<max>100</max>
+						</sidearmMoney>
+						<weaponTags>
+							<li>GrenadeDestructive</li>
+						</weaponTags>
+						<magazineCount>
+							<min>0</min>
+							<max>0</max>
 						</magazineCount>
 					</li>
 				</sidearms>
@@ -121,7 +135,7 @@
 						</weaponTags>
 					</li>
 					<li>
-						<generateChance>0.1</generateChance>
+						<generateChance>0.25</generateChance>
 						<sidearmMoney>
 							<min>10</min>
 							<max>100</max>
@@ -130,8 +144,22 @@
 							<li>GrenadeSmoke</li>
 						</weaponTags>
 						<magazineCount>
-							<min>1</min>
-							<max>2</max>
+							<min>0</min>
+							<max>1</max>
+						</magazineCount>
+					</li>
+					<li>
+						<generateChance>0.25</generateChance>
+						<sidearmMoney>
+							<min>10</min>
+							<max>100</max>
+						</sidearmMoney>
+						<weaponTags>
+							<li>GrenadeDestructive</li>
+						</weaponTags>
+						<magazineCount>
+							<min>0</min>
+							<max>0</max>
 						</magazineCount>
 					</li>
 					<li>
@@ -350,7 +378,7 @@
 						</weaponTags>
 					</li>
 					<li>
-						<generateChance>0.1</generateChance>
+						<generateChance>0.8</generateChance>
 						<sidearmMoney>
 							<min>10</min>
 							<max>100</max>
@@ -361,6 +389,21 @@
 						<magazineCount>
 							<min>1</min>
 							<max>2</max>
+						</magazineCount>
+					</li>
+					<li>
+						<generateChance>0.8</generateChance>
+						<sidearmMoney>
+							<min>60</min>
+							<max>160</max>
+						</sidearmMoney>
+						<weaponTags>
+							<li>CE_GrenadeFlashbang</li>
+							<li>GrenadeDestructive</li>
+						</weaponTags>
+						<magazineCount>
+							<min>0</min>
+							<max>1</max>
 						</magazineCount>
 					</li>
 					<li>
@@ -400,6 +443,34 @@
 						<weaponTags>
 							<li>CE_Sidearm_Melee</li>
 						</weaponTags>
+					</li>
+					<li>
+						<generateChance>0.8</generateChance>
+						<sidearmMoney>
+							<min>60</min>
+							<max>160</max>
+						</sidearmMoney>
+						<weaponTags>
+							<li>CE_GrenadeFlashbang</li>
+						</weaponTags>
+						<magazineCount>
+							<min>0</min>
+							<max>0</max>
+						</magazineCount>
+					</li>
+					<li>
+						<generateChance>0.8</generateChance>
+						<sidearmMoney>
+							<min>60</min>
+							<max>160</max>
+						</sidearmMoney>
+						<weaponTags>
+							<li>GrenadeSmoke</li>
+						</weaponTags>
+						<magazineCount>
+							<min>0</min>
+							<max>0</max>
+						</magazineCount>
 					</li>
 				</sidearms>
 			</li>


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Adds grenades to inventories of vanilla pawnkinds.
- [x] Core
- [x] Royalty
- [ ] Biotech
- [ ] Ideology
- [ ] Anomaly
- [ ] Oddyssey


- Adds tags `CE_GrenadeNeolithic_Smoke` and `CE_GrenadeNeolithic_Incendiary` to our grenades to fine tune selection
- Increases smoke grenade spawn chances on some pawns, but decreases quantity from 2-3 to 1-2

## References

Links to the associated issues or other related pull requests, e.g.
- Requires #4146 and #4138 

## Reasoning

Why did you choose to implement things this way, e.g.
- Raiders using grenades makes combat more interesting.
- Will write reasoning for each pawnkind once i finish all vanilla pawnkinds

## Alternatives

Describe alternative implementations you have considered, e.g.
- Not do it

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] Playtested a colony (specify how long)
