### PR TITLE
Updated packageID for Gulden Biome mod

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -253,7 +253,7 @@
 		<li IfModActive="detvisor.glitterweaponry">ModPatches/Glitter Weaponry</li>
 		<li IfModActive="RooAndGloomy.DragonianRaceMod">ModPatches/Gloomy Dragonian Race</li>
 		<li IfModActive="spoonshortage.gourimet">ModPatches/GouRIMet</li>
-		<li IfModActive="pphhyy.Gulden">ModPatches/Gulden Mod</li>
+		<li IfModActive="pphhyy.Guldennew">ModPatches/Gulden Mod</li>
 		<li IfModActive="Monti.HalfDragons">ModPatches/Half Dragons</li>
 		<li IfModActive="HLX.RimworldUNSCArmoury">ModPatches/Halo - UNSC Armoury</li>
 		<li IfModActive="TheInfinityIQ.Halo.UNSC">ModPatches/Halo UNSC Weapon Pack</li>


### PR DESCRIPTION
## Changes

Corrected LoadFolders PackageID for Gulden Biome mod. PackageID was changed back in 1.5 update.
Patches themselves were not changed. Do not generate errors on startup and appear to work as expected in game.

## References

Current version of the mod. https://steamcommunity.com/sharedfiles/filedetails/?id=3607066070&

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long) ~10 minutes
