### PR TITLE
Riposte Verb_MeleeApplyHediff

### DIFF
--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
@@ -763,7 +763,7 @@ public class Verb_MeleeAttackCE : Verb_MeleeAttack
                     hediffVerb.ApplyMeleeDamageToTarget(caster);
                     sound = hediffVerb.SoundHitPawn();
                 }
-                if (ceVerb == null)
+                else if (ceVerb == null)
                 {
                     Log.Error("CE failed to get attack verb for riposte from Pawn " + defender.ToString());
                 }


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Adds type check for Verb_MeleeApplyHediff

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #4312 

## Reasoning

Why did you choose to implement things this way, e.g.
- Very rarely can riposte terrain hediff and should account for this rare vanilla attack.
- So rare either need to wait a very long time or bypass all checks and always force ripostes until it happens to check if code is working

## Alternatives

Describe alternative implementations you have considered, e.g.
- Occasional errors

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
