### PR TITLE
Fix bursting projectiles trying to impact after being destroyed

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_Bursting.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_Bursting.cs
@@ -62,7 +62,7 @@ class ProjectileCE_Bursting : ProjectileCE
     public override void Tick()
     {
         base.Tick();
-        if (--this.ticksToBurst == 0)
+        if (--this.ticksToBurst == 0 && !Destroyed)
         {
             base.Impact(null);
         }


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Sometimes bursting projectiles get destroyed at the same tick as their timer runs out. This makes destroyed projectile try to impact and throw a harmless red error.

## References

Links to the associated issues or other related pull requests, e.g.
- Easy to replicate by using flamethrower with this mod, as it makes flame projectiles airburst and they sometimes hit ground:
https://steamcommunity.com/sharedfiles/filedetails/?id=2929493288&tscn=1747113855

## Reasoning

Why did you choose to implement things this way, e.g.
- Clean up red errors

## Alternatives

Describe alternative implementations you have considered, e.g.
- Check for null `Map` instead of `Destroyed`

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
only dev mode testing
