### PR TITLE
Fix NRE when magazineless weapon runs out of ammo

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompInventory.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompInventory.cs
@@ -446,7 +446,10 @@ public class CompInventory : ThingComp
         }
         else if (useFists)
         {
-            parentPawn.jobs.SuspendCurrentJob(JobCondition.InterruptForced);
+            if (parentPawn.jobs.curJob != null) //check there is a current job before attempting to suspend it
+            {
+                parentPawn.jobs.SuspendCurrentJob(JobCondition.InterruptForced);
+            }
             // Put away current weapon
             ThingWithComps eq = parentPawn.equipment?.Primary;
             if (eq != null && !parentPawn.equipment.TryTransferEquipmentToContainer(eq, container))


### PR DESCRIPTION
## Changes

- Add null check against current job before attempting to suspend it

## References

- https://discord.com/channels/278818534069501953/324222101550661663/1453616740708782194

## Reasoning

- Stops error messages from occurring when a bow or other magzineless ammo using weapon runs out of ammo

## Alternatives

- Use a different method than the brute force suspend job?

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (2 minutes)
