### PR TITLE
Fix MultiplayerCompat for 1.6

### DIFF
--- a/Source/CombatExtended/CombatExtended/Loadouts/Dialog_ManageLoadouts.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/Dialog_ManageLoadouts.cs
@@ -1102,7 +1102,11 @@ public class Dialog_ManageLoadouts : Window
     {
         if (Compatibility.Multiplayer.InMultiplayer)
         {
-            Find.WindowStack.WindowOfType<Dialog_ManageLoadouts>().CurrentLoadout = null;
+            var loadOutWindow = Find.WindowStack.WindowOfType<Dialog_ManageLoadouts>();
+            if(loadOutWindow != null && loadOutWindow.CurrentLoadout.UniqueID == loadout.UniqueID)
+            {
+                loadOutWindow.CurrentLoadout = null;
+            }
         }
         LoadoutManager.RemoveLoadout(loadout);
     }

--- a/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
+++ b/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
@@ -1,18 +1,23 @@
-﻿using System;
-using System.Diagnostics;
+﻿using CombatExtended.Loader;
+using HarmonyLib;
+using Multiplayer.API;
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using Multiplayer.API;
 using Verse;
-using CombatExtended.Loader;
-using System.Collections.Generic;
-
 using SyncMethodAttribute = global::CombatExtended.Compatibility.Multiplayer.SyncMethodAttribute;
 
 namespace CombatExtended.Compatibility.MultiplayerAPI;
 public class MultiplayerCompat : IModPart
 {
     public MultiplayerCompat() { }
+
+    public static ISyncField SyncGizmoAmmoStatusTryReloadOn;
+    //public static ISyncField SyncGizmoAmmoStatusGizmoSliderPct;
+
+    private static Harmony harmony = null;
+
     public Type GetSettingsType()
     {
         return null;
@@ -26,6 +31,7 @@ public class MultiplayerCompat : IModPart
 
     public void PostLoad(ModContentPack content, ISettingsCE _)
     {
+        harmony = new Harmony("MultiplayerCompat.HarmonyCE");
         LongEventHandler.QueueLongEvent(() => this.SlowInit(content), "CE_LongEvent_CompatibilityPatches", false, null);
     }
     public void SlowInit(ModContentPack content)
@@ -61,15 +67,71 @@ public class MultiplayerCompat : IModPart
                 syncMethod.ExposeParameter(parameter);
             }
         }
+        SyncGizmoAmmoStatusTryReloadOn = MP.RegisterSyncField(AccessTools.Field(typeof(CompAmmoUser), "tryReloadOn")).SetBufferChanges();
+        //SyncGizmoAmmoStatusGizmoSliderPct = MP.RegisterSyncField(AccessTools.Field(typeof(GizmoAmmoStatus), "targetValuePct")).SetBufferChanges();
+
+        var prefix = new HarmonyMethod(typeof(Patch_GizmoAmmoStatusGizmoOnGUI), nameof(Patch_GizmoAmmoStatusGizmoOnGUI.Prefix));
+        var postfix = new HarmonyMethod(typeof(Patch_GizmoAmmoStatusGizmoOnGUI), nameof(Patch_GizmoAmmoStatusGizmoOnGUI.Postfix));
+        harmony.Patch(AccessTools.Method(typeof(GizmoAmmoStatus), nameof(GizmoAmmoStatus.GizmoOnGUI)), prefix: prefix, postfix: postfix);
+
+
+        Type type = typeof(GizmoAmmoStatus);
+        MP.RegisterSyncWorker<GizmoAmmoStatus>(SyncGizmoAmmoStatus, type);
+
+        type = typeof(CompAmmoUser);
+        MP.RegisterSyncWorker<CompAmmoUser>(SyncCompAmmoUser, type);
+
+        type = typeof(CompFireModes);
+        MP.RegisterSyncWorker<CompFireModes>(SyncCompFireMode, type);
+
+        type = typeof(Loadout);
+        MP.RegisterSyncWorker<Loadout>(SyncLoadout, type);
+
+        type = typeof(LoadoutSlot);
+        MP.RegisterSyncWorker<LoadoutSlot>(SyncLoadoutSlot, type);
+
+        type = typeof(ITab_Inventory);
+        MP.RegisterSyncWorker<ITab_Inventory>(SyncITab_Inventory, type, shouldConstruct: true);
+
 
         MP.RegisterAll();
