### PR TITLE
Bump multiplayer compatibility version

### DIFF
--- a/Source/CombatExtended/Compatibility/Multiplayer.cs
+++ b/Source/CombatExtended/Compatibility/Multiplayer.cs
@@ -13,7 +13,7 @@ public class Multiplayer : IPatch
     public bool CanInstall()
     {
         Log.Message("Combat Extended :: Checking Multiplayer Compat");
-        return ModLister.HasActiveModWithName("Multiplayer");
+        return ModLister.HasActiveModWithName("Multiplayer") || ModLister.GetActiveModWithIdentifier("rwmt.Multiplayer") != null || ModLister.HasActiveModWithName("Multiplayer [Continuous]");
     }
 
     public void Install()

--- a/Source/MultiplayerCompat/MultiplayerCompat.csproj
+++ b/Source/MultiplayerCompat/MultiplayerCompat.csproj
@@ -42,6 +42,6 @@
 	<ItemGroup>
 		<PackageReference Include="Krafs.Rimworld.Ref" Version="1.6.4543" GeneratePathProperty="true" />
 		<PackageReference Include="Lib.Harmony" Version="2.3.6" ExcludeAssets="runtime" />
-		<PackageReference Include="RimWorld.MultiplayerAPI" Version="0.4.0" />
+		<PackageReference Include="RimWorld.MultiplayerAPI" Version="0.6.0" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
## Changes

Multiplayer API bumped from 0.4.0 to 0.6.0
Try to check for multiplayer mod by package id and mod name, including updated mod name.

## Reasoning

This is the minimal set of changes to restore proper functioning as it was in 1.5.

## Alternatives

Make everything one giant PR.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
