### PR TITLE
Temporary workaround for upstream MP bug.  Will revert once it updates on steam

### DIFF
--- a/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
+++ b/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
@@ -76,8 +76,11 @@ public class MultiplayerCompat : IModPart
             }
         }
 
-        MP.RegisterAll();
-
+        MP.RegisterSyncWorker<CompAmmoUser>(SyncCompAmmoUser);
+        MP.RegisterSyncWorker<CompFireModes>(SyncCompFireMode);
+        MP.RegisterSyncWorker<Loadout>(SyncLoadout);
+        MP.RegisterSyncWorker<LoadoutSlot>(SyncLoadoutSlot);
+        MP.RegisterSyncWorker<ITab_Inventory>(SyncITab_Inventory, shouldConstruct: true);
         global::CombatExtended.Compatibility.Multiplayer.registerCallbacks((() => MP.IsInMultiplayer),
                                                                            (() => MP.IsExecutingSyncCommand),
                                                                            (() => MP.IsExecutingSyncCommandIssuedBySelf),
@@ -94,7 +97,7 @@ public class MultiplayerCompat : IModPart
       When writing, the comp should never be null.  
      */
 #nullable enable
-    [SyncWorker]
+    //[SyncWorker]
     private static void SyncCompAmmoUser(SyncWorker sync, ref CompAmmoUser? comp)
     {
         if (sync.isWriting)
@@ -130,7 +133,7 @@ public class MultiplayerCompat : IModPart
         }
     }
 
-    [SyncWorker]
+    //[SyncWorker]
     private static void SyncCompFireMode(SyncWorker sync, ref CompFireModes? comp)
     {
         if (sync.isWriting)
@@ -166,7 +169,7 @@ public class MultiplayerCompat : IModPart
         }
     }
 
-    [SyncWorker]
+    //[SyncWorker]
     private static void SyncLoadout(SyncWorker sync, ref Loadout? loadout)
     {
         if (sync.isWriting)
@@ -180,7 +183,7 @@ public class MultiplayerCompat : IModPart
         }
     }
 
-    [SyncWorker]
+    //[SyncWorker]
     private static void SyncLoadoutSlot(SyncWorker sync, ref LoadoutSlot? loadoutSlot)
     {
         if (sync.isWriting)
@@ -223,7 +226,7 @@ public class MultiplayerCompat : IModPart
 
     // Don't sync anything, we just want a blank instance for method calling purposes
     // We only care about shouldConstruct being true
-    [SyncWorker(shouldConstruct = true)]
+    //[SyncWorker(shouldConstruct = true)]
     private static void SyncITab_Inventory(SyncWorker sync, ref ITab_Inventory? inventory)
     { }
 }


### PR DESCRIPTION

## Changes
Use explicitly typed SyncWorker registration

## Reasoning

A bug in Multiplayer introduced in 1.6 breaks auto type detection on SyncWorker attributes.  It's fixed upstream, but it's unclear how long until that fix lands on steam.  This is a temporary fix until then.
## Alternatives

Make people grab this as a draft PR or use the non-steam (github) version of Multiplayer

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
