### PR TITLE
Minor fixes

### DIFF
--- a/Defs/Ammo/Rifle/6.5Creedmoor.xml
+++ b/Defs/Ammo/Rifle/6.5Creedmoor.xml
@@ -83,7 +83,6 @@
 		</graphicData>
 		<ammoClass>IncendiaryAP</ammoClass>
 		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
-		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_65x48mmCreedmoor_Incendiary</cookOffProjectile>
 	</ThingDef>
 
@@ -95,7 +94,6 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>ExplosiveAP</ammoClass>
-		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_65x48mmCreedmoor_HE</cookOffProjectile>
 	</ThingDef>
@@ -111,7 +109,6 @@
 			<Mass>0.019</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
-		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<generateAllowChance>0.65</generateAllowChance> <!-- Make advanced ammo types less common. -->
 		<cookOffProjectile>Bullet_65x48mmCreedmoor_Sabot</cookOffProjectile>
 	</ThingDef>

--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_BlackHive_Psycasts.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_BlackHive_Psycasts.xml
@@ -200,28 +200,6 @@
 					</value>
 				</li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="AA_BlackSpelopede_Temporary"]/verbs</xpath>
-					<value>
-						<verbs>
-							<li Class="CombatExtended.VerbPropertiesCE">
-								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-								<hasStandardCommand>true</hasStandardCommand>
-								<defaultProjectile>AA_PoisonBolt</defaultProjectile>
-								<warmupTime>2.4</warmupTime>
-								<burstShotCount>1</burstShotCount>
-								<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
-								<minRange>2</minRange>
-								<range>20</range>
-								<soundCast>AA_PoisonBolt</soundCast>
-								<muzzleFlashScale>0</muzzleFlashScale>
-								<label>venomous spit</label>
-								<commonality>0.8</commonality>
-							</li>
-						</verbs>
-					</value>
-				</li>
-
 				<li Class="PatchOperationConditional">
 					<xpath>Defs/ThingDef[defName="AA_BlackSpelopede_Temporary"]/comps</xpath>
 					<nomatch Class="PatchOperationAdd">
@@ -335,28 +313,6 @@
 								<chanceFactor>0.2</chanceFactor>
 							</li>
 						</tools>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="AA_BlackSpider_Temporary"]/verbs</xpath>
-					<value>
-						<verbs>
-							<li Class="CombatExtended.VerbPropertiesCE">
-								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-								<hasStandardCommand>true</hasStandardCommand>
-								<defaultProjectile>AA_PoisonBolt</defaultProjectile>
-								<warmupTime>1.6</warmupTime>
-								<burstShotCount>1</burstShotCount>
-								<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
-								<minRange>1.9</minRange>
-								<range>32</range>
-								<soundCast>AA_PoisonBolt</soundCast>
-								<muzzleFlashScale>0</muzzleFlashScale>
-								<label>venomous spit</label>
-								<commonality>0.8</commonality>
-							</li>
-						</verbs>
 					</value>
 				</li>
 


### PR DESCRIPTION
A couple of minor fixes.

## Changes
- Remove duplicate `generationAllowChance` from 6.5 Creedmoor accidentally added by #4123 
- Remove obsolete verb patches for Alpha Animals + VPE patch.

## Reasoning
- Whoopsie.
- Bugs no longer have verbs.

## Alternatives
- Suffer.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
