### PR TITLE
Allow obsidian weapons

### DIFF
--- a/Odyssey/Patches/ThingDefs_Items/Items_Resources_Stuff.xml
+++ b/Odyssey/Patches/ThingDefs_Items/Items_Resources_Stuff.xml
@@ -31,4 +31,11 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Obsidian"]/stuffProps/categories</xpath>
+		<value>
+			<li>Metallic_Weapon</li>
+		</value>
+	</Operation>
+
 </Patch>


### PR DESCRIPTION
## Additions

- Added a metallic weapon category to make it usable as a weapon material.

## Reasoning

- It's a weapon-focused material.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
