### PR TITLE
Shift frags downwards for explosions at big heights

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompFragments.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompFragments.cs
@@ -98,9 +98,16 @@ public class CompFragments : ThingComp
 
             float height;
             FloatRange fragXZAngleRange;
+            FloatRange fragYAngleRange = PropsCE.fragAngleRange;
             if (parent is ProjectileCE projCE)
             {
                 height = projCE.ExactPosition.y;
+                //if the fragments use default value, shift the min angle lower to make it not fly over pawns when exploding at building heights
+                if (height > 0.1f && Mathf.Approximately(PropsCE.fragAngleRange.min, 0.5f))
+                {
+                    //launch with -30 angle at height of 1 vertical cell
+                    fragYAngleRange.min = -30f * height;
+                }
                 fragXZAngleRange = new FloatRange(projCE.shotRotation + PropsCE.fragXZAngleRange.min, projCE.shotRotation + PropsCE.fragXZAngleRange.max);
             }
             else
@@ -119,7 +126,7 @@ public class CompFragments : ThingComp
                 var newCount = fragment;
                 newCount.count = Mathf.RoundToInt(newCount.count * scaleFactor);
 
-                var routine = FragRoutine(pos, map, height, instigator, fragment, PropsCE.fragSpeedFactor, PropsCE.fragShadowChance, PropsCE.fragAngleRange, fragXZAngleRange);
+                var routine = FragRoutine(pos, map, height, instigator, fragment, PropsCE.fragSpeedFactor, PropsCE.fragShadowChance, fragYAngleRange, fragXZAngleRange);
                 if (!Compatibility.Multiplayer.InMultiplayer)
                 {
                     _monoDummy.GetComponent<MonoDummy>().StartCoroutine(routine);


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Explosions with default vertical angles will now get the min angle shifted downwards, if the explosion occured at height bigger than 0.1 cell. At height of 1 cell (wall's max height), frag angles will become from -30 to 5 degrees, instead of from 0.5 to 5 degrees. Calculated via formula `height * -30`.

## References

Links to the associated issues or other related pull requests, e.g.
- Contributes towards #4180

## Reasoning

Why did you choose to implement things this way, e.g.
- RPG-7 frags fly over pawns if the rocket hits a wall.

## Alternatives

Describe alternative implementations you have considered, e.g.
- Increase frag count to accomodate for increased dispersion?
- Different max value?

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
