### PR TITLE
Remove pickup order from mechs

### DIFF
--- a/Source/CombatExtended/CombatExtended/FloatMenus/FloatMenuOptionProvider_PickUp.cs
+++ b/Source/CombatExtended/CombatExtended/FloatMenus/FloatMenuOptionProvider_PickUp.cs
@@ -11,7 +11,7 @@ public class FloatMenuOptionProvider_PickUp : FloatMenuOptionProvider
     public override bool Drafted => true;
     public override bool Undrafted => true;
     public override bool Multiselect => false;
-    public override bool MechanoidCanDo => true;
+    public override bool MechanoidCanDo => false;
 
     public override IEnumerable<FloatMenuOption> GetOptionsFor(Thing clickedThing, FloatMenuContext context)
     {


### PR DESCRIPTION
## Changes

- Mechs now can no longer be ordered to pick up items

## Reasoning

- Enabled unintended behavior combined with other systems/features (e.g. swapping mech weapons)

## Alternatives

- Add a severely limited alternative, for example only allowing to pick up ammo.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
