### PR TITLE
Vertical hitchance fixes

### DIFF
--- a/Source/CombatExtended/CombatExtended/CE_Math.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Math.cs
@@ -109,7 +109,7 @@ public static class CE_Math
 
         float cos_theta = Mathf.Cos(shotAngle);
 
-        float sigma_gravity = (gravity * sigma_dist * sigma_dist) / (2 * shotSpeed * shotSpeed * cos_theta * cos_theta);
+        float sigma_gravity = (gravity * dist * sigma_dist) / (2 * shotSpeed * shotSpeed * cos_theta * cos_theta);
         float sigma_vertical = Mathf.Sqrt(sigma_y * sigma_y + sigma_gravity * sigma_gravity);
 
         float half_w = w / 2;

--- a/Source/CombatExtended/CombatExtended/CE_Math.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Math.cs
@@ -126,10 +126,10 @@ public static class CE_Math
         {
             // Becaue we might not be shooting at center of visible area, we have to calculate odds of missing high and the odds of missing low.
             // The chance of hitting is the probability of the bullet passing between the upper and lower limit.
-            float upper = (offset + half_h) / sigma_vertical;
-            float lower = (offset - half_h) / sigma_vertical;
+            float higher = (h - offset) / sigma_vertical;
+            float lower = (-offset) / sigma_vertical;
 
-            p_vertical = normal_cdf(upper) - normal_cdf(lower);
+            p_vertical = normal_cdf(higher) - normal_cdf(lower);
         }
         return p_horizontal * p_vertical;
     }

--- a/Source/CombatExtended/CombatExtended/CE_Math.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Math.cs
@@ -113,7 +113,6 @@ public static class CE_Math
         float sigma_vertical = Mathf.Sqrt(sigma_theta * sigma_theta + sigma_gravity);
 
         float half_w = w / 2;
-        float half_h = h / 2;
         float p_horizontal = 1.0f;
 
         if (sigma_horizontal > 0)

--- a/Source/CombatExtended/CombatExtended/CE_Math.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Math.cs
@@ -110,7 +110,7 @@ public static class CE_Math
         float cos_theta = Mathf.Cos(shotAngle);
 
         float sigma_gravity = (gravity * sigma_dist * sigma_dist) / (2 * shotSpeed * shotSpeed * cos_theta * cos_theta);
-        float sigma_vertical = Mathf.Sqrt(sigma_theta * sigma_theta + sigma_gravity);
+        float sigma_vertical = Mathf.Sqrt(sigma_y * sigma_y + sigma_gravity * sigma_gravity);
 
         float half_w = w / 2;
         float p_horizontal = 1.0f;

--- a/Source/CombatExtended/CombatExtended/ShiftVecReport.cs
+++ b/Source/CombatExtended/CombatExtended/ShiftVecReport.cs
@@ -87,16 +87,16 @@ public class ShiftVecReport
     public float lightingShift = 0f;
     public float weatherShift = 0f;
 
-    private float enviromentShiftInt = -1;
-    public float enviromentShift
+    private float environmentShiftInt = -1;
+    public float environmentShift
     {
         get
         {
-            if (enviromentShiftInt < 0)
+            if (environmentShiftInt < 0)
             {
-                enviromentShiftInt = ((blindFiring ? 1 : lightingShift) * 7f + weatherShift * 1.5f) * CE_Utility.LightingRangeMultiplier(shotDist) + smokeDensity;
+                environmentShiftInt = ((blindFiring ? 1 : lightingShift) * 7f + weatherShift * 1.5f) * CE_Utility.LightingRangeMultiplier(shotDist) + smokeDensity;
             }
-            return enviromentShiftInt;
+            return environmentShiftInt;
         }
     }
 
@@ -113,7 +113,7 @@ public class ShiftVecReport
                 {
                     se = 0.02f;
                 }
-                visibilityShiftInt = enviromentShift * (shotDist / 50 / se) * (2 - aimingAccuracy);
+                visibilityShiftInt = environmentShift * (shotDist / 50 / se) * (2 - aimingAccuracy);
             }
             return visibilityShiftInt;
         }
@@ -254,7 +254,7 @@ public class ShiftVecReport
         {
             stringBuilder.AppendLine("   " + $"DEBUG: visibilityShift\t\t{visibilityShift} ");
             stringBuilder.AppendLine("   " + $"DEBUG: leadDist\t\t{leadDist} ");
-            stringBuilder.AppendLine("   " + $"DEBUG: enviromentShift\t{enviromentShift}");
+            stringBuilder.AppendLine("   " + $"DEBUG: environmentShift\t{environmentShift}");
             stringBuilder.AppendLine("   " + $"DEBUG: accuracyFactor\t{accuracyFactor}");
             stringBuilder.AppendLine("   " + $"DEBUG: circularMissRadius\t{circularMissRadius}");
             stringBuilder.AppendLine("   " + $"DEBUG: sightsEfficiency\t{sightsEfficiency}");

--- a/Source/CombatExtended/CombatExtended/ShiftVecReport.cs
+++ b/Source/CombatExtended/CombatExtended/ShiftVecReport.cs
@@ -40,6 +40,7 @@ public class ShiftVecReport
                                         new Vector3(bounds.size.x, (cy_max - cy_min), bounds.size.z));
                 }
 
+                var offset = bounds.size.y / 2;
                 float dist = shotDist;
 
                 // calculate uncertainty in xz position
@@ -47,7 +48,8 @@ public class ShiftVecReport
                                       + circularMissRadius * circularMissRadius
                                       + indirectFireShift * indirectFireShift
                                       + leadShift * leadShift);
-                float prob = CE_Math.CalculateHitPercent(dist, bounds, targetHeight, shotSpeed, shotAngle, swayDegrees, spreadDegrees, VS, CE_Utility.GravityConst);
+
+                float prob = CE_Math.CalculateHitPercent(dist, bounds, offset, shotSpeed, shotAngle, swayDegrees, spreadDegrees, VS, CE_Utility.GravityConst);
 
                 hitChance = GenText.ToStringByStyle(prob * 100, ToStringStyle.FloatTwo);
             }

--- a/Source/CombatExtended/CombatExtended/ShiftVecReport.cs
+++ b/Source/CombatExtended/CombatExtended/ShiftVecReport.cs
@@ -32,6 +32,10 @@ public class ShiftVecReport
                     var cv = new CollisionVertical(cover);
                     var cy_min = Mathf.Max(bounds.min.y, cv.Max);
                     var cy_max = bounds.max.y;
+                    if (cy_max - cy_min < 0) // behind and shorter than cover
+                    {
+                        cy_max = cy_min;
+                    }
                     bounds = new Bounds(new Vector3(bounds.center.x, cy_min + cy_max / 2, bounds.center.z),
                                         new Vector3(bounds.size.x, (cy_max - cy_min), bounds.size.z));
                 }


### PR DESCRIPTION
## Changes

Several fixes in the vertical portion of the hit chance calculation

## Reasoning

There were multiple math errors that resulted in the vertical hit chance almost always being 100%, making it meaningless.  This resolves those issues.

## Alternatives
The hit chance in the tooltip always assumes shooting the target in the center of visible area.  This is because when that tooltip is generated, the point-of-impact calculation hasn't run yet, and there isn't a good handle with which to do so.  

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
