### PR TITLE
Preserve tool IDs when generating autopatched tools

### DIFF
--- a/Source/CombatExtended/Compatibility/RaceAutoPatchers/RaceUtils.cs
+++ b/Source/CombatExtended/Compatibility/RaceAutoPatchers/RaceUtils.cs
@@ -29,6 +29,7 @@ public static class RaceUtil
     {
         var newTool = new ToolCE()
         {
+            id = tool.id,
             capacities = tool.capacities,
             armorPenetrationSharp = tool.armorPenetration,
             armorPenetrationBlunt = tool.armorPenetration,


### PR DESCRIPTION
## Changes
Carry over tool IDs into autopatched tools.

## Reasoning

Our autopatcher runs via `StaticConstructorOnStartup` and replaces unpatched tools with new `ToolCE` instances, but this leaves them without tool IDs because those are populated via `ThingDef.PostLoad` which happens earlier in the loading process. This will lead to save errors if an autopatched animal has multiple tools with overlapping capacities, since verb load IDs are in the form of `OwnerName_ToolID_ManeuverName`.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony - tested that an autopatched animal with multiple tools having the same capacities no longer causes save errors