+
+
 
         global::CombatExtended.Compatibility.Multiplayer.registerCallbacks((() => MP.IsInMultiplayer), (() => MP.IsExecutingSyncCommand), (() => MP.IsExecutingSyncCommandIssuedBySelf));
     }
 
+    public static class Patch_GizmoAmmoStatusGizmoOnGUI
+    {
+        public static void Prefix(GizmoAmmoStatus __instance)
+        {
+            MP.WatchBegin();
 
+            // SyncGizmoAmmoStatusGizmoSliderPct.Watch(__instance);
+            SyncGizmoAmmoStatusTryReloadOn.Watch(__instance.compAmmo);
+        }
+        public static void Postfix(GizmoAmmoStatus __instance)
+        {
+            MP.WatchEnd();
+        }
+    }
 
-    [SyncWorker]
+    //[SyncWorker]
+    private static void SyncGizmoAmmoStatus(SyncWorker sync, ref GizmoAmmoStatus gizmo)
+    {
+        if (sync.isWriting)
+        {
+            sync.Write<CompAmmoUser>(gizmo.compAmmo);
+        }
+        else
+        {
+            var compAmmo = sync.Read<CompAmmoUser>();
+            // Need some help fix pct sync
+            gizmo = new GizmoAmmoStatus { compAmmo = compAmmo };
+        }
+    }
+
+    //[SyncWorker]
     private static void SyncCompAmmoUser(SyncWorker sync, ref CompAmmoUser comp)
     {
         if (sync.isWriting)
@@ -105,7 +167,7 @@ public class MultiplayerCompat : IModPart
         }
     }
 
-    [SyncWorker]
+    //[SyncWorker]
     private static void SyncCompFireMode(SyncWorker sync, ref CompFireModes comp)
     {
         if (sync.isWriting)
@@ -141,7 +203,7 @@ public class MultiplayerCompat : IModPart
         }
     }
 
-    [SyncWorker]
+    //[SyncWorker]
     private static void SyncLoadout(SyncWorker sync, ref Loadout loadout)
     {
         if (sync.isWriting)
@@ -155,7 +217,7 @@ public class MultiplayerCompat : IModPart
         }
     }
 
-    [SyncWorker]
+    //[SyncWorker(shouldConstruct = true)]
     private static void SyncLoadoutSlot(SyncWorker sync, ref LoadoutSlot loadoutSlot)
     {
         if (sync.isWriting)
@@ -198,7 +260,7 @@ public class MultiplayerCompat : IModPart
 
     // Don't sync anything, we just want a blank instance for method calling purposes
     // We only care about shouldConstruct being true
-    [SyncWorker(shouldConstruct = true)]
+    //[SyncWorker(shouldConstruct = true)]
     private static void SyncITab_Inventory(SyncWorker sync, ref ITab_Inventory inventory)
     { }
 }


### PR DESCRIPTION
Additions

Added MpCompat patch for GizmoAmmoStatus to sync the ammo-to-reload threshold value, which determines the minimum remaining ammo count at which a pawn will automatically reload

Changes

Replaced [SyncWorker] attribute registration with MP.RegisterSyncWorker for CompAmmoUser sync worker to fix compatibility with RimWorld 1.6
Added null check for Dialog_ManageLoadouts window in RemoveLoadout to prevent null reference exception when the dialog is not open

References

Contributes towards Multiplayer compatibility for CombatExtended

Reasoning

GizmoAmmoStatus ammo-to-reload threshold (TryReloadOn) needs to be synced so all players see and agree on when a pawn will trigger an automatic reload
Without this sync, one player adjusting the reload threshold on a shared pawn would not be seen by other players, causing inconsistent reload behavior
[SyncWorker] attribute registration broke in RimWorld 1.6, replacing with direct MP.RegisterSyncWorker call fixes this
RemoveLoadout could crash when executed as a synced command if Dialog_ManageLoadouts was not open on that client

Alternatives

Not syncing GizmoAmmoStatus threshold — players adjusting the reload slider on the same pawn would see different values and the pawn would behave inconsistently for each player

Testing

 Compiles without warnings
 Game runs without errors
 (For compatibility patches) ...with and without patched mod loaded
 Playtested a colony (1 day, tested all sync functionality)