### PR TITLE
Fix Shield Layering with Burkas

### DIFF
--- a/Defs/ThingDefs_Misc/Apparel_Shield.xml
+++ b/Defs/ThingDefs_Misc/Apparel_Shield.xml
@@ -78,7 +78,7 @@
 					<drawData>
 						<scale>0.8</scale>
 						<defaultData>
-							<layer>210</layer>
+							<layer>85</layer>
 						</defaultData>
 						<dataEast>
 							<layer>-5</layer>
@@ -166,7 +166,7 @@
 					<drawData>
 						<scale>0.8</scale>
 						<defaultData>
-							<layer>210</layer>
+							<layer>85</layer>
 						</defaultData>
 						<dataEast>
 							<layer>-5</layer>

--- a/ModPatches/Crypto Weapon Restored/Patches/Crypto Weapon Restored/Shield_Crypto.xml
+++ b/ModPatches/Crypto Weapon Restored/Patches/Crypto Weapon Restored/Shield_Crypto.xml
@@ -70,7 +70,7 @@
 							<drawData>
 								<scale>0.55</scale>
 								<defaultData>
-									<layer>210</layer>
+									<layer>85</layer>
 								</defaultData>
 								<dataEast>
 									<layer>-5</layer>

--- a/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Wearables/Shields_Patches.xml
+++ b/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Wearables/Shields_Patches.xml
@@ -107,7 +107,7 @@
 					<drawData>
 						<scale>0.8</scale>
 						<defaultData>
-							<layer>210</layer>
+							<layer>85</layer>
 						</defaultData>
 						<dataEast>
 							<layer>-5</layer>
@@ -201,7 +201,7 @@
 					<drawData>
 						<scale>0.9</scale>
 						<defaultData>
-							<layer>210</layer>
+							<layer>85</layer>
 						</defaultData>
 						<dataEast>
 							<layer>-5</layer>

--- a/ModPatches/Medieval Overhaul Barbarians/Patches/ThingDefs_Misc/Shields/BarbarianBannerShields.xml
+++ b/ModPatches/Medieval Overhaul Barbarians/Patches/ThingDefs_Misc/Shields/BarbarianBannerShields.xml
@@ -83,7 +83,7 @@
 						<drawData>
 							<scale>1.3</scale>
 							<defaultData>
-								<layer>210</layer>
+								<layer>85</layer>
 							</defaultData>
 							<dataEast>
 								<layer>-5</layer>
@@ -125,7 +125,7 @@
 						<drawData>
 							<scale>1.3</scale>
 							<defaultData>
-								<layer>210</layer>
+								<layer>85</layer>
 							</defaultData>
 							<dataEast>
 								<layer>-5</layer>
@@ -167,7 +167,7 @@
 						<drawData>
 							<scale>1.3</scale>
 							<defaultData>
-								<layer>210</layer>
+								<layer>85</layer>
 							</defaultData>
 							<dataEast>
 								<layer>-5</layer>
@@ -209,7 +209,7 @@
 						<drawData>
 							<scale>1.3</scale>
 							<defaultData>
-								<layer>210</layer>
+								<layer>85</layer>
 							</defaultData>
 							<dataEast>
 								<layer>-5</layer>

--- a/ModPatches/Medieval Overhaul Barbarians/Patches/ThingDefs_Misc/Shields/BarbarianMetalShields.xml
+++ b/ModPatches/Medieval Overhaul Barbarians/Patches/ThingDefs_Misc/Shields/BarbarianMetalShields.xml
@@ -139,7 +139,7 @@
 						<drawData>
 							<scale>0.6</scale>
 							<defaultData>
-								<layer>210</layer>
+								<layer>85</layer>
 							</defaultData>
 							<dataEast>
 								<layer>-5</layer>
@@ -180,7 +180,7 @@
 						<drawData>
 							<scale>0.6</scale>
 							<defaultData>
-								<layer>210</layer>
+								<layer>85</layer>
 							</defaultData>
 							<dataEast>
 								<layer>-5</layer>
@@ -221,7 +221,7 @@
 						<drawData>
 							<scale>0.6</scale>
 							<defaultData>
-								<layer>210</layer>
+								<layer>85</layer>
 							</defaultData>
 							<dataEast>
 								<layer>-5</layer>

--- a/ModPatches/Medieval Overhaul Barbarians/Patches/ThingDefs_Misc/Shields/BarbarianRoundShields.xml
+++ b/ModPatches/Medieval Overhaul Barbarians/Patches/ThingDefs_Misc/Shields/BarbarianRoundShields.xml
@@ -140,7 +140,7 @@
 						<drawData>
 							<scale>0.6</scale>
 							<defaultData>
-								<layer>210</layer>
+								<layer>85</layer>
 							</defaultData>
 							<dataEast>
 								<layer>-5</layer>
@@ -182,7 +182,7 @@
 						<drawData>
 							<scale>0.6</scale>
 							<defaultData>
