### PR TITLE
Communicable diseases 1.6 patch fix

### DIFF
--- a/ModPatches/Communitable Diseases/Patches/Communitable Diseases/Communitable_Disease_Apparel.xml
+++ b/ModPatches/Communitable Diseases/Patches/Communitable Diseases/Communitable_Disease_Apparel.xml
@@ -1,26 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 
-	<!-- ====================== Dust Mask ===================== -->
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Apparel_DustMask"]/apparel/layers</xpath>
-		<value>
-			<layers>
-				<li>Overhead</li>
-			</layers>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Apparel_DustMask"]/apparel/bodyPartGroups</xpath>
-		<value>
-			<bodyPartGroups>
-				<li>Teeth</li>
-			</bodyPartGroups>
-		</value>
-	</Operation>
-
 	<!-- ====================== Respirator ===================== -->
 
 	<Operation Class="PatchOperationReplace">


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Removed patch for `Dust Mask` for Communicable Diseases mod, as it removed the item in its 1.6 update.

## References

Links to the associated issues or other related pull requests, e.g.
- Mod link: https://steamcommunity.com/sharedfiles/filedetails/?id=3263015203

## Reasoning

Why did you choose to implement things this way, e.g.
- Removes red errors on startup

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
