### PR TITLE
Dragons descent patch fixes

### DIFF
--- a/ModPatches/Dragons Descent/Defs/Dragons Descent/Projectile_Dragon.xml
+++ b/ModPatches/Dragons Descent/Defs/Dragons Descent/Projectile_Dragon.xml
@@ -12,7 +12,7 @@
 			<li Class="CompProperties_Glower">
 				<overlightRadius>1.0</overlightRadius>
 				<glowRadius>1</glowRadius>
-				<glowColor>(255, 161, 0, 0.19)</glowColor>
+				<glowColor>(255, 161, 0, 48)</glowColor>
 			</li>
 		</comps>
 		<graphicData>

--- a/ModPatches/Dragons Descent/Patches/Dragons Descent/ThingDefs_Misc/Apparel_Various.xml
+++ b/ModPatches/Dragons Descent/Patches/Dragons Descent/ThingDefs_Misc/Apparel_Various.xml
@@ -24,6 +24,7 @@
 			</equippedStatOffsets>
 		</value>
 	</Operation>
+
 	<!-- wing cape -->
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="DD_Apparel_WingCape"]/statBases/StuffEffectMultiplierArmor</xpath>
@@ -33,4 +34,5 @@
 			<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
+
 </Patch>

--- a/ModPatches/Dragons Descent/Patches/Dragons Descent/ThingDefs_Misc/Weapons/MeleeDD.xml
+++ b/ModPatches/Dragons Descent/Patches/Dragons Descent/ThingDefs_Misc/Weapons/MeleeDD.xml
@@ -169,59 +169,59 @@
 			</tools>
 		</value>
 	</Operation>
+
 	<!-- focusing tome -->
-  <Operation Class="PatchOperationFindMod">
-    <mods>
-      <li>Royalty</li>
-    </mods>
-    <match Class="PatchOperationSequence">
-      <operations>
-      <li Class="PatchOperationAdd">
-        <xpath>Defs/ThingDef[defName="DDMeleeWeapon_FocusingTome"]/statBases</xpath>
-        <value>
-          <Bulk>2</Bulk>
-          <MeleeCounterParryBonus>0.14</MeleeCounterParryBonus>
-        </value>
-      </li>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Royalty</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
 
-      <li Class="PatchOperationAdd">
-        <xpath>Defs/ThingDef[defName="DDMeleeWeapon_FocusingTome"]/equippedStatOffsets</xpath>
-        <value>
-          <MeleeCritChance>0.23</MeleeCritChance>
-          <MeleeParryChance>0.14</MeleeParryChance>
-          <MeleeDodgeChance>0.07</MeleeDodgeChance>
-        </value>
-      </li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="DDMeleeWeapon_FocusingTome"]/statBases</xpath>
+				<value>
+					<Bulk>2</Bulk>
+					<MeleeCounterParryBonus>0.14</MeleeCounterParryBonus>
+				</value>
+			</li>
 
-      <li Class="PatchOperationReplace">
-        <xpath>Defs/ThingDef[defName="DDMeleeWeapon_FocusingTome"]/tools</xpath>
-        <value>
-          <tools>
-            <li Class="CombatExtended.ToolCE">
-              <label>spine</label>
-              <capacities>
-                <li>Blunt</li>
-              </capacities>
-              <power>3</power>
-              <cooldownTime>2.0</cooldownTime>
-              <armorPenetrationBlunt>1.0</armorPenetrationBlunt>
-            </li>
-          </tools>
-        </value>
-      </li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="DDMeleeWeapon_FocusingTome"]/equippedStatOffsets</xpath>
+				<value>
+					<MeleeCritChance>0.23</MeleeCritChance>
+					<MeleeParryChance>0.14</MeleeParryChance>
+					<MeleeDodgeChance>0.07</MeleeDodgeChance>
+				</value>
+			</li>
 
-      <li Class="PatchOperationAdd">
-        <xpath>Defs/ThingDef[defName="DDMeleeWeapon_FocusingTome"]</xpath>
-        <value>
-          <weaponTags>
-            <li>CE_OneHandedWeapon</li>
-          </weaponTags>
-        </value>
-      </li>
-      </operations>
-    </match>
-    
-  </Operation>
-  
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DDMeleeWeapon_FocusingTome"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>spine</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>3</power>
+							<cooldownTime>2.0</cooldownTime>
+							<armorPenetrationBlunt>1.0</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="DDMeleeWeapon_FocusingTome"]</xpath>
+				<value>
+					<weaponTags>
+						<li>CE_OneHandedWeapon</li>
+					</weaponTags>
+				</value>
+			</li>
+			</operations>
+		</match>
+	</Operation>
 
 </Patch>