-								<layer>210</layer>
+								<layer>85</layer>
 							</defaultData>
 							<dataEast>
 								<layer>-5</layer>
@@ -224,7 +224,7 @@
 						<drawData>
 							<scale>0.6</scale>
 							<defaultData>
-								<layer>210</layer>
+								<layer>85</layer>
 							</defaultData>
 							<dataEast>
 								<layer>-5</layer>

--- a/ModPatches/Medieval Overhaul Barbarians/Patches/ThingDefs_Misc/Shields/BarbarianTallShields.xml
+++ b/ModPatches/Medieval Overhaul Barbarians/Patches/ThingDefs_Misc/Shields/BarbarianTallShields.xml
@@ -144,7 +144,7 @@
 						<drawData>
 							<scale>0.8</scale>
 							<defaultData>
-								<layer>210</layer>
+								<layer>85</layer>
 							</defaultData>
 							<dataEast>
 								<layer>-5</layer>
@@ -186,7 +186,7 @@
 						<drawData>
 							<scale>0.8</scale>
 							<defaultData>
-								<layer>210</layer>
+								<layer>85</layer>
 							</defaultData>
 							<dataEast>
 								<layer>-5</layer>
@@ -228,7 +228,7 @@
 						<drawData>
 							<scale>0.8</scale>
 							<defaultData>
-								<layer>210</layer>
+								<layer>85</layer>
 							</defaultData>
 							<dataEast>
 								<layer>-5</layer>

--- a/ModPatches/Medieval Overhaul House Roxmont/Patches/Medieval Overhaul House Roxmont/MOHR_Apparel.xml
+++ b/ModPatches/Medieval Overhaul House Roxmont/Patches/Medieval Overhaul House Roxmont/MOHR_Apparel.xml
@@ -259,7 +259,7 @@
 						<drawData>
 							<scale>0.55</scale>
 							<defaultData>
-								<layer>210</layer>
+								<layer>85</layer>
 							</defaultData>
 							<dataEast>
 								<layer>-5</layer>

--- a/ModPatches/Medieval Overhaul/Patches/Medieval Overhaul/ThingDefs_Misc/Shields/MO_Shields.xml
+++ b/ModPatches/Medieval Overhaul/Patches/Medieval Overhaul/ThingDefs_Misc/Shields/MO_Shields.xml
@@ -127,7 +127,7 @@
 						<drawData>
 							<scale>0.6</scale>
 							<defaultData>
-								<layer>210</layer>
+								<layer>85</layer>
 							</defaultData>
 							<dataEast>
 								<layer>-5</layer>
@@ -176,7 +176,7 @@
 						<drawData>
 							<scale>0.55</scale>
 							<defaultData>
-								<layer>210</layer>
+								<layer>85</layer>
 							</defaultData>
 							<dataEast>
 								<layer>-5</layer>
@@ -225,7 +225,7 @@
 						<drawData>
 							<scale>0.55</scale>
 							<defaultData>
-								<layer>210</layer>
+								<layer>85</layer>
 							</defaultData>
 							<dataEast>
 								<layer>-5</layer>
@@ -275,7 +275,7 @@
 						<drawData>
 							<scale>0.55</scale>
 							<defaultData>
-								<layer>210</layer>
+								<layer>85</layer>
 							</defaultData>
 							<dataEast>
 								<layer>-5</layer>
@@ -317,7 +317,7 @@
 						<drawData>
 							<scale>0.55</scale>
 							<defaultData>
-								<layer>210</layer>
+								<layer>85</layer>
 							</defaultData>
 							<dataEast>
 								<layer>-5</layer>
@@ -359,7 +359,7 @@
 						<drawData>
 							<scale>0.55</scale>
 							<defaultData>
-								<layer>210</layer>
+								<layer>85</layer>
 							</defaultData>
 							<dataEast>
 								<layer>-5</layer>
@@ -401,7 +401,7 @@
 						<drawData>
 							<scale>0.55</scale>
 							<defaultData>
-								<layer>210</layer>
+								<layer>85</layer>
 							</defaultData>
 							<dataEast>
 								<layer>-5</layer>
@@ -464,7 +464,7 @@
 						<drawData>
 							<scale>0.55</scale>
 							<defaultData>
-								<layer>210</layer>
+								<layer>85</layer>
 							</defaultData>
 							<dataEast>
 								<layer>-5</layer>
@@ -528,7 +528,7 @@
 						<drawData>
 							<scale>0.55</scale>
 							<defaultData>
-								<layer>210</layer>
+								<layer>85</layer>
 							</defaultData>
 							<dataEast>
 								<layer>-5</layer>

--- a/ModPatches/Profaned/Patches/Profaned/ThingDefs_Misc/Profaned_Apparel_Shields.xml
+++ b/ModPatches/Profaned/Patches/Profaned/ThingDefs_Misc/Profaned_Apparel_Shields.xml
@@ -113,7 +113,7 @@
 							<drawData>
 								<scale>0.65</scale>
 								<defaultData>
