### PR TITLE
Subsequent shot rebalance draft

### DIFF
--- a/Defs/GameSetupSteps/SubsequentShotCurve.xml
+++ b/Defs/GameSetupSteps/SubsequentShotCurve.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Defs>
+
+  <GameSetupStepDef>
+    <defName>CE_SubsequentShotCurve</defName>
+    <order>1000</order>
+    <setupStep Class="CombatExtended.GameSetupStep_SubsequentShotCurve">
+      <defaultSubsequentShotCurve>
+        <points>
+          <li>(0, 0)</li><!--laser-->
+          <li>(1.5, 0.60)</li><!--m16 single shot-->
+          <li>(1.9, 0.80)</li><!--fal single-->
+          <li>(13.0, 0.95)</li><!--fal auto cyborg-->
+          <li>(17.0, 1.0)</li><!--fal auto 0 skill-->
+        </points>
+      </defaultSubsequentShotCurve>
+    </setupStep>
+  </GameSetupStepDef>
+</Defs>

--- a/Defs/GameSetupSteps/SubsequentShotCurve.xml
+++ b/Defs/GameSetupSteps/SubsequentShotCurve.xml
@@ -6,6 +6,7 @@
     <order>1000</order>
     <setupStep Class="CombatExtended.GameSetupStep_SubsequentShotCurve">
       <defaultSubsequentShotCurve>
+        <!-- (recoil accumulated this burst / subsequent shot aim time multipler) -->
         <points>
           <li>(0, 0)</li><!--laser-->
           <li>(1.5, 0.60)</li><!--m16 single shot-->

--- a/Defs/GameSetupSteps/SubsequentShotCurve.xml
+++ b/Defs/GameSetupSteps/SubsequentShotCurve.xml
@@ -5,7 +5,7 @@
     <defName>CE_SubsequentShotCurve</defName>
     <order>1000</order>
     <setupStep Class="CombatExtended.GameSetupStep_SubsequentShotCurve">
-      <defaultSubsequentShotCurve>
+      <subsequentShotRecoilCurve>
         <!-- (recoil accumulated this burst / subsequent shot aim time multipler) -->
         <points>
           <li>(0, 0)</li><!--laser-->
@@ -14,7 +14,21 @@
           <li>(13.0, 0.95)</li><!--fal auto cyborg-->
           <li>(17.0, 1.0)</li><!--fal auto 0 skill-->
         </points>
-      </defaultSubsequentShotCurve>
+      </subsequentShotRecoilCurve>
+      <subsequentShotMassCurve>
+        <!-- (weapon mass (loaded) / angle delta threshold above which penalties will apply) -->
+        <points>
+          <li>(1.25, 100)</li><!--m1911-->
+          <li>(2.82, 60)</li><!--charge smg-->
+          <li>(3.65, 35)</li><!--m16-->
+          <!--<li>(4.90, 40)</li>fn fal-->
+          <li>(8.8, 20)</li><!--charge lmg-->
+          <li>(15.3, 10)</li> <!-- hecate -->
+          <!--<li>(23.4, 20)</li>  wall gun -->
+          <li>(35, 5)</li> <!-- KPV -->
+        </points>
+      </subsequentShotMassCurve>
     </setupStep>
   </GameSetupStepDef>
+
 </Defs>

--- a/Languages/English/Keyed/ModMenu.xml
+++ b/Languages/English/Keyed/ModMenu.xml
@@ -108,6 +108,9 @@
 	<CE_Settings_FragmentsFromWallsIntensity_Desc>Controls how many wall fragments will spawn and how big they will be.</CE_Settings_FragmentsFromWallsIntensity_Desc>
 	<CE_Settings_FragmentsFromWallsIntensity_Title>Fragments from walls intensity</CE_Settings_FragmentsFromWallsIntensity_Title>
 
