### PR TITLE
Fix Odyssey BodyShapes

### DIFF
--- a/Odyssey/Patches/Odyssey/ThingDefs_Races/Races_Animals.xml
+++ b/Odyssey/Patches/Odyssey/ThingDefs_Races/Races_Animals.xml
@@ -1349,6 +1349,17 @@
 	</Operation>
 
 	<!-- === Badger === -->
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="Badger"]
+		</xpath>
+		<value>
+			<li Class="CombatExtended.RacePropertiesExtensionCE">
+				<bodyShape>Quadruped</bodyShape>
+			</li>
+		</value>
+	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Badger"]/statBases</xpath>
 		<value>

--- a/Odyssey/Patches/Odyssey/ThingDefs_Races/Races_Mechanoids.xml
+++ b/Odyssey/Patches/Odyssey/ThingDefs_Races/Races_Mechanoids.xml
@@ -2,6 +2,16 @@
 <Patch>
 
 	<!-- ========== Cyclops ========== -->
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="Mech_Cyclops"]
+		</xpath>
+		<value>
+			<li Class="CombatExtended.RacePropertiesExtensionCE">
+				<bodyShape>Humanoid</bodyShape>
+			</li>
+		</value>
+	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mech_Cyclops"]/tools</xpath>
 		<value>

--- a/Odyssey/Patches/Odyssey/ThingDefs_Races/Races_Mechanoids.xml
+++ b/Odyssey/Patches/Odyssey/ThingDefs_Races/Races_Mechanoids.xml
@@ -2,6 +2,7 @@
 <Patch>
 
 	<!-- ========== Cyclops ========== -->
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="Mech_Cyclops"]
 		</xpath>


### PR DESCRIPTION
## Additions
- Add a couple of missed `bodyShape` patches.

## Reasoning
- Patch body shape for Badger and Cyclops, which was missed first time around.

## Alternatives
- Suffer.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
