### PR TITLE
Fixes the Hide Backpacks/Tactical Vests option

### DIFF
--- a/Source/CombatExtended/CombatExtended/HideTacticalVestsAndBackpacks.cs
+++ b/Source/CombatExtended/CombatExtended/HideTacticalVestsAndBackpacks.cs
@@ -1,0 +1,42 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Verse;
+
+namespace CombatExtended.CombatExtended
+{
+    [StaticConstructorOnStartup]
+    public static class HideTacticalVestsAndBackpacksPostfix
+    {
+        static HideTacticalVestsAndBackpacksPostfix()
+        {
+            var harmony = new Harmony("com.combatextended.hidetacticalvestandbackpackspostfix");
+
+            var original = typeof(PawnRenderNodeWorker_Body).GetMethod(
+                "CanDrawNow",
+                System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance
+            );
+
+            if (original != null)
+            {
+                var postfix = typeof(HideTacticalVestsAndBackpacksPostfix).GetMethod(nameof(CanDrawNowPostfix));
+                harmony.Patch(original, postfix: new HarmonyMethod(postfix));
+            }
+        }
+
+        // Postfix
+        public static void CanDrawNowPostfix(PawnRenderNode node, PawnDrawParms parms, ref bool __result)
+        {
+            if (node?.apparel?.def == null) { return; }
+            string defName = node.apparel.def.defName;
+            if ((defName == "CE_Apparel_TacVest" && !Controller.settings.ShowTacticalVests) ||
+                (defName == "CE_Apparel_Backpack" && !Controller.settings.ShowBackpacks))
+            {
+                __result = false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Additions

Fixes the Show Backpacks and Show Tactical Vests settings so that disabling either option correctly prevents their visuals from rendering.

## Changes

Creates a postfix on the CanDrawNow function that searches specifically for the CE_Apparel_Backpack and CE_Apparel_TacVests defs.

## References
N/A
## Reasoning

As long as the CE_Apparel_TacVest/ CE_Apparel_Backpack defs don't change, this should be a sufficient fix.

## Alternatives

For debugging purposes, I postfixed the PawnRenderTree's ShouldAddNodeToTree function to log all apparel nodes. I observed that for each tactical vest and backpack, instead of one node created, there seemed to be two:

First Node:
workerClass: CombatExtended.PawnRenderNodeWorker_Webbing
baseLayer: 29
debugLabel: 
overlayLayer: Body
nodeClass: Verse.PawnRenderNode_Apparel
useGraphic: True

Second Node:
workerClass: Verse.PawnRenderNodeWorker_Apparel_Body
baseLayer: 21
debugLabel: CE_Apparel_TacVest
overlayLayer: Body
nodeClass: Verse.PawnRenderNode
useGraphic: True

Disabling the first node is not enough. It is possible to disable the second node based off the debugLabel but given that it's called debugLabel that seemed suspicious. 

Given that it's just a generic Apparel_Body, and I couldn't find any relation tying the first node to the second, so I tried to do a blanket postfix on the entire CanDrawOn function which seemed to work.

## Testing

Check tests you have performed:
- [Y] Compiles without warnings
- [Y] Game runs without errors
- [N] Playtested a colony (specify how long)  Tested with only CE on for about a minute, but it was sufficient to see the toggle working.
