### PR TITLE
Add requiresReload to underbarrel props

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmosetSwitcher.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmosetSwitcher.cs
@@ -348,7 +348,7 @@ public class CompProperties_UnderBarrel : CompProperties
 
     public bool oneAmmoHolder = false;
 
-    public bool requiresReload = true;
+    public bool requiresReload = false;
 
     [MustTranslate]
     public string underBarrelLabel;


### PR DESCRIPTION

## Additions

- New requiresReload property in CompProperties_UnderBarrel.  Forces unloading of weapon when switching to an "underbarrel" weapon like a rifle grenade.

## Reasoning

- Rifle Grenades usually use blank cartridges, requiring unloading the weapon and loading blanks.

## Alternatives

  - Suffer

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (5 minutes)
