### PR TITLE
Let manned turrets automatically shoot through smoke

### DIFF
--- a/Source/CombatExtended/CombatExtended/Things/Building_TurretGunCE.cs
+++ b/Source/CombatExtended/CombatExtended/Things/Building_TurretGunCE.cs
@@ -468,7 +468,11 @@ public class Building_TurretGunCE : Building_Turret
         if (!Projectile.projectile.flyOverhead)
         {
             targetScanFlags |= TargetScanFlags.NeedLOSToAll;
-            targetScanFlags |= TargetScanFlags.LOSBlockableByGas;
+            // Let manned turrets acquire targets through smoke.
+            if (attackTargetSearcher is not Pawn)
+            {
+                targetScanFlags |= TargetScanFlags.LOSBlockableByGas;
+            }
         }
         else
         {


### PR DESCRIPTION


## Changes
Allow manned turrets to automatically fire at new targets through smoke.


## References

- Closes #4315 

## Reasoning
Currently, manned turrets don't automatically acquire new targets if there's blind smoke between them and the target. Since pawns can shoot through smoke, and manned turrets already can fire at a manually forced target through smoke, let's allow them to automatically fire at targets though smoke.



## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony - see attached savefile: with this patch, the manned turret can shoot the yttakin while the mini-turret can't.

[manned_turret_smoke.rws.zip](https://github.com/user-attachments/files/24151630/manned_turret_smoke.rws.zip)
