### PR TITLE
Patched dread leather heat armor

### DIFF
--- a/Anomaly/Patches/Anomaly/ThingDefs_Items/Items_Resources_Stuff.xml
+++ b/Anomaly/Patches/Anomaly/ThingDefs_Items/Items_Resources_Stuff.xml
@@ -62,4 +62,12 @@
 		</value>
 	</Operation>
 
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Leather_Dread"]/statBases/StuffPower_Armor_Heat</xpath>
+		<value>
+			<StuffPower_Armor_Heat>0.014</StuffPower_Armor_Heat>
+		</value>
+	</Operation>
+
 </Patch>


### PR DESCRIPTION
Unpatched, dread leather dusters provided 750% heat armor.


## Additions
```
<Operation Class="PatchOperationReplace">
	<xpath>Defs/ThingDef[defName="Leather_Dread"]/statBases/StuffPower_Armor_Heat</xpath>
	<value>
		<StuffPower_Armor_Heat>0.014</StuffPower_Armor_Heat>
	</value>
</Operation>
```

## Reasoning
- Dread Leather Heat Armor values were unpatched, leading to absurd immunity from heat from any apparel using it.
- Dread Leather has the same heat armor value as Plainleather in base Rimworld, so I used the same value Combat Extended used to patch Plainleather.

## Testing

Check tests you have performed:
- [X] Compiles without warnings (NA, xml change)
- [X] Game runs without errors
- [X] (For compatibility patches) NA
- [X] Playtested a colony (Spawned item in dev test)
