### PR TITLE
Fixed StatWorkers to show melee stats for Ranged Weapons and Prosthetics

### DIFF
--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -1680,4 +1680,38 @@ public static class CE_Utility
         }
         return current;
     }
+
+    internal static List<Tool> GetThingDefTools(ThingDef thingDef)
+    {
+        List<Tool> tools = new List<Tool>();
+        if (thingDef.isTechHediff)
+        {
+            tools = GetTechHediffTools(thingDef);
+        }
+        else if (thingDef.IsWeapon || thingDef.category == ThingCategory.Pawn)
+        {
+            tools = thingDef.tools?.ToList();
+        }
+
+        return tools;
+    }
+
+    internal static List<Tool> GetTechHediffTools(ThingDef thingDef)
+    {
+        List<Tool> techHediffTools = new List<Tool>();
+        List<RecipeDef> allDefsListForReading = DefDatabase<RecipeDef>.AllDefsListForReading;
+        for (int i = 0; i < allDefsListForReading.Count; i++)
+        {
+            if (allDefsListForReading[i].IsIngredient(thingDef))
+            {
+                HediffDef hediffDef = allDefsListForReading[i].addsHediff;
+                HediffCompProperties_VerbGiver hediffCompProperties_VerbGiver = hediffDef?.comps?.FirstOrDefault((HediffCompProperties x) => x is HediffCompProperties_VerbGiver) as HediffCompProperties_VerbGiver;
+                if (hediffCompProperties_VerbGiver != null && !hediffCompProperties_VerbGiver.tools.NullOrEmpty() && hediffCompProperties_VerbGiver.tools.All(t => t is ToolCE))
+                {
+                    techHediffTools = hediffCompProperties_VerbGiver.tools.ToList();
+                }
+            }
+        }
+        return techHediffTools;
+    }
 }

--- a/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_MeleeArmorPenetration.cs
+++ b/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_MeleeArmorPenetration.cs
@@ -10,6 +10,25 @@ using HarmonyLib;
 namespace CombatExtended;
 public class StatWorker_MeleeArmorPenetration : StatWorker_MeleeStats
 {
+    public override bool ShouldShowFor(StatRequest req)
+    {
+        if (!(req.Def is ThingDef thingDef))
+        {
+            return false;
+        }
+
+        if (stat.category == StatCategoryDefOf.PawnCombat)
+        {
+            return req.Thing is Pawn;
+        }
+        else if (stat.category == StatCategoryDefOf.Weapon_Melee)
+        {
+            return !(req.Thing is Pawn) && !CE_Utility.GetThingDefTools(thingDef).NullOrEmpty();
+        }
+
+        return false;
+    }
+
     public override string GetStatDrawEntryLabel(StatDef stat, float value, ToStringNumberSense numberSense, StatRequest optionalReq, bool finalized = true)
     {
         return GetFinalDisplayValue(optionalReq);
@@ -17,7 +36,7 @@ public class StatWorker_MeleeArmorPenetration : StatWorker_MeleeStats
 
     public override string GetExplanationUnfinalized(StatRequest req, ToStringNumberSense numberSense)
     {
-        var tools = (req.Def as ThingDef)?.tools;
+        List<Tool> tools = CE_Utility.GetThingDefTools(req.Def as ThingDef);
 
         if (tools.NullOrEmpty())
         {
@@ -94,7 +113,7 @@ public class StatWorker_MeleeArmorPenetration : StatWorker_MeleeStats
 
     private string GetFinalDisplayValue(StatRequest optionalReq)
     {
-        var tools = (optionalReq.Def as ThingDef)?.tools;
+        List<Tool> tools = CE_Utility.GetThingDefTools(optionalReq.Def as ThingDef);
         if (tools.NullOrEmpty())
         {
             return "";

--- a/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_MeleeDamageAverage.cs
+++ b/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_MeleeDamageAverage.cs
@@ -9,6 +9,25 @@ using UnityEngine;
 namespace CombatExtended;
 public class StatWorker_MeleeDamageAverage : StatWorker_MeleeDamageBase
 {
+    public override bool ShouldShowFor(StatRequest req)
+    {
+        if (!(req.Def is ThingDef thingDef))
+        {
+            return false;
+        }
+
+        if (stat.category == StatCategoryDefOf.PawnCombat)
+        {
+            return req.Thing is Pawn;
+        }
+        else if (stat.category == StatCategoryDefOf.Weapon_Melee)
+        {
+            return !(req.Thing is Pawn) && !CE_Utility.GetThingDefTools(thingDef).NullOrEmpty();
+        }
+
+        return false;
+    }
+
     public override float GetValueUnfinalized(StatRequest req, bool applyPostProcess)
     {
         var skilledDamageVariationMin = damageVariationMin;
@@ -20,7 +39,7 @@ public class StatWorker_MeleeDamageAverage : StatWorker_MeleeDamageBase
             skilledDamageVariationMax = GetDamageVariationMax(tracker.pawn);
         }
 
-        var tools = (req.Def as ThingDef)?.tools;
+        List<Tool> tools = CE_Utility.GetThingDefTools(req.Def as ThingDef);
         if (tools.NullOrEmpty())
         {
             return 0;
@@ -66,7 +85,7 @@ public class StatWorker_MeleeDamageAverage : StatWorker_MeleeDamageBase
             }
         }
 
-        var tools = (req.Def as ThingDef)?.tools;
+        List<Tool> tools = CE_Utility.GetThingDefTools(req.Def as ThingDef);
 
         if (tools.NullOrEmpty())
         {


### PR DESCRIPTION
Added ShouldShowFor overrides for StatWorker_MeleeDamageAverage and StatWorker_MeleeArmorPenetration to get them to show for ranged weapons and prosthetics. Changed other methods to get them to correctly reference tools for prosthetics. Added helper methods to CE_Utility.

## Additions

Added ShouldShowFor overrides to StatWorker_MeleeDamageAverage and StatWorker_MeleeArmorPenetration 
Helper methods in CE_Utility to return correct tool list for prosthetics vs pawns/weapons

## Changes

Changed GetExplanationUnfinalized, GetExplanationFinalizePart, GetValueUnfinalized as necessary to use the new helper methods to get Tools list for prosthetics. See bottom two images from https://imgur.com/a/I6DaA7R for results of this PR.

## References

- Closes #4347

## Reasoning

In vanilla, ranged weapons and prosthetics show their Melee DPS and Armor Penetration values. CE omits these. For ranged weapons with decent Tools (bayonet, underbarrel chainsaw, etc.) or prosthetics, this makes judging their combat value difficult.

## Alternatives

Leave as-is, missing valuable information.

## Testing

Check tests you have performed:
- [ X ] Compiles without warnings
- [ X ] Game runs without errors
- [ X ] (For compatibility patches) ...with and without patched mod loaded
- [ X ] Playtested a colony (specify how long)
