### PR TITLE
Dont cache rotation for overhead projectiles

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -1225,7 +1225,6 @@ public abstract class ProjectileCE : ThingWithComps
         ticksToImpact--;
         FlightTicks++;
         Vector3 nextPosition = MoveForward();
-        
         if (!def.projectile.flyOverhead)
         {
             _drawRotation = Quaternion.LookRotation(nextPosition - ExactPosition);

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -1225,7 +1225,11 @@ public abstract class ProjectileCE : ThingWithComps
         ticksToImpact--;
         FlightTicks++;
         Vector3 nextPosition = MoveForward();
-        _drawRotation = Quaternion.LookRotation(nextPosition - ExactPosition);
+        
+        if (!def.projectile.flyOverhead)
+        {
+            _drawRotation = Quaternion.LookRotation(nextPosition - ExactPosition);
+        }
 
         if (!nextPosition.InBounds(Map))
         {


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Undoes caching added in #3820 specifically for overhead projectiles, since their texture gets terribly squished because of it. I am not fully familiar with the reasons of why global projectile drawing got changed for CIWS, so input from Perkins or Shashlichnik would be appreciated.

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #4173 
- Partially undoes #3820 

## Reasoning

Why did you choose to implement things this way, e.g.
- Mortar shells are difficult to see like this.
- Adding a check for flyOverhead allows CIWS bullets to keep their squishing, but leaves mortar shells using the old behaviour

## Alternatives

Describe alternative implementations you have considered, e.g.
- Move the caching behaviour to ProjectileCE_CIWS?
- Fix it some other way?

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] Playtested a colony (specify how long)
