### PR TITLE
Fix pawns matrix dodging bullets when hunkering

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompSuppressable.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompSuppressable.cs
@@ -20,6 +20,7 @@ public class CompSuppressable : ThingComp
     private const int TicksForDecayStart = 30;           // How long since last suppression before decay starts
     private const float SuppressionDecayRate = 4f;       // How much suppression decays per tick
     private const int TicksPerMote = 150;                // How many ticks between throwing a mote
+    private const int hunkeringMinDuration = 240;        // How long in ticks until pawn can try to stop hunkering
 
     private const int MinTicksUntilMentalBreak = 600;    // How long until pawn can have a mental break
     private const float ChanceBreakPerTick = 0.001f;     // How likely we are to break each tick above the threshold
@@ -120,7 +121,7 @@ public class CompSuppressable : ThingComp
     {
         get
         {
-            if (currentSuppression > (SuppressionThreshold * 10))
+             if (currentSuppression > (SuppressionThreshold * 10) || (ticksHunkered > 0 && ticksHunkered < hunkeringMinDuration))
             {
                 if (isSuppressed)
                 {
@@ -288,7 +289,7 @@ public class CompSuppressable : ThingComp
                 MoteMakerCE.ThrowText(parent.DrawPos, parent.Map, "-" + (SuppressionDecayRate * 30), Color.red);
             }
             currentSuppression -= Mathf.Min(SuppressionDecayRate * delta, currentSuppression);
-            isSuppressed = currentSuppression > 0;
+            isSuppressed = currentSuppression > 0 || (ticksHunkered > 0 && ticksHunkered < hunkeringMinDuration);
 
             // Clear crouch-walking
             if (!isSuppressed)


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Adds a minimum duration for hunkering of 240 ticks (~4 seconds) to prevent pawns from rapidly switching between states of standing and hunkering.

## References

Links to the associated issues or other related pull requests, e.g.
- Attempts to fix the depicted issue:
1) https://www.reddit.com/r/RimWorld/comments/1l7xq1j/combat_extended_artillery_how_do_i_fire_the/
2) https://discord.com/channels/278818534069501953/278818534069501953/1065251684684681257

- Savefile where the issue can be reproduced (keep refilling shotgun via godmode and check the raider's twitching behaviour)
https://drive.google.com/file/d/1NVNq6wGb_d6FJ_ZkQGFzEj16YRipfbqZ/view?usp=sharing

## Reasoning

Why did you choose to implement things this way, e.g.
- This issue happens with slow firing weapons. When gunshot frequency matches suppression decay rate, raiders might get stuck dodging bullets but being unable to do anything else. This change makes sure they will stay down long enough to make at least 1 shot against them

## Alternatives

Describe alternative implementations you have considered, e.g.
- Introduce a delay before posture change for hunkering - could be useful in addition to this change

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
