### PR TITLE
Synchronize ammo gizmo in multiplayer

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
@@ -84,7 +84,12 @@ public class CompAmmoUser : CompRangedGizmoGiver
     public int TryReloadOn
     {
         get => tryReloadOn;
-        set => tryReloadOn = value;
+        set {
+            if (tryReloadOn != value) {
+                tryReloadOn = value;
+                Compatibility.Multiplayer.syncField(this, nameof(tryReloadOn), value);
+            }
+        }
     }
     public float SafeDistanceToReload => Controller.settings.OpportunisticReloadSafeDistance;
 

--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
@@ -17,6 +17,7 @@ public class CompAmmoUser : CompRangedGizmoGiver
     #region Fields
 
     private int curMagCountInt = 0;
+    [Compatibility.Multiplayer.SyncFieldAttribute]
     private int tryReloadOn = 0;
     protected AmmoDef currentAmmoInt = null;
     protected AmmoDef selectedAmmo;

--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
@@ -84,8 +84,10 @@ public class CompAmmoUser : CompRangedGizmoGiver
     public int TryReloadOn
     {
         get => tryReloadOn;
-        set {
-            if (tryReloadOn != value) {
+        set
+        {
+            if (tryReloadOn != value)
+            {
                 tryReloadOn = value;
                 Compatibility.Multiplayer.syncField(this, nameof(tryReloadOn), value);
             }

--- a/Source/CombatExtended/Compatibility/Multiplayer.cs
+++ b/Source/CombatExtended/Compatibility/Multiplayer.cs
@@ -13,7 +13,7 @@ public class Multiplayer : IPatch
     public bool CanInstall()
     {
         Log.Message("Combat Extended :: Checking Multiplayer Compat");
-        return ModLister.HasActiveModWithName("Multiplayer");
+        return ModLister.HasActiveModWithName("Multiplayer") || ModLister.GetActiveModWithIdentifier("rwmt.Multiplayer") != null || ModLister.HasActiveModWithName("Multiplayer [Continuous]");
     }
 
     public void Install()

--- a/Source/CombatExtended/Compatibility/Multiplayer.cs
+++ b/Source/CombatExtended/Compatibility/Multiplayer.cs
@@ -79,5 +79,10 @@ public class Multiplayer : IPatch
         public int[] exposeParameters = null;
     }
 
+    [AttributeUsage(AttributeTargets.Field)]
+    public class SyncFieldAttribute : Attribute
+    {
+    }
+
 
 }

--- a/Source/CombatExtended/Compatibility/Multiplayer.cs
+++ b/Source/CombatExtended/Compatibility/Multiplayer.cs
@@ -59,8 +59,10 @@ public class Multiplayer : IPatch
         }
     }
 
-    public static void syncField<T>(T target, string field, object val) {
-        if (InMultiplayer) {
+    public static void syncField<T>(T target, string field, object val)
+    {
+        if (InMultiplayer)
+        {
             _syncField(target, typeof(T).FullName + "/" + field, val);
         }
     }

--- a/Source/CombatExtended/Compatibility/Multiplayer.cs
+++ b/Source/CombatExtended/Compatibility/Multiplayer.cs
@@ -61,7 +61,7 @@ public class Multiplayer : IPatch
 
     public static void syncField<T>(T target, string field, object val) {
         if (InMultiplayer) {
-            _syncField(target, T.FullName + "/" + field, val);
+            _syncField(target, typeof(T).FullName + "/" + field, val);
         }
     }
 

--- a/Source/CombatExtended/Compatibility/Multiplayer.cs
+++ b/Source/CombatExtended/Compatibility/Multiplayer.cs
@@ -59,12 +59,21 @@ public class Multiplayer : IPatch
         }
     }
 
-    public static void registerCallbacks(Func<bool> inMP, Func<bool> iec, Func<bool> iecibs)
+    public static void syncField<T>(T target, string field, object val) {
+        if (InMultiplayer) {
+            _syncField(target, T.FullName + "/" + field, val);
+        }
+    }
+
+    public static void registerCallbacks(Func<bool> inMP, Func<bool> iec, Func<bool> iecibs, Func<object, string, object, bool> sf)
     {
         _inMultiplayer = inMP;
         _isExecutingCommands = iec;
         _isExecutingCommandsIssuedBySelf = iecibs;
+        _syncField = sf;
     }