+	<CE_Settings_FasterRepeatShotsMultiplier_Desc>Controls how fast subsequent shot bonuses will accumulate.</CE_Settings_FasterRepeatShotsMultiplier_Desc>
+	<CE_Settings_FasterRepeatShotsMultiplier_Title>Subsequent shot difficulty</CE_Settings_FasterRepeatShotsMultiplier_Title>
+
 	<CE_Settings_FasterRepeatShots_Desc>When enabled, subsequent shots at the same, or nearby, targets are faster.</CE_Settings_FasterRepeatShots_Desc>
 	<CE_Settings_FasterRepeatShots_Title>Faster subsequent shots</CE_Settings_FasterRepeatShots_Title>
 

--- a/Source/CombatExtended/CombatExtended/GameSetupSteps/GameSetupStep_SubsequentShotCurve.cs
+++ b/Source/CombatExtended/CombatExtended/GameSetupSteps/GameSetupStep_SubsequentShotCurve.cs
@@ -1,0 +1,20 @@
+using Verse;
+
+namespace CombatExtended;
+
+public class GameSetupStep_SubsequentShotCurve : GameSetupStep
+{
+    public SimpleCurve defaultSubsequentShotCurve;
+
+    public override int SeedPart => 58224852; // unused, but required
+
+    public override void GenerateFresh()
+    {
+        Verb_ShootCE.SubsequentShotCurve = defaultSubsequentShotCurve;
+    }
+
+    public override void GenerateFromScribe()
+    {
+        Verb_ShootCE.SubsequentShotCurve = defaultSubsequentShotCurve;
+    }
+}

--- a/Source/CombatExtended/CombatExtended/GameSetupSteps/GameSetupStep_SubsequentShotCurve.cs
+++ b/Source/CombatExtended/CombatExtended/GameSetupSteps/GameSetupStep_SubsequentShotCurve.cs
@@ -4,17 +4,20 @@ namespace CombatExtended;
 
 public class GameSetupStep_SubsequentShotCurve : GameSetupStep
 {
-    public SimpleCurve defaultSubsequentShotCurve;
+    public SimpleCurve subsequentShotRecoilCurve;
+    public SimpleCurve subsequentShotMassCurve;
 
     public override int SeedPart => 58224852; // unused, but required
 
     public override void GenerateFresh()
     {
-        Verb_ShootCE.SubsequentShotCurve = defaultSubsequentShotCurve;
+        Verb_ShootCE.SubsequentShotRecoilCurve = subsequentShotRecoilCurve;
+        Verb_ShootCE.SubsequentShotMassCurve = subsequentShotMassCurve;
     }
 
     public override void GenerateFromScribe()
     {
-        Verb_ShootCE.SubsequentShotCurve = defaultSubsequentShotCurve;
+        Verb_ShootCE.SubsequentShotRecoilCurve = subsequentShotRecoilCurve;
+        Verb_ShootCE.SubsequentShotMassCurve = subsequentShotMassCurve;
     }
 }

--- a/Source/CombatExtended/CombatExtended/ModSettings/Settings.cs
+++ b/Source/CombatExtended/CombatExtended/ModSettings/Settings.cs
@@ -41,6 +41,7 @@ public class Settings : ModSettings, ISettingsCE
 
     private bool midBurstRetarget = true;
     private bool fasterRepeatShots = true;
+    private float fasterRepeatShotsRecoilMult = 1.0f;
 
     private float explosionPenMultiplier = 1.0f;
     private float explosionFalloffFactor = 1.0f;
@@ -160,6 +161,7 @@ public class Settings : ModSettings, ISettingsCE
     public float FragmentsFromWallsIntensity => fragmentsFromWallsIntensity;
 
     public bool FasterRepeatShots => fasterRepeatShots;
+    public float FasterRepeatShotsRecoilMult => fasterRepeatShotsRecoilMult;
     public bool MidBurstRetarget => midBurstRetarget;
 
     public float ExplosionPenMultiplier => explosionPenMultiplier;
