### PR TITLE
Fix Psycho causing psychite tolerance in pawns with psychite immunity

### DIFF
--- a/Defs/Drugs/Psychite_Psycho.xml
+++ b/Defs/Drugs/Psychite_Psycho.xml
@@ -53,7 +53,7 @@
 				</li>
 				<li Class="IngestionOutcomeDoer_GiveHediff">
 					<hediffDef>PsychiteTolerance</hediffDef>
-          <toleranceChemical>Psychite</toleranceChemical>
+					<toleranceChemical>Psychite</toleranceChemical>
 					<severity>0.06</severity>
 					<divideByBodySize>true</divideByBodySize>
 					<multiplyByGeneToleranceFactors>true</multiplyByGeneToleranceFactors>
@@ -258,6 +258,5 @@
 			</li>
 		</stages>
 	</ThoughtDef>
-
 
 </Defs>


### PR DESCRIPTION
## Additions

N/A

## Changes

Added `<toleranceChemical>Psychite</toleranceChemical>` to Psycho's tolerance IngestionOutcomeDoer, so it no longer causes psychite tolerance to pawns with the psychite impervious gene.

## References

N/A

## Reasoning

The psychite impervious gene is supposed to block psychite tolerance. Psycho causes it anyways due to this missing line, breaking vanilla convention.

## Alternatives

Don't change it.

## Testing

Check tests you have performed:
- [✔ ] Compiles without warnings
- [ ✔] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [✔ ] Playtested a colony (specify how long) [Long enough to snort some Psycho]
