### PR TITLE
Cleanup Gizmo UI

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompFireModes.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompFireModes.cs
@@ -278,38 +278,34 @@ public class CompFireModes : CompRangedGizmoGiver
 
     public IEnumerable<Command> GenerateGizmos()
     {
-        Command_Action toggleFireModeGizmo = new Command_Action
-        {
-            action = ToggleFireMode,
-            defaultLabel = ("CE_" + currentFireModeInt.ToString() + "Label").Translate(),
-            defaultDesc = "CE_ToggleFireModeDesc".Translate(),
-            icon = ContentFinder<Texture2D>.Get(("UI/Buttons/" + currentFireModeInt.ToString()), true),
-            tutorTag = availableFireModes.Count > 1 ? "CE_FireModeToggle" : null
-        };
         if (availableFireModes.Count > 1)
         {
+            Command_Action toggleFireModeGizmo = new Command_Action
+            {
+                action = ToggleFireMode,
+                defaultLabel = ("CE_" + currentFireModeInt.ToString() + "Label").Translate(),
+                defaultDesc = "CE_ToggleFireModeDesc".Translate(),
+                icon = ContentFinder<Texture2D>.Get(("UI/Buttons/" + currentFireModeInt.ToString()), true),
+                tutorTag = "CE_FireModeToggle"
+            };
             // Teach about fire modes
-            toggleFireModeGizmo.tutorTag = "CE_FireModeToggle";
             LessonAutoActivator.TeachOpportunity(CE_ConceptDefOf.CE_FireModes, parent, OpportunityType.GoodToKnow);
+            yield return toggleFireModeGizmo;
         }
-        yield return toggleFireModeGizmo;
-
-        Command_Action toggleAimModeGizmo = new Command_Action
-        {
-            action = ToggleAimMode,
-            defaultLabel = ("CE_" + currentAimModeInt.ToString() + "Label").Translate(),
-            defaultDesc = "CE_ToggleAimModeDesc".Translate(),
-            icon = ContentFinder<Texture2D>.Get(("UI/Buttons/" + currentAimModeInt.ToString()), true),
-        };
         if (availableAimModes.Count > 1)
         {
+            Command_Action toggleAimModeGizmo = new Command_Action
+            {
+                action = ToggleAimMode,
+                defaultLabel = ("CE_" + currentAimModeInt.ToString() + "Label").Translate(),
+                defaultDesc = "CE_ToggleAimModeDesc".Translate(),
+                icon = ContentFinder<Texture2D>.Get(("UI/Buttons/" + currentAimModeInt.ToString()), true),
+                tutorTag = "CE_AimModeToggle"
+            };
             // Teach about aim modes
-            toggleAimModeGizmo.tutorTag = "CE_AimModeToggle";
             LessonAutoActivator.TeachOpportunity(CE_ConceptDefOf.CE_AimModes, parent, OpportunityType.GoodToKnow);
+            yield return toggleAimModeGizmo;
         }
-        yield return toggleAimModeGizmo;
-
-
         if (CurrentAimMode != AimMode.SuppressFire)
         {
             if ((HandLing > 2.45f) | IsTurretMannable)


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Toggle Fire Mode Gizmo only shows if more than firemode on weapon (E.g. Bolt Aciton Rifle and Bow will not show fire mode, but LMG will)
- Toggle Aim Mode Gizmo only shows if more than aim mode on weapon (No current cases that I can find)



<img width="950" height="174" alt="image" src="https://github.com/user-attachments/assets/a5c79698-4260-4f12-91da-b655913f5f0f" />

<img width="1251" height="176" alt="image" src="https://github.com/user-attachments/assets/6a575120-bfc1-4e7b-aab6-7f577cc15a99" />


Edge Case - Of underbarrel swaps causing gizmo shifts

<img width="1309" height="157" alt="image" src="https://github.com/user-attachments/assets/ed8efc5b-ecba-4d56-9149-3db1fd495fd2" />
<img width="1203" height="163" alt="image" src="https://github.com/user-attachments/assets/25319ef0-df2d-40f9-9281-168b340a5871" />



## Reasoning

Why did you choose to implement things this way, e.g.
- Cleaner UI
- CE utilizing a lot of gizmo real estate is a common complaint. If gizmos are not going to do anything they should not be shown

## Alternatives

Describe alternative implementations you have considered, e.g.
- Clutter

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
