### PR TITLE
Set default counterparryBonus to 0

### DIFF
--- a/Defs/Stats/Stats_Weapons_Melee.xml
+++ b/Defs/Stats/Stats_Weapons_Melee.xml
@@ -109,6 +109,7 @@
 		<defaultBaseValue>0</defaultBaseValue>
 		<toStringStyle>FloatTwo</toStringStyle>
 		<displayPriorityInCategory>4</displayPriorityInCategory>
+		<showIfUndefined>false</showIfUndefined>
 	</StatDef>
 
 </Defs>


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- All weapons now default to a having counter parry bonus of 0.

## Reasoning

Why did you choose to implement things this way, e.g.
- Weapons like knives and gladiuses have counterparry bonus of 0.30 to 0.80
- Prior to this change, firearms like revolvers and rifles had the default counterparry bonus of 1. 
- Ranged weapons shouldn't outclass melee weapons at parrying

## Alternatives

Describe alternative implementations you have considered, e.g.
- Keep it as is

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
