### PR TITLE
quick dirty fix for 0 armor error logging

### DIFF
--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
@@ -351,7 +351,10 @@ public static class ArmorUtilityCE
                     {
                         if (penAmount == 0 || armorAmount == 0)
                         {
-                            if (armor.GetStatValue(StatDefOf.ArmorRating_Sharp) == 0 && armor.GetStatValue(StatDefOf.ArmorRating_Blunt) == 0 && armor.GetStatValue(StatDefOf.ArmorRating_Heat) == 0)
+                            // Skip error logging for utility stuff
+                            var apparelExt = armor.def.GetModExtension<ApparelDefExtension>();
+                            bool isUtilityApparel = apparelExt?.isBackpack == true || apparelExt?.isWebbing == true ||  (armor.def.apparel?.layers?.Count == 1 && armor.def.apparel.layers.First() == CE_ApparelLayerDefOf.StrappedHead);
+                            if (!isUtilityApparel && armor.GetStatValue(StatDefOf.ArmorRating_Sharp) == 0 && armor.GetStatValue(StatDefOf.ArmorRating_Blunt) == 0 && armor.GetStatValue(StatDefOf.ArmorRating_Heat) == 0)
                             {
                                 Log.ErrorOnce($"penAmount or armorAmount are zero for {def.armorCategory} on {armor}", armor.def.GetHashCode() + 846532021);
                             }

--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -353,7 +353,7 @@ public static class ArmorUtilityCE
                         {
                             // Skip error logging for utility stuff
                             var apparelExt = armor.def.GetModExtension<ApparelDefExtension>();
-                            bool isUtilityApparel = apparelExt?.isBackpack == true || apparelExt?.isWebbing == true ||  (armor.def.apparel?.layers?.Count == 1 && armor.def.apparel.layers.First() == CE_ApparelLayerDefOf.StrappedHead);
+                            bool isUtilityApparel = apparelExt?.isBackpack == true || apparelExt?.isWebbing == true || (armor.def.apparel?.layers?.Count == 1 && armor.def.apparel.layers.First() == CE_ApparelLayerDefOf.StrappedHead);
                             if (!isUtilityApparel && armor.GetStatValue(StatDefOf.ArmorRating_Sharp) == 0 && armor.GetStatValue(StatDefOf.ArmorRating_Blunt) == 0 && armor.GetStatValue(StatDefOf.ArmorRating_Heat) == 0)
                             {
                                 Log.ErrorOnce($"penAmount or armorAmount are zero for {def.armorCategory} on {armor}", armor.def.GetHashCode() + 846532021);

--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -352,8 +352,11 @@ public static class ArmorUtilityCE
                         if (penAmount == 0 || armorAmount == 0)
                         {
                             // Skip error logging for utility stuff
-                            var apparelExt = armor.def.GetModExtension<ApparelDefExtension>();
-                            bool isUtilityApparel = apparelExt?.isBackpack == true || apparelExt?.isWebbing == true || (armor.def.apparel?.layers?.Count == 1 && armor.def.apparel.layers.First() == CE_ApparelLayerDefOf.StrappedHead);
+                            var layers = armor.def.apparel?.layers;
+                            bool isUtilityApparel = layers?.Count == 1 && 
+                                                    (layers[0] == CE_ApparelLayerDefOf.StrappedHead ||
+                                                     layers[0] == CE_ApparelLayerDefOf.Webbing ||
+                                                     layers[0] == CE_ApparelLayerDefOf.Backpack);
                             if (!isUtilityApparel && armor.GetStatValue(StatDefOf.ArmorRating_Sharp) == 0 && armor.GetStatValue(StatDefOf.ArmorRating_Blunt) == 0 && armor.GetStatValue(StatDefOf.ArmorRating_Heat) == 0)
                             {
                                 Log.ErrorOnce($"penAmount or armorAmount are zero for {def.armorCategory} on {armor}", armor.def.GetHashCode() + 846532021);

--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -353,7 +353,7 @@ public static class ArmorUtilityCE
                         {
                             // Skip error logging for utility stuff
                             var layers = armor.def.apparel?.layers;
-                            bool isUtilityApparel = layers?.Count == 1 && 
+                            bool isUtilityApparel = layers?.Count == 1 &&
                                                     (layers[0] == CE_ApparelLayerDefOf.StrappedHead ||
                                                      layers[0] == CE_ApparelLayerDefOf.Webbing ||
                                                      layers[0] == CE_ApparelLayerDefOf.Backpack);


### PR DESCRIPTION
## Additions
the log only happens when the armor in question is not a headset nor backpack or tac vest
## Changes
2 checks added
## References
bug chat
## Reasoning
because headsets and backpack and tac vest all have something unique
## Alternatives
xml patch all the armor that can cause the error, or a flag in xml which is like this pr's check but more work
## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