-									<layer>210</layer>
+									<layer>85</layer>
 								</defaultData>
 								<dataEast>
 									<layer>-5</layer>

--- a/ModPatches/Vanilla Factions Expanded - Classical/Defs/Vanilla Factions Expanded - Classical/ThingDefs_Shields.xml
+++ b/ModPatches/Vanilla Factions Expanded - Classical/Defs/Vanilla Factions Expanded - Classical/ThingDefs_Shields.xml
@@ -69,7 +69,7 @@
 					<drawData>
 						<scale>0.65</scale>
 						<defaultData>
-							<layer>210</layer>
+							<layer>85</layer>
 						</defaultData>
 						<dataEast>
 							<layer>-5</layer>

--- a/ModPatches/Vanilla Factions Expanded - Medieval 2/Patches/Vanilla Factions Expanded - Medieval 2/ThingDefs_Misc/VFEM2_Shields.xml
+++ b/ModPatches/Vanilla Factions Expanded - Medieval 2/Patches/Vanilla Factions Expanded - Medieval 2/ThingDefs_Misc/VFEM2_Shields.xml
@@ -121,7 +121,7 @@
 						<drawData>
 							<scale>0.55</scale>
 							<defaultData>
-								<layer>210</layer>
+								<layer>85</layer>
 							</defaultData>
 							<dataEast>
 								<layer>-5</layer>
@@ -177,7 +177,7 @@
 						<drawData>
 							<scale>0.6</scale>
 							<defaultData>
-								<layer>210</layer>
+								<layer>85</layer>
 							</defaultData>
 							<dataEast>
 								<layer>-5</layer>

--- a/ModPatches/pphhyy Demigryph/Patches/pphhyy Demigryph/Demigryph_Banners.xml
+++ b/ModPatches/pphhyy Demigryph/Patches/pphhyy Demigryph/Demigryph_Banners.xml
@@ -108,7 +108,7 @@
 									<drawData>
 										<scale>1.3</scale>
 										<defaultData>
-											<layer>210</layer>
+											<layer>85</layer>
 										</defaultData>
 										<dataEast>
 											<layer>-5</layer>
@@ -161,7 +161,7 @@
 										<drawData>
 											<scale>1.3</scale>
 											<defaultData>
-												<layer>210</layer>
+												<layer>85</layer>
 											</defaultData>
 											<dataEast>
 												<layer>-5</layer>
@@ -214,7 +214,7 @@
 										<drawData>
 											<scale>1.3</scale>
 											<defaultData>
-												<layer>210</layer>
+												<layer>85</layer>
 											</defaultData>
 											<dataEast>
 												<layer>-5</layer>
@@ -267,7 +267,7 @@
 										<drawData>
 											<scale>1.3</scale>
 											<defaultData>
-												<layer>210</layer>
+												<layer>85</layer>
 											</defaultData>
 											<dataEast>
 												<layer>-5</layer>
@@ -320,7 +320,7 @@
 										<drawData>
 											<scale>1.3</scale>
 											<defaultData>
-												<layer>210</layer>
+												<layer>85</layer>
 											</defaultData>
 											<dataEast>
 												<layer>-5</layer>

--- a/ModPatches/pphhyy Demigryph/Patches/pphhyy Demigryph/Demigryph_Shields.xml
+++ b/ModPatches/pphhyy Demigryph/Patches/pphhyy Demigryph/Demigryph_Shields.xml
@@ -133,7 +133,7 @@
 									<drawData>
 										<scale>0.6</scale>
 										<defaultData>
-											<layer>210</layer>
+											<layer>85</layer>
 										</defaultData>
 										<dataEast>
 											<layer>-5</layer>
@@ -187,7 +187,7 @@
 									<drawData>
 										<scale>0.6</scale>
 										<defaultData>
-											<layer>210</layer>
+											<layer>85</layer>
 										</defaultData>
 										<dataEast>
 											<layer>-5</layer>
@@ -241,7 +241,7 @@
 									<drawData>
 										<scale>0.6</scale>
 										<defaultData>
-											<layer>210</layer>
+											<layer>85</layer>
 										</defaultData>
 										<dataEast>
 											<layer>-5</layer>
@@ -295,7 +295,7 @@
 									<drawData>
 										<scale>0.6</scale>
 										<defaultData>
-											<layer>210</layer>
+											<layer>85</layer>
 										</defaultData>
 										<dataEast>
 											<layer>-5</layer>
@@ -349,7 +349,7 @@
 									<drawData>
 										<scale>0.6</scale>
 										<defaultData>
-											<layer>210</layer>
+											<layer>85</layer>
 										</defaultData>
 										<dataEast>
 											<layer>-5</layer>


### PR DESCRIPTION
## Changes
- Increase the `renderingProperties` layer on shields from 80 to 210, so that shields do not render underneath beneath the Biotech burka,

## Reasoning
- Increases the rendering to just higher than the Burka's shell (210 vs 200) value, so that it renders correctly. 

## Alternatives
- Armored burkas?

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
