### PR TITLE
Don't empty autoloaders on gravship launch

### DIFF
--- a/Source/CombatExtended/CombatExtended/Building_AmmoContainerCE/Building_AutoloaderCE.cs
+++ b/Source/CombatExtended/CombatExtended/Building_AmmoContainerCE/Building_AutoloaderCE.cs
@@ -139,7 +139,11 @@ public class Building_AutoloaderCE : Building
     {
         TargetTurret?.SetReloading(false);
         Map.GetComponent<AutoLoaderTracker>().Unregister(this);
-        DropAmmo(mode == DestroyMode.KillFinalize);
+        if (mode != DestroyMode.WillReplace)
+        {
+            DropAmmo(mode == DestroyMode.KillFinalize);
+        }
+
         base.DeSpawn(mode);
     }
 


### PR DESCRIPTION
## Changes
Only clear/drop autoloader ammo on despawn if the mode isn't `DestroyMode.WillReplace`.

## References

- Closes #4265 

## Reasoning

A gravship launch despawns everything on board with `DestroyMode.WillReplace`, so any container onboard should handle this case separately. This is similar e.g. to gibbet cages which eject the contained corpse when destroyed, but not when despawned with `DestroyMode.WillReplace`.


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony - tested that a gravship journey no longer causes ammo in an onboard autoloader to be lost.
