### PR TITLE
disable sos2

### DIFF
--- a/Source/CombatExtended.sln
+++ b/Source/CombatExtended.sln
@@ -15,8 +15,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VehiclesCompat", "VehiclesC
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SRTSCompat", "SRTSCompat\SRTSCompat.csproj", "{2ECDEC68-5878-41C7-B494-E189B8C5C33E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SOS2Compat", "SOS2Compat\SOS2Compat.csproj", "{D7AF4074-CE88-4272-91F4-A0D63951C1F0}"
-EndProject
+#Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SOS2Broke", "SOS2Compat\SOS2Compat.csproj", "{D7AF4074-CE88-4272-91F4-A0D63951C1F0}"
+#EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PsyblastersCompat", "PsyblastersCompat\PsyblastersCompat.csproj", "{6B518120-4315-4017-B4E6-7DA8ABCCFF84}"
 EndProject
 Global
@@ -82,3 +82,4 @@ Global
 		SolutionGuid = {4F53C492-BC7E-412D-8034-479DF966AD09}
 	EndGlobalSection
 EndGlobal
+


### PR DESCRIPTION
## References

Links to the associated issues or other related pull requests, e.g.
- required after #4149 

## Reasoning
SOS2 is not updated for 1.6, and just broke when VF updated. Turn it off for now.


## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
