### PR TITLE
Respect biocoding and other equipment restrictions

### DIFF
--- a/Source/CombatExtended/CombatExtended/AI/Comps/CompUrgentWeaponPickup.cs
+++ b/Source/CombatExtended/CombatExtended/AI/Comps/CompUrgentWeaponPickup.cs
@@ -123,6 +123,10 @@ public class CompUrgentWeaponPickup : ICompTactics
                 {
                     continue;
                 }
+                if (!EquipmentUtility.CanEquip(thing, SelPawn))
+                {
+                    continue;
+                }
                 if (compAmmo == null)
                 {
                     continue;
@@ -170,6 +174,10 @@ public class CompUrgentWeaponPickup : ICompTactics
                 continue;
             }
             if (!SelPawn.CanReserve(thing))
+            {
+                continue;
+            }
+            if (!EquipmentUtility.CanEquip(thing, SelPawn))
             {
                 continue;
             }

--- a/Source/CombatExtended/CombatExtended/Comps/CompInventory.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompInventory.cs
@@ -425,39 +425,14 @@ public class CompInventory : ThingComp
             return false;
         }
 
-        ThingWithComps newEq = null;
-
         // Stop current job
         if (parentPawn.jobs != null && stopJob)
         {
             parentPawn.jobs.StopAll();
         }
 
-        // Cycle through available ranged weapons
-        foreach (ThingWithComps gun in rangedWeaponListCached)
-        {
-            if (parentPawn.equipment != null && parentPawn.equipment.Primary != gun)
-            {
-                CompAmmoUser compAmmo = gun.TryGetComp<CompAmmoUser>();
-                if ((!useAOE && gun.def.IsAOEWeapon()) || gun.def.IsIlluminationDevice())
-                {
-                    continue;
-                }
-                if ((predicate?.Invoke(gun, compAmmo) ?? true) && compAmmo == null || compAmmo.HasAndUsesAmmoOrMagazine)
-                {
-                    newEq = gun;
-                    break;
-                }
-            }
-        }
-        // If no ranged weapon was found, use first available melee weapons
-        if (newEq == null)
-        {
-            newEq = (predicate == null ? meleeWeaponListCached : meleeWeaponListCached.Where(w => predicate.Invoke(w, null))).FirstOrDefault();
-        }
-
         // Equip the weapon
