### PR TITLE
VQE cryptoaxe damage fix

### DIFF
--- a/ModPatches/Vanilla Quests Expanded - Cryptoforge/Patches/Vanilla Quests Expanded - Cryptoforge/VQEC_Things_Weapons.xml
+++ b/ModPatches/Vanilla Quests Expanded - Cryptoforge/Patches/Vanilla Quests Expanded - Cryptoforge/VQEC_Things_Weapons.xml
@@ -21,7 +21,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>edge</label>
 					<capacities>
-						<li>VQE_CryptoaxeCut</li>
+						<li>VQE_CryptoCut</li>
 					</capacities>
 					<power>32</power>
 					<cooldownTime>3.09</cooldownTime>


### PR DESCRIPTION
## Additions
n/a
## Changes
Switch VQE cryptoaxe to workaround melee capacity, the custom verb need C# to work with CE, but VQE still have it's workaround melee capacity.
## References
bugs chat
## Reasoning
n/a
## Alternatives
C# patch the verb
## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
