### PR TITLE
Vanilla Fishing Removed Patch fix

### DIFF
--- a/ModPatches/Rimefeller/Patches/Rimefeller/Napalm_Tweaks.xml
+++ b/ModPatches/Rimefeller/Patches/Rimefeller/Napalm_Tweaks.xml
@@ -1,21 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 
-	<!-- Vanilla Fishing Expanded - Fishing Treasures AddOn -->
-	<Operation Class="PatchOperationFindMod">
-		<mods>
-			<li>Vanilla Fishing Expanded - Fishing Treasures AddOn</li>
-		</mods>
-
-		<match Class="PatchOperationSequence">
-			<operations>
-				<li Class="PatchOperationRemove">
-					<xpath>Defs/VCE_Fishing.FishDef[defName="VCEF_SpecialShell_Napalm" or defName="VCEF_SpecialNapalm"]</xpath>
-				</li>
-			</operations>
-		</match>
-	</Operation>
-
 	<!-- Research -->
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ResearchProjectDef[defName="Napalm"]/label</xpath>


### PR DESCRIPTION
No longer needed, was removed from main mod.

## Changes
Removed outdated patch operation

## Reasoning

Fixes a red error on Startup. Vanilla Fishing Expanded - Fishing Treasure Addon no longer has the Rimefeller patch on their end for 1.6.

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [X] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
