### PR TITLE
Change targetMode to automatic by default.

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompFireModes.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompFireModes.cs
@@ -19,7 +19,7 @@ public class CompFireModes : CompRangedGizmoGiver
     private FireMode currentFireModeInt;
     private AimMode currentAimModeInt;
     private bool newComp = true;
-    public TargettingMode targetMode = TargettingMode.torso;
+    public TargettingMode targetMode = TargettingMode.automatic;
 
     #endregion
 
@@ -241,7 +241,7 @@ public class CompFireModes : CompRangedGizmoGiver
 
     public override IEnumerable<Gizmo> CompGetGizmosExtra()
     {
-        if (CasterPawn?.Faction == Faction.OfPlayer)
+        if (CasterPawn?.Faction == Faction.OfPlayer || DebugSettings.godMode)
         {
             foreach (Command com in GenerateGizmos())
             {


### PR DESCRIPTION
## Changes

Pawns able to pick hit locations will do so by default.
Let player change enemy target modes when in god mode

## Reasoning

A motivating factor for implementing the hit-location targeting was to make cover worthwhile.  When pawns only make center-of-mass shots, pawns have a higher survival rate in the open than they do behind cover, especially when they have body armor but no helmet.  

The initial implementation left enemies targeting center of mass, so players still are incentivized to stand in the open.  This fixes that.

Letting a god-moded player change the setting is mostly useful for debugging, if someone wants to cheat, that's not our concern.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
