### PR TITLE
tweaks for Neuralizer_weak and HALO Rimworld Psychic Pulse Armory

### DIFF
--- a/Defs/DamageDefs/Damages_LocalInjury.xml
+++ b/Defs/DamageDefs/Damages_LocalInjury.xml
@@ -160,7 +160,7 @@
 		<additionalHediffs>
 			<li>
 				<hediff>Neuralizer_weak</hediff>
-				<severityPerDamageDealt>0.015</severityPerDamageDealt>
+				<severityPerDamageDealt>0.1</severityPerDamageDealt>
 				<victimSeverityScalingByInvBodySize>true</victimSeverityScalingByInvBodySize>
 			</li>
 		</additionalHediffs>

--- a/Defs/DamageDefs/Damages_LocalInjury.xml
+++ b/Defs/DamageDefs/Damages_LocalInjury.xml
@@ -144,6 +144,7 @@
 		<defName>Neuralizer</defName>
 		<label>neuralizer</label>
 		<harmsHealth>false</harmsHealth>
+		<workerClass>DamageWorker_Stun</workerClass>
 		<additionalHediffs>
 			<li>
 				<hediff>Neuralizer</hediff>

--- a/Defs/DamageDefs/Damages_LocalInjury.xml
+++ b/Defs/DamageDefs/Damages_LocalInjury.xml
@@ -157,11 +157,10 @@
 	<DamageDef ParentName="Electrical">
 		<defName>Neuralizer_weak</defName>
 		<label>low power neuralizer</label>
-		<harmsHealth>false</harmsHealth>
 		<additionalHediffs>
 			<li>
 				<hediff>Neuralizer_weak</hediff>
-				<severityPerDamageDealt>0.1</severityPerDamageDealt>
+				<severityPerDamageDealt>0.05</severityPerDamageDealt>
 				<victimSeverityScalingByInvBodySize>true</victimSeverityScalingByInvBodySize>
 			</li>
 		</additionalHediffs>

--- a/Defs/HediffDefs/Hediffs_CE.xml
+++ b/Defs/HediffDefs/Hediffs_CE.xml
@@ -484,39 +484,38 @@
 		<maxSeverity>1</maxSeverity>
 		<isBad>false</isBad>
 		<comps>
-			<li Class="HediffCompProperties_Disappears">
-				<showRemainingTime>True</showRemainingTime>
-				<disappearsAfterTicks>
-					<min>7500</min>
-					<max>15000</max>
-				</disappearsAfterTicks>
+			<li Class="HediffCompProperties_SeverityPerDay">
+				<severityPerDay>-2</severityPerDay>
 			</li>
 		</comps>
 		<stages>
 			<li>
 				<minSeverity>0.01</minSeverity>
+				<painFactor>1.2</painFactor>
 				<capMods>
 					<li>
 						<capacity>Consciousness</capacity>
-						<postFactor>0.9</postFactor>
+						<offset>-0.2</offset>
 					</li>
 				</capMods>
 			</li>
 			<li>
 				<minSeverity>0.25</minSeverity>
+				<painFactor>1.4</painFactor>
 				<capMods>
 					<li>
 						<capacity>Consciousness</capacity>
-						<postFactor>0.8</postFactor>
+						<offset>-0.3</offset>
 					</li>
 				</capMods>
 			</li>
 			<li>
 				<minSeverity>0.5</minSeverity>
+				<painFactor>1.6</painFactor>
 				<capMods>
 					<li>
 						<capacity>Consciousness</capacity>
-						<postFactor>0.7</postFactor>
+						<offset>-0.5</offset>
 					</li>
 				</capMods>
 			</li>
@@ -525,16 +524,7 @@
 				<capMods>
 					<li>
 						<capacity>Consciousness</capacity>
