### PR TITLE
Various Patch Fixes

### DIFF
--- a/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Misc/AA_Resource_CEStuff.xml
+++ b/ModPatches/Alpha Animals/Patches/Alpha Animals/ThingDefs_Misc/AA_Resource_CEStuff.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[@Name="AA_MeatMealBase"]/statBases</xpath>
 		<value>
@@ -36,65 +37,53 @@
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="GU_RedWood"]</xpath>
 			<value>
-				<equippedStatOffsets>
-					<MeleeCritChance>0.2</MeleeCritChance>
-					<MeleeParryChance>1</MeleeParryChance>
-					<MeleeDodgeChance>0.13</MeleeDodgeChance>
-				</equippedStatOffsets>
+				<equippedStatOffsets />
 			</value>
 		</nomatch>
-		<match Class="PatchOperationReplace">
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="GU_RedWood"]/equippedStatOffsets/MeleeParryChance</xpath>
+		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="GU_RedWood"]/equippedStatOffsets</xpath>
 			<value>
-				<equippedStatOffsets>
-					<MeleeCritChance>0.2</MeleeCritChance>
-					<MeleeParryChance>1</MeleeParryChance>
-					<MeleeDodgeChance>0.13</MeleeDodgeChance>
-				</equippedStatOffsets>
+				<MeleeCritChance>0.2</MeleeCritChance>
+				<MeleeParryChance>1</MeleeParryChance>
+				<MeleeDodgeChance>0.13</MeleeDodgeChance>
 			</value>
-		</match>
+		</nomatch>
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="GU_RedWood"]/statBases/Bulk</xpath>
-		<nomatch Class="PatchOperationReplace">
+		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="GU_RedWood"]/statBases</xpath>
 			<value>
-				<statBases>
-					<Bulk>0.07</Bulk>
-					<MeleeCounterParryBonus>1.33</MeleeCounterParryBonus>
-					<StuffPower_Armor_Sharp>0.1</StuffPower_Armor_Sharp>
-					<StuffPower_Armor_Blunt>0.2</StuffPower_Armor_Blunt>
-					<StuffPower_Armor_Heat>0.025</StuffPower_Armor_Heat>
-					<MarketValue>1.2</MarketValue>
-					<MaxHitPoints>150</MaxHitPoints>
-					<Mass>0.4</Mass>
-					<Flammability>0.6</Flammability>
-					<DeteriorationRate>1</DeteriorationRate>
-					<SharpDamageMultiplier>0.7</SharpDamageMultiplier>
-					<BluntDamageMultiplier>0.5</BluntDamageMultiplier>
-				</statBases>
+				<Bulk>0.07</Bulk>
+				<MeleeCounterParryBonus>1.33</MeleeCounterParryBonus>
 			</value>
 		</nomatch>
-		<match Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="GU_RedWood"]/statBases</xpath>
-			<value>
-				<statBases>
-					<Bulk>0.07</Bulk>
-					<MeleeCounterParryBonus>1.33</MeleeCounterParryBonus>
-					<StuffPower_Armor_Sharp>0.1</StuffPower_Armor_Sharp>
-					<StuffPower_Armor_Blunt>0.2</StuffPower_Armor_Blunt>
-					<StuffPower_Armor_Heat>0.025</StuffPower_Armor_Heat>
-					<MarketValue>1.2</MarketValue>
-					<MaxHitPoints>150</MaxHitPoints>
-					<Mass>0.4</Mass>
-					<Flammability>0.6</Flammability>
-					<DeteriorationRate>1</DeteriorationRate>
-					<SharpDamageMultiplier>0.7</SharpDamageMultiplier>
-					<BluntDamageMultiplier>0.5</BluntDamageMultiplier>
-				</statBases>
-			</value>
-		</match>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GU_RedWood"]/statBases/StuffPower_Armor_Sharp</xpath>
+		<value>
+			<StuffPower_Armor_Sharp>0.1</StuffPower_Armor_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GU_RedWood"]/statBases/StuffPower_Armor_Blunt</xpath>
+		<value>
+			<StuffPower_Armor_Blunt>0.2</StuffPower_Armor_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GU_RedWood"]/statBases/StuffPower_Armor_Heat</xpath>
+		<value>
+			<StuffPower_Armor_Heat>0.025</StuffPower_Armor_Heat>
+		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
@@ -106,12 +95,6 @@
 				<MeleePenetrationFactor>0.3</MeleePenetrationFactor>
 			</value>
 		</nomatch>
-		<match Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="GU_RedWood"]/stuffProps/Mass</xpath>
-			<value>
-				<Mass>0.3</Mass>
-			</value>
-		</match>
 	</Operation>
 
 	<Operation Class="PatchOperationAddModExtension">
