### PR TITLE
Melee tooltip improvements

### DIFF
--- a/Languages/English/Keyed/Misc_Gameplay.xml
+++ b/Languages/English/Keyed/Misc_Gameplay.xml
@@ -4,6 +4,7 @@
 	<DormantCompAmmoBeacon>Ready to resupply turrets</DormantCompAmmoBeacon>
 	<CE_MeleeTargetting_CurPart>Targeted bodypart:</CE_MeleeTargetting_CurPart>
 	<CE_MeleeTargetting_CurHeight>Melee attacked area</CE_MeleeTargetting_CurHeight>
+	<CE_MeleeTargetting>Area targetting</CE_MeleeTargetting>
 	<CE_NoBP>None</CE_NoBP>
 	<CE_Yes>Yes</CE_Yes>
 	<CE_No>No</CE_No>

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
@@ -98,6 +98,8 @@ public class Verb_MeleeAttackCE : Verb_MeleeAttack
     /// </summary>
     private bool meleeTargettingInitialized;
 
+    private BodyPartHeight lastUsedBodyPartHeight;
+
     #endregion
 
     #region Methods
@@ -574,7 +576,8 @@ public class Verb_MeleeAttackCE : Verb_MeleeAttack
                 }
             }
 
-            switch (GetAttackedPartHeightCE(target.Thing))
+            lastUsedBodyPartHeight = GetAttackedPartHeightCE(target.Thing);
+            switch (lastUsedBodyPartHeight)
             {
                 case BodyPartHeight.Bottom:
                     chance *= 0.8f;
@@ -845,7 +848,16 @@ public class Verb_MeleeAttackCE : Verb_MeleeAttack
             }
         }
         stringBuilder.AppendLine("\n   " + "CE_FinalToHitChance".Translate() + ":\t\t" + GenText.ToStringByStyle(Mathf.Clamp01(toDamageChance), ToStringStyle.PercentZero));
-        stringBuilder.AppendLine("      " + "CE_CritChance".Translate() + ":\t\t" + GenText.ToStringByStyle(critChance, ToStringStyle.PercentZero));
+        switch (lastUsedBodyPartHeight)
+        {
+            case BodyPartHeight.Bottom:
+                stringBuilder.AppendLine("      " + "CE_MeleeTargetting".Translate() + ":\t\t" + GenText.ToStringByStyle(0.8f, ToStringStyle.FloatOne) + "x\n");
+                break;
+            case BodyPartHeight.Top:
+                stringBuilder.AppendLine("      " + "CE_MeleeTargetting".Translate() + ":\t\t" + GenText.ToStringByStyle(0.7f, ToStringStyle.FloatOne) + "x\n");
+                break;
+        }
+        stringBuilder.AppendLine("   " + "CE_CritChance".Translate() + ":\t\t" + GenText.ToStringByStyle(critChance, ToStringStyle.PercentZero));
 
         return stringBuilder.ToString();
     }

--- a/Source/CombatExtended/Harmony/Harmony_TooltipUtility.cs
+++ b/Source/CombatExtended/Harmony/Harmony_TooltipUtility.cs
@@ -69,7 +69,7 @@ public class Harmony_TooltipUtility_ShotCalculationTipString_Patch
                 }
             }
             // melee tooltip
-            else if (pawn != null && pawn2 != null && (pawn.Drafted || pawn.Faction != Faction.OfPlayer || pawn.InAggroMentalState))
+            else if (pawn != null && pawn2 != null && pawn != pawn2 && (pawn.Drafted || pawn.Faction != Faction.OfPlayer || pawn.InAggroMentalState))
             {
                 //if pawn doesn't have a melee weapon equipped, find another source of melee verb
                 if (meleeVerbCE == null)


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Hit chance tooltip no longer is shown when attacker and defender are the same pawn
- Added a line about the impact of melee bodypart targetting to the tooltip, to highlight how much it reduces hit chances.

## Reasoning

Why did you choose to implement things this way, e.g.
- Suggested on discord
- Helps people understand that leaving bodypart targetting on "auto" gives them -30% chance to hit

## Alternatives

Describe alternative implementations you have considered, e.g.
- show bodypart name in tooltip?

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
