### PR TITLE
Stop released prisoners from picking up weapons

### DIFF
--- a/Source/CombatExtended/CombatExtended/AI/Comps/CompUrgentWeaponPickup.cs
+++ b/Source/CombatExtended/CombatExtended/AI/Comps/CompUrgentWeaponPickup.cs
@@ -93,6 +93,11 @@ public class CompUrgentWeaponPickup : ICompTactics
         {
             return;
         }
+        if (SelPawn.guest.Released)
+        {
+            return;
+        }
+
         foreach (ThingWithComps thing in CompInventory.rangedWeaponList)
         {
             CompAmmoUser compAmmo = thing.TryGetComp<CompAmmoUser>();

--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_TakeAndEquip.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_TakeAndEquip.cs
@@ -206,7 +206,7 @@ public class JobGiver_TakeAndEquip : ThinkNode_JobGiver
         {
             return null;
         }
-        if (pawn.IsPrisoner && (pawn.HostFaction != Faction.OfPlayer || pawn.guest.interactionMode == PrisonerInteractionModeDefOf.Release))
+        if (pawn.IsPrisoner && (pawn.HostFaction != Faction.OfPlayer || pawn.guest.interactionMode == PrisonerInteractionModeDefOf.Release || pawn.guest.Released))
         {
             return null;
         }


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Stops released prisoners from trying to pickup a weapon off the ground

This happened in 2 cases:
1. when bullet impacted near released prisoner
2. somewhere from jobgiver on its own

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #4365
- Savefile: 
https://discord.com/channels/278818534069501953/322827713335394304/1467874436752347331

## Reasoning

Why did you choose to implement things this way, e.g.
- Its not very nice to get your stuff stolen by a guy that has keys to all doors

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
