### PR TITLE
Fix for RM2-VWE Subpatch

### DIFF
--- a/ModPatches/Reinforced Mechanoid 2/Patches/Reinforced Mechanoid 2/ThingDefs_Misc/RM_PlasmaWeaponry.xml
+++ b/ModPatches/Reinforced Mechanoid 2/Patches/Reinforced Mechanoid 2/ThingDefs_Misc/RM_PlasmaWeaponry.xml
@@ -294,7 +294,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VWE_Apparel_GrenadePlasmaImmolator"]/comps/li[@Class="CompProperties_Reloadable"]/ammoCountToRefill</xpath>
+					<xpath>Defs/ThingDef[defName="VWE_Apparel_GrenadePlasmaImmolator"]/comps/li[@Class="CompProperties_ApparelReloadable"]/ammoCountToRefill</xpath>
 					<value>
 						<ammoCountPerCharge>1</ammoCountPerCharge>
 					</value>


### PR DESCRIPTION
Updated the path for one of the grenades

## Changes

Modified the xpath for VWE_Apparel_GrenadePlasmaImmolator

## Reasoning

Fixes a red error on game startup.

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [X] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
