### PR TITLE
Bursting shell 12 pounder fix

### DIFF
--- a/Defs/Ammo/Medieval/CannonBall.xml
+++ b/Defs/Ammo/Medieval/CannonBall.xml
@@ -172,10 +172,10 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<speed>99</speed>
 			<damageDef>Bomb</damageDef>
-			<damageAmountBase>99</damageAmountBase>
+			<damageAmountBase>79</damageAmountBase>
 			<armorPenetrationSharp>0</armorPenetrationSharp>
 			<armorPenetrationBlunt>0</armorPenetrationBlunt>
-			<explosionRadius>2.0</explosionRadius>
+			<explosionRadius>2</explosionRadius>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
@@ -184,7 +184,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>19</Fragment_Large>
-					<Fragment_Small>12</Fragment_Small>
+					<Fragment_Small>9</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>
@@ -279,8 +279,8 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bomb</damageDef>
-			<damageAmountBase>99</damageAmountBase>
-			<explosionRadius>2.0</explosionRadius>
+			<damageAmountBase>79</damageAmountBase>
+			<explosionRadius>2</explosionRadius>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 			<preExplosionSpawnSingleThingDef>Filth_BlastMark</preExplosionSpawnSingleThingDef>
@@ -289,7 +289,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>19</Fragment_Large>
-					<Fragment_Small>12</Fragment_Small>
+					<Fragment_Small>9</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>
@@ -363,7 +363,7 @@
 						<li>FSX</li>
 					</thingDefs>
 				</filter>
-				<count>5</count>
+				<count>4</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -375,7 +375,7 @@
 		<products>
 			<Ammo_CannonBall_Bursting>5</Ammo_CannonBall_Bursting>
 		</products>
-		<workAmount>9800</workAmount>
+		<workAmount>8200</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">


### PR DESCRIPTION
## Changes

Some years ago, there was a nerf to the 12 pounder cannons explosive ammo that was reverted, however it was forgotten to update the crafting cost after the revert. 

Edit;
Updated damage as well per Sams recommendation 

## References

Combat Extended - Projectile Stats (2024)

New Sheet
https://docs.google.com/spreadsheets/d/1hzk5ZrBBJ62ketFNxGp1elnKtlMfB_lT7iz_n-u3Tzg/edit?gid=1198674278#gid=1198674278

## Reasoning

Fix to sheet standard 

## Alternatives

Suffer

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony
   Worked well on my tribal colony 
