### PR TITLE
Let manned turrets shoot over adjacent pawns

### DIFF
--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -1446,7 +1446,7 @@ public class Verb_LaunchProjectileCE : Verb
                 if (cover != null && cover != ShooterPawn && cover != caster && cover != targetThing && !cover.IsPlant() && !(cover is Pawn && cover.HostileTo(caster)))
                 {
                     //Shooter pawns don't attempt to shoot targets partially obstructed by their own faction members or allies, except when close enough to fire over their shoulder
-                    if (cover is Pawn cellPawn && !cellPawn.Downed && cellPawn.Faction != null && ShooterPawn?.Faction != null && (ShooterPawn.Faction == cellPawn.Faction || ShooterPawn.Faction.RelationKindWith(cellPawn.Faction) == FactionRelationKind.Ally) && !cellPawn.AdjacentTo8WayOrInside(ShooterPawn))
+                    if (cover is Pawn { Downed: false, Faction: not null } cellPawn && ShooterPawn?.Faction != null && (ShooterPawn.Faction == cellPawn.Faction || ShooterPawn.Faction.RelationKindWith(cellPawn.Faction) == FactionRelationKind.Ally) && !cellPawn.AdjacentTo8WayOrInside(caster))
                     {
                         return false;
                     }


### PR DESCRIPTION

## Changes
To avoid friendly fire, pawns only shoot over allies if they are adjacent to them. However, manned turrets calculate adjacency from the position of the shooter, rather than the turret itself, which yields incorrect results. So, consider the position of the caster, be it pawn or turret, rather than the position of the shooting pawn.

## References

- Closes #4314


## Alternatives

Also let manned turrets shoot over non-adjacent crouched pawns below their shot height, like unmanned turrets do. I'm not sure if we should do this because this is AIUI a friendly fire avoidance measure.

## Testing

- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony - see attached save
[manned_turret_shooting.rws.zip](https://github.com/user-attachments/files/24152415/manned_turret_shooting.rws.zip)
