### PR TITLE
Fix VTR calculation for natural armor regeneration

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompArmorDurability.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompArmorDurability.cs
@@ -310,7 +310,7 @@ public class CompProperties_ArmorDurability : CompProperties
 
         if (RegenInterval < 0)
         {
-            yield return "has negative natural armor regeneration interval";
+            yield return parentDef.defName + " has negative natural armor regeneration interval";
         }
     }
 }


### PR DESCRIPTION



## Changes
* Make `CompProperties_ArmorDurability.RegenInterval` an `int` rather than a `float`, since it's a tick interval where fractional values do not make sense. Existing patches and defs use integer values.
* Have `CompArmorDurability` compute the natural armor healing as the product of the number of regeneration intervals that elapsed since the last regeneration and the defined regeneration value.

## Reasoning
For creatures with periodic natural armor regeneration, CompArmorDurability tracks the number of ticks that elapsed since the last bout of regeneration, then increases the natural armor with the product of the regeneration value and the VTR delta. However, this is incorrect: we instead should apply the regeneration value multiplied by the number of regeneration intervals that elapsed since the last time the natural armor was regenerated. This problem is especially visible with mods that throttle VTR aggressively, such as Slower Pawn Tick Rate, since the higher VTR deltas cause incorrectly high armor regeneration.

## Testing

- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony:

1. Given this save [naturalarmor.rws.zip](https://github.com/user-attachments/files/24416132/naturalarmor.rws.zip), shoot a burst into the thrumbo, which has a natural armor regeneration value of 5 every 600 ticks.
2. If Slower Pawn Tick Rate is loaded, note how the natural armor of the thrumbo regenerates unreasonably quickly.
3. With this fix, the thrumbo's armor should regenerate by 5 every 600 ticks, both with and without the Slower Pawn Tick Rate mod.

