### PR TITLE
Stun nade stack fix 

### DIFF
--- a/Defs/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Grenades.xml
@@ -190,7 +190,7 @@
 		</graphicData>
 		<soundInteract>Interact_Grenade</soundInteract>
 		<techLevel>Industrial</techLevel>
-		<stackLimit>250</stackLimit>
+		<stackLimit>50</stackLimit>
 		<statBases>
 			<Mass>0.236</Mass>
 			<Bulk>0.61</Bulk>

--- a/Defs/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Grenades.xml
@@ -190,7 +190,6 @@
 		</graphicData>
 		<soundInteract>Interact_Grenade</soundInteract>
 		<techLevel>Industrial</techLevel>
-		<stackLimit>50</stackLimit>
 		<statBases>
 			<Mass>0.236</Mass>
 			<Bulk>0.61</Bulk>


### PR DESCRIPTION

## Changes

What is says on the tin, a one-line change to stun nade stack from 250 to 75

## Reasoning

General fixes, 250 is overkill

## Alternatives

Change the default stack to 50?

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