--- a/ModPatches/Dragons Descent/Patches/Dragons Descent/ThingDefs_Misc/Weapons/MeleeDD.xml
+++ b/ModPatches/Dragons Descent/Patches/Dragons Descent/ThingDefs_Misc/Weapons/MeleeDD.xml
@@ -170,46 +170,58 @@
 		</value>
 	</Operation>
 	<!-- focusing tome -->
-	<Operation Class="PatchOperationAdd" MayRequire="Ludeon.RimWorld.Royalty">
-		<xpath>Defs/ThingDef[defName="DDMeleeWeapon_FocusingTome"]/statBases</xpath>
-		<value>
-			<Bulk>2</Bulk>
-			<MeleeCounterParryBonus>0.14</MeleeCounterParryBonus>
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Royalty</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="DDMeleeWeapon_FocusingTome"]/statBases</xpath>
+        <value>
+          <Bulk>2</Bulk>
+          <MeleeCounterParryBonus>0.14</MeleeCounterParryBonus>
+        </value>
+      </li>
 
-	<Operation Class="PatchOperationAdd" MayRequire="Ludeon.RimWorld.Royalty">
-		<xpath>Defs/ThingDef[defName="DDMeleeWeapon_FocusingTome"]/equippedStatOffsets</xpath>
-		<value>
-			<MeleeCritChance>0.23</MeleeCritChance>
-			<MeleeParryChance>0.14</MeleeParryChance>
-			<MeleeDodgeChance>0.07</MeleeDodgeChance>
-		</value>
-	</Operation>
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="DDMeleeWeapon_FocusingTome"]/equippedStatOffsets</xpath>
+        <value>
+          <MeleeCritChance>0.23</MeleeCritChance>
+          <MeleeParryChance>0.14</MeleeParryChance>
+          <MeleeDodgeChance>0.07</MeleeDodgeChance>
+        </value>
+      </li>
 
-	<Operation Class="PatchOperationReplace" MayRequire="Ludeon.RimWorld.Royalty">
-		<xpath>Defs/ThingDef[defName="DDMeleeWeapon_FocusingTome"]/tools</xpath>
-		<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-					<label>spine</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>3</power>
-					<cooldownTime>2.0</cooldownTime>
-					<armorPenetrationBlunt>1.0</armorPenetrationBlunt>
-				</li>
-			</tools>
-		</value>
-	</Operation>
+      <li Class="PatchOperationReplace">
+        <xpath>Defs/ThingDef[defName="DDMeleeWeapon_FocusingTome"]/tools</xpath>
+        <value>
+          <tools>
+            <li Class="CombatExtended.ToolCE">
+              <label>spine</label>
+              <capacities>
+                <li>Blunt</li>
+              </capacities>
+              <power>3</power>
+              <cooldownTime>2.0</cooldownTime>
+              <armorPenetrationBlunt>1.0</armorPenetrationBlunt>
+            </li>
+          </tools>
+        </value>
+      </li>
 
-	<Operation Class="PatchOperationAdd" MayRequire="Ludeon.RimWorld.Royalty">
-		<xpath>Defs/ThingDef[defName="DDMeleeWeapon_FocusingTome"]</xpath>
-		<value>
-			<weaponTags>
-				<li>CE_OneHandedWeapon</li>
-			</weaponTags>
-		</value>
-	</Operation>
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="DDMeleeWeapon_FocusingTome"]</xpath>
+        <value>
+          <weaponTags>
+            <li>CE_OneHandedWeapon</li>
+          </weaponTags>
+        </value>
+      </li>
+      </operations>
+    </match>
+    
+  </Operation>
+  
+
 </Patch>

--- a/ModPatches/Dragons Descent/Patches/Dragons Descent/ThingDefs_Misc/Weapons/RangedDD.xml
+++ b/ModPatches/Dragons Descent/Patches/Dragons Descent/ThingDefs_Misc/Weapons/RangedDD.xml
@@ -148,4 +148,5 @@
 			</tools>
 		</value>
 	</Operation>
+
 </Patch>


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Switched from non-functioning mayrequire in operations to using PatchOperationFindMod for Royalty patches.
- Fixed invalid color value on fire breath. Colors should be in 0-1 or 0-255. Not both. 

## Reasoning

Why did you choose to implement things this way, e.g.
- I dislike the errors from failed patches

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony ~5 minutes