-						<postFactor>0.4</postFactor>
-					</li>
-				</capMods>
-			</li>
-			<li>
-				<minSeverity>0.95</minSeverity>
-				<capMods>
-					<li>
-						<capacity>Consciousness</capacity>
-						<postFactor>0.1</postFactor>
+						<setMax>0.1</setMax>
 					</li>
 				</capMods>
 			</li>

--- a/Defs/HediffDefs/Hediffs_CE.xml
+++ b/Defs/HediffDefs/Hediffs_CE.xml
@@ -491,36 +491,36 @@
 		<stages>
 			<li>
 				<minSeverity>0.01</minSeverity>
-				<painFactor>1.2</painFactor>
+				<painFactor>1.1</painFactor>
 				<capMods>
 					<li>
 						<capacity>Consciousness</capacity>
-						<offset>-0.2</offset>
+						<postFactor>0.8</postFactor>
 					</li>
 				</capMods>
 			</li>
 			<li>
 				<minSeverity>0.25</minSeverity>
-				<painFactor>1.4</painFactor>
+				<painFactor>1.2</painFactor>
 				<capMods>
 					<li>
 						<capacity>Consciousness</capacity>
-						<offset>-0.3</offset>
+						<postFactor>0.7</postFactor>
 					</li>
 				</capMods>
 			</li>
 			<li>
 				<minSeverity>0.5</minSeverity>
-				<painFactor>1.6</painFactor>
+				<painFactor>1.2</painFactor>
 				<capMods>
 					<li>
 						<capacity>Consciousness</capacity>
-						<offset>-0.5</offset>
+						<postFactor>0.55</postFactor>
 					</li>
 				</capMods>
 			</li>
 			<li>
-				<minSeverity>0.75</minSeverity>
+				<minSeverity>0.85</minSeverity>
 				<capMods>
 					<li>
 						<capacity>Consciousness</capacity>

--- a/ModPatches/HALO Rimworld Psychic Pulse Armory/Defs/HALO Rimworld Psychic Pulse Armory/Ammo/ArchotechAmmo.xml
+++ b/ModPatches/HALO Rimworld Psychic Pulse Armory/Defs/HALO Rimworld Psychic Pulse Armory/Ammo/ArchotechAmmo.xml
@@ -13,7 +13,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Neuralizer_weak</damageDef>
 			<dropsCasings>false</dropsCasings>
-			<damageAmountBase>1</damageAmountBase>
+			<damageAmountBase>2</damageAmountBase>
 			<armorPenetrationSharp>12</armorPenetrationSharp>
 			<armorPenetrationBlunt>20</armorPenetrationBlunt>
 			<speed>80</speed>
@@ -30,7 +30,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Neuralizer_weak</damageDef>
 			<dropsCasings>false</dropsCasings>
-			<damageAmountBase>2</damageAmountBase>
+			<damageAmountBase>4</damageAmountBase>
 			<armorPenetrationSharp>22</armorPenetrationSharp>
 			<armorPenetrationBlunt>30</armorPenetrationBlunt>
 			<speed>95</speed>
@@ -47,7 +47,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Neuralizer_weak</damageDef>
 			<dropsCasings>false</dropsCasings>
-			<damageAmountBase>1</damageAmountBase>
+			<damageAmountBase>2</damageAmountBase>
 			<armorPenetrationSharp>36</armorPenetrationSharp>
 			<armorPenetrationBlunt>175</armorPenetrationBlunt>
 			<speed>95</speed>
@@ -64,7 +64,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Neuralizer_weak</damageDef>
 			<dropsCasings>false</dropsCasings>
-			<damageAmountBase>2</damageAmountBase>
+			<damageAmountBase>4</damageAmountBase>
 			<armorPenetrationSharp>18</armorPenetrationSharp>
 			<armorPenetrationBlunt>25</armorPenetrationBlunt>
 			<pelletCount>10</pelletCount>
@@ -83,7 +83,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Neuralizer_weak</damageDef>
 			<dropsCasings>false</dropsCasings>
-			<damageAmountBase>2</damageAmountBase>
+			<damageAmountBase>4</damageAmountBase>
 			<armorPenetrationSharp>36</armorPenetrationSharp>
 			<armorPenetrationBlunt>175</armorPenetrationBlunt>
 			<speed>150</speed>
@@ -100,7 +100,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Neuralizer_weak</damageDef>
 			<dropsCasings>false</dropsCasings>
-			<damageAmountBase>3</damageAmountBase>
+			<damageAmountBase>6</damageAmountBase>
 			<armorPenetrationSharp>40</armorPenetrationSharp>
 			<armorPenetrationBlunt>300</armorPenetrationBlunt>
 			<speed>200</speed>
@@ -115,10 +115,9 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Neuralizer_weak</damageDef>
-			<damageAmountBase>5</damageAmountBase>
+			<damageAmountBase>8</damageAmountBase>
 			<explosionRadius>6.9</explosionRadius>
 			<explosionDelay>100</explosionDelay>
-			<speed>40</speed>
 			<ai_IsIncendiary>false</ai_IsIncendiary>
 			<flyOverhead>false</flyOverhead>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/ModPatches/HALO Rimworld Psychic Pulse Armory/Defs/HALO Rimworld Psychic Pulse Armory/Ammo/ArchotechAmmo.xml
+++ b/ModPatches/HALO Rimworld Psychic Pulse Armory/Defs/HALO Rimworld Psychic Pulse Armory/Ammo/ArchotechAmmo.xml
@@ -22,7 +22,7 @@
 
 	<ThingDef ParentName="Base556x45mmNATOBullet">
 		<defName>HRPPA_Bullet_PsychicPulseRepeaterCE</defName>
-		<label>PsychicPulse</label>
+		<label>Psychic Pulse</label>
 		<graphicData>
 			<texPath>Things/Projectile/HRPPW_PsychicPulse_Small</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -39,7 +39,7 @@
 
 	<ThingDef ParentName="Base556x45mmNATOBullet">
 		<defName>HRPPA_Bullet_PsychicPulseSpinnerCE</defName>
-		<label>PsychicPulse</label>
+		<label>Psychic Pulse</label>
 		<graphicData>
 			<texPath>Things/Projectile/HRPPW_PsychicPulse_Small</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -56,7 +56,7 @@
 
 	<ThingDef ParentName="Base556x45mmNATOBullet">
 		<defName>HRPPA_Bullet_PsychicPulseShotgunCE</defName>
-		<label>PsychicPulse</label>
+		<label>Psychic Pulse</label>
 		<graphicData>
 			<texPath>Things/Projectile/HRPPW_PsychicPulse_Small</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -75,7 +75,7 @@
 
 	<ThingDef ParentName="Base556x45mmNATOBullet">
 		<defName>HRPPA_Bullet_PsychicPulseReacherCE</defName>
-		<label>PsychicPulse</label>
+		<label>Psychic Pulse</label>
 		<graphicData>
 			<texPath>Things/Projectile/HRPPW_PsychicPulse_Small</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -92,7 +92,7 @@
 
 	<ThingDef ParentName="Base556x45mmNATOBullet">
 		<defName>HRPPA_Bullet_PsychicPulseLancerCE</defName>
-		<label>PsychicPulse</label>
+		<label>Psychic Pulse</label>
 		<graphicData>
 			<texPath>Things/Projectile/HRPPW_PsychicPulse_LanceShot</texPath>
 			<graphicClass>Graphic_Single</graphicClass>

--- a/ModPatches/HALO Rimworld Psychic Pulse Armory/Defs/HALO Rimworld Psychic Pulse Armory/Ammo/ArchotechAmmo.xml
+++ b/ModPatches/HALO Rimworld Psychic Pulse Armory/Defs/HALO Rimworld Psychic Pulse Armory/Ammo/ArchotechAmmo.xml
@@ -13,7 +13,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Neuralizer_weak</damageDef>
 			<dropsCasings>false</dropsCasings>