+
+    private static Func<object, string, object, bool> _syncField = null;
 
     private static Func<bool> _inMultiplayer = null;
 

--- a/Source/MultiplayerCompat/MultiplayerCompat.csproj
+++ b/Source/MultiplayerCompat/MultiplayerCompat.csproj
@@ -42,6 +42,6 @@
 	<ItemGroup>
 		<PackageReference Include="Krafs.Rimworld.Ref" Version="1.6.4543" GeneratePathProperty="true" />
 		<PackageReference Include="Lib.Harmony" Version="2.3.6" ExcludeAssets="runtime" />
-		<PackageReference Include="RimWorld.MultiplayerAPI" Version="0.4.0" />
+		<PackageReference Include="RimWorld.MultiplayerAPI" Version="0.6.0" />
 	</ItemGroup>
 </Project>

--- a/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
+++ b/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
@@ -83,7 +83,10 @@ public class MultiplayerCompat : IModPart
     }
 
 
-
+    private static bool SynchronizeField(object obj, string field, object val) {
+        syncFieldAttributes[field].DoSync(obj, val);
+        return true;
+    }
     /*
       We enable nullable context for the rest of this file, because the Multiplayer API can call these functions with a null thing to synchronize on the reading end.
       When writing, the comp should never be null.  

--- a/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
+++ b/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
@@ -79,7 +79,10 @@ public class MultiplayerCompat : IModPart
 
         MP.RegisterAll();
 
-        global::CombatExtended.Compatibility.Multiplayer.registerCallbacks((() => MP.IsInMultiplayer), (() => MP.IsExecutingSyncCommand), (() => MP.IsExecutingSyncCommandIssuedBySelf));
+        global::CombatExtended.Compatibility.Multiplayer.registerCallbacks((() => MP.IsInMultiplayer),
+                                                                           (() => MP.IsExecutingSyncCommand),
+                                                                           (() => MP.IsExecutingSyncCommandIssuedBySelf),
+                                                                           SynchronizeField);
     }
 
 

--- a/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
+++ b/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
@@ -8,10 +8,12 @@ using CombatExtended.Loader;
 using System.Collections.Generic;
 
 using SyncMethodAttribute = global::CombatExtended.Compatibility.Multiplayer.SyncMethodAttribute;
+using SyncFieldAttribute = global::CombatExtended.Compatibility.Multiplayer.SyncFieldAttribute;
 
 namespace CombatExtended.Compatibility.MultiplayerAPI;
 public class MultiplayerCompat : IModPart
 {
+    private static Dictionary<string, ISyncField> syncFieldAttributes;
     public MultiplayerCompat() { }
     public Type GetSettingsType()
     {
@@ -30,6 +32,19 @@ public class MultiplayerCompat : IModPart
     }
     public void SlowInit(ModContentPack content)
     {
+
+        syncFieldAttributes = new ();
+        var fields = content.assemblies.loadedAssemblies
+                      .SelectMany(a => a.GetTypes())
+                      .SelectMany(t => t.GetFields(BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public))
+                      .Where(m => m.HasAttribute<SyncFieldAttribute>());
+
+        foreach (var field in fields)
+        {
+            var syncField = MP.RegisterSyncField(field.DeclaringType, field.Name).SetBufferChanges();
+            syncFieldAttributes[field.DeclaringType.FullName + "/" + field.Name] = syncField;
+        }
+
         var methods = content.assemblies.loadedAssemblies
                       .SelectMany(a => a.GetTypes())
                       .SelectMany(t => t.GetMethods(BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public))

--- a/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
+++ b/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
@@ -75,11 +75,11 @@ public class MultiplayerCompat : IModPart
      */
 #nullable enable
     [SyncWorker]
