### PR TITLE
VFE - Empire patch no longer overwrites vacuum resistance

### DIFF
--- a/ModPatches/Vanilla Factions Expanded - Empire/Patches/Vanilla Factions Expanded - Empire/Apparel_Headgear.xml
+++ b/ModPatches/Vanilla Factions Expanded - Empire/Patches/Vanilla Factions Expanded - Empire/Apparel_Headgear.xml
@@ -255,8 +255,8 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="VFEE_Apparel_JanissaryHelmet"]/equippedStatOffsets/ToxicResistance</xpath>
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="VFEE_Apparel_JanissaryHelmet"]/equippedStatOffsets</xpath>
 		<value>
 			<AimingAccuracy>0.15</AimingAccuracy>
 			<SmokeSensitivity>-1</SmokeSensitivity>
@@ -311,4 +311,5 @@
 			</li>
 		</value>
 	</Operation>
+
 </Patch>


### PR DESCRIPTION
## Additions

- None!

## Changes

- Patch for VFE - Empire's Janissary Helmet no longer wholly overrides `equippedStatOffsets`
  - Final stat block after CE patch is identical without Odyssey
  - Final stat block after CE patch is identical but also has vacuum resist with Odyssey

## References

- Closes #4333
- Contributes towards #4316

## Reasoning

- VFE - Empire added vacuum resistance to its apparel for Odyssey
- Other patched apparel only replaced `equippedStatOffsets/ShootingAccuracyPawn` to add new stats
  - VFE - Empire's new vacuum resistance stat was preserved
- Due to lack of `ShootingAccuracyPawn` in the janissary helmet, the patch replaced the entire `equippedStatOffsets` block
  - stat block in VFE - Empires has 100% toxic resistance, 100% toxic environment resistance, and 67% vacuum resistance
  - stat block in the patch had 100% toxic environment resistance, -100% smoke sensitivity, and 15% accuracy buff
- Now patch targets `equippedStatOffsets/ToxicResistance`
  - replaces 100% toxic resistance with -100% smoke sensitivity and 15% accuracy buff
  - final stat block is now 100% toxic environment resistance, -100% smoke sensitivity, 15% accuracy buff, and 67% vacuum resistance

## Alternatives

- Just add odyssey-conditional vacuum resist to the `equippedStatOffsets` block in the patch
  - somewhat simpler fix
  - would override patches to vacuum resistance of janissary helmet depending on load order
    - significantly, Vanilla Gravships Expanded rebalances this value
    - If we overwrite it here, then the final vacuum resistance of the helmet would differ depending on whether CE or VGE was loaded first
  - the janissary helmet patch would still be out-of-line of other VFE - Empires helmet patches
  - we don't care about the vacuum resistance and shouldn't overwrite it if we don't have to
- Just add -100% smoke sensitivity and 15% accuracy to janissary helmet
  - Even less brittle to changes in VFE - Empire
    - if VFE - Empire removes toxic resistance, this approach will break
  - Would now have 100% toxic resistance and 100% toxic environment resistance
    - this is closer to the balance in base VFE - Empire
    - this is slightly different to the current balance in the CE patch

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (1 day with helmets equipped)
