### PR TITLE
Update MultiplayerCompat to match correct signatures

### DIFF
--- a/Source/CombatExtended/Compatibility/Multiplayer.cs
+++ b/Source/CombatExtended/Compatibility/Multiplayer.cs
@@ -13,7 +13,7 @@ public class Multiplayer : IPatch
     public bool CanInstall()
     {
         Log.Message("Combat Extended :: Checking Multiplayer Compat");
-        return ModLister.HasActiveModWithName("Multiplayer");
+        return ModLister.HasActiveModWithName("Multiplayer") || ModLister.GetActiveModWithIdentifier("rwmt.Multiplayer") != null || ModLister.HasActiveModWithName("Multiplayer [Continuous]");
     }
 
     public void Install()

--- a/Source/MultiplayerCompat/MultiplayerCompat.csproj
+++ b/Source/MultiplayerCompat/MultiplayerCompat.csproj
@@ -42,6 +42,6 @@
 	<ItemGroup>
 		<PackageReference Include="Krafs.Rimworld.Ref" Version="1.6.4543" GeneratePathProperty="true" />
 		<PackageReference Include="Lib.Harmony" Version="2.3.6" ExcludeAssets="runtime" />
-		<PackageReference Include="RimWorld.MultiplayerAPI" Version="0.4.0" />
+		<PackageReference Include="RimWorld.MultiplayerAPI" Version="0.6.0" />
 	</ItemGroup>
 </Project>

--- a/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
+++ b/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
@@ -75,11 +75,11 @@ public class MultiplayerCompat : IModPart
      */
 #nullable enable
     [SyncWorker]
-    private static void SyncCompAmmoUser(SyncWorker sync, ref CompAmmoUser comp)
+    private static void SyncCompAmmoUser(SyncWorker sync, ref CompAmmoUser? comp)
     {
         if (sync.isWriting)
         {
-            var caster = comp.parent.GetComp<CompEquippable>().PrimaryVerb.Caster;
+            var caster = comp!.parent.GetComp<CompEquippable>().PrimaryVerb.Caster;
 
             // Sync the turret because in that case syncing fails, due to comp.parent.Map being null,
             // which causes it to be inaccessible in MP for general syncing
@@ -111,11 +111,11 @@ public class MultiplayerCompat : IModPart
     }
 
     [SyncWorker]
-    private static void SyncCompFireMode(SyncWorker sync, ref CompFireModes comp)
+    private static void SyncCompFireMode(SyncWorker sync, ref CompFireModes? comp)
     {
         if (sync.isWriting)
         {
-            var caster = comp.Caster;
+            var caster = comp!.Caster;
 
             // Sync the turret because in that case syncing fails, due to comp.parent.Map being null,
             // which causes it to be inaccessible in MP for general syncing
@@ -147,11 +147,11 @@ public class MultiplayerCompat : IModPart
     }
 
     [SyncWorker]
-    private static void SyncLoadout(SyncWorker sync, ref Loadout loadout)
+    private static void SyncLoadout(SyncWorker sync, ref Loadout? loadout)
     {
         if (sync.isWriting)
         {
-            sync.Write(loadout.UniqueID);
+            sync.Write(loadout!.UniqueID);
         }
         else
         {
@@ -161,7 +161,7 @@ public class MultiplayerCompat : IModPart
     }
 
     [SyncWorker]
-    private static void SyncLoadoutSlot(SyncWorker sync, ref LoadoutSlot loadoutSlot)
+    private static void SyncLoadoutSlot(SyncWorker sync, ref LoadoutSlot? loadoutSlot)
     {
         if (sync.isWriting)
         {
@@ -204,7 +204,7 @@ public class MultiplayerCompat : IModPart
     // Don't sync anything, we just want a blank instance for method calling purposes
     // We only care about shouldConstruct being true
     [SyncWorker(shouldConstruct = true)]
-    private static void SyncITab_Inventory(SyncWorker sync, ref ITab_Inventory inventory)
+    private static void SyncITab_Inventory(SyncWorker sync, ref ITab_Inventory? inventory)
     { }
 }
 #nullable restore

--- a/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
+++ b/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
@@ -69,6 +69,11 @@ public class MultiplayerCompat : IModPart
 
 
 
+    /*
+      We enable nullable context for the rest of this file, because the Multiplayer API can call these functions with a null thing to synchronize on the reading end.
+      When writing, the comp should never be null.  
+     */
+#nullable enable
     [SyncWorker]
     private static void SyncCompAmmoUser(SyncWorker sync, ref CompAmmoUser comp)
     {
@@ -202,3 +207,4 @@ public class MultiplayerCompat : IModPart
     private static void SyncITab_Inventory(SyncWorker sync, ref ITab_Inventory inventory)
     { }
 }
+#nullable restore


### PR DESCRIPTION
## Changes

Make targets of `SyncWorker`s nullable refs.

## References

Links to the associated issues or other related pull requests, e.g.
- After #4512 

## Reasoning
The `SyncWorker`s from the Multiplayer API pass their target via nullable ref, to handle cases where it must be newly created by the destination end.  This makes the signature match, with required null checks included.

## Alternatives

Leave it with the subtle mismatch and hope future updates to mono don't balk at it and that no nulls ever actually get used unchecked.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
