### PR TITLE
Patched Vac Slipsuit

### DIFF
--- a/ModPatches/VacSlipsuit/Patches/VacSlipsuit/Patches_Apparel.xml
+++ b/ModPatches/VacSlipsuit/Patches/VacSlipsuit/Patches_Apparel.xml
@@ -41,13 +41,12 @@
 		</value>
 	</Operation>
 
-	<!-- Prestige Version is not stuffable and uses hyperweave
-		We will use hyperweave vacslipsuit as base-->
+	<!-- Prestige Version is not stuffable and uses hyperweave, use hyperweave vacslipsuit as base-->
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Prestige_VacSlipsuit"]/statBases/StuffEffectMultiplierArmor</xpath>
 		<value>
 			<Bulk>5</Bulk>
-			<WornBulk>3.5</WornBulk> <!-- again, hyperweave vacslipsuit --> 
+			<WornBulk>3.5</WornBulk> <!-- Hyperweave vacslipsuit. --> 
 		</value>
 	</Operation>
 
@@ -80,15 +79,14 @@
 		</value>
 	</Operation>
 
-
 	<!-- ========== Kid's VacSlipsuit ========== -->
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="KidVacSlipsuit"]/statBases/StuffEffectMultiplierArmor</xpath>
 		<value>
-			<Bulk>5</Bulk>
-			<WornBulk>2</WornBulk>
-			<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+			<Bulk>4</Bulk>
+			<WornBulk>1.5</WornBulk>
+			<StuffEffectMultiplierArmor>1.75</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
 


### PR DESCRIPTION
[VacSlipsuit mod](https://steamcommunity.com/sharedfiles/filedetails/?id=3536829054)

## Additions
- Prestige VacSlipsuit patched
  - Armor and bulk values were set identical to a  regular hyperweave VacSlipsuit
  - Hyperweave is the fabric component in the prestige recipe, so it was the best analogue.

## Changes and rational
- Bulk reduced
  - bulk to match the idea that these are superlight and futuristic space apparel.
  - I used jumpsuits as a base and made them slightly more bulky
- Heat armor values were adjusted, as they were not before
  - Unpatched, these could make you immune to heat damage 

### Unchanged
- Temperature and vacuum resistance
  - Temperature insulation *needs* to be nerfed. As it is, this item is the strongest skin layer in the game as it obviates any temperature threats base game can throw at you.  I am reducing it in my personal set of patches, but I think it's appropriate to force that change on everyone else.
  - Vacuum resistance is 60%.  This isn't as egregious as temperature, just strong. 


## Testing

Check tests you have performed:
- [-] Compiles without warnings (Just XML changes to an XML item)
- [-] Game runs without errors (None caused by this one, current dev branch has airburst stuff going on)
- [X] (For compatibility patches) ...with and without patched mod loaded
- [X] Playtested a colony (long enough to spawn an item)  
