### PR TITLE
Require pawns to be capable of manipulation to reload a turret

### DIFF
--- a/Source/CombatExtended/CombatExtended/Jobs/Utils/JobGiverUtils_Reload.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/Utils/JobGiverUtils_Reload.cs
@@ -147,6 +147,13 @@ class JobGiverUtils_Reload
             JobFailReason.Is("CE_TurretNonAllied".Translate());
             return false;
         }
+
+        if (!pawn.health.capacities.CapableOf(PawnCapacityDefOf.Manipulation))
+        {
+            CELogger.Message($"{pawn} could not reload {turret} because it's not capable of manipulation.");
+            return false;
+        }
+
         if ((turret.GetMannable()?.ManningPawn != pawn) && !pawn.CanReserveAndReach(turret, PathEndMode.ClosestTouch, forced ? Danger.Deadly : pawn.NormalMaxDanger(), MagicMaxPawns))
         {
             CELogger.Message($"{pawn} could not reload {turret} because turret is manned (or was recently manned) by someone else.");


### PR DESCRIPTION
## Changes

Have `JobGiverUtils.CanReload` check whether the pawn is capable of manipulation, otherwise the reload jobdriver fails.

## Reasoning

Not doing this causes error spam when a mech cluster with turrets has a damaged mech incapable of manipulation (e.g. lancer without arms)

## Testing
Tested that a mech cluster with turrets and an armless lancer no longer causes errors, and the damaged lancer doesn't try to reload turrets.
