### PR TITLE
Fix CompTacticalManager cache persisting between save loads

### DIFF
--- a/Source/CombatExtended/CombatExtended/AI/AI_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/AI/AI_Utility.cs
@@ -13,6 +13,11 @@ public static class AI_Utility
 {
     private static readonly Dictionary<Pawn, CompTacticalManager> _compTactical = new Dictionary<Pawn, CompTacticalManager>(2048);
 
+    public static void ResetCache()
+    {
+        _compTactical.Clear();
+    }
+
     public static CompTacticalManager GetTacticalManager(this Pawn pawn)
     {
         if (_compTactical.TryGetValue(pawn, out var comp))

--- a/Source/CombatExtended/Harmony/Harmony_Game.cs
+++ b/Source/CombatExtended/Harmony/Harmony_Game.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using CombatExtended.AI;
 using HarmonyLib;
 using Verse;
 
@@ -35,3 +36,18 @@ public static class Harmony_Game_LoadGame
     }
 }
 
+[HarmonyPatch(typeof(Game), nameof(Game.ClearCaches))]
+public static class Harmony_Game_ClearCaches
+{
+    public static void Postfix()
+    {
+        try
+        {
+            AI_Utility.ResetCache();
+        }
+        catch (Exception er)
+        {
+            Log.Error($"CE: Harmony_Game_ClearCaches {er}");
+        }
+    }
+}


### PR DESCRIPTION
## Changes

- `AI_Manager`'s `Pawn` to `CompTacticalManager` static cache (`_compTactical`) is now reset on save loads

## Reasoning

Without this change, the cache persists after a save reload, resulting in the loaded game referencing `CompTacticalManager`s  from the previously loaded game. This occurs because `Thing`s use their IDs for hashing, so the links between the newly loaded `Pawn`s (which have the same IDs as they did in the previously loaded game) and the old `CompTacticalManager`s are retained in the cache. This ends up causing strange behavior wherein AI cooldowns persist between reloads and potentially drastically change the events of a battle.

## Alternatives

- Remove the cache entirely and just access `CompTacticalManager` via `ThingWithComps.GetComp`
  - May be poor for performance, given how often `Pawn`s' `CompTacticalManager`s must be referenced (every time a bullet impacts nearby)
- Reset the cache in `Harmony_Game_LoadGame` postfix instead of adding `Harmony_Game_ClearCaches` postfix
  - Doesn't align with vanilla's loading procedure

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony: tested reloading a save to replay a battle and ensured cooldowns were reset as expected
