### PR TITLE
support for The REAL flamberg

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -578,6 +578,7 @@
 		<li IfModActive="MortStrudel.CorporationFaction">ModPatches/The Corporation - Mort's Factions</li>
 		<li IfModActive="HC.GiantRace">ModPatches/The GiantRace</li>
 		<li IfModActive="sarg.jorisexperience">ModPatches/The Joris Experience</li>
+		<li IfModActive="LeveFUN.TheREALflamberg">ModPatches/The REAL flamberg</li>
 		<li IfModActive="Wilco.Tuffalo">ModPatches/The Tuffalo</li>
 		<li IfModActive="TheVanityProject.ShibaInu">ModPatches/The Vanity Project - Shiba Inu</li>
 		<li IfModActive="Serek.TheWildFields">ModPatches/The Wild Fields</li>

--- a/ModPatches/The REAL flamberg/Patches/The REAL flamberg/MeleeUltratechFlamberge.xml
+++ b/ModPatches/The REAL flamberg/Patches/The REAL flamberg/MeleeUltratechFlamberge.xml
@@ -59,10 +59,12 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="MeleeWeapon_TheRealFLAMBERGE"]/statBases</xpath>
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_TheRealFLAMBERGE"]</xpath>
 		<value>
-			<Bulk>12</Bulk>
-			<MeleeCounterParryBonus>0.20</MeleeCounterParryBonus>
+			<statBases>
+				<Bulk>12</Bulk>
+				<MeleeCounterParryBonus>0.20</MeleeCounterParryBonus>
+			</statBases>
 		</value>
 	</Operation>
 

--- a/ModPatches/The REAL flamberg/Patches/The REAL flamberg/MeleeUltratechFlamberge.xml
+++ b/ModPatches/The REAL flamberg/Patches/The REAL flamberg/MeleeUltratechFlamberge.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- === The Real Flamberge Bladelink === -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_TheRealFLAMBERGE"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>handle</label>
+					<capacities>
+						<li>Poke</li>
+					</capacities>
+					<power>4</power>
+					<cooldownTime>2.51</cooldownTime>
+					<chanceFactor>2</chanceFactor>
+					<armorPenetrationBlunt>1.024</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>edge</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>50</power>
+					<extraMeleeDamages>
+						<li>
+							<def>Flame</def>
+							<amount>12</amount>
+							<chance>0.3</chance>
+						</li>
+					</extraMeleeDamages>
+					<cooldownTime>1.91</cooldownTime>
+					<armorPenetrationBlunt>6.4</armorPenetrationBlunt>
+					<armorPenetrationSharp>21.34</armorPenetrationSharp>
+					<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>point</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>22</power>
+					<power>26</power>
+					<extraMeleeDamages>
+						<li>
+							<def>Flame</def>
+							<amount>8</amount>
+							<chance>0.2</chance>
+						</li>
+					</extraMeleeDamages>
+					<cooldownTime>1.54</cooldownTime>
+					<armorPenetrationBlunt>2.704</armorPenetrationBlunt>
+					<armorPenetrationSharp>30.05</armorPenetrationSharp>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_TheRealFLAMBERGE"]/statBases</xpath>
+		<value>
+			<Bulk>12</Bulk>
+			<MeleeCounterParryBonus>0.20</MeleeCounterParryBonus>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_TheRealFLAMBERGE"]</xpath>
+		<value>
+			<equippedStatOffsets>
+				<MeleeCritChance>0.17</MeleeCritChance>
+				<MeleeParryChance>0.15</MeleeParryChance>
+				<MeleeDodgeChance>0.6</MeleeDodgeChance>
+			</equippedStatOffsets>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/The REAL flamberg/Patches/The REAL flamberg/MeleeUltratechFlambergeBladelink.xml
+++ b/ModPatches/The REAL flamberg/Patches/The REAL flamberg/MeleeUltratechFlambergeBladelink.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- === The Real Flamberge Bladelink === -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_TheRealFLAMBERGEBladelink"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>handle</label>
+					<capacities>
+						<li>Poke</li>
+					</capacities>
+					<power>4</power>
+					<cooldownTime>2.25</cooldownTime>
+					<chanceFactor>2</chanceFactor>
+					<armorPenetrationBlunt>1.024</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>edge</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>50</power>
+					<extraMeleeDamages>
+						<li>
+							<def>Flame</def>
+							<amount>12</amount>
+							<chance>0.3</chance>
+						</li>
+					</extraMeleeDamages>
+					<cooldownTime>1.5</cooldownTime>
+					<armorPenetrationBlunt>6.4</armorPenetrationBlunt>
+					<armorPenetrationSharp>21.34</armorPenetrationSharp>
+					<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>point</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>22</power>
+					<power>26</power>
+					<extraMeleeDamages>
+						<li>
+							<def>Flame</def>
+							<amount>8</amount>
+							<chance>0.2</chance>
+						</li>
+					</extraMeleeDamages>
+					<cooldownTime>1.2</cooldownTime>
+					<armorPenetrationBlunt>2.704</armorPenetrationBlunt>
+					<armorPenetrationSharp>30.05</armorPenetrationSharp>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_TheRealFLAMBERGEBladelink"]/statBases</xpath>
+		<value>
+			<Bulk>12</Bulk>
+			<MeleeCounterParryBonus>0.20</MeleeCounterParryBonus>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_TheRealFLAMBERGEBladelink"]</xpath>
+		<value>
+			<equippedStatOffsets>
+				<MeleeCritChance>0.17</MeleeCritChance>
+				<MeleeParryChance>0.15</MeleeParryChance>
+				<MeleeDodgeChance>0.6</MeleeDodgeChance>
+			</equippedStatOffsets>
+		</value>
+	</Operation>
+
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -552,6 +552,7 @@ Textiles+ (continued)   |
 The Corporation - Mort's Factions   |
 The Mantodean insectoid race	|
 The Profaned	|
+The REAL flamberg	|
 The Vanity Project - Shiba Inu  |
 The Wild Fields - apparel and weapons   |
 T-45b Power Armor	|


### PR DESCRIPTION
## Additions

support for https://steamcommunity.com/sharedfiles/filedetails/?id=2343072589

## Changes

Patched 1 melee weapon and its bladelink version.

## Reasoning

As per the original mod's description, this is supposed to be a larger version of the vanilla plasmasword.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [X] Game runs without errors
- [X] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)

I could not find the weapon in the dev spawn tool and I have no idea why. So... not really that well tested.
Since I have the same problem without CE, I reported to the main mod.