### PR TITLE
Rimsenal GD stuff

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -530,6 +530,7 @@
 		<li IfModActive="rimsenal.security">ModPatches/Rimsenal Security</li>
 		<li IfModActive="Rimsenal.Askbarn">ModPatches/Rimsenal Xenotype Pack - Askbarn</li>
 		<li IfModActive="Rimsenal.Harana">ModPatches/Rimsenal Xenotype Pack - Harana</li>
+    <li IfModActive="Rimsenal.Zohar">ModPatches/Rimsenal Xenotype Pack - Zohar</li>
 		<li IfModActive="SirMashedPotato.DarkDescent">ModPatches/Rimworld - The Dark Descent</li>
 		<li IfModActive="Mlie.RRUESContactLightArmory">ModPatches/Risk of Rain UES Contact Light Armory</li>
 		<li IfModActive="Ghastly.RoboticServitude">ModPatches/Robotic Servitude</li>

--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -530,7 +530,7 @@
 		<li IfModActive="rimsenal.security">ModPatches/Rimsenal Security</li>
 		<li IfModActive="Rimsenal.Askbarn">ModPatches/Rimsenal Xenotype Pack - Askbarn</li>
 		<li IfModActive="Rimsenal.Harana">ModPatches/Rimsenal Xenotype Pack - Harana</li>
-    <li IfModActive="Rimsenal.Zohar">ModPatches/Rimsenal Xenotype Pack - Zohar</li>
+		<li IfModActive="Rimsenal.Zohar">ModPatches/Rimsenal Xenotype Pack - Zohar</li>
 		<li IfModActive="SirMashedPotato.DarkDescent">ModPatches/Rimworld - The Dark Descent</li>
 		<li IfModActive="Mlie.RRUESContactLightArmory">ModPatches/Risk of Rain UES Contact Light Armory</li>
 		<li IfModActive="Ghastly.RoboticServitude">ModPatches/Robotic Servitude</li>

--- a/ModPatches/Rimsenal Core/Defs/Rimsenal Core/Ammo_GD.xml
+++ b/ModPatches/Rimsenal Core/Defs/Rimsenal Core/Ammo_GD.xml
@@ -1,97 +1,583 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
 
-	<!-- ==================== Pistol - AmmoSet ========================== -->
+	<ThingCategoryDef>
+		<defName>Ammo66Greydale</defName>
+		<label>6.6mm GD Caseless</label>
+		<parent>AmmoRifles</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberRifle</iconPath>
+	</ThingCategoryDef>
+
+	<!-- ==================== AmmoSet ========================== -->
 
 	<CombatExtended.AmmoSetDef>
-		<defName>AmmoSet_473x33mmCaseless_GDPistol</defName>
-		<label>4.73x33mm Caseless</label>
+		<defName>AmmoSet_66Greydale</defName>
+		<label>6.6mm GD Caseless</label>
 		<ammoTypes>
-			<Ammo_473x33mmCaseless_FMJ>Bullet_473x33mmGDPistol_FMJ</Ammo_473x33mmCaseless_FMJ>
-			<Ammo_473x33mmCaseless_AP>Bullet_473x33mmGDPistol_AP</Ammo_473x33mmCaseless_AP>
-			<Ammo_473x33mmCaseless_HP>Bullet_473x33mmGDPistol_HP</Ammo_473x33mmCaseless_HP>
-			<Ammo_473x33mmCaseless_Incendiary>Bullet_473x33mmGDPistol_Incendiary</Ammo_473x33mmCaseless_Incendiary>
-			<Ammo_473x33mmCaseless_HE>Bullet_473x33mmGDPistol_HE</Ammo_473x33mmCaseless_HE>
-			<Ammo_473x33mmCaseless_Sabot>Bullet_473x33mmGDPistol_Sabot</Ammo_473x33mmCaseless_Sabot>
+			<Ammo_66Greydale_FMJ>Bullet_66Greydale_FMJ</Ammo_66Greydale_FMJ>
+			<Ammo_66Greydale_AP>Bullet_66Greydale_AP</Ammo_66Greydale_AP>
+			<Ammo_66Greydale_HP>Bullet_66Greydale_HP</Ammo_66Greydale_HP>
+			<Ammo_66Greydale_Incendiary>Bullet_66Greydale_Incendiary</Ammo_66Greydale_Incendiary>
+			<Ammo_66Greydale_HE>Bullet_66Greydale_HE</Ammo_66Greydale_HE>
+			<Ammo_66Greydale_Sabot>Bullet_66Greydale_Sabot</Ammo_66Greydale_Sabot>
 		</ammoTypes>
