### PR TITLE
Fix ammo display for magless weapons

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
@@ -58,13 +58,29 @@ public class CompAmmoUser : CompRangedGizmoGiver
         }
     }
 
-    public int MagsLeftSameType
+    public int MagsLeftReadOnly
     {
         get
         {
             if (CompInventory != null)
             {
-                CompInventory.UpdateInventory();
+                int count = 0;
+                foreach (AmmoLink link in CurAmmoSet.ammoTypes)
+                {
+                    count += CompInventory.AmmoCountOfDef(link.ammo);
+                }
+                return count;
+            }
+            return 0;
+        }
+    }
+
+    public int MagsLeftSameTypeReadOnly
+    {
+        get
+        {
+            if (CompInventory != null)
+            {
                 return CompInventory.AmmoCountOfDef(CurrentAmmo);
             }
             return 0;

--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
@@ -57,6 +57,20 @@ public class CompAmmoUser : CompRangedGizmoGiver
             return 0;
         }
     }
+
+    public int MagsLeftSameType
+    {
+        get
+        {
+            if (CompInventory != null)
+            {
+                CompInventory.UpdateInventory();
+                return CompInventory.AmmoCountOfDef(CurrentAmmo);
+            }
+            return 0;
+        }
+    }
+
     public int MagSize
     {
         get

--- a/Source/CombatExtended/CombatExtended/Gizmos/GizmoAmmoStatus.cs
+++ b/Source/CombatExtended/CombatExtended/Gizmos/GizmoAmmoStatus.cs
@@ -58,7 +58,9 @@ public class GizmoAmmoStatus : Gizmo_Slider
             }
             else
             {
-                return compAmmo.MagsLeftSameType + " (" + compAmmo.MagsLeft + ")";
+                int sameTypeMags = compAmmo.MagsLeftSameType;
+                int otherTypesMags = compAmmo.MagsLeft - sameTypeMags;
+                return sameTypeMags + (otherTypesMags > 0 ? " (+" + otherTypesMags + ")" : string.Empty);
             }
         }
     }

--- a/Source/CombatExtended/CombatExtended/Gizmos/GizmoAmmoStatus.cs
+++ b/Source/CombatExtended/CombatExtended/Gizmos/GizmoAmmoStatus.cs
@@ -48,7 +48,21 @@ public class GizmoAmmoStatus : Gizmo_Slider
         return "CE_ReloadAmmoTooltip".Translate();
     }
 
-    public override string BarLabel => compAmmo.CurMagCount + " / " + compAmmo.MagSize;
+    public override string BarLabel
+    {
+        get
+        {
+            if (compAmmo.HasMagazine)
+            {
+                return compAmmo.CurMagCount + " / " + compAmmo.MagSize;
+            }
+            else
+            {
+                return compAmmo.MagsLeftSameType + " (" + compAmmo.MagsLeft + ")";
+            }
+        }
+    }
+
     public override GizmoResult GizmoOnGUI(Vector2 topLeft, float maxWidth, GizmoRenderParms parms)
     {
         if (IsDraggable)

--- a/Source/CombatExtended/CombatExtended/Gizmos/GizmoAmmoStatus.cs
+++ b/Source/CombatExtended/CombatExtended/Gizmos/GizmoAmmoStatus.cs
@@ -58,8 +58,8 @@ public class GizmoAmmoStatus : Gizmo_Slider
             }
             else
             {
-                int sameTypeMags = compAmmo.MagsLeftSameType;
-                int otherTypesMags = compAmmo.MagsLeft - sameTypeMags;
+                int sameTypeMags = compAmmo.MagsLeftSameTypeReadOnly;
+                int otherTypesMags = compAmmo.MagsLeftReadOnly - sameTypeMags;
                 return sameTypeMags + (otherTypesMags > 0 ? " (+" + otherTypesMags + ")" : string.Empty);
             }
         }


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Changes the way magazine fill gizmo shows numbers for weapons without a magazine (bows). Instead of always showing "0/0", it now shows how much ammo pawn has of the current type (i.e. steel arrow) and how much in total for this weapon (i.e. any arrow), in format like "75 (+25)", or just "75" if there's only one ammo type.

## Reasoning

Why did you choose to implement things this way, e.g.
- Opportunistic reloading PR changed the way this gizmo works. Previously it showed nothing at all for magless weapons, currently it shows 0/0.
- Showing ammo left in inventory is helpful

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
