### PR TITLE
Fix suppression decay after hunkering

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompSuppressable.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompSuppressable.cs
@@ -281,7 +281,7 @@ public class CompSuppressable : ThingComp
         {
             ticksUntilDecay -= delta;
         }
-        else if (currentSuppression > 0)
+        else if (currentSuppression > 0 || isSuppressed)
         {
             //Decay global suppression
             if (Controller.settings.DebugShowSuppressionBuildup && Gen.IsHashIntervalTick(parent, 30))


### PR DESCRIPTION


## Changes

It seems theoretically possible for a hunkered pawn's suppression amount to decay below zero before the minimum hunkering period added in #4222 elapses. This would then cause the pawn's suppressed state to never be cleared. Fix the condition so this doesn't occur.




## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] Playtested a colony 
