### PR TITLE
Cache highest cover

### DIFF
--- a/Source/CombatExtended/CombatExtended/LightingTracker.cs
+++ b/Source/CombatExtended/CombatExtended/LightingTracker.cs
@@ -18,7 +18,8 @@ public class LightingTracker : MapComponent
     private static readonly float[] AdjWeights;
     private readonly float[] glowGridCache;
     private readonly float[] coverGridCache;
-    private int lastTick = 0;
+    private int lastCoverTick = 0;
+    private int lastGlowTick = 0;
 
     static LightingTracker()
     {
@@ -250,11 +251,10 @@ public class LightingTracker : MapComponent
     public float HighestCoverAt(IntVec3 position)
     {
         int thisTick = Find.TickManager.TicksAbs;
-        if (thisTick != lastTick)
+        if (thisTick != lastCoverTick)
         {
             Array.Fill(coverGridCache, -1f);
-            Array.Fill(glowGridCache, -1f);
-            lastTick = thisTick;
+            lastCoverTick = thisTick;
         }
         float coverHeight = coverGridCache[position.x * map.Size.z + position.z];
         if (coverHeight == -1)
@@ -278,11 +278,10 @@ public class LightingTracker : MapComponent
     {
         int thisTick = Find.TickManager.TicksAbs;
 
-        if (thisTick != lastTick)
+        if (thisTick != lastGlowTick)
         {
-            Array.Fill(coverGridCache, -1f);
             Array.Fill(glowGridCache, -1f);
-            lastTick = thisTick;
+            lastGlowTick = thisTick;
         }
         float glow = glowGridCache[source.x * map.Size.z + source.z];
         if (glow == -1)

--- a/Source/CombatExtended/CombatExtended/LightingTracker.cs
+++ b/Source/CombatExtended/CombatExtended/LightingTracker.cs
@@ -256,7 +256,7 @@ public class LightingTracker : MapComponent
             Array.Fill(glowGridCache, -1f);
             lastTick = thisTick;
         }
-        float coverHeight = glowGridCache[position.x * map.Size.y + position.y];
+        float coverHeight = coverGridCache[position.x * map.Size.y + position.y];
         if (coverHeight == -1)
         {
             Thing cover = position.GetFirstPawn(map) ?? position.GetCover(map);

--- a/Source/CombatExtended/CombatExtended/LightingTracker.cs
+++ b/Source/CombatExtended/CombatExtended/LightingTracker.cs
@@ -256,7 +256,7 @@ public class LightingTracker : MapComponent
             Array.Fill(coverGridCache, -1f);
             lastCoverTick = thisTick;
         }
-        float coverHeight = coverGridCache[position.x * map.Size.z + position.z];
+        float coverHeight = coverGridCache[CellToIndex(position)];
         if (coverHeight == -1)
         {
             Thing cover = position.GetFirstPawn(map) ?? position.GetCover(map);
@@ -269,7 +269,7 @@ public class LightingTracker : MapComponent
                 Bounds bounds = CE_Utility.GetBoundsFor(cover);
                 coverHeight = bounds.size.y;
             }
-            coverGridCache[position.x * map.Size.z + position.z] = coverHeight;
+            coverGridCache[CellToIndex(position)] = coverHeight;
         }
         return coverHeight;
     }
@@ -283,10 +283,10 @@ public class LightingTracker : MapComponent
             Array.Fill(glowGridCache, -1f);
             lastGlowTick = thisTick;
         }
-        float glow = glowGridCache[source.x * map.Size.z + source.z];
+        float glow = glowGridCache[CellToIndex(source)];
         if (glow == -1)
         {
-            glowGridCache[source.x * map.Size.z + source.z] = glow = map.glowGrid.GroundGlowAt(source);
+            glowGridCache[CellToIndex(source)] = glow = map.glowGrid.GroundGlowAt(source);
         }
         return glow;
     }

--- a/Source/CombatExtended/CombatExtended/LightingTracker.cs
+++ b/Source/CombatExtended/CombatExtended/LightingTracker.cs
@@ -141,9 +141,9 @@ public class LightingTracker : MapComponent
         _cellIndices = map.cellIndices;
 
         muzzle_grid = new MuzzleRecord[NumGridCells];
-        glowGridCache = new float[map.Size.x * map.Size.y];
+        glowGridCache = new float[NumGridCells];
 
-        coverGridCache = new float[map.Size.x * map.Size.y];
+        coverGridCache = new float[NumGridCells];
     }
 
     public override void ExposeData()
@@ -256,7 +256,7 @@ public class LightingTracker : MapComponent
             Array.Fill(glowGridCache, -1f);
             lastTick = thisTick;
         }
-        float coverHeight = coverGridCache[position.x * map.Size.y + position.y];
+        float coverHeight = coverGridCache[position.x * map.Size.z + position.z];
         if (coverHeight == -1)
         {
             Thing cover = position.GetFirstPawn(map) ?? position.GetCover(map);
@@ -269,7 +269,7 @@ public class LightingTracker : MapComponent
                 Bounds bounds = CE_Utility.GetBoundsFor(cover);
                 coverHeight = bounds.size.y;
             }
-            coverGridCache[position.x * map.Size.y + position.y] = coverHeight;
+            coverGridCache[position.x * map.Size.z + position.z] = coverHeight;
         }
         return coverHeight;
     }
@@ -284,10 +284,10 @@ public class LightingTracker : MapComponent
             Array.Fill(glowGridCache, -1f);
             lastTick = thisTick;
         }
-        float glow = glowGridCache[source.x * map.Size.y + source.y];
+        float glow = glowGridCache[source.x * map.Size.z + source.z];
         if (glow == -1)
         {
-            glowGridCache[source.x * map.Size.y + source.y] = glow = map.glowGrid.GroundGlowAt(source);
+            glowGridCache[source.x * map.Size.z + source.z] = glow = map.glowGrid.GroundGlowAt(source);
         }
         return glow;
     }