-        if (newEq != null)
+        if (TryFindViableWeapon(out ThingWithComps newEq, useAOE, predicate))
         {
             if (!stopJob)
             {
@@ -513,7 +488,11 @@ public class CompInventory : ThingComp
             }
             if (parentPawn.equipment != null && parentPawn.equipment.Primary != gun)
             {
-                if (gun.def.IsAOEWeapon() && (predicate == null || predicate.Invoke(gun)))
+                if (!EquipmentUtility.CanEquip(gun, parentPawn))
+                {
+                    continue;
+                }
+                if (gun.def.IsAOEWeapon() && (predicate?.Invoke(gun) ?? true))
                 {
                     weapon = gun;
                     return true;
@@ -527,6 +506,10 @@ public class CompInventory : ThingComp
     {
         grenade = (ThingWithComps)container.FirstOrFallback(t => t.def.weaponTags?.Contains("GrenadeSmoke") ?? false, null);
         if (grenade == null)
+        {
+            return false;
+        }
+        if (!EquipmentUtility.CanEquip(grenade, parentPawn))
         {
             return false;
         }
@@ -559,6 +542,10 @@ public class CompInventory : ThingComp
                 {
                     continue;
                 }
+                if (!EquipmentUtility.CanEquip(gun, parentPawn))
+                {
+                    continue;
+                }
                 if ((predicate?.Invoke(gun, compAmmo) ?? true) && compAmmo == null || compAmmo.HasAndUsesAmmoOrMagazine)
                 {
                     weapon = gun;
@@ -569,7 +556,7 @@ public class CompInventory : ThingComp
         // If no ranged weapon was found, use first available melee weapons
         if (weapon == null)
         {
-            weapon = (predicate == null ? meleeWeaponListCached : meleeWeaponListCached.Where(w => predicate.Invoke(w, null))).FirstOrDefault();
+            weapon = meleeWeaponListCached.FirstOrDefault(w => EquipmentUtility.CanEquip(w, parentPawn) && (predicate?.Invoke(w, null) ?? true));
         }
         return weapon != null;
     }
@@ -585,6 +572,10 @@ public class CompInventory : ThingComp
                 {
                     continue;
                 }
+            }
+            if (!EquipmentUtility.CanEquip(gun, parentPawn))
+            {
+                continue;
             }
             if (gun.def.IsIlluminationDevice())
             {

--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_TakeAndEquip.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_TakeAndEquip.cs
@@ -226,7 +226,7 @@ public class JobGiver_TakeAndEquip : ThinkNode_JobGiver
                 if ((pawn.skills.GetSkill(SkillDefOf.Shooting).Level >= pawn.skills.GetSkill(SkillDefOf.Melee).Level
                         || pawn.skills.GetSkill(SkillDefOf.Shooting).Level >= 6))
                 {
-                    ThingWithComps InvListGun3 = inventory.rangedWeaponList.Find(thing => thing.TryGetComp<CompAmmoUser>() != null && thing.TryGetComp<CompAmmoUser>().HasAmmoOrMagazine);
+                    ThingWithComps InvListGun3 = inventory.rangedWeaponList.Find(thing => thing.TryGetComp<CompAmmoUser>() != null && thing.TryGetComp<CompAmmoUser>().HasAmmoOrMagazine && EquipmentUtility.CanEquip(thing, pawn));
                     if (InvListGun3 != null)
                     {
                         inventory.TrySwitchToWeapon(InvListGun3);
@@ -250,7 +250,7 @@ public class JobGiver_TakeAndEquip : ThinkNode_JobGiver
                 else
                 {
                     // For melee weapon
-                    ThingWithComps InvListMeleeWeapon = inventory.meleeWeaponList.Find(thing => thing.def.IsMeleeWeapon);
+                    ThingWithComps InvListMeleeWeapon = inventory.meleeWeaponList.Find(thing => thing.def.IsMeleeWeapon && EquipmentUtility.CanEquip(thing, pawn));
                     if (InvListMeleeWeapon != null)
                     {
                         inventory.TrySwitchToWeapon(InvListMeleeWeapon);
@@ -336,7 +336,7 @@ public class JobGiver_TakeAndEquip : ThinkNode_JobGiver
             // Find weapon in inventory and try to switch if any ammo in inventory.
             if (priority == WorkPriority.Weapon && !hasPrimary)
             {
-                ThingWithComps InvListGun2 = inventory.rangedWeaponList.Find(thing => thing.TryGetComp<CompAmmoUser>() != null);
+                ThingWithComps InvListGun2 = inventory.rangedWeaponList.Find(thing => thing.TryGetComp<CompAmmoUser>() != null && EquipmentUtility.CanEquip(thing, pawn));
 
                 if (InvListGun2 != null)
                 {
@@ -357,6 +357,7 @@ public class JobGiver_TakeAndEquip : ThinkNode_JobGiver
                 {
                     Predicate<Thing> validatorWS = (Thing w) => w.def.IsWeapon
                                                    && w.MarketValue > 500 && pawn.CanReserve(w, 1)
+                                                   && EquipmentUtility.CanEquip(w, pawn)
                                                    && pawn.Position.InHorDistOf(w.Position, 25f)
                                                    && pawn.CanReach(w, PathEndMode.Touch, Danger.Deadly, true)
                                                    && (pawn.Faction.HostileTo(Faction.OfPlayer) || pawn.Faction == Faction.OfPlayer || !pawn.Map.areaManager.Home[w.Position]);

--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_UpdateLoadout.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_UpdateLoadout.cs
@@ -214,7 +214,7 @@ public class JobGiver_UpdateLoadout : ThinkNode_JobGiver
         {
             findItem = t => t.GetInnerIfMinified().def == curSlot.thingDef;
         }
-        Predicate<Thing> search = t => findItem(t) && !t.IsForbidden(pawn) && pawn.CanReserve(t, 10, 1) && !isFoodInPrison(t) && AllowedByBiocode(t, pawn) && AllowedByFoodRestriction(t, pawn);
+        Predicate<Thing> search = t => findItem(t) && !t.IsForbidden(pawn) && pawn.CanReserve(t, 10, 1) && !isFoodInPrison(t) && EquipmentUtility.CanEquip(t, pawn) && AllowedByFoodRestriction(t, pawn);
 
         // look for a thing near the pawn.
         curThing = GenClosest.ClosestThingReachable(
@@ -269,12 +269,6 @@ public class JobGiver_UpdateLoadout : ThinkNode_JobGiver
                 }
             }
         }
-    }
-
-    private static bool AllowedByBiocode(Thing thing, Pawn pawn)
-    {
-        CompBiocodable compBiocoded = thing.TryGetComp<CompBiocodable>();
-        return (compBiocoded == null || !compBiocoded.Biocoded || compBiocoded.CodedPawn == pawn);
     }
 
     private static bool AllowedByFoodRestriction(Thing thing, Pawn pawn)


### PR DESCRIPTION
## Changes

- All equipping functionality now checks vanilla's `EquipmentUtility.CanEquip` (applied to `CompUrgentWeaponPickup`, `CompInventory`, `JobGiver_TakeAndEquip`, and `JobGiver_UpdateLoadout`)
- Also incidentally reduced code duplication in `CompInventory.SwitchToNextViableWeapon` (it previously used code identical to `CompInventory.TryFindViableWeapon` rather than calling that method)

## Reasoning

Without this check, there are several cases where pawns can equip weapons they should not be able to:
- `CompUrgentWeaponPickup`: When under fire, hostile pawns may equip biocoded (or otherwise restricted) weapons
- `CompInventory`: Any situation asking a pawn to find and equip a weapon from inventory can result in the pawn equipping biocoded (or otherwise restricted) weapons, such as when switching to a new weapon after running out of ammo
- `JobGiver_TakeAndEquip`: Equipping pawns can equip biocoded (or otherwise restricted) weapons from inventory or ground
- `JobGiver_UpdateLoadout`: Pawns fulfilling their loadouts cannot equip biocoded weapons (as this is explicitly checked), but can equip weapons that are otherwise restricted

## Alternatives

- Directly checking for biocoding
  - Doesn't respect other niche restrictions in vanilla (such as the Ideology shooting specialist's refusal to equip melee weapons)
  - Not compatible with mods that patch `EquipmentUtility.CanEquip` to add or modify equipment restrictions (e.g., EBSG Framework)

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony: tested several scenarios with development mode

Test save: [CECanEquipTest.rws.zip](https://github.com/user-attachments/files/24195859/CECanEquipTest.rws.zip)
- Without this change:
  - Raiders equip biocoded weapons without being coded to them
  - Player pawns can switch to biocoded weapons not coded to them after running out of ammo
- With this change:
  - Raiders only equip non-biocoded weapons (not coded to them)
  - Player pawns cannot switch to biocoded weapons (not coded to them) after running out of ammo
  - Player pawns can still equip and switch to weapons biocoded to them

Several runs of the save may be required to encounter all cases.
