### PR TITLE
Bring melee stat displays closer to reality

### DIFF
--- a/Patches/Core/Stats/Stats.xml
+++ b/Patches/Core/Stats/Stats.xml
@@ -485,12 +485,27 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationReplace">
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/StatDef[defName="MeleeWeapon_AverageDPS"]/category</xpath>
+    <value>
+      <category>Weapon</category>
+    </value>
+  </Operation>
+
+
+  <Operation Class="PatchOperationReplace">
 		<xpath>Defs/StatDef[defName="MeleeWeapon_AverageDPS"]/displayPriorityInCategory</xpath>
 		<value>
-			<displayPriorityInCategory>6</displayPriorityInCategory>
+      <displayPriorityInCategory>7</displayPriorityInCategory>
 		</value>
 	</Operation>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/StatDef[defName="MeleeDPS"]/workerClass</xpath>
+    <value>
+      <workerClass>CombatExtended.StatWorker_MeleeDamageAverage</workerClass>
+    </value>
+  </Operation>
 
 	<!-- Melee AP -->
 
@@ -507,5 +522,20 @@
 			<toStringStyle>FloatTwo</toStringStyle>
 		</value>
 	</Operation>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/StatDef[defName="MeleeWeapon_AverageArmorPenetration"]/category</xpath>
+    <value>
+      <category>Weapon</category>
+    </value>
+  </Operation>
+
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/StatDef[defName="MeleeWeapon_AverageArmorPenetration"]/displayPriorityInCategory</xpath>
+    <value>
+      <displayPriorityInCategory>8</displayPriorityInCategory>
+    </value>
+  </Operation>
 
 </Patch>

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -12,6 +12,7 @@ using Verse;
 using Verse.AI;
 using Random = UnityEngine.Random;
 namespace CombatExtended;
+
 public static class CE_Utility
 {
     #region Camera
@@ -1742,21 +1743,6 @@ public static class CE_Utility
             current = source.Current;
         }
         return current;
-    }
-
-    internal static List<Tool> GetThingDefTools(ThingDef thingDef)
-    {
-        List<Tool> tools = new List<Tool>();
-        if (thingDef.isTechHediff)
-        {
-            tools = GetTechHediffTools(thingDef);
-        }
-        else if (thingDef.IsWeapon || thingDef.category == ThingCategory.Pawn)
-        {
-            tools = thingDef.tools?.ToList();
-        }
-
-        return tools;
     }
 
     public static float CalculateAbsorbedDamage(ProjectileCE projectile)

--- a/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_MeleeArmorPenetration.cs
+++ b/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_MeleeArmorPenetration.cs
@@ -8,26 +8,9 @@ using UnityEngine;
 using HarmonyLib;
 
 namespace CombatExtended;
