### PR TITLE
Fix DoOutOfAmmoAction

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
@@ -659,7 +659,10 @@ public class CompAmmoUser : CompRangedGizmoGiver
             }
             if (!Holder.IsColonist || !parent.def.IsAOEWeapon())
             {
-                TryPickupAmmo();
+                if (TryPickupAmmo())
+                {
+                    return;
+                }
             }
         }
         CompInventory?.SwitchToNextViableWeapon(!this.parent.def.weaponTags.Contains("NoSwitch"), !Holder.IsColonist, stopJob: false);


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Changes bool method into an if check

## Reasoning

Why did you choose to implement things this way, e.g.
- Pawns that are going through DoOutOfAmmoAction will unequip weapon even if they find ammo on the ground. Premature unequipping of pawns doesn't help anyone.

## Alternatives

Describe alternative implementations you have considered, e.g.
- Suffer

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
