### PR TITLE
Add FireMode/AimMode Caching for AmmosetSwitcher

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmosetSwitcher.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmosetSwitcher.cs
@@ -1,13 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using CombatExtended.Compatibility;
+﻿using System.Collections.Generic;
 using RimWorld;
 using Verse;
 using UnityEngine;
-using CombatExtended.Utilities;
 
 namespace CombatExtended;
 public class CompUnderBarrel : CompRangedGizmoGiver
@@ -116,6 +110,14 @@ public class CompUnderBarrel : CompRangedGizmoGiver
 
     public bool usingUnderBarrel;
 
+    private FireMode _cachedBarrelFireMode;
+
+    private FireMode _cachedUnderbarrelFireMode;
+
+    private AimMode _cachedBarrelAimMode;
+
+    private AimMode _cachedUnderbarrelAimMode;
+
     [Compatibility.Multiplayer.SyncMethod]
     public void SwitchToUB()
     {
@@ -130,6 +132,8 @@ public class CompUnderBarrel : CompRangedGizmoGiver
         CompAmmo.props = this.Props.propsUnderBarrel;
 
         CompEq.PrimaryVerb.verbProps = Props.verbPropsUnderBarrel;
+        _cachedBarrelFireMode = CompFireModes.CurrentFireMode;
+        _cachedBarrelAimMode = CompFireModes.CurrentAimMode;
         CompFireModes.props = this.Props.propsFireModesUnderBarrel;
         if (CompAmmo.Wielder != null)
         {
@@ -146,6 +150,14 @@ public class CompUnderBarrel : CompRangedGizmoGiver
         CompEq.PrimaryVerb.verbProps.burstShotCount = this.Props.verbPropsUnderBarrel.burstShotCount;
         usingUnderBarrel = true;
         CompFireModes.InitAvailableFireModes();
+        if (CompFireModes.AvailableFireModes.Contains(_cachedUnderbarrelFireMode))
+        {
+            CompFireModes.CurrentFireMode = _cachedUnderbarrelFireMode;
+        }
+        if (CompFireModes.AvailableAimModes.Contains(_cachedUnderbarrelAimMode))
+        {
+            CompFireModes.CurrentAimMode = _cachedUnderbarrelAimMode;
+        }
     }
 
     [Compatibility.Multiplayer.SyncMethod]
@@ -162,6 +174,8 @@ public class CompUnderBarrel : CompRangedGizmoGiver
         CompAmmo.props = CompPropsAmmo;
 
         CompEq.PrimaryVerb.verbProps = DefVerbProps.MemberwiseClone();
+        _cachedUnderbarrelFireMode = CompFireModes.CurrentFireMode;
+        _cachedUnderbarrelAimMode = CompFireModes.CurrentAimMode;
         CompFireModes.props = CompPropsFireModes;
         if (CompAmmo.Wielder != null)
         {
@@ -175,6 +189,14 @@ public class CompUnderBarrel : CompRangedGizmoGiver
         CompEq.PrimaryVerb.verbProps.burstShotCount = DefVerbProps.burstShotCount;
         usingUnderBarrel = false;
         CompFireModes.InitAvailableFireModes();
+        if (CompFireModes.AvailableFireModes.Contains(_cachedBarrelFireMode))
+        {
+            CompFireModes.CurrentFireMode = _cachedBarrelFireMode;
+        }
+        if (CompFireModes.AvailableAimModes.Contains(_cachedBarrelAimMode))
+        {
+            CompFireModes.CurrentAimMode = _cachedBarrelAimMode;
+        }
     }
 
     public override IEnumerable<Gizmo> CompGetGizmosExtra()
@@ -248,6 +270,10 @@ public class CompUnderBarrel : CompRangedGizmoGiver
         Scribe_Defs.Look(ref UnderBarrelLoadedAmmo, "UnderBarrelAmmo");
         Scribe_Values.Look(ref mainGunMagCount, "magCountMainGun");
         Scribe_Values.Look(ref UnderBarrelMagCount, "UnderBarrelMagCount");
+        Scribe_Values.Look(ref _cachedBarrelFireMode, "cachedBarrelFireMode");
+        Scribe_Values.Look(ref _cachedUnderbarrelFireMode, "cachedUnderbarrelFireMode");
+        Scribe_Values.Look(ref _cachedBarrelAimMode, "cachedBarrelAimMode");
+        Scribe_Values.Look(ref _cachedUnderbarrelAimMode, "cachedUnderbarrelAimMode");
         if (Scribe.mode == LoadSaveMode.PostLoadInit)
         {
             if (usingUnderBarrel)


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Adds FireMode caching for AmmoSetSwitcher
- Adds AimMode caching for AmmoSetSwitcher

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #4163 

## Reasoning

Why did you choose to implement things this way, e.g.
- Makes sense to maintain memory of gun settings

## Alternatives

Describe alternative implementations you have considered, e.g.
- Suffer
- Reuse cache fields in SwitchToB() and SwitchToUB()

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
