### PR TITLE
Vary human hitbox size with body size

### DIFF
--- a/Languages/English/Keyed/Keys.xml
+++ b/Languages/English/Keyed/Keys.xml
@@ -11,6 +11,7 @@
 	<CE_SuppressedMote>Suppressed!</CE_SuppressedMote>
 	<CE_HunkeringMote>Hunkering!</CE_HunkeringMote>
 	<CE_CrouchWalking>Suppressed (crouch-walking)</CE_CrouchWalking>
+	<CE_Crouched>(Crouched)</CE_Crouched>
 
 	<!-- Aim/Fire modes -->
 	<CE_AutoFireLabel>Auto</CE_AutoFireLabel>

--- a/Languages/English/Keyed/ModMenu.xml
+++ b/Languages/English/Keyed/ModMenu.xml
@@ -54,6 +54,9 @@
 	<CE_Settings_RecoilAnim_Title>Show recoil animations</CE_Settings_RecoilAnim_Title>
 	<CE_Settings_RecoilAnim_Desc>When enabled, ranged weapons and turrets will play recoil animations when they fire.</CE_Settings_RecoilAnim_Desc>
 
+	<CE_Settings_VariedHumanHeight_Title>Enable varied human height</CE_Settings_VariedHumanHeight_Title>
+	<CE_Settings_VariedHumanHeight_Desc>When enabled, certain humans, such as children or tall xenotypes, will have their height and width adjusted according to body size.\n\nThis can mean that small pawns might be unable to shoot over tall cover, and some tall pawns will be less protected by cover and easier to hit with ranged weapons.\n\nWhen disabled, all humans will be 1.75 m tall regardless of body size.</CE_Settings_VariedHumanHeight_Desc>
+
 	<!-- ========== Ammo settings ========== -->
 
 	<CE_Settings_EnableAmmoSystem_Title>Enable ammunition system</CE_Settings_EnableAmmoSystem_Title>

