### PR TITLE
Fix impact position for fast projectiles

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -1455,7 +1455,22 @@ public abstract class ProjectileCE : ThingWithComps
             }
         }
 
-        var explodePos = ExactPosition;
+        // The projectile's position will have been normalized to the point of impact with the Thing,
+        // which may sit exactly on a cell boundary for Things whose hitbox precisely lines up with a cell.
+        // This would always correspond to the cell due east or north of the boundary, which,
+        // when shooting south or west, would be the previous cell on the shotline.
+        // Since we always want explosion effects to occur in the impacted cell, shift the position accordingly
+        // if it is on a cell boundary.
+        Vector3 explodePos = ExactPosition;
+        if (ShotLine.direction.x < 0 && Mathf.Approximately(explodePos.x, (int)explodePos.x))
+        {
+            explodePos.x -= 0.5f;
+        }
+        if (ShotLine.direction.z < 0 && Mathf.Approximately(explodePos.z, (int)explodePos.z))
+        {
+            explodePos.z -= 0.5f;
+        }
+
 
         if (!explodePos.ToIntVec3().IsValid)
         {


### PR DESCRIPTION
## Changes

* Always compute and return the distance to the intersection point even when the current or previous position is within the bounds of the impacted Thing.
* Ensure explosion effects spawn in the impacted cell irrespective of shooting direction.

## Reasoning
When impacting a Thing, CanCollideWith() returns the distance `d` to the Thing from the previous position of the projectile. This is then used to derive the point of impact by getting the point on the shotline that is exactly `d` distance away from its origin (the previous position). The projectile's current position is then set to this point.

Since #3907 added special-casing for when the projectile's current or previous position is already within the bounding box of the impacted Thing, this doesn't work correctly, because the special casing returns a distance of 0, so the projectile's current position is set back to its previous position following the above logic. Secondary effects such as fragments and explosions then spawn a few tiles behind.

This normalization logic also means that when impacting Things whose hitbox precisely lines up with a cell,
the projectile's final position would end up sitting precisely on a cell boundary. Since a `Vector3` -> `IntVec3` conversion is just `(int)x, 0, (int)z`, this position always corresponds to the cell due east or north of the boundary, which, when shooting south or west, would be the previous cell on the shotline. Since we always want explosion effects to occur in the impacted cell, we should shift the position accordingly if it is on a cell boundary.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony:

1. On [cannon.rws.zip](https://github.com/user-attachments/files/24417629/cannon.rws.zip), shoot the sandstone at `188, 0, 36` (it's the rocky outcropping near some of the starting steel, east-southeast of the cannon).
2. Observe how the explosion will spawn behind the impact tile without this fix.