--- a/Source/CombatExtended/CombatExtended/LightingTracker.cs
+++ b/Source/CombatExtended/CombatExtended/LightingTracker.cs
@@ -17,6 +17,7 @@ public class LightingTracker : MapComponent
     private static readonly IntVec3[] AdjCells;
     private static readonly float[] AdjWeights;
     private readonly float[] glowGridCache;
+    private readonly float[] coverGridCache;
     private int lastTick = 0;
 
     static LightingTracker()
@@ -141,6 +142,8 @@ public class LightingTracker : MapComponent
 
         muzzle_grid = new MuzzleRecord[NumGridCells];
         glowGridCache = new float[map.Size.x * map.Size.y];
+
+        coverGridCache = new float[map.Size.x * map.Size.y];
     }
 
     public override void ExposeData()
@@ -244,12 +247,40 @@ public class LightingTracker : MapComponent
         return Mathf.Min(result, IsNight ? 0.5f : 1.0f);
     }
 
+    public float HighestCoverAt(IntVec3 position)
+    {
+        int thisTick = Find.TickManager.TicksAbs;
+        if (thisTick != lastTick)
+        {
+            Array.Fill(coverGridCache, -1f);
+            Array.Fill(glowGridCache, -1f);
+            lastTick = thisTick;
+        }
+        float coverHeight = glowGridCache[position.x * map.Size.y + position.y];
+        if (coverHeight == -1)
+        {
+            Thing cover = position.GetFirstPawn(map) ?? position.GetCover(map);
+            if (cover == null)
+            {
+                coverHeight = 0;
+            }
+            else
+            {
+                Bounds bounds = CE_Utility.GetBoundsFor(cover);
+                coverHeight = bounds.size.y;
+            }
+            coverGridCache[position.x * map.Size.y + position.y] = coverHeight;
+        }
+        return coverHeight;
+    }
+
     private float GameGlowAt(IntVec3 source)
     {
         int thisTick = Find.TickManager.TicksAbs;
 
         if (thisTick != lastTick)
         {
+            Array.Fill(coverGridCache, -1f);
             Array.Fill(glowGridCache, -1f);
             lastTick = thisTick;
         }

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -922,6 +922,11 @@ public abstract class ProjectileCE : ThingWithComps
         }
         var roofChecked = false;
 
+        if (Map.GetLightingTracker().HighestCoverAt(cell) < ExactPosition.y)
+        {
+            return false;
+        }
+
         potentialCollisionCandidates.Clear();
 
         foreach (var thing in Map.thingGrid.ThingsListAtFast(cell))
@@ -1436,21 +1441,23 @@ public abstract class ProjectileCE : ThingWithComps
             }
         }
 
-        // FIXME : Early opt-out
-        Thing thing = pos.GetFirstPawn(Map);
-        if (thing != null && TryCollideWith(thing))
-        {
-            return;
-        }
-
-        var list = Map.thingGrid.ThingsListAt(pos).Where(t => t is Pawn || t.def.Fillage != FillCategory.None).ToList();
-        if (list.Count > 0)
-        {
-            foreach (var thing2 in list)
+        if (Map.GetLightingTracker().HighestCoverAt(pos) > ExactPosition.y) {
+            // FIXME : Early opt-out
+            Thing thing = pos.GetFirstPawn(Map);
+            if (thing != null && TryCollideWith(thing))
             {
-                if (TryCollideWith(thing2))
+                return;
+            }
+
+            var list = Map.thingGrid.ThingsListAt(pos).Where(t => t is Pawn || t.def.Fillage != FillCategory.None).ToList();
+            if (list.Count > 0)
+            {
+                foreach (var thing2 in list)
                 {
-                    return;
+                    if (TryCollideWith(thing2))
+                    {
+                        return;
+                    }
                 }
             }
         }

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -1441,7 +1441,8 @@ public abstract class ProjectileCE : ThingWithComps
             }
         }
 
-        if (Map.GetLightingTracker().HighestCoverAt(pos) > ExactPosition.y) {
+        if (Map.GetLightingTracker().HighestCoverAt(pos) > ExactPosition.y)
+        {
             // FIXME : Early opt-out
             Thing thing = pos.GetFirstPawn(Map);
             if (thing != null && TryCollideWith(thing))

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -1470,6 +1470,11 @@ public class Verb_LaunchProjectileCE : Verb
 
             Predicate<IntVec3> CanShootThroughCell = (IntVec3 cell) =>
             {
+                float ch = LightingTracker.HighestCoverAt(cell);
+                if (ch < shotSource.y)
+                {
+                    return true;
+                }
                 Thing cover = cell.GetFirstPawn(caster.Map) ?? cell.GetCover(caster.Map);
 
                 if (cover != null && cover != ShooterPawn && cover != caster && cover != targetThing && !cover.IsPlant() && !(cover is Pawn && cover.HostileTo(caster)))


### PR DESCRIPTION
## Additions

Adds highest cover cache to the lighting tracker

## Changes

Uses cache-based early out for impact and shot line calculations

## References

- After #4515 (could cherry-pick, but they touch similar code sections)
- Closes #4515 

## Reasoning

When scanning for targets in large battles, multiple pawns and multiply flying projectiles all end up cycling through all Things in cells to find the tallest.  That answer effectively cannot change mid-tick (strictly, it can, if something is destroyed, but with the way the cache is used, this doesn't matter, at worst it causes an off-by-one-tick issue with projectiles *not* impacting pawns which pop up from downed right as the projectile flies overhead).

This substantially reduces the shot line calculation costs, and the bullet flight costs in large battles.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