--- a/Source/CombatExtended/CombatExtended/BoundsInjector.cs
+++ b/Source/CombatExtended/CombatExtended/BoundsInjector.cs
@@ -302,7 +302,21 @@ public static class BoundsInjector
     {
         if (pawn.RaceProps.Humanlike)
         {
-            return new Vector2(0.5f, 1);
+            if (!Controller.settings.VariedHumanHeight)
+            {
+                return new Vector2(0.5f, 1);
+            }
+
+            //limit humans to never be taller than 3.5m (wall height)
+            float height = Mathf.Min(pawn.BodySize, 2.0f);
+
+            //slight height increase so that 13 y.o. can aim over embrasures and 8 y.o. can aim over sandbags
+            if (height < 1)
+            {
+                height = Mathf.Min(height+0.2f, 1);
+            }
+
+            return new Vector2(pawn.BodySize / 2f, height);
 
             // Disabling sprite bounds for humans for balance and game design reasons -NIA
             /*

--- a/Source/CombatExtended/CombatExtended/ModSettings/Settings.cs
+++ b/Source/CombatExtended/CombatExtended/ModSettings/Settings.cs
@@ -47,6 +47,8 @@ public class Settings : ModSettings, ISettingsCE
 
     private float medicineSearchRadius = 5f;
 
+    private bool variedHumanHeight = false;
+
     public bool ShowCasings => showCasings;
 
     public bool BipodMechanics => bipodMechanics;
@@ -74,6 +76,8 @@ public class Settings : ModSettings, ISettingsCE
     public float MedicineSearchRadiusSquared => medicineSearchRadius * medicineSearchRadius;
 
     public bool ShowTutorialPopup = true;
+
+    public bool VariedHumanHeight => variedHumanHeight;
 
     // Ammo settings
     private bool enableAmmoSystem = true;
@@ -190,7 +194,7 @@ public class Settings : ModSettings, ISettingsCE
         Scribe_Values.Look(ref enableArcOfFire, "enableArcOfFire", false);
 
         Scribe_Values.Look(ref showExtraStats, "showExtraStats", false);
-
+        Scribe_Values.Look(ref variedHumanHeight, "variedHumanHeight", false);
 
 #if DEBUG
         // Debug settings
@@ -367,6 +371,7 @@ public class Settings : ModSettings, ISettingsCE
         list.CheckboxLabeled("CE_Settings_ShowExtraTooltips_Title".Translate(), ref showExtraTooltips, "CE_Settings_ShowExtraTooltips_Desc".Translate());
         list.CheckboxLabeled("CE_Settings_ShowExtraStats_Title".Translate(), ref showExtraStats, "CE_Settings_ShowExtraStats_Desc".Translate());
         list.CheckboxLabeled("CE_Settings_DetailedMeleeTooltip_Title".Translate(), ref detailedMeleeTooltip, "CE_Settings_DetailedMeleeTooltip_Desc".Translate());
+        list.CheckboxLabeled("CE_Settings_VariedHumanHeight_Title".Translate(), ref variedHumanHeight, "CE_Settings_VariedHumanHeight_Desc".Translate());
         list.Gap();
         list.GapLine();
         list.Gap();
@@ -518,6 +523,7 @@ public class Settings : ModSettings, ISettingsCE
         enableWeaponToughnessAutopatcher = true;
         enableRaceAutopatcher = true;
         enablePawnKindAutopatcher = true;
+        variedHumanHeight = false;
 
 #if DEBUG
         debuggingMode = false;

--- a/Source/CombatExtended/CombatExtended/ShiftVecReport.cs
+++ b/Source/CombatExtended/CombatExtended/ShiftVecReport.cs
@@ -262,13 +262,15 @@ public class ShiftVecReport
             }
             if (target.Thing != null)
             {
-                stringBuilder.AppendLine("   " + "CE_TargetHeight".Translate() + "\t" + GenText.ToStringByStyle(new CollisionVertical(target.Thing).HeightRange.Span * CE_Utility.MetersPerCellHeight, ToStringStyle.FloatTwo) + " " + "CE_meters".Translate());
-                stringBuilder.AppendLine("   " + "CE_TargetWidth".Translate() + "\t" + GenText.ToStringByStyle(CE_Utility.GetCollisionWidth(target.Thing) * CE_Utility.MetersPerCellHeight, ToStringStyle.FloatTwo) + " " + "CE_meters".Translate());
                 var pawn = target.Thing as Pawn;
+                bool crouching = false;
                 if (pawn != null && pawn.IsCrouching())
                 {
+                    crouching = true;
                     LessonAutoActivator.TeachOpportunity(CE_ConceptDefOf.CE_Crouching, OpportunityType.GoodToKnow);
                 }
+                stringBuilder.AppendLine("   " + "CE_TargetHeight".Translate() + "\t" + GenText.ToStringByStyle(new CollisionVertical(target.Thing).HeightRange.Span * CE_Utility.MetersPerCellHeight, ToStringStyle.FloatTwo) + " " + "CE_meters".Translate() + (string)(crouching ? " " + "CE_Crouched".Translate() : ""));
+                stringBuilder.AppendLine("   " + "CE_TargetWidth".Translate() + "\t" + GenText.ToStringByStyle(CE_Utility.GetCollisionWidth(target.Thing) * CE_Utility.MetersPerCellHeight, ToStringStyle.FloatTwo) + " " + "CE_meters".Translate());
             }
             PlayerKnowledgeDatabase.KnowledgeDemonstrated(CE_ConceptDefOf.CE_AimingSystem, KnowledgeAmount.FrameDisplayed); // Show we learned about the aiming system
         }


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Adds an optional toggle to enable varying human height. When enabled, makes children, xenotypes, etc have less or more width/height, only depending on their body size. Not affected by sprite size or body type. This makes it harder to hit children and this makes them unable to shoot or get shot behind some cover.
- Height is capped to be no higher than 3.5 m. Height below <1 gets additional +0.2f from body size, to help children shoot over some cover. This makes 8 yo able to shoot over sandbags and 13 yo to be able to shoot over embrasures. Width unchanged, fully depends on body size.
- Adds a "(crouched)" text to height line of shooting tooltip, to make it easier to distinguish who's short and who's crouching.

## Reasoning

Why did you choose to implement things this way, e.g.
- Children and goblins being short is an interesting mechanic and a good buff to their survivability.
- This toggle is disabled by default to not break anything. Those who want to use this feature will have to opt-in and will be able to disable it if some unexpected issue arises.

## Alternatives

Describe alternative implementations you have considered, e.g.
- 1.75 m tall baby
- Risk it all and enable it by default

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
Tested all baseliner lifestages shooting over cover and getting shot.
