### PR TITLE
Remove lean offset multiplier for targeting

### DIFF
--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -511,7 +511,7 @@ public class Verb_LaunchProjectileCE : Verb
 
             if (report.targetPawn != null)
             {
-                v += report.targetPawn.Drawer.leaner.LeanOffset * 0.5f;
+                v += report.targetPawn.Drawer.leaner.LeanOffset;
             }
 
             newTargetLoc.Set(v.x, v.z);
@@ -1433,7 +1433,7 @@ public class Verb_LaunchProjectileCE : Verb
                 var targPawn = targetThing as Pawn;
                 if (targPawn != null)
                 {
-                    targetPos += targPawn.Drawer.leaner.LeanOffset * 0.6f;
+                    targetPos += targPawn.Drawer.leaner.LeanOffset;
                 }
             }
             else

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -322,7 +322,7 @@ public class Verb_ShootCE : Verb_LaunchProjectileCE
         Vector3 v = currentTarget.Thing?.TrueCenter() ?? currentTarget.Cell.ToVector3Shifted();
         if (currentTarget.Pawn is Pawn dtPawn)
         {
-            v += dtPawn.Drawer.leaner.LeanOffset * 0.5f;
+            v += dtPawn.Drawer.leaner.LeanOffset;
         }
 
         var d = v - u;


### PR DESCRIPTION



## Changes

Remove multiplier applied to lean offset when computing LoS and target position offset.


## Reasoning
This seems to have a positive effect on accuracy when targeting leaning pawns at narrow angles.
Without it, shooters are liable to hit the cover the target is leaning out from even at closer ranges.

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony
