### PR TITLE
Rimsenal races

### DIFF
--- a/ModPatches/Rimsenal Xenotype Pack - Askbarn/Patches/Rimsenal Xenotype Pack - Askbarn/Apparel_Askbarn_CE.xml
+++ b/ModPatches/Rimsenal Xenotype Pack - Askbarn/Patches/Rimsenal Xenotype Pack - Askbarn/Apparel_Askbarn_CE.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Bullet_EMPSurge"]</xpath>
 		<value>
 			<thingClass>CombatExtended.ProjectileCE_Bursting</thingClass>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Bullet_EMPSurge"]/projectile</xpath>
 		<value>
@@ -21,6 +23,7 @@
 			</projectile>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_SurgePack"]/verbs</xpath>
 		<value>
@@ -50,4 +53,5 @@
 			</verbs>
 		</value>
 	</Operation>
+
 </Patch>

--- a/ModPatches/Rimsenal Xenotype Pack - Askbarn/Patches/Rimsenal Xenotype Pack - Askbarn/Gene_Askbarn_CE.xml
+++ b/ModPatches/Rimsenal Xenotype Pack - Askbarn/Patches/Rimsenal Xenotype Pack - Askbarn/Gene_Askbarn_CE.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/GeneDef[defName="RSLongshot"]/statFactors</xpath>
 		<value>
@@ -8,12 +9,14 @@
 			</statFactors>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/GeneDef[defName="RSLightningReflexes"]/statOffsets/MeleeDodgeChance</xpath>
 		<value>
 			<MeleeDodgeChance>2</MeleeDodgeChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/GeneDef[defName="RSBornWarrior"]/statOffsets/MeleeDodgeChance</xpath>
 		<value>
@@ -22,6 +25,7 @@
 			<MeleeParryChance>0.15</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/GeneDef[defName="EMPRoar" or defName="EMPSurge"]</xpath>
 		<value>
@@ -30,10 +34,12 @@
 			</damageFactors>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="RaceEMPRoar" or defName="RaceBallLightning"]/projectile/damageAmountBase</xpath>
 		<value>
 			<damageAmountBase>75</damageAmountBase>
 		</value>
 	</Operation>
+
 </Patch>

--- a/ModPatches/Rimsenal Xenotype Pack - Askbarn/Patches/Rimsenal Xenotype Pack - Askbarn/Weapons_Askbarn_CE.xml
+++ b/ModPatches/Rimsenal Xenotype Pack - Askbarn/Patches/Rimsenal Xenotype Pack - Askbarn/Weapons_Askbarn_CE.xml
@@ -22,6 +22,7 @@
 						</statBases>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/thingDef[defName="JI_Sigrun"]/verbs</xpath>
 					<value>
@@ -61,9 +62,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/thingDef[
-						defName="JI_Sigrun"
-						] </xpath>
+					<xpath>Defs/thingDef[defName="JI_Sigrun"]</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -150,6 +149,7 @@
 						<li>AdvancedGun</li>
 					</weaponTags>
 				</li>
+
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="Gun_DisruptionPistol"]/tools</xpath>
 					<value>
@@ -213,6 +213,7 @@
 						<li>AdvancedGun</li>
 					</weaponTags>
 				</li>
+
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="Gun_FusterClucker"]/tools</xpath>
 					<value>

--- a/ModPatches/Rimsenal Xenotype Pack - Harana/Patches/Rimsenal Xenotype Pack - Harana/Weapons_Harana_CE.xml
+++ b/ModPatches/Rimsenal Xenotype Pack - Harana/Patches/Rimsenal Xenotype Pack - Harana/Weapons_Harana_CE.xml
@@ -4,7 +4,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>Rimsenal - Core</li>
-      <li>Rimsenal: Murder diversified</li>
+			<li>Rimsenal: Murder diversified</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>

--- a/ModPatches/Rimsenal Xenotype Pack - Zohar/Patches/Rimsenal Xenotype Pack - Zohar/Weapons_Zohar_CE.xml
+++ b/ModPatches/Rimsenal Xenotype Pack - Zohar/Patches/Rimsenal Xenotype Pack - Zohar/Weapons_Zohar_CE.xml
@@ -4,7 +4,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>Rimsenal - Core</li>
-      <li>Rimsenal: Murder diversified</li>
+			<li>Rimsenal: Murder diversified</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>


### PR DESCRIPTION
## Additions

Added EMP resist for the two emp attack genes. 

## Changes

Damage reduced on the EMP pack and genes. Gave EMP pack airburst for range consistentcy.
Updated findmod ops to look for new rimsenal core name

## Reasoning

The three EMP abilities have absurd damage due to CE now inflicting that damage. It was halved both to compensate for the EMP resist added, as well as bring it in line with other equipment in CE. Pack has been reduced accordingly as well but has proportionally longer range now.

## Alternatives

New comp to make roar/pack work without nuking the user. Alternatavely, add worn hediff for the pack that makes it so the user is immune to EMP damage instead.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