@@ -122,4 +105,5 @@
 			</li>
 		</value>
 	</Operation>
+
 </Patch>

--- a/ModPatches/Alpha Biomes/Patches/Alpha Biomes/Items_Resource_Stuff.xml
+++ b/ModPatches/Alpha Biomes/Patches/Alpha Biomes/Items_Resource_Stuff.xml
@@ -46,10 +46,10 @@
 		</value>
 	</Operation>
 
-	<!-- ======== Red, Crystal and Mushroom Wood ======== -->
+	<!-- ======== Crystal and Mushroom Wood ======== -->
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/tools</xpath>
+		<xpath>Defs/ThingDef[defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/tools</xpath>
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
@@ -65,7 +65,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="AB_MushroomWoodLog" or defName="AB_CrystalWood" or defName="GU_RedWood"]</xpath>
+		<xpath>Defs/ThingDef[defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]</xpath>
 		<value>
 			<li Class="CombatExtended.StuffToughnessMultiplierExtensionCE">
 				<toughnessMultiplier>4</toughnessMultiplier>
@@ -74,7 +74,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]</xpath>
+		<xpath>Defs/ThingDef[defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]</xpath>
 		<value>
 			<equippedStatOffsets>
 				<MeleeCritChance>0.2</MeleeCritChance>
@@ -85,7 +85,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="AB_MushroomWoodLog" or defName="AB_CrystalWood" or defName="GU_RedWood"]/statBases/StuffPower_Armor_Sharp</xpath>
+		<xpath>Defs/ThingDef[defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/StuffPower_Armor_Sharp</xpath>
 		<value>
 			<Bulk>0.07</Bulk>
 			<MeleeCounterParryBonus>1.33</MeleeCounterParryBonus>
@@ -94,16 +94,107 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/StuffPower_Armor_Blunt</xpath>
+		<xpath>Defs/ThingDef[defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/StuffPower_Armor_Blunt</xpath>
 		<value>
 			<StuffPower_Armor_Blunt>0.2</StuffPower_Armor_Blunt>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/StuffPower_Armor_Heat</xpath>
+		<xpath>Defs/ThingDef[defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/StuffPower_Armor_Heat</xpath>
 		<value>
 			<StuffPower_Armor_Heat>0.025</StuffPower_Armor_Heat>
+		</value>
+	</Operation>
+
+	<!-- ======== Red Wood ======== -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GU_RedWood"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>2</power>
+					<cooldownTime>0.99</cooldownTime>
+					<armorPenetrationBlunt>0.288</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="GU_RedWood"]/equippedStatOffsets</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="GU_RedWood"]</xpath>
+			<value>
+				<equippedStatOffsets />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="GU_RedWood"]/equippedStatOffsets/MeleeParryChance</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="GU_RedWood"]/equippedStatOffsets</xpath>
+			<value>
+				<MeleeCritChance>0.2</MeleeCritChance>
+				<MeleeParryChance>1</MeleeParryChance>
+				<MeleeDodgeChance>0.13</MeleeDodgeChance>
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="GU_RedWood"]/statBases/Bulk</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="GU_RedWood"]/statBases</xpath>
+			<value>
+				<Bulk>0.07</Bulk>
+				<MeleeCounterParryBonus>1.33</MeleeCounterParryBonus>
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GU_RedWood"]/statBases/StuffPower_Armor_Sharp</xpath>
+		<value>
+			<StuffPower_Armor_Sharp>0.1</StuffPower_Armor_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GU_RedWood"]/statBases/StuffPower_Armor_Blunt</xpath>
+		<value>
+			<StuffPower_Armor_Blunt>0.2</StuffPower_Armor_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GU_RedWood"]/statBases/StuffPower_Armor_Heat</xpath>
+		<value>
+			<StuffPower_Armor_Heat>0.025</StuffPower_Armor_Heat>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="GU_RedWood"]/stuffProps/statFactors/Mass</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="GU_RedWood"]/stuffProps/statFactors</xpath>
+			<value>
+				<Mass>0.3</Mass>
+				<MeleePenetrationFactor>0.3</MeleePenetrationFactor>
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="GU_RedWood"]</xpath>
+		<value>
+			<li Class="CombatExtended.StuffToughnessMultiplierExtensionCE">
+				<toughnessMultiplier>5</toughnessMultiplier>
+			</li>
 		</value>
 	</Operation>
 

