### PR TITLE
Pin maximum acceptable .NET SDK

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -9,15 +9,17 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
-    - uses: actions/setup-dotnet@v3
+    - uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: '7.x'
+        # Note: Runners may have different, newer .NET SDKs preinstalled.
+        # Use global.json to control the maximum acceptable version.
+        dotnet-version: '9.x'
     - name: Check C# code style
       run: |
         dotnet format --verify-no-changes Source/CombatExtendedLoader.sln

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "9.0.112",
+    "rollForward": "latestMinor"
+  }
+}


### PR DESCRIPTION
The behaviour of `dotnet format` may be different between .NET SDK versions. Confusingly, although we install a specific SDK version for our style check in CI, the `dotnet` command will by default prefer the newest installed SDK version if no explicit version constraint was specified in global.json, which can cause unexpected breakage when GitHub updates the .NET SDKs installed by default on runners.

So, pin the maximum acceptable .NET SDK version in global.json.