### PR TITLE
Fix incorrect vehicle aiming calculations.

### DIFF
--- a/Source/VehiclesCompat/VehiclesCompat/VehiclesCompat.cs
+++ b/Source/VehiclesCompat/VehiclesCompat/VehiclesCompat.cs
@@ -127,8 +127,9 @@ public class VehiclesCompat : IModPart
         }
     }
 
-    public static Vector2 ProjectileAngleCE(float speed, float range, Thing shooter, LocalTargetInfo target, Vector3 shotOrigin, bool flyOverhead, float gravity, float sway, float spread, float recoil)
+    public static Vector2 ProjectileAngleCE(float speed, float range, Thing shooter, LocalTargetInfo target, Vector3 shotOrigin, bool flyOverhead, float gravityModifier, float sway, float spread, float recoil)
     {
+        var gravity = CE_Utility.GravityConst * gravityModifier;
         // TODO: Handle cover
         var bounds = CE_Utility.GetBoundsFor(target.Thing);
         float dheight = (bounds.max.y + bounds.min.y) / 2 - shotOrigin.y;


### PR DESCRIPTION

Describe adjustments to existing features made in this merge, e.g.
- Fix incorrect gravity of vehicle aiming calculations

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #4154 (in theory should finish the issue)

## Reasoning

Why did you choose to implement things this way, e.g.
 - Seems like CE misunderstanding the contract from Vehicle Framework.
 - This fixes it with no work on their side.

## Alternatives

Describe alternative implementations you have considered, e.g.
- Alternatively vehicle framework can change theirs to provide correct gravity, but that is bad idea, as the const is CE thing.

## Testing

Check tests you have performed:
- Compiles without warnings
- Game runs without errors
- Tested vehicles specifically indirect fire, and they fired pinpoint when randomness was removed, and overall correctly with randomness.
