### PR TITLE
Fix outside tending being counted as inside for infections

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/HediffComp_InfecterCE.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/HediffComp_InfecterCE.cs
@@ -118,8 +118,8 @@ public class HediffComp_InfecterCE : HediffComp
         if (Pawn.Spawned)
         {
             var room = Pawn.GetRoom();
-            _tendedOutside = room == null;
-            _infectionModifier *= room == null ? RoomStatDefOf.InfectionChanceFactor.roomlessScore : RoomStatDefOf.InfectionChanceFactor.Worker.GetScore(room);
+            _tendedOutside = room == null || room.OutdoorsForWork;
+            _infectionModifier *= _tendedOutside || room == null ? RoomStatDefOf.InfectionChanceFactor.roomlessScore : RoomStatDefOf.InfectionChanceFactor.Worker.GetScore(room);
         }
     }
 }

--- a/Source/CombatExtended/CombatExtended/Comps/HediffComp_InfecterCE.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/HediffComp_InfecterCE.cs
@@ -119,7 +119,7 @@ public class HediffComp_InfecterCE : HediffComp
         {
             var room = Pawn.GetRoom();
             _tendedOutside = room == null || room.OutdoorsForWork;
-            _infectionModifier *= _tendedOutside || room == null ? RoomStatDefOf.InfectionChanceFactor.roomlessScore : RoomStatDefOf.InfectionChanceFactor.Worker.GetScore(room);
+            _infectionModifier *= _tendedOutside ? RoomStatDefOf.InfectionChanceFactor.roomlessScore : RoomStatDefOf.InfectionChanceFactor.Worker.GetScore(room);
         }
     }
 }


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Ce's applies different infection chances for wounds tended outside. When tending outside, room used to be `null`. Now they're not null, as it returns an outside region instead. So, we use an `isOutsideForWork` property instead of only checking for null

## References

Links to the associated issues or other related pull requests, e.g.
- reported by Glub on discord 
https://discord.com/channels/278818534069501953/278818534069501953/1411673056644169768

## Reasoning

Why did you choose to implement things this way, e.g.
- Tending in this situation counts as being in a room when debugging:
<img width="813" height="614" alt="изображение" src="https://github.com/user-attachments/assets/129c6334-fb5b-43e5-9e5d-6ddc6fbdac3b" />

room == null returns false

<img width="961" height="210" alt="изображение" src="https://github.com/user-attachments/assets/a179f690-4ee8-4c31-82fa-eced0fa9a16e" />



## Alternatives

Describe alternative implementations you have considered, e.g.
- Betray NIA's vision

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
Tested the following cases:
- Tending outdoors without sleeping spot - counted as Outdoors
- Tending outdoors on a sleeping spot - counted as Outdoors
- Tending in a roofed room with and without a sleeping spot - counted as Indoors
- Tending in a unroofed room with and without a sleeping spot - counted as Outdoors