### PR TITLE
Change Big and Small's Warmech Minigun's Caliber

### DIFF
--- a/ModPatches/Big and Small Genes/Patches/Big and Small Genes/Big and Small - Enable All Optional Content/Weapons/ThingDef_Ranged.xml
+++ b/ModPatches/Big and Small Genes/Patches/Big and Small Genes/Big and Small - Enable All Optional Content/Weapons/ThingDef_Ranged.xml
@@ -128,7 +128,7 @@
 						<SwayFactor>2.32</SwayFactor>
 					</statBases>
 					<Properties>
-						<recoilAmount>1.5</recoilAmount>
+						<recoilAmount>2.2</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>True</hasStandardCommand>
 						<defaultProjectile>Bullet_50BMG_FMJ</defaultProjectile>


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Change warmech minigun to use a more common high caliber cartridge (.50 BMG) instead of an elephant gun cartridge (.470 Nitro Express)

## References

Links to the associated issues or other related pull requests, e.g.
- Contributes towards https://github.com/CombatExtended-Continued/CombatExtended/pull/4093/

## Reasoning

Why did you choose to implement things this way, e.g.
- No sense in using a niche big game cartridge for what's supposed to be military grade equipment

## Alternatives

Describe alternative implementations you have considered, e.g.
- 12.7x108mm

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
