### PR TITLE
Fix HEDP cookoff null SoundDef

### DIFF
--- a/Patches/Core/DamageDefs/Damages_LocalInjury.xml
+++ b/Patches/Core/DamageDefs/Damages_LocalInjury.xml
@@ -236,4 +236,13 @@
 		</value>
 	</Operation>
 
+	<!-- ========== Add soundExplosion to Bullet for cookoff ========== -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/DamageDef[defName="Bullet"]</xpath>
+		<value>
+			<soundExplosion>Explosion_Bomb</soundExplosion>
+		</value>
+	</Operation>
+
 </Patch>


### PR DESCRIPTION
## Additions
- Patch `Bullet` damageDef to have an explosion sound.

## References
- Closes #4499

## Reasoning
- When these rounds cookoff, they use `soundExplosion` from the damageDef, which `Bullet` doesn't have since in vanilla the damage type isn't otherwise tied to explosions. Set it to use the same soundDef as the `Bomb` damage type.

## Alternatives
- Could rework the cookoff sound to use `cookOffSound` as sent in xml rather than the explosion sound, as the code currently doesn't appear to support this.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
