### PR TITLE
Fix failed registration of SyncWorkers for MultiplayerCompat

### DIFF
--- a/Source/CombatExtended/Compatibility/Multiplayer.cs
+++ b/Source/CombatExtended/Compatibility/Multiplayer.cs
@@ -13,7 +13,7 @@ public class Multiplayer : IPatch
     public bool CanInstall()
     {
         Log.Message("Combat Extended :: Checking Multiplayer Compat");
-        return ModLister.HasActiveModWithName("Multiplayer");
+        return ModLister.HasActiveModWithName("Multiplayer") || ModLister.GetActiveModWithIdentifier("rwmt.Multiplayer") != null || ModLister.HasActiveModWithName("Multiplayer [Continuous]");
     }
 
     public void Install()

--- a/Source/MultiplayerCompat/MultiplayerCompat.csproj
+++ b/Source/MultiplayerCompat/MultiplayerCompat.csproj
@@ -42,6 +42,6 @@
 	<ItemGroup>
 		<PackageReference Include="Krafs.Rimworld.Ref" Version="1.6.4543" GeneratePathProperty="true" />
 		<PackageReference Include="Lib.Harmony" Version="2.3.6" ExcludeAssets="runtime" />
-		<PackageReference Include="RimWorld.MultiplayerAPI" Version="0.4.0" />
+		<PackageReference Include="RimWorld.MultiplayerAPI" Version="0.6.0" />
 	</ItemGroup>
 </Project>

--- a/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
+++ b/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
@@ -74,7 +74,7 @@ public class MultiplayerCompat : IModPart
     {
         if (sync.isWriting)
         {
-            var caster = comp.parent.GetComp<CompEquippable>().PrimaryVerb.Caster;
+            var caster = comp?.parent.GetComp<CompEquippable>().PrimaryVerb.Caster;
 
             // Sync the turret because in that case syncing fails, due to comp.parent.Map being null,
             // which causes it to be inaccessible in MP for general syncing
@@ -109,7 +109,7 @@ public class MultiplayerCompat : IModPart
     {
         if (sync.isWriting)
         {
-            var caster = comp.Caster;
+            var caster = comp?.Caster;
 
             // Sync the turret because in that case syncing fails, due to comp.parent.Map being null,
             // which causes it to be inaccessible in MP for general syncing

--- a/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
+++ b/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
@@ -70,9 +70,7 @@ public class MultiplayerCompat : IModPart
     }
 #nullable enable
 
-
-
-    private static void SyncCompAmmoUser(SyncWorker sync, ref CompAmmoUser comp)
+    private static void SyncCompAmmoUser(SyncWorker sync, ref CompAmmoUser? comp)
     {
         if (sync.isWriting)
         {
@@ -107,7 +105,7 @@ public class MultiplayerCompat : IModPart
         }
     }
 
-    private static void SyncCompFireMode(SyncWorker sync, ref CompFireModes comp)
+    private static void SyncCompFireMode(SyncWorker sync, ref CompFireModes? comp)
     {
         if (sync.isWriting)
         {

--- a/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
+++ b/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
@@ -72,7 +72,6 @@ public class MultiplayerCompat : IModPart
 
 
 
-    [SyncWorker]
     private static void SyncCompAmmoUser(SyncWorker sync, ref CompAmmoUser comp)
     {
         if (sync.isWriting)
@@ -108,7 +107,6 @@ public class MultiplayerCompat : IModPart
         }
     }
 
-    [SyncWorker]
     private static void SyncCompFireMode(SyncWorker sync, ref CompFireModes comp)
     {
         if (sync.isWriting)
@@ -144,7 +142,6 @@ public class MultiplayerCompat : IModPart
         }
     }
 
-    [SyncWorker]
     private static void SyncLoadout(SyncWorker sync, ref Loadout loadout)
     {
         if (sync.isWriting)
@@ -158,7 +155,6 @@ public class MultiplayerCompat : IModPart
         }
     }
 
-    [SyncWorker]
     private static void SyncLoadoutSlot(SyncWorker sync, ref LoadoutSlot loadoutSlot)
     {
         if (sync.isWriting)
@@ -201,7 +197,6 @@ public class MultiplayerCompat : IModPart
 
     // Don't sync anything, we just want a blank instance for method calling purposes
     // We only care about shouldConstruct being true
-    [SyncWorker(shouldConstruct = true)]
     private static void SyncITab_Inventory(SyncWorker sync, ref ITab_Inventory inventory)
     { }
 }

--- a/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
+++ b/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
@@ -68,6 +68,7 @@ public class MultiplayerCompat : IModPart
         MP.RegisterSyncWorker<ITab_Inventory>(SyncITab_Inventory, shouldConstruct: true);
         global::CombatExtended.Compatibility.Multiplayer.registerCallbacks((() => MP.IsInMultiplayer), (() => MP.IsExecutingSyncCommand), (() => MP.IsExecutingSyncCommandIssuedBySelf));
     }
+#nullable enable
 
 
 
@@ -204,3 +205,5 @@ public class MultiplayerCompat : IModPart
     private static void SyncITab_Inventory(SyncWorker sync, ref ITab_Inventory inventory)
     { }
 }
+
+#nullable restore

--- a/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
+++ b/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using Multiplayer.API;

--- a/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
+++ b/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
@@ -62,8 +62,11 @@ public class MultiplayerCompat : IModPart
             }
         }
 
-        MP.RegisterAll();
-
+        MP.RegisterSyncWorker<CompAmmoUser>(SyncCompAmmoUser);
+        MP.RegisterSyncWorker<CompFireModes>(SyncCompFireMode);
+        MP.RegisterSyncWorker<Loadout>(SyncLoadout);
+        MP.RegisterSyncWorker<LoadoutSlot>(SyncLoadoutSlot);
+        MP.RegisterSyncWorker<ITab_Inventory>(SyncITab_Inventory, shouldConstruct: true);
         global::CombatExtended.Compatibility.Multiplayer.registerCallbacks((() => MP.IsInMultiplayer), (() => MP.IsExecutingSyncCommand), (() => MP.IsExecutingSyncCommandIssuedBySelf));
     }
 


### PR DESCRIPTION
## Changes

Use templated registration of sync workers.
Use nullable types.

## References

Covers the first half of #4505

## Reasoning

The new mono runtime included with Rimworld is stricter about argument type matching with automatic delegate construction.  This entirely breaks automatic SyncWorker registration via the `[SyncWorker]` attribute, so we make that explicit.

Additionally, the multiplayer API and internal representation use nullable types for the comps, which implies the method might get called with the ref parameter holding a `null`.  Enabling `#nullable` for that section ensures all accesses must be checked.

## Alternatives

#4505 has a slightly alternative implementation, which explicitly passes the target type as an extra parameter.  This is not required when using the templated version, but would be harmless to include.  It also doesn't use nullable parameters.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (minutes)
