### PR TITLE
Check Damage Def Default ArmorPen

### DIFF
--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -516,6 +516,10 @@ public static class ArmorUtilityCE
             {
                 localPenAmount = Verb_MeleeAttackCE.LastAttackVerb.ArmorPenetrationBlunt;
             }
+            else if (dinfo.defInt.defaultArmorPenetration > 0)
+            {
+                localPenAmount = dinfo.defInt.defaultArmorPenetration;
+            }
             else
             {
                 //LastAttackVerb is already checked in GetAfterArmorDamage(). Only known case of code arriving here is with the ancient soldiers


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Fixes edge case of not having armor pen values by adding check for damage def default armor pen prior to default fallback of 50. No longer have the below messages for projectiles that come from apparel.

<img width="1087" height="55" alt="image" src="https://github.com/user-attachments/assets/b887076b-6975-45dc-8f46-454b01429d75" />

## Reasoning

Why did you choose to implement things this way, e.g.
- Fixes error that could have better armor pen

## Alternatives

Describe alternative implementations you have considered, e.g.
- Annoying message popup
- Slower but more versatile mod extension check on ``dinfo.Weapon`` but doesn't fix issues if null.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