+
 public class StatWorker_MeleeArmorPenetration : StatWorker_MeleeStats
 {
-    public override bool ShouldShowFor(StatRequest req)
-    {
-        if (!(req.Def is ThingDef thingDef))
-        {
-            return false;
-        }
-
-        if (stat.category == StatCategoryDefOf.PawnCombat)
-        {
-            return req.Thing is Pawn;
-        }
-        else if (stat.category == StatCategoryDefOf.Weapon_Melee)
-        {
-            return !(req.Thing is Pawn) && !CE_Utility.GetThingDefTools(thingDef).NullOrEmpty();
-        }
-
-        return false;
-    }
 
     public override string GetStatDrawEntryLabel(StatDef stat, float value, ToStringNumberSense numberSense, StatRequest optionalReq, bool finalized = true)
     {
@@ -36,16 +19,18 @@ public class StatWorker_MeleeArmorPenetration : StatWorker_MeleeStats
 
     public override string GetExplanationUnfinalized(StatRequest req, ToStringNumberSense numberSense)
     {
-        List<Tool> tools = CE_Utility.GetThingDefTools(req.Def as ThingDef);
-
-        if (tools.NullOrEmpty())
+        if (req.Def is not ThingDef thingDef)
         {
             return base.GetExplanationUnfinalized(req, numberSense);
         }
+
+        var pawn = GetCurrentWielder(req);
+
+        var skillFactor = GetSkillFactor(pawn);
+        var otherFactors = GetOtherFactors(pawn);
+
         var stringBuilder = new StringBuilder();
-        var penetrationFactor = GetPenetrationFactor(req);
-        var skillFactor = GetSkillFactor(req);
-        stringBuilder.AppendLine("CE_WeaponPenetrationFactor".Translate() + ": " + penetrationFactor.ToStringByStyle(ToStringStyle.PercentZero));
+
         if (Mathf.Abs(skillFactor - 1f) > 0.001f)
         {
             stringBuilder.AppendLine("CE_WeaponPenetrationSkillFactor".Translate() + ": " + skillFactor.ToStringByStyle(ToStringStyle.PercentZero));
@@ -53,26 +38,83 @@ public class StatWorker_MeleeArmorPenetration : StatWorker_MeleeStats
 
         stringBuilder.AppendLine();
 
-        foreach (ToolCE tool in tools)
+        if (req.Thing is Pawn)
         {
-            var maneuvers = DefDatabase<ManeuverDef>.AllDefsListForReading.Where(d => tool.capacities.Contains(d.requiredCapacity));
-            var maneuverString = "(";
-            foreach (var maneuver in maneuvers)
+            var meleeVerbs = pawn.meleeVerbs.GetUpdatedAvailableVerbsList(terrainTools: false);
+            var cumulativeWeights = meleeVerbs.Sum(verbEntry => verbEntry.GetSelectionWeight(null));
+            foreach (var verbEntry in meleeVerbs)
             {
-                maneuverString += maneuver.ToString() + "/";
-            }
-            maneuverString = maneuverString.TrimmedToLength(maneuverString.Length - 1) + ")";
-            stringBuilder.AppendLine("  " + "Tool".Translate() + ": " + tool.ToString() + " " + maneuverString);
-            var otherFactors = GetOtherFactors(req).Aggregate(1f, (x, y) => x * y);
-            if (Mathf.Abs(otherFactors - 1f) > 0.001f)
-            {
-                stringBuilder.AppendLine("   " + "CE_WeaponPenetrationOtherFactors".Translate() + ": " + otherFactors.ToStringByStyle(ToStringStyle.PercentZero));
-            }
+                var penetrationFactor =
+                    verbEntry.verb.EquipmentSource?.GetStatValue(CE_StatDefOf.MeleePenetrationFactor) ?? 1f;
+                var chance = verbEntry.GetSelectionWeight(null) / cumulativeWeights;
 
+                if (chance > 0)
+                {
+                    ShowExplanationForVerb(
+                        stringBuilder,
+                        verbEntry.verb.tool,
+                        verbEntry.verb.maneuver,
+                        skillFactor,
+                        otherFactors,
+                        penetrationFactor,
+                        chance
+                    );
+                }
+            }
+        }
+        else
+        {
+            var penetrationFactor = GetPenetrationFactor(req);
+            var meleeVerbPropsWithSource = AllMeleeVerbPropsWithSource(thingDef);
+            var cumulativeWeights = meleeVerbPropsWithSource.Sum(vps => AdjustedMeleeSelectionWeight(vps, pawn, req));
+            foreach (var vps in meleeVerbPropsWithSource)
+            {
+                var chance = AdjustedMeleeSelectionWeight(vps, pawn, req) / cumulativeWeights;
+                ShowExplanationForVerb(
+                    stringBuilder,
+                    vps.tool,
+                    vps.maneuver,
+                    skillFactor,
+                    otherFactors,
+                    penetrationFactor,
+                    chance
+                );
+            }
+        }
+
+        return stringBuilder.ToString();
+    }
+
+    private void ShowExplanationForVerb(StringBuilder stringBuilder, Tool verbTool, ManeuverDef maneuver,
+        float skillFactor,
+        float otherFactors,
+        float penetrationFactor,
+        float chance)
+    {
+        if (verbTool is not ToolCE tool)
+        {
+            return;
+        }
+
+        var maneuverString = "(" + maneuver + ")";
+        stringBuilder.AppendLine("  " + "Tool".Translate() + ": " + tool.ToString() + " " + maneuverString);
+
+
+        stringBuilder.AppendLine("   " + "CE_WeaponPenetrationFactor".Translate() + ": " + penetrationFactor.ToStringByStyle(ToStringStyle.PercentZero));
+
+        if (Mathf.Abs(otherFactors - 1f) > 0.001f)
+        {
+            stringBuilder.AppendLine("   " + "CE_WeaponPenetrationOtherFactors".Translate() + ": " + otherFactors.ToStringByStyle(ToStringStyle.PercentZero));
+        }
+
+        if (!Mathf.Approximately(tool.armorPenetrationSharp, 0f))
+        {
             stringBuilder.Append(string.Format("    {0}: {1} x {2}",
-                                                   "CE_DescSharpPenetration".Translate(),
-                                                   tool.armorPenetrationSharp.ToStringByStyle(ToStringStyle.FloatMaxTwo),
-                                                   penetrationFactor.ToStringByStyle(ToStringStyle.FloatMaxThree)));
+                                       "CE_DescSharpPenetration".Translate(),
+                                       tool.armorPenetrationSharp.ToStringByStyle(ToStringStyle.FloatMaxTwo),
+                                       penetrationFactor.ToStringByStyle(ToStringStyle.FloatMaxThree)));
+
+
             if (Mathf.Abs(skillFactor - 1f) > 0.001f)
             {
                 stringBuilder.Append(string.Format(" x {0}", skillFactor.ToStringByStyle(ToStringStyle.FloatMaxTwo)));
@@ -84,26 +126,29 @@ public class StatWorker_MeleeArmorPenetration : StatWorker_MeleeStats
             stringBuilder.AppendLine(string.Format(" = {0} {1}",
                                                     (tool.armorPenetrationSharp * penetrationFactor * skillFactor * otherFactors).ToStringByStyle(ToStringStyle.FloatMaxTwo),
                                                     "CE_mmRHA".Translate()));
-
-
-            stringBuilder.Append(string.Format("    {0}: {1} x {2}",
-                                                   "CE_DescBluntPenetration".Translate(),
-                                                   tool.armorPenetrationBlunt.ToStringByStyle(ToStringStyle.FloatMaxTwo),
-                                                   penetrationFactor.ToStringByStyle(ToStringStyle.FloatMaxThree)));
-            if (Mathf.Abs(skillFactor - 1f) > 0.001f)
-            {
-                stringBuilder.Append(string.Format(" x {0}", skillFactor.ToStringByStyle(ToStringStyle.FloatMaxTwo)));
-            }
-            if (Mathf.Abs(otherFactors - 1f) > 0.001f)
-            {
-                stringBuilder.Append(string.Format(" x {0}", otherFactors.ToStringByStyle(ToStringStyle.FloatMaxTwo)));
-            }
-            stringBuilder.AppendLine(string.Format(" = {0} {1}",
-                                                   (tool.armorPenetrationBlunt * penetrationFactor * skillFactor * otherFactors).ToStringByStyle(ToStringStyle.FloatMaxTwo),
-                                                   "CE_MPa".Translate()));
-            stringBuilder.AppendLine();
         }
-        return stringBuilder.ToString();
+        else
+        {
+            stringBuilder.AppendLine(string.Format(" = 0 {0}", "CE_mmRHA".Translate()));
+        }
+
+        stringBuilder.Append(string.Format("    {0}: {1} x {2}",
+                                               "CE_DescBluntPenetration".Translate(),
+                                               tool.armorPenetrationBlunt.ToStringByStyle(ToStringStyle.FloatMaxTwo),
+                                               penetrationFactor.ToStringByStyle(ToStringStyle.FloatMaxThree)));
+        if (Mathf.Abs(skillFactor - 1f) > 0.001f)
+        {
+            stringBuilder.Append(string.Format(" x {0}", skillFactor.ToStringByStyle(ToStringStyle.FloatMaxTwo)));
+        }
+        if (Mathf.Abs(otherFactors - 1f) > 0.001f)
+        {
+            stringBuilder.Append(string.Format(" x {0}", otherFactors.ToStringByStyle(ToStringStyle.FloatMaxTwo)));
+        }
+        stringBuilder.AppendLine(string.Format(" = {0} {1}",
+                                               (tool.armorPenetrationBlunt * penetrationFactor * skillFactor * otherFactors).ToStringByStyle(ToStringStyle.FloatMaxTwo),
+                                               "CE_MPa".Translate()));
+        stringBuilder.AppendLine("    " + "CE_ChanceFactor".Translate() + ": " + chance.ToStringByStyle(ToStringStyle.FloatMaxTwo));
+        stringBuilder.AppendLine();
     }
 
     public override string GetExplanationFinalizePart(StatRequest req, ToStringNumberSense numberSense, float finalVal)
@@ -111,39 +156,58 @@ public class StatWorker_MeleeArmorPenetration : StatWorker_MeleeStats
         return "StatsReport_FinalValue".Translate() + ": " + GetFinalDisplayValue(req);
     }
 
