### PR TITLE
Make volt laser cells actually craftable.

### DIFF
--- a/ModPatches/Volt Weaponry/Defs/Volt Weaponry/Ammo_volt.xml
+++ b/ModPatches/Volt Weaponry/Defs/Volt Weaponry/Ammo_volt.xml
@@ -38,6 +38,9 @@
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="LaserChargePackBase">
 		<defName>Ammo_VoltLaserCellPack</defName>
 		<label>volt laser cell</label>
+		<tradeTags>
+			<li>CE_AutoEnableCrafting_TableMachining</li>
+		</tradeTags>
 		<graphicData>
 			<texPath>ThirdParty/Volt Weaponry/Ammo/VoltBattery</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>


### PR DESCRIPTION
## Additions

- Made it so that volt laser cells for [Volt Weaponry](https://steamcommunity.com/sharedfiles/filedetails/?id=3551721422) can be actually crafted at the machining table, same as the volt weapons themselves.
 
## Reasoning

- We can't just leave volt laser cells to be uncraftable and make volt weapons unable to be practically fielded by players.
- Obviously, volt laser cells should be craftable at the same building where you get volt weapons (which are Industrial tier and thus craftable at the Machining Table unlike most other energy weapons).

## Alternatives

- Leave volt weapons without craftable ammo, for some reason.

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [X] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