-			<damageAmountBase>2</damageAmountBase>
+			<damageAmountBase>6</damageAmountBase>
 			<armorPenetrationSharp>12</armorPenetrationSharp>
 			<armorPenetrationBlunt>20</armorPenetrationBlunt>
 			<speed>80</speed>
@@ -30,7 +30,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Neuralizer_weak</damageDef>
 			<dropsCasings>false</dropsCasings>
-			<damageAmountBase>4</damageAmountBase>
+			<damageAmountBase>8</damageAmountBase>
 			<armorPenetrationSharp>22</armorPenetrationSharp>
 			<armorPenetrationBlunt>30</armorPenetrationBlunt>
 			<speed>95</speed>
@@ -47,7 +47,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Neuralizer_weak</damageDef>
 			<dropsCasings>false</dropsCasings>
-			<damageAmountBase>2</damageAmountBase>
+			<damageAmountBase>6</damageAmountBase>
 			<armorPenetrationSharp>36</armorPenetrationSharp>
 			<armorPenetrationBlunt>175</armorPenetrationBlunt>
 			<speed>95</speed>
@@ -83,7 +83,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Neuralizer_weak</damageDef>
 			<dropsCasings>false</dropsCasings>
-			<damageAmountBase>4</damageAmountBase>
+			<damageAmountBase>10</damageAmountBase>
 			<armorPenetrationSharp>36</armorPenetrationSharp>
 			<armorPenetrationBlunt>175</armorPenetrationBlunt>
 			<speed>150</speed>
@@ -100,7 +100,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Neuralizer_weak</damageDef>
 			<dropsCasings>false</dropsCasings>
-			<damageAmountBase>6</damageAmountBase>
+			<damageAmountBase>12</damageAmountBase>
 			<armorPenetrationSharp>40</armorPenetrationSharp>
 			<armorPenetrationBlunt>300</armorPenetrationBlunt>
 			<speed>200</speed>
@@ -115,7 +115,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Neuralizer_weak</damageDef>
-			<damageAmountBase>8</damageAmountBase>
+			<damageAmountBase>20</damageAmountBase>
 			<explosionRadius>6.9</explosionRadius>
 			<explosionDelay>100</explosionDelay>
 			<ai_IsIncendiary>false</ai_IsIncendiary>

--- a/ModPatches/HALO Rimworld Psychic Pulse Armory/Patches/HALO Rimworld Psychic Pulse Armory/RangedArchotech.xml
+++ b/ModPatches/HALO Rimworld Psychic Pulse Armory/Patches/HALO Rimworld Psychic Pulse Armory/RangedArchotech.xml
@@ -307,20 +307,14 @@
 		<xpath>Defs/ThingDef[defName="HRPPA_PsychicPulseGrenade"]/verbs</xpath>
 	</Operation>
 
-	<Operation Class="PatchOperationSequence">
-		<success>Always</success>
-		<operations>
-			<li Class="PatchOperationTest">
-				<xpath>Defs/ThingDef[defName="HRPPA_PsychicPulseGrenade"]/comps</xpath>
-				<success>Invert</success>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="HRPPA_PsychicPulseGrenade"]</xpath>
-				<value>
-					<comps />
-				</value>
-			</li>
-		</operations>
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="HRPPA_PsychicPulseGrenade"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="HRPPA_PsychicPulseGrenade"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
 	</Operation>
 
 	<Operation Class="PatchOperationAttributeSet">


### PR DESCRIPTION
## Additions
none
## Changes
buff damage Neuralizer_weak to hediff rate buff hediff Neuralizer_weak and all damage amount of the halo pcychic weapons
## References
none
## Reasoning
they kill pawns before knocking them down
## Alternatives
crank damage up without touching hediff
## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long) 
