### PR TITLE
Updated DA_PhrakShot patch to target DA's new VFE Ability

### DIFF
--- a/ModPatches/Dark Ages - Beasts and Monsters/Patches/Dark Ages - Beasts and Monsters/AbilityDef/DABeasts_CE_Patch_Abilities.xml
+++ b/ModPatches/Dark Ages - Beasts and Monsters/Patches/Dark Ages - Beasts and Monsters/AbilityDef/DABeasts_CE_Patch_Abilities.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- PhrakShot -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AbilityDef[defName="DA_ToxicBarbspike"]/verbProperties</xpath>
+		<value>
+			<verbProperties Class="CombatExtended.VerbPropertiesCE">
+				<verbClass>CombatExtended.Verb_AbilityShootCE</verbClass>
+				<defaultProjectile>DA_Shot_Phrak</defaultProjectile>
+				<range>20</range>
+				<muzzleFlashScale>0</muzzleFlashScale>
+				<warmupTime>2.4</warmupTime>
+				<soundCast>DA_PhrakShot</soundCast>
+				<burstShotCount>3</burstShotCount>
+				<commonality>0.50</commonality>
+				<ticksBetweenBurstShots>8</ticksBetweenBurstShots>
+				<minRange>2</minRange>
+				<targetParams>
+					<canTargetPawns>true</canTargetPawns>
+				</targetParams>
+				<ai_IsWeapon>false</ai_IsWeapon>	
+			</verbProperties>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Dark Ages - Beasts and Monsters/Patches/Dark Ages - Beasts and Monsters/ThingDef_Races/DABeasts_CE_Patch_Race_Phrak.xml
+++ b/ModPatches/Dark Ages - Beasts and Monsters/Patches/Dark Ages - Beasts and Monsters/ThingDef_Races/DABeasts_CE_Patch_Race_Phrak.xml
@@ -60,26 +60,4 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="DA_Phrak"]/verbs</xpath>
-		<value>
-			<verbs>
-				<li Class="CombatExtended.VerbPropertiesCE">
-					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-					<hasStandardCommand>true</hasStandardCommand>
-					<defaultProjectile>DA_Shot_Phrak</defaultProjectile>
-					<warmupTime>2.4</warmupTime>
-					<burstShotCount>3</burstShotCount>
-					<ticksBetweenBurstShots>8</ticksBetweenBurstShots>
-					<minRange>2</minRange>
-					<range>20</range>
-					<soundCast>DA_PhrakShot</soundCast>
-					<muzzleFlashScale>0</muzzleFlashScale>
-					<label>toxic barbpike</label>
-					<commonality>0.50</commonality>
-				</li>
-			</verbs>
-		</value>
-	</Operation>
-
 </Patch>


### PR DESCRIPTION
## Additions

None!

## Changes

 - Dark Ages : Beasts and Monsters CE patch for Phrak's ranged attack now correctly targets Phrak's new `DA_ToxicBarbspike` ability
   - Dark Ages: Beasts and Monsters used to use a verb for this ranged attack, but now uses a VEF ability instead.
   - Patch approach was inspired by the Alpha Animals CE patch. Values were kept the same as in the old patch.

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #4331

## Reasoning

 - Looked at other patches that targeted VEF abilities, and found the Alpha Animals patch.
 - Cross comparison of:
   - base Alpha Animals `AA_Bullet_VenomBarb_Minor` ability
   - Alpha Animals patch `Defs/AbilityDef[defName="AA_Bullet_VenomBarb_Minor"]/verbProperties`
   - base Dark Ages : Beasts and Monsters `DA_ToxicBarbspike` ability
   - Dark Ages : Beasts and Monsters patch `Defs/ThingDef[defName="DA_Phrak"]/verbs`
 - Set up new ability patch in the style of `Defs/AbilityDef[defName="AA_Bullet_VenomBarb_Minor"]/verbProperties` patch, targeting `DA_ToxicBarbspike` with the stats of the old `Defs/ThingDef[defName="DA_Phrak"]/verbs` patch.

## Alternatives

 - Removing the `Defs/ThingDef[defName="DA_Phrak"]/verbs` patch and leaving it at that
   - range attack would no longer be patched for Combat Extended, defeating the point

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors (a [Dark Ages: Beasts and Monsters] error still appears, but is a bug on Dark Ages: Beasts and Monsters side)
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (1 day without Phrak, 1 day with Phrak)