--- a/ModPatches/Alpha Memes/Patches/Alpha Memes/ThingDefs_Items/AM_Resource_CE_Stuff.xml
+++ b/ModPatches/Alpha Memes/Patches/Alpha Memes/ThingDefs_Items/AM_Resource_CE_Stuff.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- ======== Red Wood ======== -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GU_RedWood"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>2</power>
+					<cooldownTime>0.99</cooldownTime>
+					<armorPenetrationBlunt>0.288</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="GU_RedWood"]/equippedStatOffsets</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="GU_RedWood"]</xpath>
+			<value>
+				<equippedStatOffsets>
+					<MeleeCritChance>0.2</MeleeCritChance>
+					<MeleeParryChance>1</MeleeParryChance>
+					<MeleeDodgeChance>0.13</MeleeDodgeChance>
+				</equippedStatOffsets>
+			</value>
+		</nomatch>
+		<match Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="GU_RedWood"]/equippedStatOffsets</xpath>
+			<value>
+				<equippedStatOffsets>
+					<MeleeCritChance>0.2</MeleeCritChance>
+					<MeleeParryChance>1</MeleeParryChance>
+					<MeleeDodgeChance>0.13</MeleeDodgeChance>
+				</equippedStatOffsets>
+			</value>
+		</match>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="GU_RedWood"]/statBases/Bulk</xpath>
+		<nomatch Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="GU_RedWood"]/statBases</xpath>
+			<value>
+				<statBases>
+					<Bulk>0.07</Bulk>
+					<MeleeCounterParryBonus>1.33</MeleeCounterParryBonus>
+					<StuffPower_Armor_Sharp>0.1</StuffPower_Armor_Sharp>
+					<StuffPower_Armor_Blunt>0.2</StuffPower_Armor_Blunt>
+					<StuffPower_Armor_Heat>0.025</StuffPower_Armor_Heat>
+					<MarketValue>1.2</MarketValue>
+					<MaxHitPoints>150</MaxHitPoints>
+					<Mass>0.4</Mass>
+					<Flammability>0.6</Flammability>
+					<DeteriorationRate>1</DeteriorationRate>
+					<SharpDamageMultiplier>0.7</SharpDamageMultiplier>
+					<BluntDamageMultiplier>0.5</BluntDamageMultiplier>
+				</statBases>
+			</value>
+		</nomatch>
+		<match Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="GU_RedWood"]/statBases</xpath>
+			<value>
+				<statBases>
+					<Bulk>0.07</Bulk>
+					<MeleeCounterParryBonus>1.33</MeleeCounterParryBonus>
+					<StuffPower_Armor_Sharp>0.1</StuffPower_Armor_Sharp>
+					<StuffPower_Armor_Blunt>0.2</StuffPower_Armor_Blunt>
+					<StuffPower_Armor_Heat>0.025</StuffPower_Armor_Heat>
+					<MarketValue>1.2</MarketValue>
+					<MaxHitPoints>150</MaxHitPoints>
+					<Mass>0.4</Mass>
+					<Flammability>0.6</Flammability>
+					<DeteriorationRate>1</DeteriorationRate>
+					<SharpDamageMultiplier>0.7</SharpDamageMultiplier>
+					<BluntDamageMultiplier>0.5</BluntDamageMultiplier>
+				</statBases>
+			</value>
+		</match>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="GU_RedWood"]/stuffProps/statFactors/Mass</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="GU_RedWood"]/stuffProps/statFactors</xpath>
+			<value>
+				<Mass>0.3</Mass>
+				<MeleePenetrationFactor>0.3</MeleePenetrationFactor>
+			</value>
+		</nomatch>
+		<match Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="GU_RedWood"]/stuffProps/Mass</xpath>
+			<value>
+				<Mass>0.3</Mass>
+			</value>
+		</match>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="GU_RedWood"]</xpath>
+		<value>
+			<li Class="CombatExtended.StuffToughnessMultiplierExtensionCE">
+				<toughnessMultiplier>5</toughnessMultiplier>
+			</li>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Alpha Memes/Patches/Alpha Memes/ThingDefs_Items/AM_Resource_CE_Stuff.xml
+++ b/ModPatches/Alpha Memes/Patches/Alpha Memes/ThingDefs_Items/AM_Resource_CE_Stuff.xml
@@ -23,65 +23,53 @@
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="GU_RedWood"]</xpath>
 			<value>
-				<equippedStatOffsets>
-					<MeleeCritChance>0.2</MeleeCritChance>
-					<MeleeParryChance>1</MeleeParryChance>
-					<MeleeDodgeChance>0.13</MeleeDodgeChance>
-				</equippedStatOffsets>
+				<equippedStatOffsets />
 			</value>
 		</nomatch>