@@ -256,6 +258,7 @@ public class Settings : ModSettings, ISettingsCE
         Scribe_Values.Look(ref fragmentsFromWallsReflected, "fragmentsFromWallsReflected", false);
         Scribe_Values.Look(ref fragmentsFromWallsIntensity, "fragmentsFromWallsIntensity", 1.0f);
         Scribe_Values.Look(ref fasterRepeatShots, "fasterRepeatShots", false);
+        Scribe_Values.Look(ref fasterRepeatShotsRecoilMult, "fasterRepeatShotsRecoilMult", 1.0f);
         Scribe_Values.Look(ref midBurstRetarget, "midBurstRetarget", true);
         Scribe_Values.Look(ref explosionPenMultiplier, "explosionPenMultiplier", 1.0f);
         Scribe_Values.Look(ref explosionFalloffFactor, "explosionFalloffFactor", 1.0f);
@@ -305,7 +308,6 @@ public class Settings : ModSettings, ISettingsCE
         left.CheckboxLabeled("CE_Settings_AllowMeleeHunting_Title".Translate(), ref allowMeleeHunting, "CE_Settings_AllowMeleeHunting_Desc".Translate());
         left.CheckboxLabeled("CE_Settings_SmokeEffects_Title".Translate(), ref smokeEffects, "CE_Settings_SmokeEffects_Desc".Translate());
         left.CheckboxLabeled("CE_Settings_TurretsBreakShields_Title".Translate(), ref turretsBreakShields, "CE_Settings_TurretsBreakShields_Desc".Translate());
-        left.CheckboxLabeled("CE_Settings_FasterRepeatShots_Title".Translate(), ref fasterRepeatShots, "CE_Settings_FasterRepeatShots_Desc".Translate());
         left.CheckboxLabeled("CE_Settings_MidBurstRetarget_Title".Translate(), ref midBurstRetarget, "CE_Settings_MidBurstRetarget_Desc".Translate());
         left.CheckboxLabeled("CE_Settings_EnableArcOfFire_Title".Translate(), ref enableArcOfFire, "CE_Settings_EnableArcOfFire_Desc".Translate());
         left.CheckboxLabeled("CE_Settings_EnableCIWS".Translate(), ref enableCIWS, "CE_Settings_EnableCIWS_Desc".Translate());
@@ -333,6 +335,9 @@ public class Settings : ModSettings, ISettingsCE
         right.Label("CE_Settings_StabilizationSettings".Translate());
         right.Gap();
         medicineSearchRadius = right.SliderLabeled("CE_Settings_MedicineSearchRadius_Title".Translate() + ": " + medicineSearchRadius.ToString("F0"), medicineSearchRadius, 1f, 100f, tooltip: "CE_Settings_MedicineSearchRadius_Desc".Translate(), labelPct: 0.6f);
+        right.GapLine();
+        left.CheckboxLabeled("CE_Settings_FasterRepeatShots_Title".Translate(), ref fasterRepeatShots, "CE_Settings_FasterRepeatShots_Desc".Translate());
+        fasterRepeatShotsRecoilMult = left.SliderLabeled("CE_Settings_FasterRepeatShotsMultiplier_Title".Translate() + ": " + fasterRepeatShotsRecoilMult.ToString("F1"), fasterRepeatShotsRecoilMult, 0.1f, 3f, tooltip: "CE_Settings_FasterRepeatShotsMultiplier_Desc".Translate(), labelPct: 0.6f);
         right.End();
     }
 
@@ -499,6 +504,7 @@ public class Settings : ModSettings, ISettingsCE
         smokeEffects = true;
         turretsBreakShields = true;
         fasterRepeatShots = true;
+        fasterRepeatShotsRecoilMult = 1.0f;
         midBurstRetarget = true;
         enableCIWS = true;
         fragmentsFromWalls = false;