+		<similarTo>AmmoSet_RifleIntermediate</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="66GreydaleBase" ParentName="SmallAmmoBase" Abstract="True">
+		<description>Caseless bullet with a solid propellant enveloping the projectile.</description>
+		<statBases>
+			<Mass>0.022</Mass>
+			<Bulk>0.01</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
+		<thingCategories>
+			<li>Ammo66Greydale</li>
+		</thingCategories>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="66GreydaleBase">
+		<defName>Ammo_66Greydale_FMJ</defName>
+		<label>6.6mm GD Caseless (FMJ)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/FMJ</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<ammoClass>FullMetalJacket</ammoClass>
+		<cookOffProjectile>Bullet_66Greydale_FMJ</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="66GreydaleBase">
+		<defName>Ammo_66Greydale_AP</defName>
+		<label>6.6mm GD Caseless (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_66Greydale_AP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="66GreydaleBase">
+		<defName>Ammo_66Greydale_HP</defName>
+		<label>6.6mm GD Caseless (HP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/HP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<ammoClass>HollowPoint</ammoClass>
+		<cookOffProjectile>Bullet_66Greydale_HP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="66GreydaleBase">
+		<defName>Ammo_66Greydale_Incendiary</defName>
+		<label>6.6mm GD Caseless (AP-I)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/Incendiary</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<ammoClass>IncendiaryAP</ammoClass>
+		<cookOffProjectile>Bullet_66Greydale_Incendiary</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="66GreydaleBase">
+		<defName>Ammo_66Greydale_HE</defName>
+		<label>6.6mm GD Caseless (AP-HE)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<ammoClass>ExplosiveAP</ammoClass>
+		<cookOffProjectile>Bullet_66Greydale_HE</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="66GreydaleBase">
+		<defName>Ammo_66Greydale_Sabot</defName>
+		<label>6.6mm GD Caseless (Sabot)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/Sabot</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<Mass>0.019</Mass>
+		</statBases>
+		<ammoClass>Sabot</ammoClass>
+		<cookOffProjectile>Bullet_66Greydale_Sabot</cookOffProjectile>
+	</ThingDef>
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef Name="Base66GreydaleBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Gbullet</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>158</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base66GreydaleBullet">
+		<defName>Bullet_66Greydale_FMJ</defName>
+		<label>6.6mm GD Caseless bullet (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>18</damageAmountBase>
+			<armorPenetrationSharp>6.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>59.6</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base66GreydaleBullet">
+		<defName>Bullet_66Greydale_AP</defName>
+		<label>6.6mm GD Caseless bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>11</damageAmountBase>
+			<armorPenetrationSharp>13</armorPenetrationSharp>
+			<armorPenetrationBlunt>59.6</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base66GreydaleBullet">
+		<defName>Bullet_66Greydale_HP</defName>
+		<label>6.6mm GD Caseless bullet (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>23</damageAmountBase>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationBlunt>59.6</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base66GreydaleBullet">
+		<defName>Bullet_66Greydale_Incendiary</defName>
+		<label>6.6mm GD Caseless bullet (AP-I)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>11</damageAmountBase>
+			<armorPenetrationSharp>13</armorPenetrationSharp>
+			<armorPenetrationBlunt>59.6</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+					<def>Flame_Secondary</def>
+					<amount>5</amount>
+				</li>
+			</secondaryDamage>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base66GreydaleBullet">
+		<defName>Bullet_66Greydale_HE</defName>
+		<label>6.6mm GD Caseless bullet (AP-HE)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>18</damageAmountBase>
+			<armorPenetrationSharp>6</armorPenetrationSharp>
+			<armorPenetrationBlunt>59.6</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+					<def>Bomb_Secondary</def>
+					<amount>7</amount>
+				</li>
+			</secondaryDamage>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base66GreydaleBullet">
+		<defName>Bullet_66Greydale_Sabot</defName>
+		<label>6.6mm GD Caseless bullet (Sabot)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>9</damageAmountBase>
+			<armorPenetrationSharp>22.75</armorPenetrationSharp>
+			<armorPenetrationBlunt>67.26</armorPenetrationBlunt>
+			<speed>203</speed>
+		</projectile>
+	</ThingDef>
+
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_66Greydale_FMJ</defName>
+		<label>make 6.6mm GD Caseless (FMJ) cartridge x500</label>
+		<description>Craft 500 6.6mm GD Caseless (FMJ) cartridges.</description>
+		<jobString>Making 6.6mm GD Caseless (FMJ) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>24</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_66Greydale_FMJ>500</Ammo_66Greydale_FMJ>
+		</products>
+		<workAmount>2400</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_66Greydale_AP</defName>
+		<label>make 6.6mm GD Caseless (AP) cartridge x500</label>
+		<description>Craft 500 6.6mm GD Caseless (AP) cartridges.</description>
+		<jobString>Making 6.6mm GD Caseless (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>24</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_66Greydale_AP>500</Ammo_66Greydale_AP>
+		</products>
+		<workAmount>2880</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_66Greydale_HP</defName>
+		<label>make 6.6mm GD Caseless (HP) cartridge x500</label>
+		<description>Craft 500 6.6mm GD Caseless (HP) cartridges.</description>
+		<jobString>Making 6.6mm GD Caseless (HP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>24</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_66Greydale_HP>500</Ammo_66Greydale_HP>
+		</products>
+		<workAmount>2400</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_66Greydale_Incendiary</defName>
+		<label>make 6.6mm GD Caseless (AP-I) cartridge x500</label>
+		<description>Craft 500 6.6mm GD Caseless (AP-I) cartridges.</description>
+		<jobString>Making 6.6mm GD Caseless (AP-I) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>24</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Prometheum</li>
+					</thingDefs>
+				</filter>
+				<count>2</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Prometheum</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_66Greydale_Incendiary>500</Ammo_66Greydale_Incendiary>
+		</products>
+		<workAmount>3200</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_66Greydale_HE</defName>
+		<label>make 6.6mm GD Caseless (AP-HE) cartridge x500</label>
+		<description>Craft 500 6.6mm GD Caseless (AP-HE) cartridges.</description>
+		<jobString>Making 6.6mm GD Caseless (AP-HE) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>24</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>FSX</li>
+					</thingDefs>
+				</filter>
+				<count>5</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>FSX</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_66Greydale_HE>500</Ammo_66Greydale_HE>
+		</products>
+		<workAmount>4400</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_66Greydale_Sabot</defName>
+		<label>make 6.6mm GD Caseless (Sabot) cartridge x500</label>
+		<description>Craft 500 6.6mm GD Caseless (Sabot) cartridges.</description>
+		<jobString>Making 6.6mm GD Caseless (Sabot) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>14</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Uranium</li>
+					</thingDefs>
+				</filter>
+				<count>3</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Chemfuel</li>
+					</thingDefs>
+				</filter>
+				<count>3</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Uranium</li>
+				<li>Chemfuel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_66Greydale_Sabot>500</Ammo_66Greydale_Sabot>
+		</products>
+		<workAmount>3200</workAmount>
+	</RecipeDef>
+
+	<!-- ==================== Carbine - AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_66GreydaleSB</defName>
+		<label>6.6mm GD Caseless (Short Barrel)</label>
+		<ammoTypes>
+			<Ammo_66Greydale_FMJ>Bullet_66GreydaleSB_FMJ</Ammo_66Greydale_FMJ>
+			<Ammo_66Greydale_AP>Bullet_66GreydaleSB_AP</Ammo_66Greydale_AP>
+			<Ammo_66Greydale_HP>Bullet_66GreydaleSB_HP</Ammo_66Greydale_HP>
+			<Ammo_66Greydale_Incendiary>Bullet_66GreydaleSB_Incendiary</Ammo_66Greydale_Incendiary>
+			<Ammo_66Greydale_HE>Bullet_66GreydaleSB_HE</Ammo_66Greydale_HE>
+			<Ammo_66Greydale_Sabot>Bullet_66GreydaleSB_Sabot</Ammo_66Greydale_Sabot>
+		</ammoTypes>
+		<similarTo>AmmoSet_RifleIntermediate</similarTo>
 	</CombatExtended.AmmoSetDef>
 
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef ParentName="Base473x33mmCaselessBullet">
-		<defName>Bullet_473x33mmGDPistol_FMJ</defName>
-		<label>4.73mm Caseless bullet (FMJ)</label>
+	<ThingDef ParentName="Base66GreydaleBullet">
+		<defName>Bullet_66GreydaleSB_FMJ</defName>
+		<label>6.6mm GD Caseless bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>10</damageAmountBase>
+			<damageAmountBase>15</damageAmountBase>
 			<armorPenetrationSharp>5</armorPenetrationSharp>
-			<armorPenetrationBlunt>14.06</armorPenetrationBlunt>
-			<speed>129</speed>
+			<armorPenetrationBlunt>33.8</armorPenetrationBlunt>
+			<speed>128</speed>
 		</projectile>
 	</ThingDef>
 
-	<ThingDef ParentName="Base473x33mmCaselessBullet">
-		<defName>Bullet_473x33mmGDPistol_AP</defName>
-		<label>4.73mm Caseless bullet (AP)</label>
+	<ThingDef ParentName="Base66GreydaleBullet">
+		<defName>Bullet_66GreydaleSB_AP</defName>
+		<label>6.6mm GD Caseless bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>6</damageAmountBase>
+			<damageAmountBase>9</damageAmountBase>
 			<armorPenetrationSharp>12</armorPenetrationSharp>
-			<armorPenetrationBlunt>14.06</armorPenetrationBlunt>
-			<speed>129</speed>
+			<armorPenetrationBlunt>33.8</armorPenetrationBlunt>
+			<speed>128</speed>
 		</projectile>
 	</ThingDef>
 
-	<ThingDef ParentName="Base473x33mmCaselessBullet">
-		<defName>Bullet_473x33mmGDPistol_HP</defName>
-		<label>4.73mm Caseless bullet (HP)</label>
+	<ThingDef ParentName="Base66GreydaleBullet">
+		<defName>Bullet_66GreydaleSB_HP</defName>
+		<label>6.6mm GD Caseless bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>12</damageAmountBase>
+			<damageAmountBase>19</damageAmountBase>
 			<armorPenetrationSharp>3</armorPenetrationSharp>
-			<armorPenetrationBlunt>14.06</armorPenetrationBlunt>
-			<speed>129</speed>
+			<armorPenetrationBlunt>33.8</armorPenetrationBlunt>
+			<speed>128</speed>
 		</projectile>
 	</ThingDef>
 
-	<ThingDef ParentName="Base473x33mmCaselessBullet">
-		<defName>Bullet_473x33mmGDPistol_Incendiary</defName>
-		<label>4.73mm Caseless bullet (AP-I)</label>
+	<ThingDef ParentName="Base66GreydaleBullet">
+		<defName>Bullet_66GreydaleSB_Incendiary</defName>
+		<label>6.6mm GD Caseless bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>6</damageAmountBase>
+			<damageAmountBase>9</damageAmountBase>
 			<armorPenetrationSharp>10</armorPenetrationSharp>
-			<armorPenetrationBlunt>14.06</armorPenetrationBlunt>
+			<armorPenetrationBlunt>33.8</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>4</amount>
+					<amount>5</amount>
 				</li>
 			</secondaryDamage>
-			<speed>129</speed>
+			<speed>128</speed>
 		</projectile>
 	</ThingDef>
 
-	<ThingDef ParentName="Base473x33mmCaselessBullet">
-		<defName>Bullet_473x33mmGDPistol_HE</defName>
-		<label>4.73mm Caseless bullet (HE)</label>
+	<ThingDef ParentName="Base66GreydaleBullet">
+		<defName>Bullet_66GreydaleSB_HE</defName>
+		<label>6.6mm GD Caseless bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>10</damageAmountBase>
+			<damageAmountBase>15</damageAmountBase>
 			<armorPenetrationSharp>5</armorPenetrationSharp>
-			<armorPenetrationBlunt>14.06</armorPenetrationBlunt>
+			<armorPenetrationBlunt>33.8</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>6</amount>
+					<amount>7</amount>
+				</li>
+			</secondaryDamage>
+			<speed>128</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base66GreydaleBullet">
+		<defName>Bullet_66GreydaleSB_Sabot</defName>
+		<label>6.6mm GD Caseless bullet (Sabot)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>7</damageAmountBase>
+			<armorPenetrationSharp>18</armorPenetrationSharp>
+			<armorPenetrationBlunt>38.14</armorPenetrationBlunt>
+			<speed>164</speed>
+		</projectile>
+	</ThingDef>
+	
+	<!-- ==================== Pistol - AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_66GreydalePistol</defName>
+		<label>6.6mm GD Caseless (Pistol)</label>
+		<ammoTypes>
+			<Ammo_66Greydale_FMJ>Bullet_66GreydalePistol_FMJ</Ammo_66Greydale_FMJ>
+			<Ammo_66Greydale_AP>Bullet_66GreydalePistol_AP</Ammo_66Greydale_AP>
+			<Ammo_66Greydale_HP>Bullet_66GreydalePistol_HP</Ammo_66Greydale_HP>
+			<Ammo_66Greydale_Incendiary>Bullet_66GreydalePistol_Incendiary</Ammo_66Greydale_Incendiary>
+			<Ammo_66Greydale_HE>Bullet_66GreydalePistol_HE</Ammo_66Greydale_HE>
+			<Ammo_66Greydale_Sabot>Bullet_66GreydalePistol_Sabot</Ammo_66Greydale_Sabot>
+		</ammoTypes>
+		<similarTo>AmmoSet_RifleIntermediate</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef ParentName="Base66GreydaleBullet">
+		<defName>Bullet_66GreydalePistol_FMJ</defName>
+		<label>6.6mm GD Caseless bullet (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>12</damageAmountBase>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationBlunt>19</armorPenetrationBlunt>
+			<speed>103</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base66GreydaleBullet">
+		<defName>Bullet_66GreydalePistol_AP</defName>
+		<label>6.6mm GD Caseless bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>8</damageAmountBase>
+			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationBlunt>14.06</armorPenetrationBlunt>
+			<speed>103</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base66GreydaleBullet">
+		<defName>Bullet_66GreydalePistol_HP</defName>
+		<label>6.6mm GD Caseless bullet (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>15</damageAmountBase>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationBlunt>19</armorPenetrationBlunt>
+			<speed>129</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base66GreydaleBullet">
+		<defName>Bullet_66GreydalePistol_Incendiary</defName>
+		<label>6.6mm GD Caseless bullet (AP-I)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>8</damageAmountBase>
+			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationBlunt>19</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+					<def>Flame_Secondary</def>
+					<amount>5</amount>
 				</li>
 			</secondaryDamage>
 			<speed>129</speed>
 		</projectile>
 	</ThingDef>
 
-	<ThingDef ParentName="Base473x33mmCaselessBullet">
-		<defName>Bullet_473x33mmGDPistol_Sabot</defName>
-		<label>4.73mm Caseless bullet (Sabot)</label>
+	<ThingDef ParentName="Base66GreydaleBullet">
+		<defName>Bullet_66GreydalePistol_HE</defName>
+		<label>6.6mm GD Caseless bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>5</damageAmountBase>
-			<armorPenetrationSharp>18</armorPenetrationSharp>
-			<armorPenetrationBlunt>18.06</armorPenetrationBlunt>
+			<damageAmountBase>12</damageAmountBase>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationBlunt>19</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+					<def>Bomb_Secondary</def>
+					<amount>7</amount>
+				</li>
+			</secondaryDamage>
+			<speed>129</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base66GreydaleBullet">
+		<defName>Bullet_66GreydalePistol_Sabot</defName>
+		<label>6.6mm GD Caseless bullet (Sabot)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>6</damageAmountBase>
+			<armorPenetrationSharp>14</armorPenetrationSharp>
+			<armorPenetrationBlunt>21.46</armorPenetrationBlunt>
 			<speed>175</speed>
 		</projectile>
 	</ThingDef>
@@ -99,95 +585,120 @@
 	<!-- ==================== Hybrid - AmmoSet ========================== -->
 
 	<CombatExtended.AmmoSetDef>
-		<defName>AmmoSet_473x33mmCaseless_GDHybrid</defName>
-		<label>4.73x33mm Caseless</label>
+		<defName>AmmoSet_66GreydaleHybrid</defName>
+		<label>6.6mm GD Caseless (Hybrid)</label>
 		<ammoTypes>
-			<Ammo_473x33mmCaseless_FMJ>Bullet_473x33mmGDHybrid_FMJ</Ammo_473x33mmCaseless_FMJ>
-			<Ammo_473x33mmCaseless_AP>Bullet_473x33mmGDHybrid_AP</Ammo_473x33mmCaseless_AP>
-			<Ammo_473x33mmCaseless_HP>Bullet_473x33mmGDHybrid_HP</Ammo_473x33mmCaseless_HP>
-			<Ammo_473x33mmCaseless_Incendiary>Bullet_473x33mmGDHybrid_Incendiary</Ammo_473x33mmCaseless_Incendiary>
-			<Ammo_473x33mmCaseless_HE>Bullet_473x33mmGDHybrid_HE</Ammo_473x33mmCaseless_HE>
-			<Ammo_473x33mmCaseless_Sabot>Bullet_473x33mmGDHybrid_Sabot</Ammo_473x33mmCaseless_Sabot>
+			<Ammo_66Greydale_FMJ>Bullet_66GreydaleHybrid_FMJ</Ammo_66Greydale_FMJ>
+			<Ammo_66Greydale_AP>Bullet_66GreydaleHybrid_AP</Ammo_66Greydale_AP>
+			<Ammo_66Greydale_HP>Bullet_66GreydaleHybrid_HP</Ammo_66Greydale_HP>
+			<Ammo_66Greydale_Incendiary>Bullet_66GreydaleHybrid_Incendiary</Ammo_66Greydale_Incendiary>
+			<Ammo_66Greydale_HE>Bullet_66GreydaleHybrid_HE</Ammo_66Greydale_HE>
+			<Ammo_66Greydale_Sabot>Bullet_66GreydaleHybrid_Sabot</Ammo_66Greydale_Sabot>
 		</ammoTypes>
+		<similarTo>AmmoSet_RifleIntermediate</similarTo>
 	</CombatExtended.AmmoSetDef>
 
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef ParentName="Base473x33mmCaselessBullet">
-		<defName>Bullet_473x33mmGDHybrid_FMJ</defName>
-		<label>4.73mm Caseless bullet (FMJ)</label>
+	<ThingDef ParentName="Base66GreydaleBullet">
+		<graphicData>
+			<texPath>Things/Projectile/GbulletHybrid</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<defName>Bullet_66GreydaleHybrid_FMJ</defName>
+		<label>6.6mm GD Caseless bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>15</damageAmountBase>
-			<armorPenetrationSharp>9</armorPenetrationSharp>
-			<armorPenetrationBlunt>47.96</armorPenetrationBlunt>
-			<speed>129</speed>
+			<damageAmountBase>21</damageAmountBase>
+			<armorPenetrationSharp>10</armorPenetrationSharp>
+			<armorPenetrationBlunt>94.46</armorPenetrationBlunt>
+			<speed>188</speed>
 		</projectile>
 	</ThingDef>
 
-	<ThingDef ParentName="Base473x33mmCaselessBullet">
-		<defName>Bullet_473x33mmGDHybrid_AP</defName>
-		<label>4.73mm Caseless bullet (AP)</label>
+	<ThingDef ParentName="Base66GreydaleBullet">
+		<graphicData>
+			<texPath>Things/Projectile/GbulletHybrid</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<defName>Bullet_66GreydaleHybrid_AP</defName>
+		<label>6.6mm GD Caseless bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>9</damageAmountBase>
-			<armorPenetrationSharp>16</armorPenetrationSharp>
-			<armorPenetrationBlunt>47.96</armorPenetrationBlunt>
-			<speed>129</speed>
+			<damageAmountBase>13</damageAmountBase>
+			<armorPenetrationSharp>20</armorPenetrationSharp>
+			<armorPenetrationBlunt>94.46</armorPenetrationBlunt>
+			<speed>188</speed>
 		</projectile>
 	</ThingDef>
 
-	<ThingDef ParentName="Base473x33mmCaselessBullet">
-		<defName>Bullet_473x33mmGDHybrid_HP</defName>
-		<label>4.73mm Caseless bullet (HP)</label>
+	<ThingDef ParentName="Base66GreydaleBullet">
+		<graphicData>
+			<texPath>Things/Projectile/GbulletHybrid</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<defName>Bullet_66GreydaleHybrid_HP</defName>
+		<label>6.6mm GD Caseless bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>19</damageAmountBase>
+			<damageAmountBase>26</damageAmountBase>
 			<armorPenetrationSharp>5</armorPenetrationSharp>
-			<armorPenetrationBlunt>47.96</armorPenetrationBlunt>
-			<speed>129</speed>
+			<armorPenetrationBlunt>94.46</armorPenetrationBlunt>
+			<speed>188</speed>
 		</projectile>
 	</ThingDef>
 
-	<ThingDef ParentName="Base473x33mmCaselessBullet">
-		<defName>Bullet_473x33mmGDHybrid_Incendiary</defName>
-		<label>4.73mm Caseless bullet (AP-I)</label>
+	<ThingDef ParentName="Base66GreydaleBullet">
+		<graphicData>
+			<texPath>Things/Projectile/GbulletHybrid</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<defName>Bullet_66GreydaleHybrid_Incendiary</defName>
+		<label>6.6mm GD Caseless bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>9</damageAmountBase>
-			<armorPenetrationSharp>18</armorPenetrationSharp>
-			<armorPenetrationBlunt>47.96</armorPenetrationBlunt>
+			<damageAmountBase>13</damageAmountBase>
+			<armorPenetrationSharp>20</armorPenetrationSharp>
+			<armorPenetrationBlunt>94.46</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>6</amount>
+					<amount>5</amount>
 				</li>
 			</secondaryDamage>
-			<speed>129</speed>
+			<speed>188</speed>
 		</projectile>
 	</ThingDef>
 
-	<ThingDef ParentName="Base473x33mmCaselessBullet">
-		<defName>Bullet_473x33mmGDHybrid_HE</defName>
-		<label>4.73mm Caseless bullet (HE)</label>
+	<ThingDef ParentName="Base66GreydaleBullet">
+		<graphicData>
+			<texPath>Things/Projectile/GbulletHybrid</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<defName>Bullet_66GreydaleHybrid_HE</defName>
+		<label>6.6mm GD Caseless bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>15</damageAmountBase>
-			<armorPenetrationSharp>9</armorPenetrationSharp>
-			<armorPenetrationBlunt>47.96</armorPenetrationBlunt>
+			<damageAmountBase>21</damageAmountBase>
+			<armorPenetrationSharp>10</armorPenetrationSharp>
+			<armorPenetrationBlunt>94.46</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>9</amount>
+					<amount>7</amount>
 				</li>
 			</secondaryDamage>
-			<speed>129</speed>
+			<speed>188</speed>
 		</projectile>
 	</ThingDef>
 
-	<ThingDef ParentName="Base473x33mmCaselessBullet">
-		<defName>Bullet_473x33mmGDHybrid_Sabot</defName>
-		<label>4.73mm Caseless bullet (Sabot)</label>
+	<ThingDef ParentName="Base66GreydaleBullet">
+		<graphicData>
+			<texPath>Things/Projectile/GbulletHybrid</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<defName>Bullet_66GreydaleHybrid_Sabot</defName>
+		<label>6.6mm GD Caseless bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>7</damageAmountBase>
-			<armorPenetrationSharp>31.5</armorPenetrationSharp>
-			<armorPenetrationBlunt>52.68</armorPenetrationBlunt>
-			<speed>175</speed>
+			<damageAmountBase>11</damageAmountBase>
+			<armorPenetrationSharp>35</armorPenetrationSharp>
+			<armorPenetrationBlunt>106.88</armorPenetrationBlunt>
+			<speed>242</speed>
 		</projectile>
 	</ThingDef>
 

--- a/ModPatches/Rimsenal Core/Defs/Rimsenal Core/Ammo_GD.xml
+++ b/ModPatches/Rimsenal Core/Defs/Rimsenal Core/Ammo_GD.xml
@@ -24,6 +24,54 @@
 		<similarTo>AmmoSet_RifleIntermediate</similarTo>
 	</CombatExtended.AmmoSetDef>
 
+	<!-- Carbine - AmmoSet -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_66Greydale_SB</defName>
+		<label>6.6mm GD Caseless (Short Barrel)</label>
+		<ammoTypes>
+			<Ammo_66Greydale_FMJ>Bullet_66Greydale_FMJ_SB</Ammo_66Greydale_FMJ>
+			<Ammo_66Greydale_AP>Bullet_66Greydale_AP_SB</Ammo_66Greydale_AP>
+			<Ammo_66Greydale_HP>Bullet_66Greydale_HP_SB</Ammo_66Greydale_HP>
+			<Ammo_66Greydale_Incendiary>Bullet_66Greydale_Incendiary_SB</Ammo_66Greydale_Incendiary>
+			<Ammo_66Greydale_HE>Bullet_66Greydale_HE_SB</Ammo_66Greydale_HE>
+			<Ammo_66Greydale_Sabot>Bullet_66Greydale_Sabot_SB</Ammo_66Greydale_Sabot>
+		</ammoTypes>
+		<similarTo>AmmoSet_RifleIntermediate</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- Pistol - AmmoSet -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_66Greydale_Pistol</defName>
+		<label>6.6mm GD Caseless (Pistol)</label>
+		<ammoTypes>
+			<Ammo_66Greydale_FMJ>Bullet_66Greydale_FMJ_Pistol</Ammo_66Greydale_FMJ>
+			<Ammo_66Greydale_AP>Bullet_66Greydale_AP_Pistol</Ammo_66Greydale_AP>
+			<Ammo_66Greydale_HP>Bullet_66Greydale_HP_Pistol</Ammo_66Greydale_HP>
+			<Ammo_66Greydale_Incendiary>Bullet_66Greydale_Incendiary_Pistol</Ammo_66Greydale_Incendiary>
+			<Ammo_66Greydale_HE>Bullet_66Greydale_HE_Pistol</Ammo_66Greydale_HE>
+			<Ammo_66Greydale_Sabot>Bullet_66Greydale_Sabot_Pistol</Ammo_66Greydale_Sabot>
+		</ammoTypes>
+		<similarTo>AmmoSet_RifleIntermediate</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- Hybrid - AmmoSet -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_66Greydale_Hybrid</defName>
+		<label>6.6mm GD Caseless (Hybrid)</label>
+		<ammoTypes>
+			<Ammo_66Greydale_FMJ>Bullet_66Greydale_FMJ_Hybrid</Ammo_66Greydale_FMJ>
+			<Ammo_66Greydale_AP>Bullet_66Greydale_AP_Hybrid</Ammo_66Greydale_AP>
+			<Ammo_66Greydale_HP>Bullet_66Greydale_HP_Hybrid</Ammo_66Greydale_HP>
+			<Ammo_66Greydale_Incendiary>Bullet_66Greydale_Incendiary_Hybrid</Ammo_66Greydale_Incendiary>
+			<Ammo_66Greydale_HE>Bullet_66Greydale_HE_Hybrid</Ammo_66Greydale_HE>
+			<Ammo_66Greydale_Sabot>Bullet_66Greydale_Sabot_Hybrid</Ammo_66Greydale_Sabot>
+		</ammoTypes>
+		<similarTo>AmmoSet_RifleIntermediate</similarTo>
+	</CombatExtended.AmmoSetDef>
+
 	<!-- ==================== Ammo ========================== -->
 
 	<ThingDef Class="CombatExtended.AmmoDef" Name="66GreydaleBase" ParentName="SmallAmmoBase" Abstract="True">
@@ -193,6 +241,252 @@
 			<armorPenetrationSharp>22.75</armorPenetrationSharp>
 			<armorPenetrationBlunt>67.26</armorPenetrationBlunt>
 			<speed>203</speed>
+		</projectile>
+	</ThingDef>
+
+	<!-- Projectiles - Carbine -->
+
+	<ThingDef ParentName="Base66GreydaleBullet">
+		<defName>Bullet_66Greydale_FMJ_SB</defName>
+		<label>6.6mm GD Caseless bullet (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>15</damageAmountBase>
+			<armorPenetrationSharp>5</armorPenetrationSharp>
+			<armorPenetrationBlunt>33.8</armorPenetrationBlunt>
+			<speed>128</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base66GreydaleBullet">
+		<defName>Bullet_66Greydale_AP_SB</defName>
+		<label>6.6mm GD Caseless bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>9</damageAmountBase>
+			<armorPenetrationSharp>12</armorPenetrationSharp>
+			<armorPenetrationBlunt>33.8</armorPenetrationBlunt>
+			<speed>128</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base66GreydaleBullet">
+		<defName>Bullet_66Greydale_HP_SB</defName>
+		<label>6.6mm GD Caseless bullet (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>19</damageAmountBase>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationBlunt>33.8</armorPenetrationBlunt>
+			<speed>128</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base66GreydaleBullet">
+		<defName>Bullet_66Greydale_Incendiary_SB</defName>
+		<label>6.6mm GD Caseless bullet (AP-I)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>9</damageAmountBase>
+			<armorPenetrationSharp>10</armorPenetrationSharp>
+			<armorPenetrationBlunt>33.8</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+					<def>Flame_Secondary</def>
+					<amount>5</amount>
+				</li>
+			</secondaryDamage>
+			<speed>128</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base66GreydaleBullet">
+		<defName>Bullet_66Greydale_HE_SB</defName>
+		<label>6.6mm GD Caseless bullet (HE)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>15</damageAmountBase>
+			<armorPenetrationSharp>5</armorPenetrationSharp>
+			<armorPenetrationBlunt>33.8</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+					<def>Bomb_Secondary</def>
+					<amount>7</amount>
+				</li>
+			</secondaryDamage>
+			<speed>128</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base66GreydaleBullet">
+		<defName>Bullet_66Greydale_Sabot_SB</defName>
+		<label>6.6mm GD Caseless bullet (Sabot)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>7</damageAmountBase>
+			<armorPenetrationSharp>18</armorPenetrationSharp>
+			<armorPenetrationBlunt>38.14</armorPenetrationBlunt>
+			<speed>164</speed>
+		</projectile>
+	</ThingDef>
+
+	<!-- Projectiles - Pistol -->
+
+	<ThingDef ParentName="Base66GreydaleBullet">
+		<defName>Bullet_66Greydale_FMJ_Pistol</defName>
+		<label>6.6mm GD Caseless bullet (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>12</damageAmountBase>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationBlunt>19</armorPenetrationBlunt>
+			<speed>103</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base66GreydaleBullet">
+		<defName>Bullet_66Greydale_AP_Pistol</defName>
+		<label>6.6mm GD Caseless bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>8</damageAmountBase>
+			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationBlunt>14.06</armorPenetrationBlunt>
+			<speed>103</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base66GreydaleBullet">
+		<defName>Bullet_66Greydale_HP_Pistol</defName>
+		<label>6.6mm GD Caseless bullet (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>15</damageAmountBase>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationBlunt>19</armorPenetrationBlunt>
+			<speed>103</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base66GreydaleBullet">
+		<defName>Bullet_66Greydale_Incendiary_Pistol</defName>
+		<label>6.6mm GD Caseless bullet (AP-I)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>8</damageAmountBase>
+			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationBlunt>19</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+					<def>Flame_Secondary</def>
+					<amount>5</amount>
+				</li>
+			</secondaryDamage>
+			<speed>103</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base66GreydaleBullet">
+		<defName>Bullet_66Greydale_HE_Pistol</defName>
+		<label>6.6mm GD Caseless bullet (HE)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>12</damageAmountBase>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationBlunt>19</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+					<def>Bomb_Secondary</def>
+					<amount>7</amount>
+				</li>
+			</secondaryDamage>
+			<speed>103</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base66GreydaleBullet">
+		<defName>Bullet_66Greydale_Sabot_Pistol</defName>
+		<label>6.6mm GD Caseless bullet (Sabot)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>6</damageAmountBase>
+			<armorPenetrationSharp>14</armorPenetrationSharp>
+			<armorPenetrationBlunt>21.46</armorPenetrationBlunt>
+			<speed>139</speed>
+		</projectile>
+	</ThingDef>
+
+	<!-- Projectiles - Hybrid -->
+
+	<ThingDef Name="Base66GreydaleBullet_Hybrid" ParentName="Base66GreydaleBullet" Abstract="True">
+		<graphicData>
+			<texPath>Things/Projectile/GbulletHybrid</texPath>
+		</graphicData>
+	</ThingDef>
+
+	<ThingDef ParentName="Base66GreydaleBullet_Hybrid">
+		<defName>Bullet_66Greydale_FMJ_Hybrid</defName>
+		<label>6.6mm GD Caseless bullet (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>21</damageAmountBase>
+			<armorPenetrationSharp>10</armorPenetrationSharp>
+			<armorPenetrationBlunt>94.46</armorPenetrationBlunt>
+			<speed>188</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base66GreydaleBullet_Hybrid">
+		<defName>Bullet_66Greydale_AP_Hybrid</defName>
+		<label>6.6mm GD Caseless bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>13</damageAmountBase>
+			<armorPenetrationSharp>20</armorPenetrationSharp>
+			<armorPenetrationBlunt>94.46</armorPenetrationBlunt>
+			<speed>188</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base66GreydaleBullet_Hybrid">
+		<defName>Bullet_66Greydale_HP_Hybrid</defName>
+		<label>6.6mm GD Caseless bullet (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>26</damageAmountBase>
+			<armorPenetrationSharp>5</armorPenetrationSharp>
+			<armorPenetrationBlunt>94.46</armorPenetrationBlunt>
+			<speed>188</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base66GreydaleBullet_Hybrid">
+		<defName>Bullet_66Greydale_Incendiary_Hybrid</defName>
+		<label>6.6mm GD Caseless bullet (AP-I)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>13</damageAmountBase>
+			<armorPenetrationSharp>20</armorPenetrationSharp>
+			<armorPenetrationBlunt>94.46</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+					<def>Flame_Secondary</def>
+					<amount>5</amount>
+				</li>
+			</secondaryDamage>
+			<speed>188</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base66GreydaleBullet_Hybrid">
+		<defName>Bullet_66Greydale_HE_Hybrid</defName>
+		<label>6.6mm GD Caseless bullet (HE)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>21</damageAmountBase>
+			<armorPenetrationSharp>10</armorPenetrationSharp>
+			<armorPenetrationBlunt>94.46</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+					<def>Bomb_Secondary</def>
+					<amount>7</amount>
+				</li>
+			</secondaryDamage>
+			<speed>188</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base66GreydaleBullet_Hybrid">
+		<defName>Bullet_66Greydale_Sabot_Hybrid</defName>
+		<label>6.6mm GD Caseless bullet (Sabot)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>11</damageAmountBase>
+			<armorPenetrationSharp>35</armorPenetrationSharp>
+			<armorPenetrationBlunt>106.88</armorPenetrationBlunt>
+			<speed>242</speed>
 		</projectile>
 	</ThingDef>
 
@@ -389,317 +683,5 @@
 		</products>
 		<workAmount>3200</workAmount>
 	</RecipeDef>
-
-	<!-- ==================== Carbine - AmmoSet ========================== -->
-
-	<CombatExtended.AmmoSetDef>
-		<defName>AmmoSet_66GreydaleSB</defName>
-		<label>6.6mm GD Caseless (Short Barrel)</label>
-		<ammoTypes>
-			<Ammo_66Greydale_FMJ>Bullet_66GreydaleSB_FMJ</Ammo_66Greydale_FMJ>
-			<Ammo_66Greydale_AP>Bullet_66GreydaleSB_AP</Ammo_66Greydale_AP>
-			<Ammo_66Greydale_HP>Bullet_66GreydaleSB_HP</Ammo_66Greydale_HP>
-			<Ammo_66Greydale_Incendiary>Bullet_66GreydaleSB_Incendiary</Ammo_66Greydale_Incendiary>
-			<Ammo_66Greydale_HE>Bullet_66GreydaleSB_HE</Ammo_66Greydale_HE>
-			<Ammo_66Greydale_Sabot>Bullet_66GreydaleSB_Sabot</Ammo_66Greydale_Sabot>
-		</ammoTypes>
-		<similarTo>AmmoSet_RifleIntermediate</similarTo>
-	</CombatExtended.AmmoSetDef>
-
-	<!-- ================== Projectiles ================== -->
-
-	<ThingDef ParentName="Base66GreydaleBullet">
-		<defName>Bullet_66GreydaleSB_FMJ</defName>
-		<label>6.6mm GD Caseless bullet (FMJ)</label>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>15</damageAmountBase>
-			<armorPenetrationSharp>5</armorPenetrationSharp>
-			<armorPenetrationBlunt>33.8</armorPenetrationBlunt>
-			<speed>128</speed>
-		</projectile>
-	</ThingDef>
-
-	<ThingDef ParentName="Base66GreydaleBullet">
-		<defName>Bullet_66GreydaleSB_AP</defName>
-		<label>6.6mm GD Caseless bullet (AP)</label>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>9</damageAmountBase>
-			<armorPenetrationSharp>12</armorPenetrationSharp>
-			<armorPenetrationBlunt>33.8</armorPenetrationBlunt>
-			<speed>128</speed>
-		</projectile>
-	</ThingDef>
-
-	<ThingDef ParentName="Base66GreydaleBullet">
-		<defName>Bullet_66GreydaleSB_HP</defName>
-		<label>6.6mm GD Caseless bullet (HP)</label>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>19</damageAmountBase>
-			<armorPenetrationSharp>3</armorPenetrationSharp>
-			<armorPenetrationBlunt>33.8</armorPenetrationBlunt>
-			<speed>128</speed>
-		</projectile>
-	</ThingDef>
-
-	<ThingDef ParentName="Base66GreydaleBullet">
-		<defName>Bullet_66GreydaleSB_Incendiary</defName>
-		<label>6.6mm GD Caseless bullet (AP-I)</label>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>9</damageAmountBase>
-			<armorPenetrationSharp>10</armorPenetrationSharp>
-			<armorPenetrationBlunt>33.8</armorPenetrationBlunt>
-			<secondaryDamage>
-				<li>
-					<def>Flame_Secondary</def>
-					<amount>5</amount>
-				</li>
-			</secondaryDamage>
-			<speed>128</speed>
-		</projectile>
-	</ThingDef>
-
-	<ThingDef ParentName="Base66GreydaleBullet">
-		<defName>Bullet_66GreydaleSB_HE</defName>
-		<label>6.6mm GD Caseless bullet (HE)</label>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>15</damageAmountBase>
-			<armorPenetrationSharp>5</armorPenetrationSharp>
-			<armorPenetrationBlunt>33.8</armorPenetrationBlunt>
-			<secondaryDamage>
-				<li>
-					<def>Bomb_Secondary</def>
-					<amount>7</amount>
-				</li>
-			</secondaryDamage>
-			<speed>128</speed>
-		</projectile>
-	</ThingDef>
-
-	<ThingDef ParentName="Base66GreydaleBullet">
-		<defName>Bullet_66GreydaleSB_Sabot</defName>
-		<label>6.6mm GD Caseless bullet (Sabot)</label>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>7</damageAmountBase>
-			<armorPenetrationSharp>18</armorPenetrationSharp>
-			<armorPenetrationBlunt>38.14</armorPenetrationBlunt>
-			<speed>164</speed>
-		</projectile>
-	</ThingDef>
-	
-	<!-- ==================== Pistol - AmmoSet ========================== -->
-
-	<CombatExtended.AmmoSetDef>
-		<defName>AmmoSet_66GreydalePistol</defName>
-		<label>6.6mm GD Caseless (Pistol)</label>
-		<ammoTypes>
-			<Ammo_66Greydale_FMJ>Bullet_66GreydalePistol_FMJ</Ammo_66Greydale_FMJ>
-			<Ammo_66Greydale_AP>Bullet_66GreydalePistol_AP</Ammo_66Greydale_AP>
-			<Ammo_66Greydale_HP>Bullet_66GreydalePistol_HP</Ammo_66Greydale_HP>
-			<Ammo_66Greydale_Incendiary>Bullet_66GreydalePistol_Incendiary</Ammo_66Greydale_Incendiary>
-			<Ammo_66Greydale_HE>Bullet_66GreydalePistol_HE</Ammo_66Greydale_HE>
-			<Ammo_66Greydale_Sabot>Bullet_66GreydalePistol_Sabot</Ammo_66Greydale_Sabot>
-		</ammoTypes>
-		<similarTo>AmmoSet_RifleIntermediate</similarTo>
-	</CombatExtended.AmmoSetDef>
-
-	<!-- ================== Projectiles ================== -->
-
-	<ThingDef ParentName="Base66GreydaleBullet">
-		<defName>Bullet_66GreydalePistol_FMJ</defName>
-		<label>6.6mm GD Caseless bullet (FMJ)</label>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>12</damageAmountBase>
-			<armorPenetrationSharp>4</armorPenetrationSharp>
-			<armorPenetrationBlunt>19</armorPenetrationBlunt>
-			<speed>103</speed>
-		</projectile>
-	</ThingDef>
-
-	<ThingDef ParentName="Base66GreydaleBullet">
-		<defName>Bullet_66GreydalePistol_AP</defName>
-		<label>6.6mm GD Caseless bullet (AP)</label>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>8</damageAmountBase>
-			<armorPenetrationSharp>8</armorPenetrationSharp>
-			<armorPenetrationBlunt>14.06</armorPenetrationBlunt>
-			<speed>103</speed>
-		</projectile>
-	</ThingDef>
-
-	<ThingDef ParentName="Base66GreydaleBullet">
-		<defName>Bullet_66GreydalePistol_HP</defName>
-		<label>6.6mm GD Caseless bullet (HP)</label>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>15</damageAmountBase>
-			<armorPenetrationSharp>2</armorPenetrationSharp>
-			<armorPenetrationBlunt>19</armorPenetrationBlunt>
-			<speed>129</speed>
-		</projectile>
-	</ThingDef>
-
-	<ThingDef ParentName="Base66GreydaleBullet">
-		<defName>Bullet_66GreydalePistol_Incendiary</defName>
-		<label>6.6mm GD Caseless bullet (AP-I)</label>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>8</damageAmountBase>
-			<armorPenetrationSharp>8</armorPenetrationSharp>
-			<armorPenetrationBlunt>19</armorPenetrationBlunt>
-			<secondaryDamage>
-				<li>
-					<def>Flame_Secondary</def>
-					<amount>5</amount>
-				</li>
-			</secondaryDamage>
-			<speed>129</speed>
-		</projectile>
-	</ThingDef>
-
-	<ThingDef ParentName="Base66GreydaleBullet">
-		<defName>Bullet_66GreydalePistol_HE</defName>
-		<label>6.6mm GD Caseless bullet (HE)</label>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>12</damageAmountBase>
-			<armorPenetrationSharp>4</armorPenetrationSharp>
-			<armorPenetrationBlunt>19</armorPenetrationBlunt>
-			<secondaryDamage>
-				<li>
-					<def>Bomb_Secondary</def>
-					<amount>7</amount>
-				</li>
-			</secondaryDamage>
-			<speed>129</speed>
-		</projectile>
-	</ThingDef>
-
-	<ThingDef ParentName="Base66GreydaleBullet">
-		<defName>Bullet_66GreydalePistol_Sabot</defName>
-		<label>6.6mm GD Caseless bullet (Sabot)</label>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>6</damageAmountBase>
-			<armorPenetrationSharp>14</armorPenetrationSharp>
-			<armorPenetrationBlunt>21.46</armorPenetrationBlunt>
-			<speed>175</speed>
-		</projectile>
-	</ThingDef>
-
-	<!-- ==================== Hybrid - AmmoSet ========================== -->
-
-	<CombatExtended.AmmoSetDef>
-		<defName>AmmoSet_66GreydaleHybrid</defName>
-		<label>6.6mm GD Caseless (Hybrid)</label>
-		<ammoTypes>
-			<Ammo_66Greydale_FMJ>Bullet_66GreydaleHybrid_FMJ</Ammo_66Greydale_FMJ>
-			<Ammo_66Greydale_AP>Bullet_66GreydaleHybrid_AP</Ammo_66Greydale_AP>
-			<Ammo_66Greydale_HP>Bullet_66GreydaleHybrid_HP</Ammo_66Greydale_HP>
-			<Ammo_66Greydale_Incendiary>Bullet_66GreydaleHybrid_Incendiary</Ammo_66Greydale_Incendiary>
-			<Ammo_66Greydale_HE>Bullet_66GreydaleHybrid_HE</Ammo_66Greydale_HE>
-			<Ammo_66Greydale_Sabot>Bullet_66GreydaleHybrid_Sabot</Ammo_66Greydale_Sabot>
-		</ammoTypes>
-		<similarTo>AmmoSet_RifleIntermediate</similarTo>
-	</CombatExtended.AmmoSetDef>
-
-	<!-- ================== Projectiles ================== -->
-
-	<ThingDef ParentName="Base66GreydaleBullet">
-		<graphicData>
-			<texPath>Things/Projectile/GbulletHybrid</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<defName>Bullet_66GreydaleHybrid_FMJ</defName>
-		<label>6.6mm GD Caseless bullet (FMJ)</label>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>21</damageAmountBase>
-			<armorPenetrationSharp>10</armorPenetrationSharp>
-			<armorPenetrationBlunt>94.46</armorPenetrationBlunt>
-			<speed>188</speed>
-		</projectile>
-	</ThingDef>
-
-	<ThingDef ParentName="Base66GreydaleBullet">
-		<graphicData>
-			<texPath>Things/Projectile/GbulletHybrid</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<defName>Bullet_66GreydaleHybrid_AP</defName>
-		<label>6.6mm GD Caseless bullet (AP)</label>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>13</damageAmountBase>
-			<armorPenetrationSharp>20</armorPenetrationSharp>
-			<armorPenetrationBlunt>94.46</armorPenetrationBlunt>
-			<speed>188</speed>
-		</projectile>
-	</ThingDef>
-
-	<ThingDef ParentName="Base66GreydaleBullet">
-		<graphicData>
-			<texPath>Things/Projectile/GbulletHybrid</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<defName>Bullet_66GreydaleHybrid_HP</defName>
-		<label>6.6mm GD Caseless bullet (HP)</label>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>26</damageAmountBase>
-			<armorPenetrationSharp>5</armorPenetrationSharp>
-			<armorPenetrationBlunt>94.46</armorPenetrationBlunt>
-			<speed>188</speed>
-		</projectile>
-	</ThingDef>
-
-	<ThingDef ParentName="Base66GreydaleBullet">
-		<graphicData>
-			<texPath>Things/Projectile/GbulletHybrid</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<defName>Bullet_66GreydaleHybrid_Incendiary</defName>
-		<label>6.6mm GD Caseless bullet (AP-I)</label>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>13</damageAmountBase>
-			<armorPenetrationSharp>20</armorPenetrationSharp>
-			<armorPenetrationBlunt>94.46</armorPenetrationBlunt>
-			<secondaryDamage>
-				<li>
-					<def>Flame_Secondary</def>
-					<amount>5</amount>
-				</li>
-			</secondaryDamage>
-			<speed>188</speed>
-		</projectile>
-	</ThingDef>
-
-	<ThingDef ParentName="Base66GreydaleBullet">
-		<graphicData>
-			<texPath>Things/Projectile/GbulletHybrid</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<defName>Bullet_66GreydaleHybrid_HE</defName>
-		<label>6.6mm GD Caseless bullet (HE)</label>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>21</damageAmountBase>
-			<armorPenetrationSharp>10</armorPenetrationSharp>
-			<armorPenetrationBlunt>94.46</armorPenetrationBlunt>
-			<secondaryDamage>
-				<li>
-					<def>Bomb_Secondary</def>
-					<amount>7</amount>
-				</li>
-			</secondaryDamage>
-			<speed>188</speed>
-		</projectile>
-	</ThingDef>
-
-	<ThingDef ParentName="Base66GreydaleBullet">
-		<graphicData>
-			<texPath>Things/Projectile/GbulletHybrid</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<defName>Bullet_66GreydaleHybrid_Sabot</defName>
-		<label>6.6mm GD Caseless bullet (Sabot)</label>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>11</damageAmountBase>
-			<armorPenetrationSharp>35</armorPenetrationSharp>
-			<armorPenetrationBlunt>106.88</armorPenetrationBlunt>
-			<speed>242</speed>
-		</projectile>
-	</ThingDef>
 
 </Defs>

--- a/ModPatches/Rimsenal Core/Defs/Rimsenal Core/Ammo_GD_Mauler.xml
+++ b/ModPatches/Rimsenal Core/Defs/Rimsenal Core/Ammo_GD_Mauler.xml
@@ -1,0 +1,397 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+	<ThingCategoryDef>
+		<defName>Ammo132Greydale</defName>
+		<label>13.2x77mm GD</label>
+		<parent>AmmoRifles</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberRifle</iconPath>
+	</ThingCategoryDef>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_132Greydale</defName>
+		<label>13.2x77mm GD</label>
+		<ammoTypes>
+			<Ammo_132Greydale_FMJ>Bullet_132Greydale_FMJ</Ammo_132Greydale_FMJ>
+			<Ammo_132Greydale_AP>Bullet_132Greydale_AP</Ammo_132Greydale_AP>
+			<Ammo_132Greydale_HP>Bullet_132Greydale_HP</Ammo_132Greydale_HP>
+			<Ammo_132Greydale_Incendiary>Bullet_132Greydale_Incendiary</Ammo_132Greydale_Incendiary>
+			<Ammo_132Greydale_HE>Bullet_132Greydale_HE</Ammo_132Greydale_HE>
+			<Ammo_132Greydale_Sabot>Bullet_132Greydale_Sabot</Ammo_132Greydale_Sabot>
+		</ammoTypes>
+		<similarTo>AmmoSet_RifleMagnum</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="132GreydaleBase" ParentName="SmallAmmoBase" Abstract="True">
+		<description>High caliber subsonic cartridge designed for suppressed fire.</description>
+		<statBases>
+			<Mass>0.08</Mass>
+			<Bulk>0.04</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
+		<thingCategories>
+			<li>Ammo132Greydale</li>
+		</thingCategories>
+		<stackLimit>5000</stackLimit>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="132GreydaleBase">
+		<defName>Ammo_132Greydale_FMJ</defName>
+		<label>13.2x77mm GD (FMJ)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/SovietLarge/FMJ</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<ammoClass>FullMetalJacket</ammoClass>
+		<cookOffProjectile>Bullet_132Greydale_FMJ</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="132GreydaleBase">
+		<defName>Ammo_132Greydale_AP</defName>
+		<label>13.2x77mm GD (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/SovietLarge/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_132Greydale_AP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="132GreydaleBase">
+		<defName>Ammo_132Greydale_HP</defName>
+		<label>13.2x77mm GD (HP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/SovietLarge/HP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<ammoClass>HollowPoint</ammoClass>
+		<cookOffProjectile>Bullet_132Greydale_HP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="132GreydaleBase">
+		<defName>Ammo_132Greydale_Incendiary</defName>
+		<label>13.2x77mm GD (AP-I)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/SovietLarge/Incendiary</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<ammoClass>IncendiaryAP</ammoClass>
+		<cookOffProjectile>Bullet_132Greydale_Incendiary</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="132GreydaleBase">
+		<defName>Ammo_132Greydale_HE</defName>
+		<label>13.2x77mm GD (AP-HE)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/SovietLarge/HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<ammoClass>ExplosiveAP</ammoClass>
+		<cookOffProjectile>Bullet_132Greydale_HE</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="132GreydaleBase">
+		<defName>Ammo_132Greydale_Sabot</defName>
+		<label>13.2x77mm GD (Sabot)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/SovietLarge/Sabot</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<Mass>0.054</Mass>
+		</statBases>
+		<ammoClass>Sabot</ammoClass>
+		<cookOffProjectile>Bullet_132Greydale_Sabot</cookOffProjectile>
+	</ThingDef>
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef Name="Base132GreydaleBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_Amarok</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>69</speed>
+			<dropsCasings>true</dropsCasings>
+			<casingMoteDefname>Fleck_RifleAmmoCasings_HighCal</casingMoteDefname>
+			<casingFilthDefname>Filth_RifleAmmoCasings_HighCal</casingFilthDefname>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base132GreydaleBullet">
+		<defName>Bullet_132Greydale_FMJ</defName>
+		<label>13.2mm bullet (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>23</damageAmountBase>
+			<armorPenetrationSharp>7</armorPenetrationSharp>
+			<armorPenetrationBlunt>62.72</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base132GreydaleBullet">
+		<defName>Bullet_132Greydale_AP</defName>
+		<label>13.2mm bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>14</damageAmountBase>
+			<armorPenetrationSharp>14</armorPenetrationSharp>
+			<armorPenetrationBlunt>62.72</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base132GreydaleBullet">
+		<defName>Bullet_132Greydale_HP</defName>
+		<label>13.2mm bullet (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>29</damageAmountBase>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationBlunt>62.72</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base132GreydaleBullet">
+		<defName>Bullet_132Greydale_Incendiary</defName>
+		<label>13.2mm bullet (AP-I)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>14</damageAmountBase>
+			<secondaryDamage>
+				<li>
+					<def>Flame_Secondary</def>
+					<amount>20</amount>
+				</li>
+			</secondaryDamage>
+			<armorPenetrationSharp>14</armorPenetrationSharp>
+			<armorPenetrationBlunt>62.72</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base132GreydaleBullet">
+		<defName>Bullet_132Greydale_HE</defName>
+		<label>13.2mm bullet (AP-HE)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>23</damageAmountBase>
+			<secondaryDamage>
+				<li>
+					<def>Bomb_Secondary</def>
+					<amount>27</amount>
+				</li>
+			</secondaryDamage>
+			<armorPenetrationSharp>7</armorPenetrationSharp>
+			<armorPenetrationBlunt>62.72</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base132GreydaleBullet">
+		<defName>Bullet_132Greydale_Sabot</defName>
+		<label>13.2mm bullet (Sabot)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>11</damageAmountBase>
+			<armorPenetrationSharp>24</armorPenetrationSharp>
+			<armorPenetrationBlunt>69.36</armorPenetrationBlunt>
+			<speed>80</speed>
+		</projectile>
+	</ThingDef>
+
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_132Greydale_FMJ</defName>
+		<label>make 13.2x77mm GD (FMJ) cartridge x500</label>
+		<description>Craft 500 13.2x77mm GD (FMJ) cartridges.</description>
+		<jobString>Making 13.2x77mm GD (FMJ) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>42</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_132Greydale_FMJ>200</Ammo_132Greydale_FMJ>
+		</products>
+		<workAmount>4200</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_132Greydale_AP</defName>
+		<label>make 13.2x77mm GD (AP) cartridge x500</label>
+		<description>Craft 500 13.2x77mm GD (AP) cartridges.</description>
+		<jobString>Making 13.2x77mm GD (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>42</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_132Greydale_AP>200</Ammo_132Greydale_AP>
+		</products>
+		<workAmount>5040</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_132Greydale_HP</defName>
+		<label>make 13.2x77mm GD (HP) cartridge x500</label>
+		<description>Craft 500 13.2x77mm GD (HP) cartridges.</description>
+		<jobString>Making 13.2x77mm GD (HP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>42</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_132Greydale_HP>200</Ammo_132Greydale_HP>
+		</products>
+		<workAmount>8200</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_132Greydale_Incendiary</defName>
+		<label>make 13.2x77mm GD cartridge (AP-I) cartridge x500</label>
+		<description>Craft 500 13.2x77mm GD cartridge (AP-I) cartridge.</description>
+		<jobString>Making 13.2x77mm GD cartridge (AP-I) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>42</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Prometheum</li>
+					</thingDefs>
+				</filter>
+				<count>8</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Prometheum</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_132Greydale_Incendiary>200</Ammo_132Greydale_Incendiary>
+		</products>
+		<workAmount>7400</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_132Greydale_HE</defName>
+		<label>make 13.2x77mm GD cartridge (AP-HE) cartridge x200</label>
+		<description>Craft 200 13.2x77mm GD cartridge (AP-HE) cartridge.</description>
+		<jobString>Making 13.2x77mm GD cartridge (AP-HE) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>42</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>FSX</li>
+					</thingDefs>
+				</filter>
+				<count>16</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>FSX</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_132Greydale_HE>200</Ammo_132Greydale_HE>
+		</products>
+		<workAmount>10600</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_132Greydale_Sabot</defName>
+		<label>make 13.2x77mm GD cartridge (Sabot) cartridge x500</label>
+		<description>Craft 500 13.2x77mm GD cartridge (Sabot) cartridge.</description>
+		<jobString>Making 13.2x77mm GD cartridge (Sabot) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>10</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Uranium</li>
+					</thingDefs>
+				</filter>
+				<count>15</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Chemfuel</li>
+					</thingDefs>
+				</filter>
+				<count>15</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Uranium</li>
+				<li>Chemfuel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_132Greydale_Sabot>200</Ammo_132Greydale_Sabot>
+		</products>
+		<workAmount>10000</workAmount>
+	</RecipeDef>
+
+</Defs>

--- a/ModPatches/Rimsenal Core/Patches/Rimsenal Core/Apparel_RS_CE.xml
+++ b/ModPatches/Rimsenal Core/Patches/Rimsenal Core/Apparel_RS_CE.xml
@@ -564,7 +564,8 @@
 		<xpath>Defs/ThingDef[defName="Apparel_NomadH"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
 		<value>
 			<SmokeSensitivity>-1</SmokeSensitivity>
-			<AimingAccuracy>0.15</AimingAccuracy>
+			<AimingAccuracy>0.40</AimingAccuracy>
+			<ShootingAccuracyPawn>0.8</ShootingAccuracyPawn>
 		</value>
 	</Operation>
 

--- a/ModPatches/Rimsenal Core/Patches/Rimsenal Core/Weapons_GD_CE.xml
+++ b/ModPatches/Rimsenal Core/Patches/Rimsenal Core/Weapons_GD_CE.xml
@@ -13,10 +13,11 @@
 
 	<!-- Pistols -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="GD_MSSH" or
+		<xpath>Defs/ThingDef[
+			defName="GD_MSSH" or
 			defName="GD_MSST" or
 			defName="GD_MSSF"
-			]/tools </xpath>
+			]/tools</xpath>
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
@@ -46,13 +47,14 @@
 
 	<!-- Long guns-->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="GD_HybridRifle" or
+		<xpath>Defs/ThingDef[
+			defName="GD_HybridRifle" or
 			defName="GD_ModularCarbine" or
 			defName="GD_ModularRifle" or
 			defName="GD_ModularDMR" or
 			defName="GD_ModularLMG" or
 			defName="GD_GrenadeLauncher"
-			]/tools </xpath>
+			]/tools</xpath>
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
@@ -105,7 +107,7 @@
 			<recoilAmount>2.00</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_66GreydaleHybrid_FMJ</defaultProjectile>
+			<defaultProjectile>Bullet_66Greydale_FMJ_Hybrid</defaultProjectile>
 			<warmupTime>1.05</warmupTime>
 			<range>58</range>
 			<burstShotCount>6</burstShotCount>
@@ -117,7 +119,7 @@
 		<AmmoUser>
 			<magazineSize>36</magazineSize>
 			<reloadTime>4</reloadTime>
-			<ammoSet>AmmoSet_66GreydaleHybrid</ammoSet>
+			<ammoSet>AmmoSet_66Greydale_Hybrid</ammoSet>
 		</AmmoUser>
 		<FireModes>
 			<aimedBurstShotCount>3</aimedBurstShotCount>
@@ -133,7 +135,7 @@
 		</value>
 	</Operation>
 
-	<!-- ==========  Hybrid Ocelot =========== -->
+	<!-- ========== Hybrid Ocelot =========== -->
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>GD_MSSH</defName>
 		<statBases>
@@ -149,7 +151,7 @@
 			<recoilAmount>2.92</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_66GreydaleHybrid_FMJ</defaultProjectile>
+			<defaultProjectile>Bullet_66Greydale_FMJ_Hybrid</defaultProjectile>
 			<warmupTime>0.65</warmupTime>
 			<range>23</range>
 			<soundCast>ShotGRH</soundCast>
@@ -159,7 +161,7 @@
 		<AmmoUser>
 			<magazineSize>12</magazineSize>
 			<reloadTime>3.5</reloadTime>
-			<ammoSet>AmmoSet_66GreydaleHybrid</ammoSet>
+			<ammoSet>AmmoSet_66Greydale_Hybrid</ammoSet>
 		</AmmoUser>
 		<FireModes>
 		</FireModes>
@@ -190,7 +192,7 @@
 			<recoilAmount>1.27</recoilAmount><!--Halved from base-->
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_66GreydalePistol_FMJ</defaultProjectile>
+			<defaultProjectile>Bullet_66Greydale_FMJ_Pistol</defaultProjectile>
 			<warmupTime>0.6</warmupTime>
 			<burstShotCount>3</burstShotCount>
 			<ticksBetweenBurstShots>1</ticksBetweenBurstShots>
@@ -203,7 +205,7 @@
 		<AmmoUser>
 			<magazineSize>12</magazineSize>
 			<reloadTime>3.5</reloadTime>
-			<ammoSet>AmmoSet_66GreydalePistol</ammoSet>
+			<ammoSet>AmmoSet_66Greydale_Pistol</ammoSet>
 		</AmmoUser>
 		<FireModes>
 			<noSingleShot>true</noSingleShot>
@@ -256,7 +258,7 @@
 					<recoilAmount>2.31</recoilAmount>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
-					<defaultProjectile>Bullet_66GreydalePistol_FMJ</defaultProjectile>
+					<defaultProjectile>Bullet_66Greydale_FMJ_Pistol</defaultProjectile>
 					<warmupTime>0.6</warmupTime>
 					<burstShotCount>5</burstShotCount>
 					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
@@ -276,7 +278,7 @@
 				<li Class="CombatExtended.CompProperties_AmmoUser">
 					<magazineSize>36</magazineSize>
 					<reloadTime>4</reloadTime>
-					<ammoSet>AmmoSet_66GreydalePistol</ammoSet>
+					<ammoSet>AmmoSet_66Greydale_Pistol</ammoSet>
 				</li>
 				<li Class="CombatExtended.CompProperties_FireModes">
 					<aimedBurstShotCount>3</aimedBurstShotCount>
@@ -406,7 +408,7 @@
 			<recoilAmount>2.06</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_66GreydaleSB_FMJ</defaultProjectile>
+			<defaultProjectile>Bullet_66Greydale_FMJ_SB</defaultProjectile>
 			<warmupTime>0.85</warmupTime>
 			<range>36</range>
 			<burstShotCount>6</burstShotCount>
@@ -418,7 +420,7 @@
 		<AmmoUser>
 			<magazineSize>36</magazineSize>
 			<reloadTime>4</reloadTime>
-			<ammoSet>AmmoSet_66GreydaleSB</ammoSet>
+			<ammoSet>AmmoSet_66Greydale_SB</ammoSet>
 		</AmmoUser>
 		<FireModes>
 			<aiUseBurstMode>false</aiUseBurstMode>

--- a/ModPatches/Rimsenal Core/Patches/Rimsenal Core/Weapons_GD_CE.xml
+++ b/ModPatches/Rimsenal Core/Patches/Rimsenal Core/Weapons_GD_CE.xml
@@ -102,22 +102,22 @@
 			<Bulk>9.6</Bulk>
 		</statBases>
 		<Properties>
-			<recoilAmount>1.34</recoilAmount>
+			<recoilAmount>2.00</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_473x33mmGDHybrid_FMJ</defaultProjectile>
+			<defaultProjectile>Bullet_66GreydaleHybrid_FMJ</defaultProjectile>
 			<warmupTime>1.05</warmupTime>
 			<range>58</range>
 			<burstShotCount>6</burstShotCount>
-			<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+			<ticksBetweenBurstShots>7</ticksBetweenBurstShots>
 			<soundCast>ShotGRH</soundCast>
 			<soundCastTail>GunTail_Medium</soundCastTail>
 			<muzzleFlashScale>9</muzzleFlashScale>
 		</Properties>
 		<AmmoUser>
-			<magazineSize>45</magazineSize>
+			<magazineSize>36</magazineSize>
 			<reloadTime>4</reloadTime>
-			<ammoSet>AmmoSet_473x33mmCaseless_GDHybrid</ammoSet>
+			<ammoSet>AmmoSet_66GreydaleHybrid</ammoSet>
 		</AmmoUser>
 		<FireModes>
 			<aimedBurstShotCount>3</aimedBurstShotCount>
@@ -146,9 +146,10 @@
 			<RangedWeapon_Cooldown>0.33</RangedWeapon_Cooldown>
 		</statBases>
 		<Properties>
+			<recoilAmount>2.92</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_473x33mmGDHybrid_FMJ</defaultProjectile>
+			<defaultProjectile>Bullet_66GreydaleHybrid_FMJ</defaultProjectile>
 			<warmupTime>0.65</warmupTime>
 			<range>23</range>
 			<soundCast>ShotGRH</soundCast>
@@ -156,9 +157,9 @@
 			<muzzleFlashScale>12</muzzleFlashScale>
 		</Properties>
 		<AmmoUser>
-			<magazineSize>15</magazineSize>
+			<magazineSize>12</magazineSize>
 			<reloadTime>3.5</reloadTime>
-			<ammoSet>AmmoSet_473x33mmCaseless_GDHybrid</ammoSet>
+			<ammoSet>AmmoSet_66GreydaleHybrid</ammoSet>
 		</AmmoUser>
 		<FireModes>
 		</FireModes>
@@ -186,10 +187,10 @@
 			<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 		</statBases>
 		<Properties>
-			<recoilAmount>1.12</recoilAmount><!--Halved from base-->
+			<recoilAmount>1.27</recoilAmount><!--Halved from base-->
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_473x33mmGDPistol_FMJ</defaultProjectile>
+			<defaultProjectile>Bullet_66GreydalePistol_FMJ</defaultProjectile>
 			<warmupTime>0.6</warmupTime>
 			<burstShotCount>3</burstShotCount>
 			<ticksBetweenBurstShots>1</ticksBetweenBurstShots>
@@ -200,9 +201,9 @@
 			<recoilPattern>Mounted</recoilPattern>
 		</Properties>
 		<AmmoUser>
-			<magazineSize>15</magazineSize>
+			<magazineSize>12</magazineSize>
 			<reloadTime>3.5</reloadTime>
-			<ammoSet>AmmoSet_473x33mmCaseless_GDPistol</ammoSet>
+			<ammoSet>AmmoSet_66GreydalePistol</ammoSet>
 		</AmmoUser>
 		<FireModes>
 			<noSingleShot>true</noSingleShot>
@@ -252,10 +253,10 @@
 		<value>
 			<verbs>
 				<li Class="CombatExtended.VerbPropertiesCE">
-					<recoilAmount>2.04</recoilAmount>
+					<recoilAmount>2.31</recoilAmount>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
-					<defaultProjectile>Bullet_473x33mmGDPistol_FMJ</defaultProjectile>
+					<defaultProjectile>Bullet_66GreydalePistol_FMJ</defaultProjectile>
 					<warmupTime>0.6</warmupTime>
 					<burstShotCount>5</burstShotCount>
 					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
@@ -273,9 +274,9 @@
 		<value>
 			<comps>
 				<li Class="CombatExtended.CompProperties_AmmoUser">
-					<magazineSize>45</magazineSize>
+					<magazineSize>36</magazineSize>
 					<reloadTime>4</reloadTime>
-					<ammoSet>AmmoSet_473x33mmCaseless_GDPistol</ammoSet>
+					<ammoSet>AmmoSet_66GreydalePistol</ammoSet>
 				</li>
 				<li Class="CombatExtended.CompProperties_FireModes">
 					<aimedBurstShotCount>3</aimedBurstShotCount>
@@ -348,6 +349,7 @@
 			<RangedWeapon_Cooldown>1.06</RangedWeapon_Cooldown>
 		</statBases>
 		<Properties>
+			<recoilAmount>3.65</recoilAmount><!--Halved from base-->
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_25x40mmGrenade_HE</defaultProjectile>
@@ -401,12 +403,12 @@
 			<Chemfuel>10</Chemfuel>
 		</costList>
 		<Properties>
-			<recoilAmount>1.56</recoilAmount>
+			<recoilAmount>2.06</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_473x33mmCaseless_FMJ</defaultProjectile>
+			<defaultProjectile>Bullet_66GreydaleSB_FMJ</defaultProjectile>
 			<warmupTime>0.85</warmupTime>
-			<range>40</range>
+			<range>36</range>
 			<burstShotCount>6</burstShotCount>
 			<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
 			<soundCast>ShotGRC</soundCast>
@@ -414,9 +416,9 @@
 			<muzzleFlashScale>11</muzzleFlashScale>
 		</Properties>
 		<AmmoUser>
-			<magazineSize>45</magazineSize>
+			<magazineSize>36</magazineSize>
 			<reloadTime>4</reloadTime>
-			<ammoSet>AmmoSet_473x33mmCaseless</ammoSet>
+			<ammoSet>AmmoSet_66GreydaleSB</ammoSet>
 		</AmmoUser>
 		<FireModes>
 			<aiUseBurstMode>false</aiUseBurstMode>
@@ -437,10 +439,10 @@
 			<Bulk>9.45</Bulk>
 		</statBases>
 		<Properties>
-			<recoilAmount>1.32</recoilAmount>
+			<recoilAmount>2.00</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_473x33mmCaseless_FMJ</defaultProjectile>
+			<defaultProjectile>Bullet_66Greydale_FMJ</defaultProjectile>
 			<warmupTime>1.2</warmupTime>
 			<range>62</range>
 			<burstShotCount>6</burstShotCount>
@@ -450,9 +452,9 @@
 			<muzzleFlashScale>7</muzzleFlashScale>
 		</Properties>
 		<AmmoUser>
-			<magazineSize>45</magazineSize>
+			<magazineSize>36</magazineSize>
 			<reloadTime>4</reloadTime>
-			<ammoSet>AmmoSet_473x33mmCaseless</ammoSet>
+			<ammoSet>AmmoSet_66Greydale</ammoSet>
 		</AmmoUser>
 		<FireModes>
 			<aimedBurstShotCount>3</aimedBurstShotCount>
@@ -527,23 +529,23 @@
 			<Bulk>11.85</Bulk>
 		</statBases>
 		<Properties>
-			<recoilAmount>0.12</recoilAmount><!--Further reduction of the recoil from 0.2x to 0.1x to facilitate aimed shots a bit better-->
+			<recoilAmount>1.87</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_473x33mmCaseless_FMJ</defaultProjectile>
+			<defaultProjectile>Bullet_66Greydale_FMJ</defaultProjectile>
 			<warmupTime>1.9</warmupTime>
 			<range>81</range>
 			<burstShotCount>3</burstShotCount>
-			<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+			<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
 			<soundCast>ShotGRM</soundCast>
 			<soundCastTail>GunTail_Heavy</soundCastTail>
 			<muzzleFlashScale>9</muzzleFlashScale>
 			<recoilPattern>Mounted</recoilPattern>
 		</Properties>
 		<AmmoUser>
-			<magazineSize>45</magazineSize>
+			<magazineSize>36</magazineSize>
 			<reloadTime>4</reloadTime>
-			<ammoSet>AmmoSet_473x33mmCaseless</ammoSet>
+			<ammoSet>AmmoSet_66Greydale</ammoSet>
 		</AmmoUser>
 		<FireModes>
 			<aimedBurstShotCount>2</aimedBurstShotCount>
@@ -576,10 +578,10 @@
 			<Bulk>11.75</Bulk>
 		</statBases>
 		<Properties>
-			<recoilAmount>0.87</recoilAmount>
+			<recoilAmount>1.40</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_473x33mmCaseless_FMJ</defaultProjectile>
+			<defaultProjectile>Bullet_66Greydale_FMJ</defaultProjectile>
 			<warmupTime>1.3</warmupTime>
 			<range>67</range>
 			<burstShotCount>10</burstShotCount>
@@ -593,9 +595,9 @@
 			<recoilPattern>Mounted</recoilPattern>
 		</Properties>
 		<AmmoUser>
-			<magazineSize>150</magazineSize>
+			<magazineSize>108</magazineSize>
 			<reloadTime>7.8</reloadTime>
-			<ammoSet>AmmoSet_473x33mmCaseless</ammoSet>
+			<ammoSet>AmmoSet_66Greydale</ammoSet>
 		</AmmoUser>
 		<FireModes>
 			<aimedBurstShotCount>5</aimedBurstShotCount>

--- a/ModPatches/Rimsenal Xenotype Pack - Zohar/Patches/Rimsenal Xenotype Pack - Zohar/Weapons_Zohar_CE.xml
+++ b/ModPatches/Rimsenal Xenotype Pack - Zohar/Patches/Rimsenal Xenotype Pack - Zohar/Weapons_Zohar_CE.xml
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Rimsenal - Core</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- ==========  GD CQC Gun =========== -->
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="GD_Amarok"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>stock</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>8</power>
+								<cooldownTime>1.55</cooldownTime>
+								<chanceFactor>1.5</chanceFactor>
+								<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>barrel</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>5</power>
+								<cooldownTime>2.02</cooldownTime>
+								<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>muzzle</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>8</power>
+								<cooldownTime>1.55</cooldownTime>
+								<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+							</li>
+						</tools>
+					</value>
+				</li>
+
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>GD_Amarok</defName>
+					<statBases>
+						<SightsEfficiency>1.1</SightsEfficiency>
+						<ShotSpread>0.2</ShotSpread>
+						<SwayFactor>1.57</SwayFactor>
+						<Bulk>10.75</Bulk>
+						<Mass>5.00</Mass>
+						<RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
+					</statBases>
+					<Properties>
+						<recoilAmount>2.99</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_132Greydale_FMJ</defaultProjectile>
+						<warmupTime>1</warmupTime>
+						<burstShotCount>5</burstShotCount>
+						<ticksBetweenBurstShots>12</ticksBetweenBurstShots>
+						<range>31</range>
+						<soundCast>GunShotA</soundCast>
+						<soundCastTail>GunTail_Heavy</soundCastTail>
+						<muzzleFlashScale>0</muzzleFlashScale>
+					</Properties>					
+					<AmmoUser>
+						<magazineSize>18</magazineSize>
+						<reloadTime>4</reloadTime>
+						<ammoSet>AmmoSet_132Greydale</ammoSet>
+					</AmmoUser>
+					<FireModes>
+						<aimedBurstShotCount>3</aimedBurstShotCount>
+						<aiAimMode>Snapshot</aiAimMode>
+					</FireModes>
+					<weaponTags>
+						<li>CE_AI_AR</li>
+					</weaponTags>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="GD_Amarok"]/comps/li[@Class="CompProperties_EquippableAbilityReloadable"]/ammoDef</xpath>
+					<value>
+						<ammoDef>MSSKit</ammoDef>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Grenade_MicroTurret"]/thingClass</xpath>
+					<value>
+						<thingClass>CombatExtended.ProjectileCE_SpawnsThing</thingClass>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Grenade_MicroTurret"]/projectile</xpath>
+					<value>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<dropsCasings>false</dropsCasings>
+							<dangerFactor>0</dangerFactor>
+							<airborneSuppressionFactor>0</airborneSuppressionFactor>
+							<speed>12</speed>
+							<spawnsThingDef>Turret_MicroTurret</spawnsThingDef>
+						</projectile>
+					</value>
+				</li>
+				
+				<!-- ========== Micro-Turret ========== -->
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Turret_MicroTurret"]/thingClass</xpath>
+					<value>
+						<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Turret_MicroTurret"]/statBases</xpath>
+					<value>
+						<AimingAccuracy>0.25</AimingAccuracy>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Turret_MicroTurret"]/statBases/ShootingAccuracyTurret</xpath>
+					<value>
+						<ShootingAccuracyTurret>0.5</ShootingAccuracyTurret>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Turret_MicroTurret"]/fillPercent</xpath>
+					<value>
+						<fillPercent>0.85</fillPercent>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Turret_MicroTurret"]/building/turretBurstCooldownTime</xpath>
+					<value>
+						<turretBurstCooldownTime>0.38</turretBurstCooldownTime>
+					</value>
+				</li>
+				
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>Gun_MicroTurret</defName>
+					<statBases>
+						<SightsEfficiency>1.0</SightsEfficiency>
+						<ShotSpread>0.16</ShotSpread>
+						<SwayFactor>0.40</SwayFactor>
+						<Bulk>3.00</Bulk>
+						<Mass>1.25</Mass>
+						<RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
+					</statBases>
+					<Properties>
+						<recoilAmount>2.26</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_66GreydalePistol_FMJ</defaultProjectile>
+						<warmupTime>0.6</warmupTime>
+						<burstShotCount>1</burstShotCount>
+						<ticksBetweenBurstShots>1</ticksBetweenBurstShots>
+						<range>18</range>
+						<soundCast>GunShotA</soundCast>
+						<soundCastTail>GunTail_Light</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+						<recoilPattern>Mounted</recoilPattern>
+					</Properties>
+					<AmmoUser>
+						<magazineSize>36</magazineSize>
+						<reloadTime>4</reloadTime>
+						<ammoSet>AmmoSet_66GreydalePistol</ammoSet>
+					</AmmoUser>
+					<FireModes>
+						<aiAimMode>AimedShot</aiAimMode>
+						<noSnapshot>true</noSnapshot>
+					</FireModes>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/ModPatches/Rimsenal Xenotype Pack - Zohar/Patches/Rimsenal Xenotype Pack - Zohar/Weapons_Zohar_CE.xml
+++ b/ModPatches/Rimsenal Xenotype Pack - Zohar/Patches/Rimsenal Xenotype Pack - Zohar/Weapons_Zohar_CE.xml
@@ -163,7 +163,7 @@
 						<recoilAmount>2.26</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
-						<defaultProjectile>Bullet_66GreydalePistol_FMJ</defaultProjectile>
+						<defaultProjectile>Bullet_66Greydale_FMJ_Pistol</defaultProjectile>
 						<warmupTime>0.6</warmupTime>
 						<burstShotCount>1</burstShotCount>
 						<ticksBetweenBurstShots>1</ticksBetweenBurstShots>
@@ -176,7 +176,7 @@
 					<AmmoUser>
 						<magazineSize>36</magazineSize>
 						<reloadTime>4</reloadTime>
-						<ammoSet>AmmoSet_66GreydalePistol</ammoSet>
+						<ammoSet>AmmoSet_66Greydale_Pistol</ammoSet>
 					</AmmoUser>
 					<FireModes>
 						<aiAimMode>AimedShot</aiAimMode>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -502,6 +502,7 @@ Rimsenal - Security Pack |
 Rimsenal - Spacer Faction Pack  |
 Rimsenal Xenotype Pack - Askbarn    |
 Rimsenal Xenotype Pack - Harana |
+Rimsenal Xenotype Pack - Zohar  |
 RimTraits - General Traits  |
 RimTraits – Medieval Talents    |
 Rimworld - The Dark Descent |


### PR DESCRIPTION
## Additions

Patch for Rimsenal Xenotype Pack - Zohar
New ammo types and set defs for rimsenal core, as the zohar mod gun requires rimsenal core to load in the first place, and all assets bar the gun itself are included in core pack too.

## Changes

GD Modular weapons have been standardized to a new GD 6.6mm caseless ammo type. Ammo count generally reduced across the board and the significant difference in properties means the recoil's shot way up but that's what happens when you have a featherweight carbine.

Also buffed the nomad helmet since it has +2 aiming accuracy in vanilla, so brought it up a bit closer to gunlink performace including handling offset.

## Reasoning

Mauler is a high damage suppressed gun. It's 17 damage in vanilla which is quite a lot, so it's been given effectively a round simmilar to 12.7x55. Properties are a little different to make it specifically a pain to handle, even compared to the now amped up 6.6mm caseless.

New information from the xenotype mod indicates the Greydale stuff uses some form of 6.6mm caseless. Mostly this means that the default round is now much closer to a battle rifle, which paired with their low weight across the board means they're somewhat hard to handle in full auto but yeah.

The turret deploy doesn't use the underbarrel comp since it's a bit excessive and it isn't really a regular underbarrel for the turret launcher ability.

## Alternatives

Leave ammo as is and make the Zohar gun use a conventional ammo.

Switch turret launch ability to underbarrel.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