-    private string GetFinalDisplayValue(StatRequest optionalReq)
+    private string GetFinalDisplayValue(StatRequest req)
     {
-        List<Tool> tools = CE_Utility.GetThingDefTools(optionalReq.Def as ThingDef);
-        if (tools.NullOrEmpty())
+        if (req.Def is not ThingDef thingDef)
         {
             return "";
         }
-        if (tools.Any(x => !(x is ToolCE)))
+
+        var pawn = GetCurrentWielder(req);
+        var otherFactors = GetOtherFactors(pawn);
+        var skillFactor = GetSkillFactor(pawn);
+
+        float totalAveragePenSharp;
+        float totalAveragePenBlunt;
+
+        if (req.Thing is Pawn)
         {
-            Log.Error($"Trying to get stat MeleeArmorPenetration from {optionalReq.Def.defName} which has no support for Combat Extended.");
-            return "";
+            // When computing average armor penetration for a pawn, consider the weighted average of the armor penetration of all their available melee verbs.
+            // The penetration factor in this case depends on the weapon that provides a given verb.
+            var meleeVerbs = pawn.meleeVerbs.GetUpdatedAvailableVerbsList(terrainTools: false);
+
+            totalAveragePenSharp = meleeVerbs.AverageWeighted(
+                verbEntry => verbEntry.GetSelectionWeight(null),
+                verbEntry => verbEntry.verb.tool is ToolCE tool ? tool.armorPenetrationSharp * otherFactors * verbEntry.verb.EquipmentSource?.GetStatValue(CE_StatDefOf.MeleePenetrationFactor) ?? 1f : 0f
+                );
+            totalAveragePenBlunt = meleeVerbs.AverageWeighted(
+                verbEntry => verbEntry.GetSelectionWeight(null),
+                verbEntry => verbEntry.verb.tool is ToolCE tool ? tool.armorPenetrationBlunt * otherFactors * verbEntry.verb.EquipmentSource?.GetStatValue(CE_StatDefOf.MeleePenetrationFactor) ?? 1f : 0f
+            );
+        }
+        else
+        {
+            // Otherwise, when calculating average armor penetration for a single weapon (or def), be it wielded or unwielded,
+            // consider the weighted average of each verb and derive the penetration factor from the weapon/def.
+            var verbPropsWithSource = AllMeleeVerbPropsWithSource(thingDef);
+            totalAveragePenSharp = verbPropsWithSource.AverageWeighted(
+                vps => AdjustedMeleeSelectionWeight(vps, pawn, req),
+                vps => vps.tool is ToolCE tool ? tool.armorPenetrationSharp * otherFactors : 0f
+            );
+            totalAveragePenBlunt = verbPropsWithSource.AverageWeighted(
+                vps => AdjustedMeleeSelectionWeight(vps, pawn, req),
+                vps => vps.tool is ToolCE tool ? tool.armorPenetrationBlunt * otherFactors : 0f
+            );
+
+            var penetrationFactor = GetPenetrationFactor(req);
+
+            totalAveragePenSharp *= penetrationFactor;
+            totalAveragePenBlunt *= penetrationFactor;
         }
 
-        float totalSelectionWeight = 0f;
-        foreach (Tool tool in tools)
-        {
-            totalSelectionWeight += tool.chanceFactor;
-        }
-        float totalAveragePenSharp = 0f;
-        float totalAveragePenBlunt = 0f;
-        foreach (ToolCE tool in tools)
-        {
-            var weightFactor = tool.chanceFactor / totalSelectionWeight;
-            var otherFactors = GetOtherFactors(optionalReq).Aggregate(1f, (x, y) => x * y);
-            totalAveragePenSharp += weightFactor * tool.armorPenetrationSharp * otherFactors;
-            totalAveragePenBlunt += weightFactor * tool.armorPenetrationBlunt * otherFactors;
-        }
-        var penetrationFactor = GetPenetrationFactor(optionalReq);
-        var skillFactor = GetSkillFactor(optionalReq);
-
-        return (totalAveragePenSharp * penetrationFactor * skillFactor).ToStringByStyle(ToStringStyle.FloatMaxTwo) + " " + "CE_mmRHA".Translate()
+        return (totalAveragePenSharp * skillFactor).ToStringByStyle(ToStringStyle.FloatMaxTwo) + " " + "CE_mmRHA".Translate()
                + ", "
-               + (totalAveragePenBlunt * penetrationFactor * skillFactor).ToStringByStyle(ToStringStyle.FloatMaxTwo) + " " + "CE_MPa".Translate();
+               + (totalAveragePenBlunt * skillFactor).ToStringByStyle(ToStringStyle.FloatMaxTwo) + " " + "CE_MPa".Translate();
     }
 
     private float GetPenetrationFactor(StatRequest req)
@@ -163,30 +227,23 @@ public class StatWorker_MeleeArmorPenetration : StatWorker_MeleeStats
     }
     public const float skillFactorPerLevel = (25f / 19f) / 100f;
     public const float powerForOtherFactors = 0.75f;
-    private float GetSkillFactor(StatRequest req)
+    private float GetSkillFactor(Pawn pawn)
     {
         var skillFactor = 1f;
-        if (req.Thing is Pawn pawn && pawn.skills != null)
+        if (pawn?.skills != null)
         {
             skillFactor += skillFactorPerLevel * (pawn.skills.GetSkill(SkillDefOf.Melee).Level - 1);
         }
-        else
-        {
-            var thingHolder = (req.Thing?.ParentHolder as Pawn_EquipmentTracker)?.pawn;
-            if (thingHolder != null && thingHolder.skills != null)
-            {
-                skillFactor += skillFactorPerLevel * (thingHolder.skills.GetSkill(SkillDefOf.Melee).Level - 1);
-            }
-        }
         return skillFactor;
     }
