### PR TITLE
Fix Stun Dodge/Parry Mechanic

### DIFF
--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
@@ -595,6 +595,10 @@ public class Verb_MeleeAttackCE : Verb_MeleeAttack
 
     private float GetDodgeChance(Pawn defender)
     {
+        if (defender.stances?.stunner?.Stunned == true)
+        {
+            return 0f;
+        }
         float chance = defender.GetStatValue(StatDefOf.MeleeDodgeChance);
 
         if (!ModsConfig.IdeologyActive)
@@ -654,7 +658,7 @@ public class Verb_MeleeAttackCE : Verb_MeleeAttack
             var pawn = target.Thing as Pawn;
 
             float equivalentTargetWeight = pawn.GetStatValue(StatDefOf.Mass);
-            RacePropertiesExtensionCE bodyShape = pawn.def.GetModExtension<RacePropertiesExtensionCE>();
+            RacePropertiesExtensionCE bodyShape = pawn?.def.GetModExtension<RacePropertiesExtensionCE>();
             if (bodyShape != null)
             {
                 equivalentTargetWeight *= (bodyShape.bodyShape.width / bodyShape.bodyShape.height);
@@ -694,6 +698,7 @@ public class Verb_MeleeAttackCE : Verb_MeleeAttack
                 || (!pawn.RaceProps.Humanlike && (pawn.def.GetModExtension<RacePropertiesExtensionCE>()?.canParry != true))
                 || !pawn.health.capacities.CapableOf(PawnCapacityDefOf.Manipulation)
                 || IsTargetImmobile(pawn)
+                || pawn.stances?.stunner?.Stunned == true
                 || pawn.MentalStateDef == MentalStateDefOf.SocialFighting)
         {
             return false;


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- CanDoParry now checks if pawn is stunned
- Sets dodge chance to 0 if stunned
- Fix bonus possible NRE location

## References

Links to the associated issues or other related pull requests, e.g.
- Contributes towards #4167

## Reasoning

Why did you choose to implement things this way, e.g.
- Stunned pawns being able to dodge and parry makes little sense

## Alternatives

Describe alternative implementations you have considered, e.g.
- Leave it

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
