### PR TITLE
Bioferrite ammo availability reduction

### DIFF
--- a/Defs/Ammo/Other/Flamethrower.xml
+++ b/Defs/Ammo/Other/Flamethrower.xml
@@ -89,6 +89,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<ammoClass>Bioferrite</ammoClass>
+		<generateAllowChance>0.4</generateAllowChance>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
 				<damageAmountBase>2</damageAmountBase>
@@ -248,6 +249,7 @@
 		<label>make bioferrite-infused chemfuel x100</label>
 		<description>Craft 100 units of bioferrite-infused chemfuel.</description>
 		<jobString>Making bioferrite-infused chemfuel.</jobString>
+		<researchPrerequisite>BioferriteIgnition</researchPrerequisite>
 		<ingredients>
 			<li>
 				<filter>

--- a/Defs/Ammo/Other/Flare.xml
+++ b/Defs/Ammo/Other/Flare.xml
@@ -256,6 +256,7 @@
 		<label>make bioferrite flare x200</label>
 		<description>Craft 200 bioferrite flare shells.</description>
 		<jobString>Making bioferrite flare shells.</jobString>
+		<researchPrerequisite>DisruptorFlares</researchPrerequisite>
 		<ingredients>
 			<li>
 				<filter>


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Reduces the chance of bioferrite flare and infused flamethrower ammo spawning on raiders.
- Adds anomaly research requirements to both items.

## Reasoning

Why did you choose to implement things this way, e.g.
- It appears on every 2nd raider that has a flare gun, but it's worse at providing light compared to the normal one. 
- Not every raider has a monster factory at home.
- Doesn't make sense that you can make bioferrite fuel for your normal flamethrower before discovering the anomaly flamer.

## Alternatives

Describe alternative implementations you have considered, e.g.
- Also add research requirements to nerve spiker - would leave player with no craftable ammo for captured spikers.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
