### PR TITLE
Move Injector Loop

### DIFF
--- a/Source/CombatExtended/CombatExtended/AmmoInjector.cs
+++ b/Source/CombatExtended/CombatExtended/AmmoInjector.cs
@@ -203,12 +203,12 @@ public static class AmmoInjector
                                     Log.Error("Combat Extended :: AmmoInjector trying to inject " + ammoDef.ToString() + " but no crafting bench with defName=" + benchName + " could be found for tag " + curTag);
                                     continue;
                                 }
-                                if (BenchesByTag.TryGetValue(curTag, out HashSet<ThingDef> benchHashSet))
+                            }
+                            if (BenchesByTag.TryGetValue(curTag, out HashSet<ThingDef> benchHashSet))
+                            {
+                                foreach (ThingDef optionBench in benchHashSet)
                                 {
-                                    foreach (ThingDef optionBench in benchHashSet)
-                                    {
-                                        ToggleRecipeOnBench(recipe, optionBench, ammoEnabled);
-                                    }
+                                    ToggleRecipeOnBench(recipe, optionBench, ammoEnabled);
                                 }
                             }
                             ToggleRecipeOnBench(recipe, bench, ammoEnabled);


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Moves adding ammo to injector options outside of if else

## Reasoning

Why did you choose to implement things this way, e.g.
- Allows for injector options to also effect base CE_AutoEnableCrafting to allow for Ammo that is on AmmoBench.
- Mostly transparent to end users, but gives modders an option to easily copy all recipes from CE_AutoEnableCrafting to their new bench

## Alternatives

Describe alternative implementations you have considered, e.g.
- Leave it be and can use the normal options

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
