### PR TITLE
Add shooting skill comparison to sway stat page

### DIFF
--- a/Defs/Stats/Stats_Weapons_Ranged.xml
+++ b/Defs/Stats/Stats_Weapons_Ranged.xml
@@ -98,6 +98,7 @@
 		<toStringStyle>FloatTwo</toStringStyle>
 		<showIfUndefined>false</showIfUndefined>
 		<displayPriorityInCategory>894</displayPriorityInCategory>
+		<workerClass>CombatExtended.StatWorker_SwayFactor</workerClass>
 		<parts>
 			<li Class="CombatExtended.StatPart_Attachments" />
 			<li Class="CombatExtended.Bipod_Sway_StatPart" />

--- a/Languages/English/Keyed/Stats.xml
+++ b/Languages/English/Keyed/Stats.xml
@@ -11,6 +11,6 @@
 	<CE_Long_Range_Radio>Long range radio</CE_Long_Range_Radio>
 	<CE_StatPart_MinimaExplanation>Picks the lowest value of available</CE_StatPart_MinimaExplanation>
 	<CE_StatPart_MaximaExplanation>Picks the highest value of available</CE_StatPart_MaximaExplanation>
-	<CE_StatWorker_Sway_Explanation>Baseline shooting skill needed to reduce {0} sway to {1} degrees of error:</CE_StatWorker_Sway_Explanation>
+	<CE_StatWorker_Sway_Explanation>Baseline Shooting skill needed to reduce {0} sway to {1} degrees of error:</CE_StatWorker_Sway_Explanation>
 
 </LanguageData>

--- a/Languages/English/Keyed/Stats.xml
+++ b/Languages/English/Keyed/Stats.xml
@@ -11,5 +11,6 @@
 	<CE_Long_Range_Radio>Long range radio</CE_Long_Range_Radio>
 	<CE_StatPart_MinimaExplanation>Picks the lowest value of available</CE_StatPart_MinimaExplanation>
 	<CE_StatPart_MaximaExplanation>Picks the highest value of available</CE_StatPart_MaximaExplanation>
+	<CE_StatWorker_Sway_Explanation>Baseline shooting skill needed to reduce {0} sway to {1} degrees of error:</CE_StatWorker_Sway_Explanation>
 
 </LanguageData>

--- a/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_SwayFactor.cs
+++ b/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_SwayFactor.cs
@@ -1,0 +1,41 @@
+using System.Drawing;
+using System.Text;
+using Verse;
+using RimWorld;
+
+namespace CombatExtended;
+
+public class StatWorker_SwayFactor : StatWorker
+{
+    private float CalculateRequiredSkill(float swayFactor, float benchmarkSwayAmplitude, out float weaponHandling)
+    {
+        weaponHandling = -((benchmarkSwayAmplitude / swayFactor) - 4.5f);
+
+        float shootingPoints = StatDefOf.ShootingAccuracyPawn.postProcessCurve.EvaluateInverted(weaponHandling);
+
+        if (StatDefOf.ShootingAccuracyPawn.skillNeedOffsets.Find(x => x is SkillNeed_BaseBonus) is SkillNeed_BaseBonus baseStats)
+        {
+            return (shootingPoints - baseStats.baseValue) / baseStats.bonusPerLevel;
+        }
+
+        return 0f;
+    }
+
+
+    public override string GetExplanationFinalizePart(StatRequest req, ToStringNumberSense numberSense, float finalVal)
+    {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.Append(base.GetExplanationFinalizePart(req, numberSense, finalVal));
+
+        float benchmarkSwayAmplitude = 3.0f;
+        float weaponHandling = 0f;
+        float skillLevel = CalculateRequiredSkill(finalVal, benchmarkSwayAmplitude, out weaponHandling);
+        stringBuilder.AppendLine("\n\n" + "CE_StatWorker_Sway_Explanation".Translate(finalVal.ToStringByStyle(ToStringStyle.FloatTwo),
+                                            benchmarkSwayAmplitude)
+                                        + "\n" + skillLevel.ToStringByStyle(ToStringStyle.FloatOne)
+                                        + " (" + weaponHandling.ToStringByStyle(ToStringStyle.PercentZero) + " " +
+                                        StatDefOf.ShootingAccuracyPawn.label + ")");
+
+        return stringBuilder.ToString().TrimEndNewlines();
+    }
+}


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Adds a line to sway stat in weapons info page to help compare how much sway a weapon has. Inverts the usual sway calculation to figure out how much weapon handling a pawn needs to reduce it to an acceptable level.
<img width="935" height="519" alt="изображение" src="https://github.com/user-attachments/assets/0094e174-241f-412b-9fde-0c0b12faefb7" />

## Reasoning

Why did you choose to implement things this way, e.g.
- Helps compare the differences in pawn skill required between guns. I.e., for our shotguns, it suggests that differences in skill needed is:

Mossberg - 7 skill
Saiga - 6
Usas - 10
KS23 - 9

AKM - 5 skill
M16 - 7 skill
FN FAL - 10 skill

- For most users its difficult to understand what sway does, this gives examples in understandable terms.
- 3 degrees of deviation was arbitarily picked as a value that is achievable for most weapons and lands them in 0-20 skill range.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
