### PR TITLE
Add Dark Ages: Beasts and Monsters to loadBefore

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -51,7 +51,8 @@
 		<li>sarg.alphagenes</li>
 		<li>sarg.alphabiomes</li>
 		<li>accurex.medievalempireoverhaul</li>
-		<li>BlackMarket420.Kerberos</li>		
+		<li>BlackMarket420.Kerberos</li>	
+		<li>van.beasts</li>	
 	</loadBefore>
 	<loadAfter>
 		<li>brrainz.harmony</li>


### PR DESCRIPTION
## Changes

- Added Dark Ages: Beasts and Monster to loadBefore in about.xml

## References

- Relevant report: https://discord.com/channels/278818534069501953/324222101550661663/1464629530940674204
  - Failure to inherit causes a null thingClass, which in turn fails to start a game.

## Reasoning

- The patched projectile in the mod inherits from BaseBulletCE, which requires it to be loaded after it.

## Alternatives

- Patch in all required fields to the projectile instead of inheriting.

## Testing

Check tests you have performed:
- [x] Mod manager correctly complains about wrong order.
