### PR TITLE
feat: add patch for The Force Standalone mod 

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -597,6 +597,7 @@
 		<li IfModActive="Mlie.SpidercampsHorses">ModPatches/Spidercamp's Horses</li>
 		<li IfModActive="akri.starcraftersarmory">ModPatches/Star Crafter's Armory</li>
 		<li IfModActive="projectjedi.factions">ModPatches/Star Wars - Factions</li>
+		<li IfModActive="lee.theforce.standalone">ModPatches/Star Wars - The Force Standalone</li>
 		<li IfModActive="walkingproblem.arachnid">ModPatches/Starship Troopers Arachnids</li>
 		<li IfModActive="Koni.Misc.SteamworldUniforms">ModPatches/Steamworld Uniforms</li>
 		<li IfModActive="Scurvyez.Bastyon">ModPatches/Steves Animals</li>

--- a/ModPatches/Star Wars - The Force Standalone/Patches/Star Wars - The Force Standalone/Patch_Hediffs.xml
+++ b/ModPatches/Star Wars - The Force Standalone/Patches/Star Wars - The Force Standalone/Patch_Hediffs.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- ===== Limb-adding hediffs (melee tools) ===== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/HediffDef[defName="Force_MechuDeruArm"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>fist</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>6</power>
+					<cooldownTime>1.05</cooldownTime>
+					<armorPenetrationBlunt>2.00</armorPenetrationBlunt>
+					<soundMeleeHit>MeleeHit_BionicPunch</soundMeleeHit>
+					<soundMeleeMiss>MeleeMiss_BionicPunch</soundMeleeMiss>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/HediffDef[defName="Force_ConstructedArm"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>fist</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>1</power>
+					<cooldownTime>1.26</cooldownTime>
+					<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<!-- ===== Hediff armor offsets ===== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/HediffDef[defName="Force_MechuDeruMembrane"]/stages/li/statOffsets/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>14</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/HediffDef[defName="Force_MechuDeruMembrane"]/stages/li/statOffsets/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>21</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/HediffDef[defName="Force_MechuDeruMembrane"]/stages/li/statOffsets/ArmorRating_Heat</xpath>
+		<value>
+			<ArmorRating_Heat>0.65</ArmorRating_Heat>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Star Wars - The Force Standalone/Patches/Star Wars - The Force Standalone/Patch_Melee.xml
+++ b/ModPatches/Star Wars - The Force Standalone/Patches/Star Wars - The Force Standalone/Patch_Melee.xml
@@ -10,12 +10,12 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>handle</label>
 					<capacities>
-						<li>Blunt</li>
+						<li>Poke</li>
 					</capacities>
-					<power>4</power>
+					<power>2</power>
 					<chanceFactor>0.1</chanceFactor>
-					<cooldownTime>1.28</cooldownTime>
-					<armorPenetrationBlunt>0.8</armorPenetrationBlunt>
+					<cooldownTime>1.36</cooldownTime>
+					<armorPenetrationBlunt>0.605</armorPenetrationBlunt>
 					<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
 				</li>
 				<li Class="CombatExtended.ToolCE">
@@ -23,10 +23,10 @@
 					<capacities>
 						<li>Cut</li>
 					</capacities>
-					<power>30</power>
-					<cooldownTime>0.68</cooldownTime>
-					<armorPenetrationBlunt>2.8</armorPenetrationBlunt>
-					<armorPenetrationSharp>22.5</armorPenetrationSharp>
+					<power>21</power>
+					<cooldownTime>0.74</cooldownTime>
+					<armorPenetrationBlunt>3.485</armorPenetrationBlunt>
+					<armorPenetrationSharp>21.78</armorPenetrationSharp>
 					<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
 				</li>
 				<li Class="CombatExtended.ToolCE">
@@ -34,10 +34,10 @@
 					<capacities>
 						<li>Stab</li>
 					</capacities>
-					<power>24</power>
-					<cooldownTime>0.76</cooldownTime>
-					<armorPenetrationBlunt>1.8</armorPenetrationBlunt>
-					<armorPenetrationSharp>28</armorPenetrationSharp>
+					<power>9</power>
+					<cooldownTime>0.85</cooldownTime>
+					<armorPenetrationBlunt>1.173</armorPenetrationBlunt>
+					<armorPenetrationSharp>30.24</armorPenetrationSharp>
 				</li>
 			</tools>
 		</value>
@@ -46,8 +46,8 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Force_SithBladelink"]/statBases</xpath>
 		<value>
-			<Bulk>3.5</Bulk>
-			<MeleeCounterParryBonus>0.40</MeleeCounterParryBonus>
+			<Bulk>4</Bulk>
+			<MeleeCounterParryBonus>0.50</MeleeCounterParryBonus>
 		</value>
 	</Operation>
 
@@ -55,9 +55,9 @@
 		<xpath>Defs/ThingDef[defName="Force_SithBladelink"]</xpath>
 		<value>
 			<equippedStatOffsets>
-				<MeleeCritChance>1.25</MeleeCritChance>
-				<MeleeParryChance>0.40</MeleeParryChance>
-				<MeleeDodgeChance>0.45</MeleeDodgeChance>
+				<MeleeCritChance>1.10</MeleeCritChance>
+				<MeleeParryChance>0.50</MeleeParryChance>
+				<MeleeDodgeChance>0.37</MeleeDodgeChance>
 			</equippedStatOffsets>
 		</value>
 	</Operation>

--- a/ModPatches/Star Wars - The Force Standalone/Patches/Star Wars - The Force Standalone/Patch_Melee.xml
+++ b/ModPatches/Star Wars - The Force Standalone/Patches/Star Wars - The Force Standalone/Patch_Melee.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- ========== Sith Warblade ========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Force_SithBladelink"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>handle</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>4</power>
+					<chanceFactor>0.1</chanceFactor>
+					<cooldownTime>1.28</cooldownTime>
+					<armorPenetrationBlunt>0.8</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>edge</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>30</power>
+					<cooldownTime>0.68</cooldownTime>
+					<armorPenetrationBlunt>2.8</armorPenetrationBlunt>
+					<armorPenetrationSharp>22.5</armorPenetrationSharp>
+					<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>point</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>24</power>
+					<cooldownTime>0.76</cooldownTime>
+					<armorPenetrationBlunt>1.8</armorPenetrationBlunt>
+					<armorPenetrationSharp>28</armorPenetrationSharp>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Force_SithBladelink"]/statBases</xpath>
+		<value>
+			<Bulk>3.5</Bulk>
+			<MeleeCounterParryBonus>0.40</MeleeCounterParryBonus>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Force_SithBladelink"]</xpath>
+		<value>
+			<equippedStatOffsets>
+				<MeleeCritChance>1.25</MeleeCritChance>
+				<MeleeParryChance>0.40</MeleeParryChance>
+				<MeleeDodgeChance>0.45</MeleeDodgeChance>
+			</equippedStatOffsets>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="Force_SithBladelink"]/weaponTags</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Force_SithBladelink"]</xpath>
+			<value>
+				<weaponTags />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Force_SithBladelink"]/weaponTags</xpath>
+		<value>
+			<li>CE_OneHandedWeapon</li>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Star Wars - The Force Standalone/Patches/Star Wars - The Force Standalone/Patch_Pawns.xml
+++ b/ModPatches/Star Wars - The Force Standalone/Patches/Star Wars - The Force Standalone/Patch_Pawns.xml
@@ -1,0 +1,191 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- ===== Force Wraith ===== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Force_DarksideWraithRace"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>shadow claws</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>22</power>
+					<cooldownTime>1.5</cooldownTime>
+					<armorPenetrationSharp>4</armorPenetrationSharp>
+					<armorPenetrationBlunt>6</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>shadow claws</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>14</power>
+					<cooldownTime>1.25</cooldownTime>
+					<armorPenetrationSharp>22</armorPenetrationSharp>
+					<armorPenetrationBlunt>10</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<!-- ===== Terentatek ===== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="SithSorcery_Terentatek_Pawn"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>left leg</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>22</power>
+					<cooldownTime>2.0</cooldownTime>
+					<armorPenetrationBlunt>12</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Feet</linkedBodyPartsGroup>
+					<surpriseAttack>
+						<extraMeleeDamages>
+							<li>
+								<def>Stun</def>
+								<amount>5</amount>
+							</li>
+						</extraMeleeDamages>
+					</surpriseAttack>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>right leg</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>22</power>
+					<cooldownTime>2.0</cooldownTime>
+					<armorPenetrationBlunt>12</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Feet</linkedBodyPartsGroup>
+					<surpriseAttack>
+						<extraMeleeDamages>
+							<li>
+								<def>Stun</def>
+								<amount>5</amount>
+							</li>
+						</extraMeleeDamages>
+					</surpriseAttack>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>teeth</label>
+					<capacities>
+						<li>Bite</li>
+					</capacities>
+					<power>38</power>
+					<cooldownTime>2.2</cooldownTime>
+					<armorPenetrationSharp>17</armorPenetrationSharp>
+					<armorPenetrationBlunt>11</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>Left claws</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>45</power>
+					<cooldownTime>2.0</cooldownTime>
+					<armorPenetrationSharp>27</armorPenetrationSharp>
+					<armorPenetrationBlunt>17</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>SithSorcery_Terentatek_LeftFingerClaw</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>Right claws</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>45</power>
+					<cooldownTime>2.0</cooldownTime>
+					<armorPenetrationSharp>27</armorPenetrationSharp>
+					<armorPenetrationBlunt>17</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>SithSorcery_Terentatek_RightFingerClaw</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>tusks</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>38</power>
+					<cooldownTime>2.2</cooldownTime>
+					<armorPenetrationSharp>22</armorPenetrationSharp>
+					<armorPenetrationBlunt>10</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>22</power>
+					<cooldownTime>2.5</cooldownTime>
+					<armorPenetrationBlunt>11</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+					<chanceFactor>0.2</chanceFactor>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<!-- ===== Inquisitor mechanoid (Biotech) ===== -->
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Biotech</li>
+		</mods>
+		<match Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Force_Mech_Inquisitor"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>left fist</label>
+						<labelNoLocation>fist</labelNoLocation>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>5</power>
+						<cooldownTime>1.11</cooldownTime>
+						<armorPenetrationBlunt>1.688</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+						<alwaysTreatAsWeapon>false</alwaysTreatAsWeapon>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>right fist</label>
+						<labelNoLocation>fist</labelNoLocation>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>5</power>
+						<cooldownTime>1.11</cooldownTime>
+						<armorPenetrationBlunt>1.688</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+						<alwaysTreatAsWeapon>false</alwaysTreatAsWeapon>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>5</power>
+						<cooldownTime>1.85</cooldownTime>
+						<armorPenetrationBlunt>0.625</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+						<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+						<chanceFactor>0.2</chanceFactor>
+					</li>
+				</tools>
+			</value>
+		</match>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Star Wars - The Force Standalone/Patches/Star Wars - The Force Standalone/Patch_Projectiles.xml
+++ b/ModPatches/Star Wars - The Force Standalone/Patches/Star Wars - The Force Standalone/Patch_Projectiles.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- ===== DamageDef rescaling ===== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/DamageDef[defName="Force_Lightning"]/defaultArmorPenetration</xpath>
+		<value>
+			<defaultArmorPenetration>0.75</defaultArmorPenetration>
+		</value>
+	</Operation>
+
+	<!-- ===== Ability projectiles ===== -->
+
+	<Operation Class="PatchOperationAttributeSet">
+		<xpath>Defs/ThingDef[defName="Force_MagickScream"]/projectile</xpath>
+		<attribute>Class</attribute>
+		<value>CombatExtended.ProjectilePropertiesCE</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Force_MagickScream"]/projectile</xpath>
+		<value>
+			<armorPenetrationSharp>0.10</armorPenetrationSharp>
+			<armorPenetrationBlunt>2</armorPenetrationBlunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAttributeSet">
+		<xpath>Defs/ThingDef[defName="Force_ThrowItem"]/projectile</xpath>
+		<attribute>Class</attribute>
+		<value>CombatExtended.ProjectilePropertiesCE</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Force_ThrowItem"]/projectile</xpath>
+		<value>
+			<armorPenetrationSharp>0.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>10</armorPenetrationBlunt>
+		</value>
+	</Operation>
+
+	<!-- ===== Ability explosion comps ===== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AbilityDef[defName="Force_Destruction"]/comps/li[@Class="TheForce_Standalone.Abilities.Darkside.CompProperties_AbilityForceDestruction"]/armorPenetration</xpath>
+		<value>
+			<armorPenetration>10</armorPenetration>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AbilityDef[defName="Force_Lightning"]/comps/li[@Class="TheForce_Standalone.Generic.CompProperties_ExplosionWithDirection"]/armorPenetration</xpath>
+		<value>
+			<armorPenetration>0.75</armorPenetration>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AbilityDef[defName="Force_ElectricJudgment"]/comps/li[@Class="TheForce_Standalone.Generic.CompProperties_ExplosionWithDirection"]/armorPenetration</xpath>
+		<value>
+			<armorPenetration>1.0</armorPenetration>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AbilityDef[defName="Force_FireyEnergy"]/comps/li[@Class="TheForce_Standalone.Generic.CompProperties_ExplosionWithDirection"]/armorPenetration</xpath>
+		<value>
+			<armorPenetration>0.75</armorPenetration>
+		</value>
+	</Operation>
+
+</Patch>


### PR DESCRIPTION
## Additions

- CE compatibility patch for Star Wars : The Force Standalone mod
- Sith Warblade melee weapon (`Patch_Melee.xml`)
- Limb-adding hediffs with melee tools and the membrane armor implant (`Patch_Hediffs.xml`)
- Ability projectiles + Force_Lightning DamageDef + ability explosion comps (`Patch_Projectiles.xml`)
- Race/mech tools for Force Wraith, Terentatek, and Inquisitor mechanoid (`Patch_Pawns.xml`)

## Reasoning

Addresses @N7Huntsman's review (hediffs that add limbs with melee tools, hediffs that apply armor, abilities that fire projectiles). Pawn tools added because the mod ships three combat creatures with vanilla-scale tools that needed CE conversion.

## References

- Bionic fist tools: `Patches/Core/HediffDefs/Hediffs_Local_AddedParts.xml` (BionicArm / SimpleProstheticArm baselines)
- Membrane armor: composite vest tier (mmRHA Sharp/Blunt + 0-1 fractional Heat per `ArmorUtilityCE.GetAmbientPostArmorDamage`)
- Race tools cross-checked against RM2, VFE Mechanoids, AMW, Alpha Mechs
- Heat-category ambient AP cross-checked against Crypto Weapon and Dragons Descent flame patches
- Inquisitor mech mirrors VFE Lancer fist baseline (power=5, cd=1.11, AP_Blunt=1.688)
- Inquisitor patch gated with `PatchOperationFindMod` for Biotech

## Testing

- [x] Compiles without warnings
- [x] All patch XML well-formed
- [ ] Game runs without errors
- [ ] With and without patched mod loaded
- [ ] Playtested a colony