### PR TITLE
Dont show stuck projectiles when hitting pawn

### DIFF
--- a/Source/CombatExtended/Contrib/ProjectileImpactFX/ImpactFleckThrower.cs
+++ b/Source/CombatExtended/Contrib/ProjectileImpactFX/ImpactFleckThrower.cs
@@ -149,7 +149,7 @@ public static class ImpactFleckThrower
             map.flecks.CreateFleck(creationData);
         }
 
-        if (Controller.settings.StuckArrowsAsFlecks && StuckProjectileFleck != null)
+        if (Controller.settings.StuckArrowsAsFlecks && StuckProjectileFleck != null && hitThing is not Pawn)
         {
             FleckCreationData creationData = FleckMaker.GetDataStatic(loc, map, StuckProjectileFleck);
             creationData.scale = ext.StuckProjectileFleckSize;


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Prevents the spawning of stuck projectile fleck if HitThing is a pawn

## Reasoning

Why did you choose to implement things this way, e.g.
- It looks weird when a stuck arrow spawns below the victim, which implies they werent hit

## Alternatives

Describe alternative implementations you have considered, e.g.
- There is a way to attach the fleck to the pawn instead, but i couldnt figure out how to override fleck's draw layer in this situation, as it needs to be above pawn here, but below pawn if missed

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
