### PR TITLE
Small patch update for FSF Advanced Bionics.

### DIFF
--- a/ModPatches/FSF Advanced Bionics Expansion/Patches/FSF Advanced Bionics Expansion/HediffDefs/FSFAdvancedBionics_AddedParts.xml
+++ b/ModPatches/FSF Advanced Bionics Expansion/Patches/FSF Advanced Bionics Expansion/HediffDefs/FSFAdvancedBionics_AddedParts.xml
@@ -12,8 +12,7 @@
 					</capacities>
 					<power>7</power>
 					<cooldownTime>1.21</cooldownTime>
-					<armorPenetrationSharp>0</armorPenetrationSharp>
-					<armorPenetrationBlunt>15</armorPenetrationBlunt>
+					<armorPenetrationBlunt>8</armorPenetrationBlunt>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 					<soundMeleeHit>MeleeHit_BionicPunch</soundMeleeHit>
 					<soundMeleeMiss>MeleeMiss_BionicPunch</soundMeleeMiss>
@@ -106,7 +105,6 @@
 					</capacities>
 					<power>15</power>
 					<cooldownTime>1.21</cooldownTime>
-					<armorPenetrationSharp>0</armorPenetrationSharp>
 					<armorPenetrationBlunt>30</armorPenetrationBlunt>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 					<soundMeleeHit>MeleeHit_BionicPunch</soundMeleeHit>


### PR DESCRIPTION
## Additions
-patches 2 fsf advanced bionics prosthetics, the basic bionic power arm and basic bionic breacher arm.
-stats are half(rounding down) of those present for advanced variants.

## Reasoning

- The lack of patch was causing these prosthetics to runtime and disappear when used by a pawn as a weapon.
- Values were determined largely by vibe, 25% power dock over adv version felt a bit too strong for something available relatively early, it also felt like it may devalue the upgraded version.
## Alternatives

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (just long enough to test the parts.)
