### PR TITLE
restore beam repeater warmup mote

### DIFF
--- a/Odyssey/Patches/Odyssey/ThingDefs_Misc/Ranged_Spacer.xml
+++ b/Odyssey/Patches/Odyssey/ThingDefs_Misc/Ranged_Spacer.xml
@@ -94,6 +94,8 @@
 			<targetParams>
 				<canTargetLocations>true</canTargetLocations>
 			</targetParams>
+			<aimingChargeMote>Mote_BeamRepeater_Charge</aimingChargeMote>
+			<aimingChargeMoteOffset>1.07</aimingChargeMoteOffset>
 		</Properties>
 		<AmmoUser>
 			<magazineSize>300</magazineSize>


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Restores odyssey beam repeater's mote, that appears when weapon is aiming. Vanilla had it, but it is missing in ce patch.

## Reasoning

Why did you choose to implement things this way, e.g.
- no reason to disable that mote

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