-    private IEnumerable<float> GetOtherFactors(StatRequest req)
+    private float GetOtherFactors(Pawn pawn)
     {
-        var pawn = req.Thing as Pawn ?? (req.Thing?.ParentHolder as Pawn_EquipmentTracker)?.pawn;
         if (pawn != null)
         {
-            yield return Mathf.Pow(pawn.ageTracker.CurLifeStage.meleeDamageFactor, powerForOtherFactors);
-            yield return Mathf.Pow(pawn.GetStatValue(StatDefOf.MeleeDamageFactor, true, -1), powerForOtherFactors);
+            return Mathf.Pow(pawn.ageTracker.CurLifeStage.meleeDamageFactor, powerForOtherFactors) *
+                   Mathf.Pow(pawn.GetStatValue(StatDefOf.MeleeDamageFactor, true, -1), powerForOtherFactors);
         }
+
+        return 1f;
     }
 }

--- a/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_MeleeDamage.cs
+++ b/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_MeleeDamage.cs
@@ -8,6 +8,7 @@ using UnityEngine;
 using HarmonyLib;
 
 namespace CombatExtended;
+
 public class StatWorker_MeleeDamage : StatWorker_MeleeDamageBase
 {
     public override string GetStatDrawEntryLabel(StatDef stat, float value, ToStringNumberSense numberSense, StatRequest optionalReq, bool finalized = true)
@@ -17,25 +18,16 @@ public class StatWorker_MeleeDamage : StatWorker_MeleeDamageBase
 
     public override string GetExplanationUnfinalized(StatRequest req, ToStringNumberSense numberSense)
     {
-        var skilledDamageVariationMin = damageVariationMin;
-        var skilledDamageVariationMax = damageVariationMax;
-        var meleeSkillLevel = -1;
 
-        if (req.Thing?.ParentHolder is Pawn_EquipmentTracker tracker && tracker.pawn != null)
-        {
-            var pawnHolder = tracker.pawn;
-            skilledDamageVariationMin = GetDamageVariationMin(pawnHolder);
-            skilledDamageVariationMax = GetDamageVariationMax(pawnHolder);
+        var pawn = GetCurrentWielder(req);
 
-            if (pawnHolder.skills != null)
-            {
-                meleeSkillLevel = pawnHolder.skills.GetSkill(SkillDefOf.Melee).Level;
-            }
-        }
+        var skilledDamageVariationMin = GetDamageVariationMin(pawn);
+        var skilledDamageVariationMax = GetDamageVariationMax(pawn);
+        var meleeSkillLevel = pawn?.skills?.GetSkill(SkillDefOf.Melee).Level ?? -1;
 
-        var tools = (req.Def as ThingDef)?.tools;
+        bool hasSkilledDamageVariation = !(Mathf.Approximately(skilledDamageVariationMin, 1.0f) && Mathf.Approximately(skilledDamageVariationMax, 1.0f));
 
-        if (tools.NullOrEmpty())
+        if (req.Def is not ThingDef thingDef)
         {
             return base.GetExplanationUnfinalized(req, numberSense);
         }
@@ -46,28 +38,39 @@ public class StatWorker_MeleeDamage : StatWorker_MeleeDamageBase
         {
             stringBuilder.AppendLine("CE_WielderSkillLevel".Translate() + ": " + meleeSkillLevel);
         }
-        stringBuilder.AppendLine(string.Format("CE_DamageVariation".Translate() + ": {0}% - {1}%",
-                                               (100 * skilledDamageVariationMin).ToStringByStyle(ToStringStyle.FloatMaxTwo),
-                                               (100 * skilledDamageVariationMax).ToStringByStyle(ToStringStyle.FloatMaxTwo)));
-        stringBuilder.AppendLine("");
-        foreach (Tool tool in tools)
+
+        if (hasSkilledDamageVariation)
         {
-            if (tool is ToolCE toolCE)
+            stringBuilder.AppendLine(string.Format("CE_DamageVariation".Translate() + ": {0}% - {1}%",
+                                                   (100 * skilledDamageVariationMin).ToStringByStyle(ToStringStyle.FloatMaxTwo),
+                                                   (100 * skilledDamageVariationMax).ToStringByStyle(ToStringStyle.FloatMaxTwo)));
+        }
+
+        stringBuilder.AppendLine("");
+
+        foreach (var vps in AllMeleeVerbPropsWithSource(thingDef))
+        {
+            if (vps.tool is ToolCE toolCE)
             {
-                var adjustedToolDamage = GetAdjustedDamage(toolCE, req.Thing);
-                var maneuvers = DefDatabase<ManeuverDef>.AllDefsListForReading.Where(d => toolCE.capacities.Contains(d.requiredCapacity));
-                var maneuverString = "(";
-                foreach (var maneuver in maneuvers)
-                {
-                    maneuverString += maneuver.ToString() + "/";
-                }
-                maneuverString = maneuverString.TrimmedToLength(maneuverString.Length - 1) + ")";
+                var adjustedToolDamage = AdjustedMeleeDamageAmount(vps, pawn, req);
+                var maneuverString = "(" + vps.maneuver + ")";
                 stringBuilder.AppendLine("  " + "Tool".Translate() + ": " + toolCE.ToString() + " " + maneuverString);
                 stringBuilder.AppendLine("    " + "CE_DescBaseDamage".Translate() + ": " + toolCE.power.ToStringByStyle(ToStringStyle.FloatMaxTwo));
-                stringBuilder.AppendLine("    " + "CE_AdjustedForWeapon".Translate() + ": " + adjustedToolDamage.ToStringByStyle(ToStringStyle.FloatMaxTwo));
-                stringBuilder.AppendLine(string.Format("    " + "StatsReport_FinalValue".Translate() + ": {0} - {1}",
-                                                       (adjustedToolDamage * skilledDamageVariationMin).ToStringByStyle(ToStringStyle.FloatMaxTwo),
-                                                       (adjustedToolDamage * skilledDamageVariationMax).ToStringByStyle(ToStringStyle.FloatMaxTwo)));
+                if (!Mathf.Approximately(vps.tool.power, adjustedToolDamage))
+                {
+                    stringBuilder.AppendLine("    " + "CE_AdjustedForWeapon".Translate() + ": " + adjustedToolDamage.ToStringByStyle(ToStringStyle.FloatMaxTwo));
+                }
+
+                if (hasSkilledDamageVariation)
+                {
+                    stringBuilder.AppendLine(string.Format("    " + "StatsReport_FinalValue".Translate() + ": {0} - {1}",
+                                                           (adjustedToolDamage * skilledDamageVariationMin).ToStringByStyle(ToStringStyle.FloatMaxTwo),
+                                                           (adjustedToolDamage * skilledDamageVariationMax).ToStringByStyle(ToStringStyle.FloatMaxTwo)));
+                }
+                else
+                {
+                    stringBuilder.AppendLine(string.Format("    " + "StatsReport_FinalValue".Translate() + ": {0}", adjustedToolDamage.ToStringByStyle(ToStringStyle.FloatMaxTwo)));
+                }
                 stringBuilder.AppendLine();
             }
             else
@@ -87,36 +90,23 @@ public class StatWorker_MeleeDamage : StatWorker_MeleeDamageBase
         return "StatsReport_FinalValue".Translate() + ": " + GetFinalDisplayValue(req);
     }
 
-    private string GetFinalDisplayValue(StatRequest optionalReq)
+    private string GetFinalDisplayValue(StatRequest req)
     {
-        var skilledDamageVariationMin = damageVariationMin;
-        var skilledDamageVariationMax = damageVariationMax;
+        var pawn = GetCurrentWielder(req);
 
-        if (optionalReq.Thing?.ParentHolder is Pawn_EquipmentTracker tracker)
-        {
-            skilledDamageVariationMin = GetDamageVariationMin(tracker.pawn);
-            skilledDamageVariationMax = GetDamageVariationMax(tracker.pawn);
-        }
+        var skilledDamageVariationMin = GetDamageVariationMin(pawn);
+        var skilledDamageVariationMax = GetDamageVariationMax(pawn);
 
-        var tools = (optionalReq.Def as ThingDef)?.tools;
-        if (tools.NullOrEmpty())
+        if (req.Def is not ThingDef thingDef)
         {
             return "";
-        }
-        if (tools.Any(x => !(x is ToolCE)))
-        {
-            if (DebugSettings.godMode)
-            {
-                Log.Error($"Trying to get stat MeleeDamage from {optionalReq.Def.defName} which has no support for Combat Extended.");
-            }
-            return "CE_UnpatchedWeaponShort".Translate();
         }
 
         float lowestDamage = Int32.MaxValue;
         float highestDamage = 0f;
-        foreach (ToolCE tool in tools)
+        foreach (var vps in AllMeleeVerbPropsWithSource(thingDef))
         {
-            var toolDamage = GetAdjustedDamage(tool, optionalReq.Thing);
+            var toolDamage = AdjustedMeleeDamageAmount(vps, pawn, req);
             if (toolDamage > highestDamage)
             {
                 highestDamage = toolDamage;

--- a/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_MeleeDamageAverage.cs
+++ b/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_MeleeDamageAverage.cs
@@ -7,87 +7,77 @@ using Verse;
 using UnityEngine;
 
 namespace CombatExtended;
+
 public class StatWorker_MeleeDamageAverage : StatWorker_MeleeDamageBase
 {
-    public override bool ShouldShowFor(StatRequest req)
+
+    public override float GetValueUnfinalized(StatRequest req, bool applyPostProcess = true)
     {
-        if (!(req.Def is ThingDef thingDef))
-        {
-            return false;
-        }
+        var wielder = GetCurrentWielder(req);
 
-        if (stat.category == StatCategoryDefOf.PawnCombat)
-        {
-            return req.Thing is Pawn;
-        }
-        else if (stat.category == StatCategoryDefOf.Weapon_Melee)
-        {
-            return !(req.Thing is Pawn) && !CE_Utility.GetThingDefTools(thingDef).NullOrEmpty();
-        }
+        var skilledDamageVariationMin = GetDamageVariationMin(wielder);
+        var skilledDamageVariationMax = GetDamageVariationMax(wielder);
 
-        return false;
-    }
-
-    public override float GetValueUnfinalized(StatRequest req, bool applyPostProcess)
-    {
-        var skilledDamageVariationMin = damageVariationMin;
-        var skilledDamageVariationMax = damageVariationMax;
-
-        if (req.Thing?.ParentHolder is Pawn_EquipmentTracker tracker)
-        {
-            skilledDamageVariationMin = GetDamageVariationMin(tracker.pawn);
-            skilledDamageVariationMax = GetDamageVariationMax(tracker.pawn);
-        }
-
-        List<Tool> tools = CE_Utility.GetThingDefTools(req.Def as ThingDef);
-        if (tools.NullOrEmpty())
+        if (req.Def is not ThingDef thingDef)
         {
             return 0;
         }
-        if (tools.Any(x => !(x is ToolCE)))
+
+        float AverageDamageWithVariation(float baseDamage)
         {
-            Log.Error($"Trying to get stat MeleeDamageAverage from {req.Def.defName} which has no support for Combat Extended.");
-            return 0;
+            var minDamage = baseDamage * skilledDamageVariationMin;
+            var maxDamage = baseDamage * skilledDamageVariationMax;
+            return (minDamage + maxDamage) / 2f;
         }
 
-        var totalSelectionWeight = 0f;
-        foreach (var tool in tools)
+        float averageDamage;
+        float averageCooldown;
+
+        if (req.Thing is Pawn pawn)
         {
-            totalSelectionWeight += tool.chanceFactor;
+            var meleeVerbs = pawn.meleeVerbs.GetUpdatedAvailableVerbsList(terrainTools: false);
+            averageDamage = meleeVerbs.AverageWeighted(
+                verbEntry => verbEntry.GetSelectionWeight(null),
+                verbEntry => AverageDamageWithVariation(verbEntry.verb.verbProps.AdjustedMeleeDamageAmount(verbEntry.verb, pawn))
+            );
+            averageCooldown = meleeVerbs.AverageWeighted(
+                verbEntry => verbEntry.GetSelectionWeight(null),
+                verbEntry => verbEntry.verb.verbProps.AdjustedCooldown(verbEntry.verb, pawn)
+            );
+
         }
-        var totalDPS = 0f;
-        foreach (var tool in tools)
+        else
         {
-            var toolDamage = GetAdjustedDamage((ToolCE)tool, req.Thing);
-            var minDPS = toolDamage / tool.cooldownTime * skilledDamageVariationMin;
-            var maxDPS = toolDamage / tool.cooldownTime * skilledDamageVariationMax;
-            var weightFactor = tool.chanceFactor / totalSelectionWeight;
-            totalDPS += weightFactor * ((minDPS + maxDPS) / 2f);
+            var verbPropsWithSource = AllMeleeVerbPropsWithSource(thingDef);
+            averageDamage = verbPropsWithSource.AverageWeighted(
+                vps => AdjustedMeleeSelectionWeight(vps, wielder, req),
+                vps => AverageDamageWithVariation(AdjustedMeleeDamageAmount(vps, wielder, req))
+            );
+            averageCooldown = verbPropsWithSource.AverageWeighted(
+                vps => AdjustedMeleeSelectionWeight(vps, wielder, req),
+                vps => AdjustedCooldown(vps, wielder, req)
+            );
         }
-        return totalDPS;
+
+        float dps = averageDamage / averageCooldown;
+
+        if (wielder != null)
+        {
+            dps *= wielder.GetStatValue(StatDefOf.MeleeHitChance);
+        }
+
+        return dps;
     }
 
     public override string GetExplanationUnfinalized(StatRequest req, ToStringNumberSense numberSense)
     {
-        var skilledDamageVariationMin = damageVariationMin;
-        var skilledDamageVariationMax = damageVariationMax;
-        var meleeSkillLevel = -1;
+        var wielder = GetCurrentWielder(req);
 
-        if (req.Thing?.ParentHolder is Pawn_EquipmentTracker tracker && tracker.pawn != null)
-        {
-            var pawnHolder = tracker.pawn;
-            skilledDamageVariationMin = GetDamageVariationMin(pawnHolder);
-            skilledDamageVariationMax = GetDamageVariationMax(pawnHolder);
+        var skilledDamageVariationMin = GetDamageVariationMin(wielder);
+        var skilledDamageVariationMax = GetDamageVariationMax(wielder);
+        var meleeSkillLevel = wielder?.skills?.GetSkill(SkillDefOf.Melee).Level ?? -1;
 
-            if (pawnHolder.skills != null)
-            {
-                meleeSkillLevel = pawnHolder.skills.GetSkill(SkillDefOf.Melee).Level;
-            }
-        }
-
-        List<Tool> tools = CE_Utility.GetThingDefTools(req.Def as ThingDef);
-
-        if (tools.NullOrEmpty())
+        if (req.Def is not ThingDef thingDef)
         {
             return base.GetExplanationUnfinalized(req, numberSense);
         }
@@ -104,33 +94,98 @@ public class StatWorker_MeleeDamageAverage : StatWorker_MeleeDamageBase
                                                (100 * skilledDamageVariationMax).ToStringByStyle(ToStringStyle.FloatMaxTwo)));
         stringBuilder.AppendLine("");
 
-        foreach (ToolCE tool in tools)
+        if (req.Thing is Pawn pawn)
         {
-            var adjustedToolDamage = GetAdjustedDamage(tool, req.Thing);
-            var minDPS = adjustedToolDamage / tool.cooldownTime * skilledDamageVariationMin;
-            var maxDPS = adjustedToolDamage / tool.cooldownTime * skilledDamageVariationMax;
-
-            var maneuvers = DefDatabase<ManeuverDef>.AllDefsListForReading.Where(d => tool.capacities.Contains(d.requiredCapacity));
-            var maneuverString = "(";
-            foreach (var maneuver in maneuvers)
+            var meleeVerbs = pawn.meleeVerbs.GetUpdatedAvailableVerbsList(terrainTools: false);
+            var cumulativeSelectionWeights = meleeVerbs.Sum(verbEntry => verbEntry.GetSelectionWeight(null));
+            foreach (var verbEntry in meleeVerbs)
             {
-                maneuverString += maneuver.ToString() + "/";
-            }
-            maneuverString = maneuverString.TrimmedToLength(maneuverString.Length - 1) + ")";
+                var adjustedDamage = verbEntry.verb.verbProps.AdjustedMeleeDamageAmount(verbEntry.verb, pawn);
+                var adjustedCooldownTime = verbEntry.verb.verbProps.AdjustedCooldown(verbEntry.verb, pawn);
+                var chanceFactor = verbEntry.GetSelectionWeight(null) / cumulativeSelectionWeights;
 
-            stringBuilder.AppendLine("  " + "Tool".Translate() + ": " + tool.ToString() + " " + maneuverString);
-            stringBuilder.AppendLine("    " + "CE_DescBaseDamage".Translate() + ": " + tool.power.ToStringByStyle(ToStringStyle.FloatMaxTwo));
-            stringBuilder.AppendLine("    " + "CE_AdjustedForWeapon".Translate() + ": " + adjustedToolDamage.ToStringByStyle(ToStringStyle.FloatMaxTwo));
-            stringBuilder.AppendLine("    " + "CooldownTime".Translate() + ": " + tool.cooldownTime.ToStringByStyle(ToStringStyle.FloatMaxTwo) + " seconds");
-            stringBuilder.AppendLine("    " + "CE_DPS".Translate() + ": " + (adjustedToolDamage / tool.cooldownTime).ToStringByStyle(ToStringStyle.FloatMaxTwo));
-            stringBuilder.AppendLine(string.Format("    " + "CE_DamageVariation".Translate() + ": {0} - {1}",
-                                                   minDPS.ToStringByStyle(ToStringStyle.FloatMaxTwo),
-                                                   maxDPS.ToStringByStyle(ToStringStyle.FloatMaxTwo)));
-            stringBuilder.AppendLine("    " + "CE_FinalAverageDamage".Translate() + ": " + ((minDPS + maxDPS) / 2f).ToStringByStyle(ToStringStyle.FloatMaxTwo));
-            stringBuilder.AppendLine("    " + "CE_ChanceFactor".Translate() + ": " + tool.chanceFactor.ToStringByStyle(ToStringStyle.FloatMaxTwo));
-            stringBuilder.AppendLine();
+                if (chanceFactor > 0)
+                {
+                    ShowExplanationForVerb(
+                        stringBuilder,
+                        verbEntry.verb.tool,
+                        verbEntry.verb.maneuver,
+                        skilledDamageVariationMin,
+                        skilledDamageVariationMax,
+                        adjustedDamage,
+                        adjustedCooldownTime,
+                        chanceFactor);
+                }
+            }
         }
+        else
+        {
+            var verbPropsWithSource = AllMeleeVerbPropsWithSource(thingDef);
+
+            var cumulativeSelectionWeights = verbPropsWithSource.Sum(vps => AdjustedMeleeSelectionWeight(vps, wielder, req));
+
+            foreach (var vps in verbPropsWithSource)
+            {
+                var adjustedDamage = AdjustedMeleeDamageAmount(vps, wielder, req);
+                var adjustedCooldownTime = AdjustedCooldown(vps, wielder, req);
+                var chanceFactor = AdjustedMeleeSelectionWeight(vps, wielder, req) / cumulativeSelectionWeights;
+
+                ShowExplanationForVerb(
+                    stringBuilder,
+                    vps.tool,
+                    vps.maneuver,
+                    skilledDamageVariationMin,
+                    skilledDamageVariationMax,
+                    adjustedDamage,
+                    adjustedCooldownTime,
+                    chanceFactor);
+            }
+        }
+
+        if (wielder != null)
+        {
+            var hitChanceReq = StatRequest.For(wielder);
+            stringBuilder.AppendLine(StatDefOf.MeleeHitChance.Worker.GetExplanationUnfinalized(hitChanceReq, StatDefOf.MeleeHitChance.toStringNumberSense).TrimEndNewlines().Indented());
+            stringBuilder.Append(StatDefOf.MeleeHitChance.Worker.GetExplanationFinalizePart(hitChanceReq, StatDefOf.MeleeHitChance.toStringNumberSense, wielder.GetStatValue(StatDefOf.MeleeHitChance)).Indented());
+        }
+
         return stringBuilder.ToString();
+    }
+
+    private void ShowExplanationForVerb(
+        StringBuilder stringBuilder,
+        Tool tool,
+        ManeuverDef maneuver,
+        float skilledDamageVariationMin,
+        float skilledDamageVariationMax,
+        float adjustedDamage,
+        float adjustedCooldownTime,
+        float chanceFactor)
+    {
+        var minDPS = adjustedDamage / adjustedCooldownTime * skilledDamageVariationMin;
+        var maxDPS = adjustedDamage / adjustedCooldownTime * skilledDamageVariationMax;
+
+        var maneuverString = "(" + maneuver + ")";
+
+        stringBuilder.AppendLine("  " + "Tool".Translate() + ": " + tool.ToString() + " " + maneuverString);
+        stringBuilder.AppendLine("    " + "CE_DescBaseDamage".Translate() + ": " + tool.power.ToStringByStyle(ToStringStyle.FloatMaxTwo));
+        if (!Mathf.Approximately(tool.power, adjustedDamage))
+        {
+            stringBuilder.AppendLine("    " + "CE_AdjustedForWeapon".Translate() + ": " + adjustedDamage.ToStringByStyle(ToStringStyle.FloatMaxTwo));
+        }
+        stringBuilder.AppendLine("    " + "CooldownTime".Translate() + ": " + adjustedCooldownTime.ToStringByStyle(ToStringStyle.FloatMaxTwo) + " seconds");
+        stringBuilder.AppendLine("    " + "CE_DPS".Translate() + ": " + (adjustedDamage / adjustedCooldownTime).ToStringByStyle(ToStringStyle.FloatMaxTwo));
+
+        bool hasSkilledDamageVariation = !(Mathf.Approximately(skilledDamageVariationMin, 1.0f) && Mathf.Approximately(skilledDamageVariationMax, 1.0f));
+        if (hasSkilledDamageVariation)
+        {
+            stringBuilder.AppendLine(string.Format("    " + "CE_DamageVariation".Translate() + ": {0} - {1}",
+                minDPS.ToStringByStyle(ToStringStyle.FloatMaxTwo),
+                maxDPS.ToStringByStyle(ToStringStyle.FloatMaxTwo)));
+        }
+        stringBuilder.AppendLine("    " + "CE_FinalAverageDamage".Translate() + ": " + ((minDPS + maxDPS) / 2f).ToStringByStyle(ToStringStyle.FloatMaxTwo));
+        stringBuilder.AppendLine("    " + "CE_ChanceFactor".Translate() + ": " + chanceFactor.ToStringByStyle(ToStringStyle.FloatMaxTwo));
+        stringBuilder.AppendLine();
     }
 
 }

--- a/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_MeleeDamageBase.cs
+++ b/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_MeleeDamageBase.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using RimWorld;
 using Verse;
@@ -54,9 +53,35 @@ public class StatWorker_MeleeDamageBase : StatWorker_MeleeStats
         return true;
     }
 
-    public static float GetAdjustedDamage(ToolCE tool, Thing thingOwner)
+
+    /// <summary>
+    /// Get the melee damaged dealt by a single VerbProperties + Tool combination of a weapon,
+    /// adjusted according to the wielder's (if any) stats/capacities and multipliers from the weapon's stuff.
+    /// </summary>
+    /// <param name="vps">Verb data (VerbProperties + Tool + Maneuver)</param>
+    /// <param name="pawn">The wielder of the weapon, or null if the stat request is for an unwielded weapon.</param>
+    /// <param name="req">Stat request for a weapon or weapon def</param>
+    /// <returns>Melee damage adjusted for the wielder and weapon.</returns>
+    protected float AdjustedMeleeDamageAmount(VerbUtility.VerbPropertiesWithSource vps, Pawn pawn, StatRequest req)
     {
-        return tool.AdjustedBaseMeleeDamageAmount(thingOwner, tool.capacities?.First()?.VerbsProperties?.First()?.meleeDamageDef);
+        return req.HasThing ?
+            vps.verbProps.AdjustedMeleeDamageAmount(vps.tool, pawn, req.Thing, hediffCompSource: null) :
+            vps.verbProps.AdjustedMeleeDamageAmount(vps.tool, pawn, req.Def as ThingDef, req.StuffDef, hediffCompSource: null);
+    }
+
+    /// <summary>
+    /// Get the cooldown (in seconds) a single VerbProperties + Tool combination of a weapon,
+    /// adjusted according to the wielder's (if any) stats/capacities and multipliers from the weapon's stuff.
+    /// </summary>
+    /// <param name="vps">Verb data (VerbProperties + Tool + Maneuver)</param>
+    /// <param name="pawn">The wielder of the weapon, or null if the stat request is for an unwielded weapon.</param>
+    /// <param name="req">Stat request for a weapon or weapon def</param>
+    /// <returns>Cooldown time in seconds, adjusted for the wielder and weapon.</returns>
+    protected float AdjustedCooldown(VerbUtility.VerbPropertiesWithSource vps, Pawn pawn, StatRequest req)
+    {
+        return req.HasThing ?
+            vps.verbProps.AdjustedCooldown(vps.tool, pawn, req.Thing) :
+            vps.verbProps.AdjustedCooldown(vps.tool, pawn, req.Def as ThingDef, req.StuffDef);
     }
 
     #endregion

--- a/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_MeleeStats.cs
+++ b/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_MeleeStats.cs
@@ -13,4 +13,68 @@ public class StatWorker_MeleeStats : StatWorker
     {
         return thing?.def?.building?.IsTurret ?? base.IsDisabledFor(thing);
     }
+
+    public override bool ShouldShowFor(StatRequest req)
+    {
+        if (base.ShouldShowFor(req))
+        {
+            return true;
+        }
+
+        // Show melee stats for artificial body parts that add melee tools.
+        return stat.category == StatCategoryDefOf.Weapon &&
+               req.Def is ThingDef { isTechHediff: true } thingDef && AllMeleeVerbPropsWithSource(thingDef).Any();
+    }
+
+    /// <summary>
+    /// Get all melee verbs provided by a given weapon or tech hediff (e.g. artificial body part).
+    /// </summary>
+    /// <param name="thingDef">The def to fetch verbs for.</param>
+    /// <returns>Available melee VerbProperties + Tool + Maneuver combinations for the given def.</returns>
+    protected IEnumerable<VerbUtility.VerbPropertiesWithSource> AllMeleeVerbPropsWithSource(ThingDef thingDef)
+    {
+        var verbs = thingDef.Verbs;
+        var tools = thingDef.tools;
+
+        // For tech hediffs like artificial body parts, lookup whether they add any verbs when installed
+        // and return them if so.
+        if (thingDef.isTechHediff)
+        {
+            var props = DefDatabase<RecipeDef>.AllDefsListForReading
+                .Where(recipe => recipe.IsIngredient(thingDef))
+                .Select(recipe => recipe.addsHediff.CompProps<HediffCompProperties_VerbGiver>())
+                .FirstOrDefault(props => props != null);
+
+            if (props?.tools.All(tool => tool is ToolCE) ?? false)
+            {
+                verbs = props.verbs;
+                tools = props.tools;
+            }
+        }
+
+        return VerbUtility
+            .GetAllVerbProperties(verbs, tools)
+            .Where(vps => vps.verbProps.IsMeleeAttack);
+    }
+
+    /// <summary>
+    /// Get the selection weight fir a single VerbProperties + Tool combination of a weapon,
+    /// adjusted according to the wielder's (if any) stats/capacities and multipliers from the weapon's stuff.
+    ///
+    /// Note that this is only correct for calculating weights for a single weapon, since a pawn will likely
+    /// have "natural" melee verbs provided by body parts, which may influence final weighting.
+    /// </summary>
+    /// <param name="vps">Verb data (VerbProperties + Tool + Maneuver)</param>
+    /// <param name="pawn">The wielder of the weapon, or null if the stat request is for an unwielded weapon.</param>
+    /// <param name="req">Stat request for a weapon or weapon def</param>
+    /// <returns>Selection weight adjusted for the wielder and weapon.</returns>
+
+    protected float AdjustedMeleeSelectionWeight(VerbUtility.VerbPropertiesWithSource vps, Pawn pawn, StatRequest req)
+    {
+        return req.HasThing ?
+            vps.verbProps.AdjustedMeleeSelectionWeight(vps.tool, pawn, req.Thing, hediffCompSource: null, comesFromPawnNativeVerbs: false) :
+            vps.verbProps.AdjustedMeleeSelectionWeight(vps.tool, pawn, req.Def as ThingDef, req.StuffDef, hediffCompSource: null, comesFromPawnNativeVerbs: false);
+    }
+
+    protected Pawn GetCurrentWielder(StatRequest req) => req.Thing as Pawn ?? (req.Thing?.ParentHolder as Pawn_EquipmentTracker)?.pawn;
 }


### PR DESCRIPTION
## Changes
* Patch the MeleeDPS stat to use our StatWorker.
* In StatWorker_MeleeDamageAverage and StatWorker_MeleeArmorPenetration, use the pawn's list of melee verbs when computing the stat for a pawn, since the available verbs impact their weighting relative to each other. For instance, a pawn wielding a club may still choose to fight with fists some % of the time, but won't do so if wielding a masterwork longsword.
* Always obtain melee verbs from `VerbUtility.GetAllVerbProperties` when computing stats for a single weapon (which may be wielded by a pawn), so that damage, cooldown and tool use chance can be computed via `VerbProperties` helpers that take stuffing into account.
* Show the chance to use a given tool in the armor penetration stat explainer for clarity.

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #3937
- Closes #3938
- Closes #3939
- Closes #4347 

## Reasoning

Our current melee stat displays leave much to be desired:

* The "Melee DPS" stat shown prominently for pawns is an unpatched vanilla stat, which doesn't take CE's damage scaling into account.
* The stuff a weapon is made of isn't factored into stats, which impacts not just damage and cooldown but also the chance to pick a given tool relative to other tools.
* The armor penetration stat shown for humans doesn't consider the wielded weapon.


## Testing

- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony - tested stat displays for various weapons wielded and unwielded.
