### PR TITLE
Fix wall fragments not spawning

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_DamageWorker.cs
+++ b/Source/CombatExtended/Harmony/Harmony_DamageWorker.cs
@@ -70,13 +70,14 @@ internal static class Harmony_DamageWorker_Apply
                     backArc = new FloatRange(dinfo.Angle - 90, dinfo.Angle + 90);
                 }
 
+                Vector3 spawnOffset = Quaternion.Euler(0, dinfo.Angle, 0) * Vector3.forward;
                 if (smallFragments > 0)
                 {
                     int reflectedFrags = (int)(smallFragments * (hitPoints / maxHitPoints));
                     smallFragments -= reflectedFrags;
                     if (reflectedFrags > 0)
                     {
-                        var fr = CompFragments.FragRoutine(pos,
+                        var fr = CompFragments.FragRoutine(pos - spawnOffset,
                                                            map,
                                                            height,
                                                            dinfo.Instigator,
@@ -90,7 +91,7 @@ internal static class Harmony_DamageWorker_Apply
                         while (fr.MoveNext()) { }
                     }
                     {
-                        var fr = CompFragments.FragRoutine(pos,
+                        var fr = CompFragments.FragRoutine(pos + spawnOffset,
                                                            map,
                                                            height,
                                                            dinfo.Instigator,
@@ -107,7 +108,7 @@ internal static class Harmony_DamageWorker_Apply
                 }
                 if (largeFragments > 0)
                 {
-                    var fr = CompFragments.FragRoutine(pos,
+                    var fr = CompFragments.FragRoutine(pos + spawnOffset,
                                                        map,
                                                        height,
                                                        dinfo.Instigator,


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Adds an offset to spawning of wall fragments - one half in front of the wall, the other behind.

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #4162 

## Reasoning

Why did you choose to implement things this way, e.g.
- The recent frag optimization, which made frags tick once during spawning, caused all wall fragments to hit the wall that spawned it. This makes frags spawn on the nearby tiles.

## Alternatives

Describe alternative implementations you have considered, e.g.
- change it from a prefix to a postfix

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
