### PR TITLE
Disable newline enforcement after module-level namespaces.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ indent_size = 2
 [*.cs]
 indent_brace_style = Allman
 # don't enforce newline after module-level namespaces
-dotnet_diagnostic.IDE0161.severity = none
+csharp_new_line_after_file_scoped_namespace_declaration = false
 
 #### Core EditorConfig Options ####
 


### PR DESCRIPTION

## Reasoning

Something changed regarding the default value of this field, resulting in the style checker complaining. We could conform to the new specification, but without reproducing the issue locally, that is tedious to do. So we'll just suppress the error instead.

