### PR TITLE
Patch Better Traders Guild

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -84,6 +84,7 @@
 		<li IfModActive="ElSov.Beliar">ModPatches/Beliar Xenotype</li>
 		<li IfModActive="Starppole.Beta.AnimeHair1.6">ModPatches/Beta Anime Hair</li>
 		<li IfModActive="Beta.GuPHAA">ModPatches/Beta GnP Hair and Apparel</li>		
+		<li IfModActive="shunter.bettertradersguild">ModPatches/Better Traders Guild</li>
 		<li IfModActive="divineDerivative.AutoWool">ModPatches/Better Wool Production</li>
 		<li IfModActive="RedMattis.Heaven">ModPatches/Big and Small - Heaven and Hell</li>
 		<li IfModActive="RedMattis.BigSmall.MedievalOverhaulFactions">ModPatches/Big and Small - MO</li>

--- a/ModPatches/Better Traders Guild/Patches/Better Traders Guild/CE_Scenario.xml
+++ b/ModPatches/Better Traders Guild/Patches/Better Traders Guild/CE_Scenario.xml
@@ -5,7 +5,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ScenarioDef[defName="BTG_IndependentTraders"]/scenario/parts</xpath>
 		<value>
-			<li Class="ScenPart_ScatterThingsNearPlayerStart">
+			<li Class="ScenPart_StartingThing_Defined">
 				<def>StartingThing_Defined</def>
 				<thingDef>Ammo_6x24mmCharged</thingDef>
 				<count>300</count>
@@ -16,7 +16,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ScenarioDef[defName="BTG_IndependentTraders"]/scenario/parts</xpath>
 		<value>
-			<li Class="ScenPart_ScatterThingsNearPlayerStart">
+			<li Class="ScenPart_StartingThing_Defined">
 				<def>StartingThing_Defined</def>
 				<thingDef>Ammo_44Magnum_FMJ</thingDef>
 				<count>60</count>
@@ -28,7 +28,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ScenarioDef[defName="BTG_ExiledTraders"]/scenario/parts</xpath>
 		<value>
-			<li Class="ScenPart_ScatterThingsNearPlayerStart">
+			<li Class="ScenPart_StartingThing_Defined">
 				<def>StartingThing_Defined</def>
 				<thingDef>Ammo_6x24mmCharged</thingDef>
 				<count>300</count>
@@ -39,7 +39,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ScenarioDef[defName="BTG_ExiledTraders"]/scenario/parts</xpath>
 		<value>
-			<li Class="ScenPart_ScatterThingsNearPlayerStart">
+			<li Class="ScenPart_StartingThing_Defined">
 				<def>StartingThing_Defined</def>
 				<thingDef>Ammo_44Magnum_FMJ</thingDef>
 				<count>60</count>

--- a/ModPatches/Better Traders Guild/Patches/Better Traders Guild/CE_Scenario.xml
+++ b/ModPatches/Better Traders Guild/Patches/Better Traders Guild/CE_Scenario.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- Independent Traders -->
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ScenarioDef[defName="BTG_IndependentTraders"]/scenario/parts</xpath>
+		<value>
+			<li Class="ScenPart_ScatterThingsNearPlayerStart">
+				<def>StartingThing_Defined</def>
+				<thingDef>Ammo_6x24mmCharged</thingDef>
+				<count>300</count>
+			</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ScenarioDef[defName="BTG_IndependentTraders"]/scenario/parts</xpath>
+		<value>
+			<li Class="ScenPart_ScatterThingsNearPlayerStart">
+				<def>StartingThing_Defined</def>
+				<thingDef>Ammo_44Magnum_FMJ</thingDef>
+				<count>60</count>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- Exiled Traders -->
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ScenarioDef[defName="BTG_ExiledTraders"]/scenario/parts</xpath>
+		<value>
+			<li Class="ScenPart_ScatterThingsNearPlayerStart">
+				<def>StartingThing_Defined</def>
+				<thingDef>Ammo_6x24mmCharged</thingDef>
+				<count>300</count>
+			</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ScenarioDef[defName="BTG_ExiledTraders"]/scenario/parts</xpath>
+		<value>
+			<li Class="ScenPart_ScatterThingsNearPlayerStart">
+				<def>StartingThing_Defined</def>
+				<thingDef>Ammo_44Magnum_FMJ</thingDef>
+				<count>60</count>
+			</li>
+		</value>
+	</Operation>
+
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -135,6 +135,7 @@ Beeralope Squad	|
 Beliar Xenotype |
 Beta Anime Hair	|
 Beta Girls und Panzer Hair and Apparel	|
+Better Traders Guild    |
 Better Wool Production - C# Edition	|
 Big and Small - Genes & More	|
 Big and Small - Heaven and Hell


### PR DESCRIPTION
## Additions
- Quick, simple patch for Better Traders Guild to add ammo to the scenarios.

## Reasoning
- Quick and easy to do. In line with existing patches.

## Alternatives
- Leave it unpatched, I suppose.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