-		<match Class="PatchOperationReplace">
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="GU_RedWood"]/equippedStatOffsets/MeleeParryChance</xpath>
+		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="GU_RedWood"]/equippedStatOffsets</xpath>
 			<value>
-				<equippedStatOffsets>
-					<MeleeCritChance>0.2</MeleeCritChance>
-					<MeleeParryChance>1</MeleeParryChance>
-					<MeleeDodgeChance>0.13</MeleeDodgeChance>
-				</equippedStatOffsets>
+				<MeleeCritChance>0.2</MeleeCritChance>
+				<MeleeParryChance>1</MeleeParryChance>
+				<MeleeDodgeChance>0.13</MeleeDodgeChance>
 			</value>
-		</match>
+		</nomatch>
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="GU_RedWood"]/statBases/Bulk</xpath>
-		<nomatch Class="PatchOperationReplace">
+		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="GU_RedWood"]/statBases</xpath>
 			<value>
-				<statBases>
-					<Bulk>0.07</Bulk>
-					<MeleeCounterParryBonus>1.33</MeleeCounterParryBonus>
-					<StuffPower_Armor_Sharp>0.1</StuffPower_Armor_Sharp>
-					<StuffPower_Armor_Blunt>0.2</StuffPower_Armor_Blunt>
-					<StuffPower_Armor_Heat>0.025</StuffPower_Armor_Heat>
-					<MarketValue>1.2</MarketValue>
-					<MaxHitPoints>150</MaxHitPoints>
-					<Mass>0.4</Mass>
-					<Flammability>0.6</Flammability>
-					<DeteriorationRate>1</DeteriorationRate>
-					<SharpDamageMultiplier>0.7</SharpDamageMultiplier>
-					<BluntDamageMultiplier>0.5</BluntDamageMultiplier>
-				</statBases>
+				<Bulk>0.07</Bulk>
+				<MeleeCounterParryBonus>1.33</MeleeCounterParryBonus>
 			</value>
 		</nomatch>
-		<match Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="GU_RedWood"]/statBases</xpath>
-			<value>
-				<statBases>
-					<Bulk>0.07</Bulk>
-					<MeleeCounterParryBonus>1.33</MeleeCounterParryBonus>
-					<StuffPower_Armor_Sharp>0.1</StuffPower_Armor_Sharp>
-					<StuffPower_Armor_Blunt>0.2</StuffPower_Armor_Blunt>
-					<StuffPower_Armor_Heat>0.025</StuffPower_Armor_Heat>
-					<MarketValue>1.2</MarketValue>
-					<MaxHitPoints>150</MaxHitPoints>
-					<Mass>0.4</Mass>
-					<Flammability>0.6</Flammability>
-					<DeteriorationRate>1</DeteriorationRate>
-					<SharpDamageMultiplier>0.7</SharpDamageMultiplier>
-					<BluntDamageMultiplier>0.5</BluntDamageMultiplier>
-				</statBases>
-			</value>
-		</match>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GU_RedWood"]/statBases/StuffPower_Armor_Sharp</xpath>
+		<value>
+			<StuffPower_Armor_Sharp>0.1</StuffPower_Armor_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GU_RedWood"]/statBases/StuffPower_Armor_Blunt</xpath>
+		<value>
+			<StuffPower_Armor_Blunt>0.2</StuffPower_Armor_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GU_RedWood"]/statBases/StuffPower_Armor_Heat</xpath>
+		<value>
+			<StuffPower_Armor_Heat>0.025</StuffPower_Armor_Heat>
+		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
@@ -93,12 +81,6 @@
 				<MeleePenetrationFactor>0.3</MeleePenetrationFactor>
 			</value>
 		</nomatch>
-		<match Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="GU_RedWood"]/stuffProps/Mass</xpath>
-			<value>
-				<Mass>0.3</Mass>
-			</value>
-		</match>
 	</Operation>
 
 	<Operation Class="PatchOperationAddModExtension">

