### PR TITLE
fix gorehulk attack NRE

### DIFF
--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -1140,7 +1140,7 @@ public class Verb_LaunchProjectileCE : Verb
             projectile.mount = caster.Position.GetThingList(caster.Map).FirstOrDefault(t => t is Pawn && t != caster);
             projectile.AccuracyFactor = report.accuracyFactor * report.swayDegrees * ((numShotsFired + 1) * 0.75f);
 
-            if (EquipmentSource.TryGetComp(out CompUniqueWeapon comp))
+            if (EquipmentSource != null && EquipmentSource.TryGetComp(out CompUniqueWeapon comp))
             {
                 foreach (WeaponTraitDef trait in comp.TraitsListForReading)
                 {


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Fixes gorehulk failing to attack and throwing NRE due to not having an equipment source in the unique weapon comp check

## References

Links to the associated issues or other related pull requests, e.g.
- Reported by ProfessorRosen on discord:
https://discord.com/channels/278818534069501953/668604879526428713/1415129658759974955

## Reasoning

Why did you choose to implement things this way, e.g.
- Gorehulks dont have equipment, needs a null check

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (tested a gorehulk in devmode before and after)
