### PR TITLE
Fix DamageInfo Missing Intended Target

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -122,6 +122,7 @@ public abstract class ProjectileCE : ThingWithComps
                 launcher,
                 null,
                 def,
+                intendedTarget: intendedTargetThing,
                 instigatorGuilty: InstigatorGuilty);
 
     public float RemainingKineticEnergyPct => TrajectoryWorker is BallisticsTrajectoryWorker ? (shotSpeed * shotSpeed) / (initialSpeed * initialSpeed) : 1f;


### PR DESCRIPTION
## Additions

DamageInfo now registers its inteded target

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #4247 

## Alternatives

Of course, considering how easy one can exploit this feature with ce, we can implement a much more complex system, but...

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