--- a/ModPatches/Alpha Memes/Patches/Alpha Memes/ThingDefs_Races/Race_AM_Eyeling.xml
+++ b/ModPatches/Alpha Memes/Patches/Alpha Memes/ThingDefs_Races/Race_AM_Eyeling.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="AA_Eyeling"]/modExtensions/li[@Class="CombatExtended.RacePropertiesExtensionCE"]</xpath>
+		<nomatch Class="PatchOperationAddModExtension">
+			<xpath>Defs/ThingDef[defName="AA_Eyeling"]</xpath>
+			<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="AA_Eyeling"]/statBases/MeleeParryChance</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="AA_Eyeling"]/statBases</xpath>
+			<value>
+				<MeleeDodgeChance>0.1</MeleeDodgeChance>
+				<MeleeCritChance>0.1</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AA_Eyeling"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<capacities>
+						<li>AM_ToxicSting</li>
+					</capacities>
+					<power>12</power>
+					<cooldownTime>1.65</cooldownTime>
+					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					<surpriseAttack>
+						<extraMeleeDamages>
+							<li>
+								<def>Stun</def>
+								<amount>10</amount>
+							</li>
+						</extraMeleeDamages>
+					</surpriseAttack>
+					<armorPenetrationSharp>1.0</armorPenetrationSharp>
+					<armorPenetrationBlunt>0.544</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Vanilla Animals Expanded - Endangered/Patches/Vanilla Animals Expanded - Endangered/VAE_Resources.xml
+++ b/ModPatches/Vanilla Animals Expanded - Endangered/Patches/Vanilla Animals Expanded - Endangered/VAE_Resources.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- === Raw Fish === -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AEXP_RawFish"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>raw fish</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>2</power>
+					<cooldownTime>1.39</cooldownTime>
+					<armorPenetrationBlunt>0.288</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="AEXP_RawFish"]/equippedStatOffsets</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="AEXP_RawFish"]</xpath>
+			<value>
+				<equippedStatOffsets />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="AEXP_RawFish"]/equippedStatOffsets/MeleeParryChance</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="AEXP_RawFish"]/equippedStatOffsets</xpath>
+			<value>
+				<MeleeCritChance>0.1</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				<MeleeDodgeChance>0.1</MeleeDodgeChance>
+			</value>				
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="AEXP_RawFish"]/statBases/Bulk</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="AEXP_RawFish"]/statBases</xpath>
+			<value>
+				<Bulk>0.05</Bulk>
+				<MeleeCounterParryBonus>0.05</MeleeCounterParryBonus>
+			</value>				
+		</nomatch>
+		<match Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="AEXP_RawFish"]/statBases</xpath>
+			<value>
+				<Bulk>0.05</Bulk>
+				<MeleeCounterParryBonus>0.05</MeleeCounterParryBonus>
+			</value>
+		</match>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Vanilla Animals Expanded - Endangered/Patches/Vanilla Animals Expanded - Endangered/VAE_Resources.xml
+++ b/ModPatches/Vanilla Animals Expanded - Endangered/Patches/Vanilla Animals Expanded - Endangered/VAE_Resources.xml
@@ -50,13 +50,6 @@
 				<MeleeCounterParryBonus>0.05</MeleeCounterParryBonus>
 			</value>				
 		</nomatch>
-		<match Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="AEXP_RawFish"]/statBases</xpath>
-			<value>
-				<Bulk>0.05</Bulk>
-				<MeleeCounterParryBonus>0.05</MeleeCounterParryBonus>
-			</value>
-		</match>
 	</Operation>
 
 </Patch>

--- a/ModPatches/Vanilla Races Expanded - Phytokin/Patches/Vanilla Races Expanded - Phytokin/GeneDefs/Races_Animal_Ideology.xml
+++ b/ModPatches/Vanilla Races Expanded - Phytokin/Patches/Vanilla Races Expanded - Phytokin/GeneDefs/Races_Animal_Ideology.xml
@@ -19,6 +19,13 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VRE_CompanionDryad"]/comps</xpath>
+					<value>
+						<li Class="CombatExtended.CompProperties_Inventory"/>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="VRE_CompanionDryad"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.20</MeleeDodgeChance>

--- a/ModPatches/Vanilla Weapons Expanded/Patches/Vanilla Weapons Expanded/Industrial_Ranged.xml
+++ b/ModPatches/Vanilla Weapons Expanded/Patches/Vanilla Weapons Expanded/Industrial_Ranged.xml
@@ -623,8 +623,8 @@
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>True</hasStandardCommand>
 			<defaultProjectile>Bullet_3030Winchester_FMJ</defaultProjectile>
-			<warmupTime>48</warmupTime>
-			<range>31</range>
+			<warmupTime>0.9</warmupTime>
+			<range>48</range>
 			<soundCast>VWE_Shot_LeverActionRifle</soundCast>
 			<soundCastTail>GunTail_Heavy</soundCastTail>
 			<muzzleFlashScale>9</muzzleFlashScale>


### PR DESCRIPTION
## Changes
- Patch Red Wood (AM/AB), Eyeling (AA/AM) and Raw Fish (VAE-E/VFE) in other mods where they occur.
- Fix typo in VWE lever action rifle.

## Reasoning
- defNames are identical. Patching is very defensive to prevent issues when using mods where multiple occur. 

## Alternatives
- Leave unpatched.
- World's slowest lever-action.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
