### PR TITLE
Further fixes for hit chances

### DIFF
--- a/Source/CombatExtended/CombatExtended/CE_Math.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Math.cs
@@ -38,7 +38,7 @@ public static class CE_Math
         }
 
         // See article above for explanation of this section.
-        if (p < 0.5)
+        if (p <= 0.5)
         {
             // F^-1(p) = - G^-1(p)
             return -RationalApproximation(Math.Sqrt(-2.0 * Math.Log(p)));


### PR DESCRIPTION
## Changes

Pick the faster branch when possible

## Reasoning

When the p-value is exactly 0.5, both branches produce the same value.  In this case, the branch that avoids the extra subtraction is marginally faster, so prefer it.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
