### PR TITLE
Fixed patches for Machines Of War

### DIFF
--- a/ModPatches/Machines of War/Patches/Machines of War/ThingDefs_Misc/StormCharger.xml
+++ b/ModPatches/Machines of War/Patches/Machines of War/ThingDefs_Misc/StormCharger.xml
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 
-	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="MOW_Gun_EMMarksmanRifle"]</xpath>
-	</Operation>
-
 	<Operation Class="PatchOperationReplace">
 		<xpath>
 			Defs/ThingDef[defName="MOW_Gun_StormChargeScatter"]/tools

--- a/ModPatches/Machines of War/Patches/Machines of War/ThingDefs_Races/CicadaRaces.xml
+++ b/ModPatches/Machines of War/Patches/Machines of War/ThingDefs_Races/CicadaRaces.xml
@@ -74,22 +74,6 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="MOW_Mech_Cicada"]/comps</xpath>
 		<value>
-			<li>
-				<compClass>CombatExtended.CompPawnGizmo</compClass>
-			</li>
-			<li>
-				<compClass>CombatExtended.CompAmmoGiver</compClass>
-			</li>
-			<li Class="CombatExtended.CompProperties_MechAmmo">
-				<gizmoIconSetMagCount>UI/Buttons/SetMagCount</gizmoIconSetMagCount>
-				<gizmoIconTakeAmmoNow>UI/Buttons/TakeAmmoNow</gizmoIconTakeAmmoNow>
-			</li>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="MOW_Mech_Cicada"]/comps</xpath>
-		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
 				<Durability>1580</Durability>
 				<Regenerates>true</Regenerates>

--- a/ModPatches/Machines of War/Patches/Machines of War/ThingDefs_Races/DemolisherRaces.xml
+++ b/ModPatches/Machines of War/Patches/Machines of War/ThingDefs_Races/DemolisherRaces.xml
@@ -75,22 +75,6 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="MOW_Mech_Demolisher"]/comps</xpath>
 		<value>
-			<li>
-				<compClass>CombatExtended.CompPawnGizmo</compClass>
-			</li>
-			<li>
-				<compClass>CombatExtended.CompAmmoGiver</compClass>
-			</li>
-			<li Class="CombatExtended.CompProperties_MechAmmo">
-				<gizmoIconSetMagCount>UI/Buttons/SetMagCount</gizmoIconSetMagCount>
-				<gizmoIconTakeAmmoNow>UI/Buttons/TakeAmmoNow</gizmoIconTakeAmmoNow>
-			</li>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="MOW_Mech_Demolisher"]/comps</xpath>
-		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
 				<Durability>3950</Durability>
 				<Regenerates>true</Regenerates>

--- a/ModPatches/Machines of War/Patches/Machines of War/ThingDefs_Races/EnforcerBreachRaces .xml
+++ b/ModPatches/Machines of War/Patches/Machines of War/ThingDefs_Races/EnforcerBreachRaces .xml
@@ -74,22 +74,6 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="MOW_Mech_Enforcer_Breacher"]/comps</xpath>
 		<value>
-			<li>
-				<compClass>CombatExtended.CompPawnGizmo</compClass>
-			</li>
-			<li>
-				<compClass>CombatExtended.CompAmmoGiver</compClass>
-			</li>
-			<li Class="CombatExtended.CompProperties_MechAmmo">
-				<gizmoIconSetMagCount>UI/Buttons/SetMagCount</gizmoIconSetMagCount>
-				<gizmoIconTakeAmmoNow>UI/Buttons/TakeAmmoNow</gizmoIconTakeAmmoNow>
-			</li>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="MOW_Mech_Enforcer_Breacher"]/comps</xpath>
-		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
 				<Durability>1310</Durability>
 				<Regenerates>true</Regenerates>

--- a/ModPatches/Machines of War/Patches/Machines of War/ThingDefs_Races/EnforcerRaces.xml
+++ b/ModPatches/Machines of War/Patches/Machines of War/ThingDefs_Races/EnforcerRaces.xml
@@ -74,22 +74,6 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="MOW_Mech_Enforcer"]/comps</xpath>
 		<value>
-			<li>
-				<compClass>CombatExtended.CompPawnGizmo</compClass>
-			</li>
-			<li>
-				<compClass>CombatExtended.CompAmmoGiver</compClass>
-			</li>
-			<li Class="CombatExtended.CompProperties_MechAmmo">
-				<gizmoIconSetMagCount>UI/Buttons/SetMagCount</gizmoIconSetMagCount>
-				<gizmoIconTakeAmmoNow>UI/Buttons/TakeAmmoNow</gizmoIconTakeAmmoNow>
-			</li>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="MOW_Mech_Enforcer"]/comps</xpath>
-		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
 				<Durability>1310</Durability>
 				<Regenerates>true</Regenerates>


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Removed non-functioning patches. 
- MOW_Gun_EMMarksmanRifle Was removed from the active mod.
- Mechs inherit from BaseMechanoidWalker which inherits from BaseMechanoid so assigning CombatExtended.CompPawnGizmo and other comps was redundant and generating errors on pawn spawn.

## Reasoning

Why did you choose to implement things this way, e.g.
- Patches were unnecessary

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony ~5 minutes
