### PR TITLE
Update VQE - Ancients patch

### DIFF
--- a/ModPatches/Vanilla Quests Expanded - Ancients/Patches/Vanilla Quests Expanded - Ancients/Genes/GeneDefs_Ancients.xml
+++ b/ModPatches/Vanilla Quests Expanded - Ancients/Patches/Vanilla Quests Expanded - Ancients/Genes/GeneDefs_Ancients.xml
@@ -43,6 +43,7 @@
 			</statOffsets>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/GeneDef[defName="VQEA_PerfectVision"]/statFactors/ShootingAccuracyFactor_Long</xpath>
 		<value>
@@ -50,6 +51,7 @@
 			<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/GeneDef[defName="VQEA_PerfectVision"]/statFactors/ShootingAccuracyFactor_Medium</xpath>
 	</Operation>

--- a/ModPatches/Vanilla Quests Expanded - Ancients/Patches/Vanilla Quests Expanded - Ancients/ThingDefs_Misc/Weapons_Melee.xml
+++ b/ModPatches/Vanilla Quests Expanded - Ancients/Patches/Vanilla Quests Expanded - Ancients/ThingDefs_Misc/Weapons_Melee.xml
@@ -37,4 +37,5 @@
 			<MeleeDodgeChance>0.05</MeleeDodgeChance>
 		</value>
 	</Operation>
+
 </Patch>

--- a/ModPatches/Vanilla Quests Expanded - Ancients/Patches/Vanilla Quests Expanded - Ancients/ThingDefs_Races/Races_Splicelings.xml
+++ b/ModPatches/Vanilla Quests Expanded - Ancients/Patches/Vanilla Quests Expanded - Ancients/ThingDefs_Races/Races_Splicelings.xml
@@ -11,6 +11,7 @@
 			<ArmorRating_Blunt>2.7</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="VQEA_Splicefiend"]/comps</xpath>
 		<value>
@@ -221,7 +222,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="VQEA_Splicefiend"]/tools</xpath>
+		<xpath>Defs/ThingDef[defName="VQEA_Splicetoot"]/tools</xpath>
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
@@ -238,4 +239,5 @@
 			</tools>
 		</value>
 	</Operation>
+
 </Patch>


### PR DESCRIPTION
## Changes
Turns out, I missed some weapon-related stat offsets last time:
<img width="584" height="471" alt="old" src="https://github.com/user-attachments/assets/86366fb4-492a-4b82-9db2-30d6682c747d" />

Fixed those. In testing, the VE weapon range stat *does* work, so this gene is fully functional.
As with the original patch's PR, my reasoning here for these numbers is the genes already being quite strong in the base mod.

## References
- The base pull request for this patch was #4383

## Testing

Check tests you have performed:
- [ ] Compiles without warnings - Changes do not require a recompile
- [X] Game runs without errors
- [X] (For compatibility patches) ...with and without patched mod loaded
- [X] Playtested a colony (specify how long) - About ten minutes in dev quicktest, mostly testing the weapon range functionality to be honest. The stat offsets here are otherwise pretty mundane.