--- a/Source/CombatExtended/CombatExtended/ModSettings/Settings.cs
+++ b/Source/CombatExtended/CombatExtended/ModSettings/Settings.cs
@@ -122,6 +122,7 @@ public class Settings : ModSettings, ISettingsCE
     private bool debugDisplayCellCoverRating = false;
     private bool debugDisplayAttritionInfo = false;
     private bool debugWorldShellingDamageRandomness = false;
+    private bool debugSubsequentShotLogging = false;
 
     public bool DebuggingMode => debuggingMode;
     public bool DebugVerbose => debugVerbose;
@@ -137,6 +138,7 @@ public class Settings : ModSettings, ISettingsCE
     public bool DebugDisplayCellCoverRating => debugDisplayCellCoverRating && debuggingMode;
     public bool DebugDisplayAttritionInfo => debugDisplayAttritionInfo && debuggingMode;
     public bool DebugWorldShellingDamageRandomness => debugWorldShellingDamageRandomness && debuggingMode;
+    public bool DebugSubsequentShotLogging => debugSubsequentShotLogging && debuggingMode;
     #endregion
 
     #region Autopatcher
@@ -222,6 +224,7 @@ public class Settings : ModSettings, ISettingsCE
         Scribe_Values.Look(ref debugDisplayCellCoverRating, "debugDisplayCellCoverRating", false);
         Scribe_Values.Look(ref debugDisplayAttritionInfo, "debugDisplayAttritionInfo", false);
         Scribe_Values.Look(ref debugWorldShellingDamageRandomness, "debugWorldShellingDamageRandomness", false);
+        Scribe_Values.Look(ref debugSubsequentShotLogging, "debugSubsequentShotLogging", false);
         Scribe_Values.Look(ref debugGenClosetPawn, "debugGenClosetPawn", false);
         Scribe_Values.Look(ref debugVerbose, "debugVerbose", false);
         Scribe_Values.Look(ref debugMuzzleFlash, "debugMuzzleFlash", false);
@@ -440,6 +443,7 @@ public class Settings : ModSettings, ISettingsCE
             list.CheckboxLabeled("Display danger buildup within cells", ref debugDisplayDangerBuildup);
             list.CheckboxLabeled("Display cover rating of cells of suppressed pawns", ref debugDisplayCellCoverRating);
             list.CheckboxLabeled("Disable randomness in world shelling", ref debugWorldShellingDamageRandomness);
+            list.CheckboxLabeled("Log subsequent shot calculations", ref debugSubsequentShotLogging);
         }
 #endif
         list.Gap();
@@ -573,6 +577,7 @@ public class Settings : ModSettings, ISettingsCE
         debugDisplayDangerBuildup = false;
         debugDisplayCellCoverRating = false;
         debugWorldShellingDamageRandomness = false;
+        debugSubsequentShotLogging = false;
 #endif
     }
     #endregion

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -620,8 +620,7 @@ public class Verb_LaunchProjectileCE : Verb
         rotation += recoilMagnitude * Rand.Range(minX, maxX);
         var trd = Rand.Range(minY, maxY);
         angle += recoilMagnitude * Mathf.Deg2Rad * trd;
-        Log.Message($"{EquipmentSource.def.label}: {lastRecoilDeg + nextRecoilMagnitude * recoil} = {lastRecoilDeg} + {nextRecoilMagnitude} * {recoil}");
-        lastRecoilDeg += nextRecoilMagnitude * recoil; //always store max recoil for subsequent shot purposes
+        lastRecoilDeg += nextRecoilMagnitude * recoil; //always store non-randomized max recoil for subsequent shot purposes
     }
 
     /// <summary>
@@ -1084,7 +1083,7 @@ public class Verb_LaunchProjectileCE : Verb
         didRetarget = Retarget();
         repeating = true;
         doRetarget = true;
-        storedShotReduction = null;
+
         var props = VerbPropsCE;
         var midBurst = numShotsFired > 0;
         var suppressing = CompFireModes?.CurrentAimMode == AimMode.SuppressFire;

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -620,7 +620,8 @@ public class Verb_LaunchProjectileCE : Verb
         rotation += recoilMagnitude * Rand.Range(minX, maxX);
         var trd = Rand.Range(minY, maxY);
         angle += recoilMagnitude * Mathf.Deg2Rad * trd;
