### PR TITLE
1.6 Armor Coverage Consistency Fixes

### DIFF
--- a/Defs/ThingDefs_Misc/Apparel_Carrying.xml
+++ b/Defs/ThingDefs_Misc/Apparel_Carrying.xml
@@ -88,7 +88,7 @@
 				</li>
 			</renderNodeProperties>
 			<bodyPartGroups>
-				<li>Shoulders</li>
+				<li>Torso</li>
 			</bodyPartGroups>
 			<layers>
 				<li>Webbing</li>

--- a/Defs/ThingDefs_Misc/Apparel_Various.xml
+++ b/Defs/ThingDefs_Misc/Apparel_Various.xml
@@ -41,7 +41,6 @@
 		<apparel>
 			<bodyPartGroups>
 				<li>Torso</li>
-				<li>Shoulders</li>
 				<li>Neck</li>
 			</bodyPartGroups>
 			<wornGraphicPath>Things/Apparel/CompositeVest/CompositeVest</wornGraphicPath>
@@ -79,14 +78,12 @@
 						<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
 						<parts>
 							<li>Neck</li>
-							<li>Shoulder</li>
 						</parts>
 					</li>
 					<li>
 						<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
 						<parts>
 							<li>Neck</li>
-							<li>Shoulder</li>
 						</parts>
 					</li>
 				</stats>

--- a/Patches/Core/ThingDefs_Misc/Apparel_Various.xml
+++ b/Patches/Core/ThingDefs_Misc/Apparel_Various.xml
@@ -240,14 +240,12 @@
 						<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
 						<parts>
 							<li>Neck</li>
-							<li>Shoulder</li>
 						</parts>
 					</li>
 					<li>
 						<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
 						<parts>
 							<li>Neck</li>
-							<li>Shoulder</li>
 						</parts>
 					</li>
 				</stats>


### PR DESCRIPTION
## Changes
- Composite Vest no longer covers shoulders to match the vanilla Armor Vest.
- Removed shoulders from the Armor Vest's partial armor coverage.
- Tac Vest coverage changed from shoulders to torso.

## Reasoning
- 1.6 changed the coverage of the Flak Vest to now only cover the torso and neck. This PR simply follows suit.
- Since the tac vest only covered the shoulders and not the torso, it was able to be worn with vests which occupy both the middle and webbing layer but didn't cover the shoulders. Considering it's mostly worn on the chest, I don't see why it shouldn't cover the torso.

## Alternatives
- Nothing

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
