### PR TITLE
Misc. Shelling Tweaks

### DIFF
--- a/Defs/Ammo/Rocket/50mmRocket.xml
+++ b/Defs/Ammo/Rocket/50mmRocket.xml
@@ -67,9 +67,9 @@
 			<gravityFactor>5</gravityFactor>
 			<shellingProps>
 				<iconPath>Things/WorldObjects/Munitions/Rocket</iconPath>
-				<tilesPerTick>0.35</tilesPerTick>
+				<tilesPerTick>0.05</tilesPerTick>
 				<range>12</range>
-				<damage>0.43</damage>
+				<damage>0.1</damage>
 			</shellingProps>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Rocket/57mmS5Rocket.xml
+++ b/Defs/Ammo/Rocket/57mmS5Rocket.xml
@@ -146,9 +146,9 @@
 			<gravityFactor>5</gravityFactor>
 			<shellingProps>
 				<iconPath>Things/WorldObjects/Munitions/Rocket</iconPath>
-				<tilesPerTick>0.35</tilesPerTick>
+				<tilesPerTick>0.05</tilesPerTick>
 				<range>12</range>
-				<damage>0.43</damage>
+				<damage>0.11</damage>
 			</shellingProps>
 		</projectile>
 		<comps Inherit="false">

--- a/Defs/Ammo/Shell/152mmHowitzer.xml
+++ b/Defs/Ammo/Shell/152mmHowitzer.xml
@@ -100,7 +100,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>GrenadeIncendiary</ammoClass>
-		<detonateProjectile>Bullet_155mmHowitzerShell_Incendiary</detonateProjectile>
+		<detonateProjectile>Bullet_152mmHowitzerShell_Incendiary</detonateProjectile>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="152mmHowitzerShellBase">


### PR DESCRIPTION
## Changes
- Fix the 152mm incendiary detonate projectile. Leaving it as the 155mm was almost certainly just a typo.
- Adjust bombardment damage value of the 57mm S-6 rockets.
  - Prior values were too high, giving the rocket (~1.2 kg warhead) more bombardment damage than the 155mm HE (~10 kg filler).
  - Adjusted the 50mm rocket along similar lines.

## Reasoning
- Typo.
- Less boom should mean less boom.

## Alternatives
- Suffer.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