-        lastRecoilDeg += nextRecoilMagnitude * trd;
+        Log.Message($"{EquipmentSource.def.label}: {lastRecoilDeg + nextRecoilMagnitude * recoil} = {lastRecoilDeg} + {nextRecoilMagnitude} * {recoil}");
+        lastRecoilDeg += nextRecoilMagnitude * recoil; //always store max recoil for subsequent shot purposes
     }
 
     /// <summary>

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -253,6 +253,7 @@ public class Verb_LaunchProjectileCE : Verb
         lastShootLine = null;
         repeating = false;
         storedShotReduction = null;
+        lastRecoilDeg = 0;
         didRetarget = false;
     }
 
@@ -1083,7 +1084,7 @@ public class Verb_LaunchProjectileCE : Verb
         didRetarget = Retarget();
         repeating = true;
         doRetarget = true;
-
+        storedShotReduction = null;
         var props = VerbPropsCE;
         var midBurst = numShotsFired > 0;
         var suppressing = CompFireModes?.CurrentAimMode == AimMode.SuppressFire;

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -30,6 +30,8 @@ public class Verb_ShootCE : Verb_LaunchProjectileCE
 
     public Vector3 drawPos;
 
+    internal static SimpleCurve SubsequentShotCurve = new SimpleCurve(); // Populated on game start from a SetupStepDef
+
     #endregion
 
     #region Properties
@@ -327,13 +329,15 @@ public class Verb_ShootCE : Verb_LaunchProjectileCE
 
         var d = v - u;
         var newShotRotation = (-90 + Mathf.Rad2Deg * Mathf.Atan2(d.z, d.x)) % 360;
-        var delta = Mathf.Abs(newShotRotation - lastShotRotation) + lastRecoilDeg;
-        lastRecoilDeg = 0;
+        var delta = Mathf.Abs(newShotRotation - lastShotRotation);
+
         var maxReduction = storedShotReduction ?? (CompFireModes?.CurrentAimMode == AimMode.SuppressFire ?
-                                                   0.1f :
-                                                   (_isAiming ? 0.5f : 0.25f));
-        var reduction = Mathf.Max(maxReduction, delta / 45f);
+                                                   0.1f + RecoilAmount*RecoilAmount/10 :
+                                                   (_isAiming ? 0.5f : 0.25f)) + RecoilAmount*RecoilAmount/10;
+        var reduction = Mathf.Max(maxReduction, delta / 45f + SubsequentShotCurve.Evaluate(lastRecoilDeg) * Controller.settings.FasterRepeatShotsRecoilMult);
+        lastRecoilDeg = 0;
         storedShotReduction = reduction;