-    private static void SyncCompAmmoUser(SyncWorker sync, ref CompAmmoUser comp)
+    private static void SyncCompAmmoUser(SyncWorker sync, ref CompAmmoUser? comp)
     {
         if (sync.isWriting)
         {
-            var caster = comp.parent.GetComp<CompEquippable>().PrimaryVerb.Caster;
+            var caster = comp!.parent.GetComp<CompEquippable>().PrimaryVerb.Caster;
 
             // Sync the turret because in that case syncing fails, due to comp.parent.Map being null,
             // which causes it to be inaccessible in MP for general syncing
@@ -111,11 +111,11 @@ public class MultiplayerCompat : IModPart
     }
 
     [SyncWorker]
-    private static void SyncCompFireMode(SyncWorker sync, ref CompFireModes comp)
+    private static void SyncCompFireMode(SyncWorker sync, ref CompFireModes? comp)
     {
         if (sync.isWriting)
         {
-            var caster = comp.Caster;
+            var caster = comp!.Caster;
 
             // Sync the turret because in that case syncing fails, due to comp.parent.Map being null,
             // which causes it to be inaccessible in MP for general syncing
@@ -147,11 +147,11 @@ public class MultiplayerCompat : IModPart
     }
 
     [SyncWorker]
-    private static void SyncLoadout(SyncWorker sync, ref Loadout loadout)
+    private static void SyncLoadout(SyncWorker sync, ref Loadout? loadout)
     {
         if (sync.isWriting)
         {
-            sync.Write(loadout.UniqueID);
+            sync.Write(loadout!.UniqueID);
         }
         else
         {
@@ -161,7 +161,7 @@ public class MultiplayerCompat : IModPart
     }
 
     [SyncWorker]
-    private static void SyncLoadoutSlot(SyncWorker sync, ref LoadoutSlot loadoutSlot)
+    private static void SyncLoadoutSlot(SyncWorker sync, ref LoadoutSlot? loadoutSlot)
     {
         if (sync.isWriting)
         {
@@ -204,7 +204,7 @@ public class MultiplayerCompat : IModPart
     // Don't sync anything, we just want a blank instance for method calling purposes
     // We only care about shouldConstruct being true
     [SyncWorker(shouldConstruct = true)]
-    private static void SyncITab_Inventory(SyncWorker sync, ref ITab_Inventory inventory)
+    private static void SyncITab_Inventory(SyncWorker sync, ref ITab_Inventory? inventory)
     { }
 }
 #nullable restore

--- a/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
+++ b/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
@@ -69,6 +69,11 @@ public class MultiplayerCompat : IModPart
 
 
 
+    /*
+      We enable nullable context for the rest of this file, because the Multiplayer API can call these functions with a null thing to synchronize on the reading end.
+      When writing, the comp should never be null.  
+     */
+#nullable enable
     [SyncWorker]
     private static void SyncCompAmmoUser(SyncWorker sync, ref CompAmmoUser comp)
     {
@@ -202,3 +207,4 @@ public class MultiplayerCompat : IModPart
     private static void SyncITab_Inventory(SyncWorker sync, ref ITab_Inventory inventory)
     { }
 }
+#nullable restore

--- a/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
+++ b/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
@@ -32,8 +32,7 @@ public class MultiplayerCompat : IModPart
     }
     public void SlowInit(ModContentPack content)
     {
-
-        syncFieldAttributes = new ();
+        syncFieldAttributes = new();
         var fields = content.assemblies.loadedAssemblies
                       .SelectMany(a => a.GetTypes())
                       .SelectMany(t => t.GetFields(BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public))
@@ -85,8 +84,8 @@ public class MultiplayerCompat : IModPart
                                                                            SynchronizeField);
     }
 
-
-    private static bool SynchronizeField(object obj, string field, object val) {
+    private static bool SynchronizeField(object obj, string field, object val)
+    {
         syncFieldAttributes[field].DoSync(obj, val);
         return true;
     }


### PR DESCRIPTION
## Additions

Adds a new `Compatibility.Multiplayer.SyncFieldAttribute` to mark fields which require explicit synchronization.
Uses new `SyncFieldAttribute` to register `tryReloadOn` field for synchronization.
Detects changes via the `TryReloadOn` setter and buffers changes to multiplayer peers.

## References

Links to the associated issues or other related pull requests, e.g.
- After #4513 

## Reasoning

No types from Multiplayer or MultiplayerAPI are directly accessible in CE assemblies outside MultiplayerCompat.  The MP api has a set of methods to register a field for synchronization, and then turn on and off synchronization for that field on each UI call.  However if the field is updated by means other than the UI, this method is insufficient.  It also is designed to be non-intrusive, but carriest a higher complexity and performance cost as a result.

Since non-ui-triggered updates require explicit synchronization *anyway*, and since we have the ability to easily manually trigger synchronization on changes *anyway*, we can remove the need for 3 function pointers by relying on manually triggering the sync when required.  This also has a minimal increase in our code size, and relies on an easily inlined / JIT friendly boolean to early out in the non-multiplayer case.

## Alternatives

Provide function pointers to all three UI-related calls from the MP API and use them in our UI code.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
