### PR TITLE
Ammo Tweaks

### DIFF
--- a/Defs/Ammo/Rocket/80mmS8Rocket.xml
+++ b/Defs/Ammo/Rocket/80mmS8Rocket.xml
@@ -222,6 +222,7 @@
 			<shellingProps>
 				<iconPath>Things/WorldObjects/Munitions/Rocket</iconPath>
 				<tilesPerTick>0.35</tilesPerTick>
+        <damage>0.15</damage>
 				<range>13</range>
 			</shellingProps>
 		</projectile>
@@ -238,9 +239,6 @@
 			<damageAmountBase>200</damageAmountBase>
 			<explosionRadius>3</explosionRadius>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-			<shellingProps>
-				<damage>0.061</damage>
-			</shellingProps>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
@@ -264,9 +262,6 @@
 			<damageAmountBase>222</damageAmountBase>
 			<armorPenetrationSharp>420</armorPenetrationSharp>
 			<armorPenetrationBlunt>47.913</armorPenetrationBlunt>
-			<shellingProps>
-				<damage>0.042</damage>
-			</shellingProps>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
@@ -299,9 +294,6 @@
 			<armorPenetrationBlunt>0</armorPenetrationBlunt>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 			<ai_IsIncendiary>true</ai_IsIncendiary>
-			<shellingProps>
-				<damage>0.185</damage>
-			</shellingProps>
 		</projectile>
 	</ThingDef>
 
@@ -439,4 +431,5 @@
 	</RecipeDef>
 
 </Defs>
+
 

--- a/Defs/Ammo/Shell/120mmMortar.xml
+++ b/Defs/Ammo/Shell/120mmMortar.xml
@@ -154,6 +154,9 @@
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
+      <shellingProps>
+				<damage>0.28</damage>
+			</shellingProps>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
@@ -183,7 +186,7 @@
 			<ai_IsIncendiary>true</ai_IsIncendiary>
 			<aimHeightOffset>8</aimHeightOffset>
 			<shellingProps>
-				<damage>0.013</damage>
+				<damage>0.28</damage>
 			</shellingProps>
 		</projectile>
 		<comps>
@@ -217,6 +220,9 @@
 			<preExplosionSpawnChance>0.2</preExplosionSpawnChance>
 			<soundExplode>MortarIncendiary_Explode</soundExplode>
 			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
+      <shellingProps>
+				<damage>0.28</damage>
+			</shellingProps>
 		</projectile>
 	</ThingDef>
 
@@ -231,6 +237,9 @@
 			<damageDef>EMP</damageDef>
 			<damageAmountBase>237</damageAmountBase>
 			<explosionRadius>6.5</explosionRadius>
+      <shellingProps>
+				<damage>0.20</damage>
+			</shellingProps>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Shell/120x570mmR.xml
+++ b/Defs/Ammo/Shell/120x570mmR.xml
@@ -43,7 +43,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="120mmCannonShellBase">
 		<defName>Ammo_120mmCannonShell_HEAT</defName>
-		<label>120mm cannon shell (HEAT)</label>
+		<label>120x570mmR cannon shell (HEAT)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Cannon/Tank/HEATFS</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="120mmCannonShellBase">
 		<defName>Ammo_120mmCannonShell_HE</defName>