+        Log.Message($"reduction {reduction}; maxReduction {maxReduction} lastRecoilDeg {lastRecoilDeg}; storedShotReduction {storedShotReduction};");
 
         if (reduction < 1.0f)
         {

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -346,7 +346,7 @@ public class Verb_ShootCE : Verb_LaunchProjectileCE
         reduction = Mathf.Max(maxReduction, reduction);
         if (Controller.settings.DebugSubsequentShotLogging)
         {
-            Log.Message($"{caster?.LabelShort} ({EquipmentSource?.LabelShort}) subsequent shot:\nreduction {reduction}; storedShotReduction {storedShotReduction}; maxReduction {maxReduction}; lastRecoilDeg {lastRecoilDeg}; delta {delta}; delta/45 {delta/45f}");
+            Log.Message($"{caster?.LabelShort} ({EquipmentSource?.LabelShort}) subsequent shot:\nreduction {reduction}; storedShotReduction {storedShotReduction}; maxReduction {maxReduction}; lastRecoilDeg {lastRecoilDeg}; delta {delta}; delta/45 {delta / 45f}");
         }
 
         lastRecoilDeg = 0;

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -331,13 +331,26 @@ public class Verb_ShootCE : Verb_LaunchProjectileCE
         var newShotRotation = (-90 + Mathf.Rad2Deg * Mathf.Atan2(d.z, d.x)) % 360;
         var delta = Mathf.Abs(newShotRotation - lastShotRotation);
 
-        var maxReduction = storedShotReduction ?? (CompFireModes?.CurrentAimMode == AimMode.SuppressFire ?
-                                                   0.1f + RecoilAmount*RecoilAmount/10 :
-                                                   (_isAiming ? 0.5f : 0.25f)) + RecoilAmount*RecoilAmount/10;
-        var reduction = Mathf.Max(maxReduction, delta / 45f + SubsequentShotCurve.Evaluate(lastRecoilDeg) * Controller.settings.FasterRepeatShotsRecoilMult);
+        //max possible reduction for this weapon
+        float maxReduction = CompFireModes?.CurrentAimMode == AimMode.SuppressFire ? 0.1f : _isAiming ? 0.5f : 0.25f;
+        maxReduction += RecoilAmount * RecoilAmount * 0.1f;
+
+        //current reduction after pawn stats
+        float reduction = (delta / 45f) + (SubsequentShotCurve.Evaluate(lastRecoilDeg) * Controller.settings.FasterRepeatShotsRecoilMult);
+
+        if (storedShotReduction != null)
+        {
+            reduction *= (float)storedShotReduction;
+        }
+
+        reduction = Mathf.Max(maxReduction, reduction);
+        if (Controller.settings.DebugSubsequentShotLogging)
+        {
+            Log.Message($"{caster?.LabelShort} ({EquipmentSource?.LabelShort}) subsequent shot:\nreduction {reduction}; storedShotReduction {storedShotReduction}; maxReduction {maxReduction}; lastRecoilDeg {lastRecoilDeg}; delta {delta}; delta/45 {delta/45f}");
+        }
+
         lastRecoilDeg = 0;
-        Log.Message($"reduction {reduction}; maxReduction {maxReduction} lastRecoilDeg {lastRecoilDeg}; storedShotReduction {storedShotReduction};");
-        storedShotReduction = reduction;
+        storedShotReduction = Mathf.Clamp01(reduction);
 
         if (reduction < 1.0f)
         {

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -336,8 +336,8 @@ public class Verb_ShootCE : Verb_LaunchProjectileCE
                                                    (_isAiming ? 0.5f : 0.25f)) + RecoilAmount*RecoilAmount/10;
         var reduction = Mathf.Max(maxReduction, delta / 45f + SubsequentShotCurve.Evaluate(lastRecoilDeg) * Controller.settings.FasterRepeatShotsRecoilMult);
         lastRecoilDeg = 0;
-        storedShotReduction = reduction;
         Log.Message($"reduction {reduction}; maxReduction {maxReduction} lastRecoilDeg {lastRecoilDeg}; storedShotReduction {storedShotReduction};");
+        storedShotReduction = reduction;
 
         if (reduction < 1.0f)
         {

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -30,7 +30,8 @@ public class Verb_ShootCE : Verb_LaunchProjectileCE
 
     public Vector3 drawPos;
 
-    internal static SimpleCurve SubsequentShotCurve = new SimpleCurve(); // Populated on game start from a SetupStepDef
+    internal static SimpleCurve SubsequentShotRecoilCurve = new SimpleCurve(); // Populated on game start from a SetupStepDef
+    internal static SimpleCurve SubsequentShotMassCurve = new SimpleCurve();
 
     #endregion
 
@@ -331,12 +332,17 @@ public class Verb_ShootCE : Verb_LaunchProjectileCE
         var newShotRotation = (-90 + Mathf.Rad2Deg * Mathf.Atan2(d.z, d.x)) % 360;
         var delta = Mathf.Abs(newShotRotation - lastShotRotation);
 
-        //max possible reduction for this weapon
         float maxReduction = CompFireModes?.CurrentAimMode == AimMode.SuppressFire ? 0.1f : _isAiming ? 0.5f : 0.25f;
-        maxReduction += RecoilAmount * RecoilAmount * 0.1f;
+
+        //how easy it is to turn the weapon around depending on heaviness, angle and weapon handling
+        float relativeWeaponMass = EquipmentSource.GetStatValue(StatDefOf.Mass) / (ShooterPawn?.BodySize ?? 1f);
+        float angleFactor = Mathf.Max(0, ((delta % 180) / SubsequentShotMassCurve.Evaluate(relativeWeaponMass) / (1 + ShootingAccuracy / 9f)) - 1f);
+
+        //how easy it is to control vertical recoil
+        float recoilFactor = SubsequentShotRecoilCurve.Evaluate(lastRecoilDeg) * Controller.settings.FasterRepeatShotsRecoilMult;
 
         //current reduction after pawn stats
-        float reduction = (delta / 45f) + (SubsequentShotCurve.Evaluate(lastRecoilDeg) * Controller.settings.FasterRepeatShotsRecoilMult);
+        float reduction = angleFactor + recoilFactor;
 
         if (storedShotReduction != null)
         {
@@ -346,10 +352,9 @@ public class Verb_ShootCE : Verb_LaunchProjectileCE
         reduction = Mathf.Max(maxReduction, reduction);
         if (Controller.settings.DebugSubsequentShotLogging)
         {
-            Log.Message($"{caster?.LabelShort} ({EquipmentSource?.LabelShort}) subsequent shot:\nreduction {reduction}; storedShotReduction {storedShotReduction}; maxReduction {maxReduction}; lastRecoilDeg {lastRecoilDeg}; delta {delta}; delta/45 {delta / 45f}");
+            Log.Message($"{caster?.LabelShort} ({EquipmentSource?.LabelShort}) SS:\nreduction {reduction}; storedShotReduction {storedShotReduction}; maxReduction {maxReduction}; lastRecoilDeg {lastRecoilDeg}; angle factor {angleFactor}; recoil factor {recoilFactor}");
         }
 
-        lastRecoilDeg = 0;
         storedShotReduction = Mathf.Clamp01(reduction);
 
         if (reduction < 1.0f)


### PR DESCRIPTION
## Changes

Redoes the way subsequent shot warmup time reductions are calculated: 

- Reduction now depends on 2 factors: weapon mass and recoil. Low-recoil weapons are good at repeating shots at static targets, while lightweight weapons are good at being turned horizontally to shoot a new target.
- New mass penalties are reduced by high bodysize and slightly reduced by high weapon handling.
- Amount of reduction after each burst is determined by accumulated recoil as before, but it is now evaluated with a curve to make a bigger difference between single shot of rifles, while still allowing bursts to get time reductions. Curve is tweakable in xml
- Adds a settings slider to control how impactful subsequent shot reductions are. Adds a debug setting to log these reductions in console.
- Subsequent shots calculation is no longer affected by recoil randomization - every burst will get the same amount of time reduction. Would be too unpredictable otherwise.

## Reasoning

The problems of the current system:
- Too much aim time reduction takes away the difference between weapon classes. 
- It is too easy to receive the reductions. Any shooter, no matter the skill, quickly reaches max reduction on a full auto m16.


Goals of this rebalance:
- Make weapons preserve their differences in aim time by making recoil more impactful for SS.
- Make it harder to achieve max reduction for low-skill shooters.
- Favor low-caliber semi-auto weapons with these buffs.
- Make pistols good at quickly turning around (they get penalized by heavy recoil for repeat shots)
- Make HMGs good at shooting the same target, bad at turning around.

## Alternatives

Describe alternative implementations you have considered, e.g.
- Return the idea of accumulating reduction over several burst.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] Playtested a colony (specify how long)
