### PR TITLE
Don't assume `ThingFilter.AllowedThingDefs` returns a `HashSet`

### DIFF
--- a/Source/VehiclesCompat/VehiclesCompat/VehiclesCompat.cs
+++ b/Source/VehiclesCompat/VehiclesCompat/VehiclesCompat.cs
@@ -111,11 +111,10 @@ public class VehiclesCompat : IModPart
                             var ammunition = vtd.ammunition = new ThingFilter();
                             vtd.genericAmmo = false;
                             vtd.chargePerAmmoCount = 1f / asd.ammoConsumedPerShot;
-                            HashSet<ThingDef> allowedAmmo = (HashSet<ThingDef>)ammunition.AllowedThingDefs;
 
                             foreach (var al in asd.ammoTypes)
                             {
-                                allowedAmmo.Add(al.ammo);
+                                ammunition.SetAllow(al.ammo, allow: true);
                                 yield return al.ammo;
                             }
 


### PR DESCRIPTION
While this accessor is just `public IEnumerable<ThingDef> AllowedThingDefs => allowedDefs;` where `allowedDefs` is a `HashSet`, other mods might postfix this accessor and cause it to return something else. So populate the allowed ammo types for vehicles via `SetAllow` instead.