-		<label>120mm cannon shell (HE)</label>
+		<label>120x570mmR cannon shell (HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Cannon/Tank/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -80,7 +80,7 @@
 
 	<ThingDef ParentName="Base120mmCannonShell">
 		<defName>Bullet_120mmCannonShell_HEAT</defName>
-		<label>120mm cannon shell (HEAT)</label>
+		<label>120x570mmR cannon shell (HEAT)</label>
 		<graphicData>
 			<texPath>Things/Projectile/Cannon/HEAT</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -110,7 +110,7 @@
 
 	<ThingDef ParentName="Base120mmCannonShell">
 		<defName>Bullet_120mmCannonShell_HE</defName>
-		<label>120mm cannon shell (HE)</label>
+		<label>120x570mmR cannon shell (HE)</label>
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		<graphicData>
 			<texPath>Things/Projectile/Cannon/HE</texPath>
@@ -138,9 +138,9 @@
 
 	<RecipeDef ParentName="CannonAmmoRecipeBase">
 		<defName>MakeAmmo_120mmCannonShell_HEAT</defName>
-		<label>make 120mm (HEAT) cannon shells x2</label>
-		<description>Craft 2 120mm (HEAT) cannon shells.</description>
-		<jobString>Making 120mm (HEAT) cannon shells.</jobString>
+		<label>make 120x570mmR (HEAT) cannon shells x2</label>
+		<description>Craft 2 120x570mmR (HEAT) cannon shells.</description>
+		<jobString>Making 120x570mmR (HEAT) cannon shells.</jobString>
 		<researchPrerequisite Inherit="False" />
 		<researchPrerequisites>
 			<li>CE_TurretHeavyWeapons</li>
@@ -187,9 +187,9 @@
 
 	<RecipeDef ParentName="CannonAmmoRecipeBase">
 		<defName>MakeAmmo_120mmCannonShell_HE</defName>
-		<label>make 120mm (HE) cannon shells x2</label>
-		<description>Craft 2 120mm (HE) cannon shells.</description>
-		<jobString>Making 120mm (HE) cannon shells.</jobString>
+		<label>make 120x570mmR (HE) cannon shells x2</label>
+		<description>Craft 2 120x570mmR (HE) cannon shells.</description>
+		<jobString>Making 120x570mmR (HE) cannon shells.</jobString>
 		<workAmount>15400</workAmount>
 		<ingredients>
 			<li>

--- a/Defs/Ammo/Shell/120x570mmR.xml
+++ b/Defs/Ammo/Shell/120x570mmR.xml
@@ -2,8 +2,8 @@
 <Defs>
 
 	<ThingCategoryDef>
-		<defName>Ammo120mmCannonShells</defName>
-		<label>120mm cannon shell</label>
+		<defName>Ammo120x570mmRCannonShells</defName>
+		<label>120x570mmR cannon shell</label>
 		<parent>AmmoShells</parent>
 		<iconPath>UI/Icons/ThingCategories/CaliberCannon</iconPath>
 	</ThingCategoryDef>
@@ -11,21 +11,21 @@
 	<!-- ==================== AmmoSet ========================== -->
 
 	<CombatExtended.AmmoSetDef>
-		<defName>AmmoSet_120mmCannonShell</defName>
-		<label>120mm cannon shells</label>
+		<defName>AmmoSet_120x570mmRCannonShell</defName>
+		<label>120x570mmR cannon shells</label>
 		<ammoTypes>
-			<Ammo_120mmCannonShell_HEAT>Bullet_120mmCannonShell_HEAT</Ammo_120mmCannonShell_HEAT>
-			<Ammo_120mmCannonShell_HE>Bullet_120mmCannonShell_HE</Ammo_120mmCannonShell_HE>
+			<Ammo_120x570mmRCannonShell_HEAT>Bullet_120x570mmRCannonShell_HEAT</Ammo_120x570mmRCannonShell_HEAT>
+			<Ammo_120x570mmRCannonShell_HE>Bullet_120x570mmRCannonShell_HE</Ammo_120x570mmRCannonShell_HE>
 		</ammoTypes>
 		<similarTo>AmmoSet_HeavyCannon</similarTo>
 	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="120mmCannonShellBase" ParentName="HeavyAmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="120x570mmRCannonShellBase" ParentName="HeavyAmmoBase" Abstract="True">
 		<description>Large cannon shells, typically used by 120mm smoothbore tank guns.</description>
 		<thingCategories>
-			<li>Ammo120mmCannonShells</li>
+			<li>Ammo120x570mmRCannonShells</li>
 		</thingCategories>
 		<stackLimit>25</stackLimit>
 		<tradeTags>
@@ -41,31 +41,31 @@
 		<cookOffSound>MortarBomb_Explode</cookOffSound>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="120mmCannonShellBase">
-		<defName>Ammo_120mmCannonShell_HEAT</defName>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="120x570mmRCannonShellBase">
+		<defName>Ammo_120x570mmRCannonShell_HEAT</defName>
 		<label>120x570mmR cannon shell (HEAT)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Cannon/Tank/HEATFS</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>RocketHEAT</ammoClass>
-		<detonateProjectile>Bullet_120mmCannonShell_HEAT</detonateProjectile>
+		<detonateProjectile>Bullet_120x570mmRCannonShell_HEAT</detonateProjectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="120mmCannonShellBase">
-		<defName>Ammo_120mmCannonShell_HE</defName>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="120x570mmRCannonShellBase">
+		<defName>Ammo_120x570mmRCannonShell_HE</defName>
 		<label>120x570mmR cannon shell (HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Cannon/Tank/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>GrenadeHE</ammoClass>
-		<detonateProjectile>Bullet_120mmCannonShell_HE</detonateProjectile>
+		<detonateProjectile>Bullet_120x570mmRCannonShell_HE</detonateProjectile>
 	</ThingDef>
 
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef Name="Base120mmCannonShell" ParentName="BaseExplosiveBullet" Abstract="true">
+	<ThingDef Name="Base120x570mmRCannonShell" ParentName="BaseExplosiveBullet" Abstract="true">
 		<graphicData>
 			<shaderType>TransparentPostLight</shaderType>
 		</graphicData>
@@ -78,8 +78,8 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef ParentName="Base120mmCannonShell">
-		<defName>Bullet_120mmCannonShell_HEAT</defName>
+	<ThingDef ParentName="Base120x570mmRCannonShell">
+		<defName>Bullet_120x570mmRCannonShell_HEAT</defName>
 		<label>120x570mmR cannon shell (HEAT)</label>
 		<graphicData>
 			<texPath>Things/Projectile/Cannon/HEAT</texPath>
@@ -108,8 +108,8 @@
 		</comps>
 	</ThingDef>
 
-	<ThingDef ParentName="Base120mmCannonShell">
-		<defName>Bullet_120mmCannonShell_HE</defName>
+	<ThingDef ParentName="Base120x570mmRCannonShell">
+		<defName>Bullet_120x570mmRCannonShell_HE</defName>
 		<label>120x570mmR cannon shell (HE)</label>
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		<graphicData>
@@ -137,7 +137,7 @@
 	<!-- ==================== Recipes ========================== -->
 
 	<RecipeDef ParentName="CannonAmmoRecipeBase">
-		<defName>MakeAmmo_120mmCannonShell_HEAT</defName>
+		<defName>MakeAmmo_120x570mmRCannonShell_HEAT</defName>
 		<label>make 120x570mmR (HEAT) cannon shells x2</label>
 		<description>Craft 2 120x570mmR (HEAT) cannon shells.</description>
 		<jobString>Making 120x570mmR (HEAT) cannon shells.</jobString>
@@ -181,12 +181,12 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_120mmCannonShell_HEAT>2</Ammo_120mmCannonShell_HEAT>
+			<Ammo_120x570mmRCannonShell_HEAT>2</Ammo_120x570mmRCannonShell_HEAT>
 		</products>
 	</RecipeDef>
 
 	<RecipeDef ParentName="CannonAmmoRecipeBase">
-		<defName>MakeAmmo_120mmCannonShell_HE</defName>
+		<defName>MakeAmmo_120x570mmRCannonShell_HE</defName>
 		<label>make 120x570mmR (HE) cannon shells x2</label>
 		<description>Craft 2 120x570mmR (HE) cannon shells.</description>
 		<jobString>Making 120x570mmR (HE) cannon shells.</jobString>
@@ -225,7 +225,7 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_120mmCannonShell_HE>2</Ammo_120mmCannonShell_HE>
+			<Ammo_120x570mmRCannonShell_HE>2</Ammo_120x570mmRCannonShell_HE>
 		</products>
 	</RecipeDef>
 


### PR DESCRIPTION
## Changes

1. Modified the unreasonable ShellingProps values in the ammunition Def of the S8 rocket and 120mm mortar.

2. Changed "120mmCannonShell" to the more easily recognizable name "120x570mmR." If you believe the defname should not be modified, only the label can be changed instead.