### PR TITLE
Expand bulk and weight tooltip

### DIFF
--- a/Languages/English/Keyed/BulkAndWeight.xml
+++ b/Languages/English/Keyed/BulkAndWeight.xml
@@ -13,10 +13,10 @@
 	<CE_outfit>outfit</CE_outfit>
 	<CE_drugs>drug policy</CE_drugs>
 	<CE_loadout>loadout</CE_loadout>
-	<CE_DetailedWeightTip>Current weight: {1}\nCapacity: {0}\n\nMove speed factor: {2}\nEncumbrance penalty: {3}</CE_DetailedWeightTip>
-	<CE_DetailedBulkTip>Current bulk: {1}\nCapacity: {0}\n\nWork speed factor: {2}</CE_DetailedBulkTip>
-	<CE_DetailedBaseWeightTip>Current weight: {1}\nBase capacity: {0}\n\nMove speed factor: {2}\nEncumbrance penalty: {3}</CE_DetailedBaseWeightTip>
-	<CE_DetailedBaseBulkTip>Current bulk: {1}\nBase capacity: {0}\n\nWork speed factor: {2}</CE_DetailedBaseBulkTip>
+	<CE_DetailedWeightTip>Current weight: {1}\nCapacity: {0}\n\nMove speed factor: {2}\nMelee dodge chance factor: {3}\nEncumbrance penalty: {4}</CE_DetailedWeightTip>
+	<CE_DetailedBulkTip>Current bulk: {1}\nCapacity: {0}\n\nWork speed factor: {2}\nMelee hit chance factor: {3}\nMelee dodge chance factor: {4}</CE_DetailedBulkTip>
+	<CE_DetailedBaseWeightTip>Current weight: {1}\nBase capacity: {0}\n\nMove speed factor: {2}\nMelee dodge chance factor: {3}\nEncumbrance penalty: {4}</CE_DetailedBaseWeightTip>
+	<CE_DetailedBaseBulkTip>Current bulk: {1}\nBase capacity: {0}\n\nWork speed factor: {2}\nMelee hit chance factor: {3}\nMelee dodge chance factor: {4}</CE_DetailedBaseBulkTip>
 	<CE_EmptyLoadoutName>Nothing</CE_EmptyLoadoutName>
 	<CE_NoLoadouts>No Loadouts</CE_NoLoadouts>
 	<CE_SelectLoadout>Select loadout...</CE_SelectLoadout>

--- a/Source/CombatExtended/CombatExtended/Comps/CompInventory.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompInventory.cs
@@ -100,6 +100,20 @@ public class CompInventory : ThingComp
             return MassBulkUtility.DodgeWeightFactor(currentWeight, capacityWeight);
         }
     }
+    public float meleeHitChanceFactorBulk
+    {
+        get
+        {
+            return MassBulkUtility.HitChanceBulkFactor(currentBulk, capacityBulk);
+        }
+    }
+    public float dodgeChanceFactorBulk
+    {
+        get
+        {
+            return MassBulkUtility.DodgeChanceFactor(currentBulk, capacityBulk);
+        }
+    }
     public float workSpeedFactor
     {
         get

--- a/Source/CombatExtended/CombatExtended/Loadouts/Utility_Loadouts.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/Utility_Loadouts.cs
@@ -117,11 +117,15 @@ public static class Utility_Loadouts
     public static string GetBulkTip(this Loadout loadout)
     {
         float workSpeedFactor = MassBulkUtility.WorkSpeedFactor(loadout.Bulk, medianBulkCapacity);
+        float hitChanceFactor = MassBulkUtility.HitChanceBulkFactor(loadout.Bulk, medianBulkCapacity);
+        float dodgeChanceFactor = MassBulkUtility.DodgeChanceFactor(loadout.Bulk, medianBulkCapacity);
 
         return "CE_DetailedBaseBulkTip".Translate(
                    CE_StatDefOf.CarryBulk.ValueToString(medianBulkCapacity, CE_StatDefOf.CarryBulk.toStringNumberSense),
                    CE_StatDefOf.CarryBulk.ValueToString(loadout.Bulk, CE_StatDefOf.CarryBulk.toStringNumberSense),
-                   workSpeedFactor.ToStringPercent());
+                   workSpeedFactor.ToStringPercent(),
+                   hitChanceFactor.ToStringPercent(),
+                   dodgeChanceFactor.ToStringPercent());
     }
 
     public static string GetBulkTip(this Pawn pawn)
@@ -129,8 +133,11 @@ public static class Utility_Loadouts
         CompInventory comp = pawn.TryGetComp<CompInventory>();
         if (comp != null)
         {
-            return "CE_DetailedBulkTip".Translate(CE_StatDefOf.CarryBulk.ValueToString(comp.capacityBulk, CE_StatDefOf.CarryBulk.toStringNumberSense), CE_StatDefOf.CarryBulk.ValueToString(comp.currentBulk, CE_StatDefOf.CarryBulk.toStringNumberSense),
-                                                  comp.workSpeedFactor.ToStringPercent());
+            return "CE_DetailedBulkTip".Translate(CE_StatDefOf.CarryBulk.ValueToString(comp.capacityBulk, CE_StatDefOf.CarryBulk.toStringNumberSense),
+                CE_StatDefOf.CarryBulk.ValueToString(comp.currentBulk, CE_StatDefOf.CarryBulk.toStringNumberSense),
+                comp.workSpeedFactor.ToStringPercent(),
+                comp.meleeHitChanceFactorBulk.ToStringPercent(),
+                comp.dodgeChanceFactorBulk.ToStringPercent());
         }
         else
         {
@@ -216,10 +223,12 @@ public static class Utility_Loadouts
     public static string GetWeightTip(this Loadout loadout)
     {
         float moveSpeedFactor = MassBulkUtility.MoveSpeedFactor(loadout.Weight, medianWeightCapacity);
+        float dodgeFactor = MassBulkUtility.DodgeWeightFactor(loadout.Weight, medianWeightCapacity);
         float encumberPenalty = MassBulkUtility.EncumberPenalty(loadout.Weight, medianWeightCapacity);
 
         return "CE_DetailedBaseWeightTip".Translate(CE_StatDefOf.CarryWeight.ValueToString(medianWeightCapacity, CE_StatDefOf.CarryWeight.toStringNumberSense), CE_StatDefOf.CarryWeight.ValueToString(loadout.Weight, CE_StatDefOf.CarryWeight.toStringNumberSense),
                 moveSpeedFactor.ToStringPercent(),
+                dodgeFactor.ToStringPercent(),
                 encumberPenalty.ToStringPercent());
     }
 
@@ -230,6 +239,7 @@ public static class Utility_Loadouts
         {
             return "CE_DetailedWeightTip".Translate(CE_StatDefOf.CarryWeight.ValueToString(comp.capacityWeight, CE_StatDefOf.CarryWeight.toStringNumberSense), CE_StatDefOf.CarryWeight.ValueToString(comp.currentWeight, CE_StatDefOf.CarryWeight.toStringNumberSense),
                                                     comp.moveSpeedFactor.ToStringPercent(),
+                                                    comp.dodgeChanceFactorWeight.ToStringPercent(),
                                                     comp.encumberPenalty.ToStringPercent());
         }
         else


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Adds information about dodge and melee hit chance penalties from bulk and weight. Displayed when hovering over bulk/weight in pawn inventory or loadout tab.

## Reasoning

Why did you choose to implement things this way, e.g.
- I never knew these penalties even existed
- Expose esoteric information to the masses

## Alternatives

Describe alternative implementations you have considered, e.g.
- Display them only when penalties exceed 0?

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
