### PR TITLE
fix VAE patch break odyssey stat and other VE patches

### DIFF
--- a/ModPatches/Vanilla Armour Expanded/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Spacer.xml
+++ b/ModPatches/Vanilla Armour Expanded/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Spacer.xml
@@ -229,8 +229,8 @@
 		</nomatch>
 	</Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/equippedStatOffsets/PainShockThreshold</xpath>
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/equippedStatOffsets</xpath>
 		<value>
 			<AimingAccuracy>0.15</AimingAccuracy>
 			<ToxicEnvironmentResistance>0.5</ToxicEnvironmentResistance>
@@ -295,10 +295,6 @@
 		<value>
 			<Flammability>0</Flammability>
 		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/equippedStatOffsets/PainShockThreshold</xpath>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
@@ -412,8 +408,8 @@
 				</nomatch>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_RoyalSiegeHelmet"]/equippedStatOffsets/PainShockThreshold</xpath>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="VAE_Headgear_RoyalSiegeHelmet"]/equippedStatOffsets</xpath>
 				<value>
 					<AimingAccuracy>0.15</AimingAccuracy>
 					<ToxicEnvironmentResistance>0.5</ToxicEnvironmentResistance>
@@ -433,10 +429,6 @@
 						<Gold>10</Gold>
 					</costList>
 				</value>
-			</li>
-
-			<li Class="PatchOperationRemove">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_RoyalSiegeArmor"]/equippedStatOffsets/PainShockThreshold</xpath>
 			</li>
 
 			<li Class="PatchOperationReplace">

--- a/ModPatches/Vanilla Armour Expanded/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Spacer.xml
+++ b/ModPatches/Vanilla Armour Expanded/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Spacer.xml
@@ -230,14 +230,12 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/equippedStatOffsets</xpath>
+		<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/equippedStatOffsets/PainShockThreshold</xpath>
 		<value>
-			<equippedStatOffsets>
-				<AimingAccuracy>0.15</AimingAccuracy>
-				<ToxicEnvironmentResistance>0.5</ToxicEnvironmentResistance>
-				<SmokeSensitivity>-1</SmokeSensitivity>
-				<MeleeDodgeChance>-0.15</MeleeDodgeChance>
-			</equippedStatOffsets>
+			<AimingAccuracy>0.15</AimingAccuracy>
+			<ToxicEnvironmentResistance>0.5</ToxicEnvironmentResistance>
+			<SmokeSensitivity>-1</SmokeSensitivity>
+			<MeleeDodgeChance>-0.15</MeleeDodgeChance>
 		</value>
 	</Operation>
 
@@ -299,15 +297,17 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/equippedStatOffsets/PainShockThreshold</xpath>
+	</Operation>
+
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/equippedStatOffsets</xpath>
+		<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/equippedStatOffsets/MoveSpeed</xpath>
 		<value>
-			<equippedStatOffsets>
-				<CarryWeight>100</CarryWeight>
-				<CarryBulk>20</CarryBulk>
-				<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
-				<ToxicEnvironmentResistance>0.5</ToxicEnvironmentResistance>
-			</equippedStatOffsets>
+			<CarryWeight>100</CarryWeight>
+			<CarryBulk>20</CarryBulk>
+			<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
+			<ToxicEnvironmentResistance>0.5</ToxicEnvironmentResistance>
 		</value>
 	</Operation>
 
@@ -413,16 +413,12 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_RoyalSiegeHelmet"]/equippedStatOffsets</xpath>
+				<xpath>Defs/ThingDef[defName="VAE_Headgear_RoyalSiegeHelmet"]/equippedStatOffsets/PainShockThreshold</xpath>
 				<value>
-					<equippedStatOffsets>
-						<AimingAccuracy>0.15</AimingAccuracy>
-						<ToxicEnvironmentResistance>0.5</ToxicEnvironmentResistance>
-						<SmokeSensitivity>-1</SmokeSensitivity>
-						<PsychicSensitivity>0.05</PsychicSensitivity>
-						<PsychicEntropyRecoveryRate>0.033</PsychicEntropyRecoveryRate>
-						<MeleeDodgeChance>-0.15</MeleeDodgeChance>
-					</equippedStatOffsets>
+					<AimingAccuracy>0.15</AimingAccuracy>
+					<ToxicEnvironmentResistance>0.5</ToxicEnvironmentResistance>
+					<SmokeSensitivity>-1</SmokeSensitivity>
+					<MeleeDodgeChance>-0.15</MeleeDodgeChance>
 				</value>
 			</li>
 
@@ -439,17 +435,17 @@
 				</value>
 			</li>
 
+			<li Class="PatchOperationRemove">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_RoyalSiegeArmor"]/equippedStatOffsets/PainShockThreshold</xpath>
+			</li>
+
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_RoyalSiegeArmor"]/equippedStatOffsets</xpath>
+				<xpath>Defs/ThingDef[defName="VAE_Apparel_RoyalSiegeArmor"]/equippedStatOffsets/MoveSpeed</xpath>
 				<value>
-					<equippedStatOffsets>
-						<CarryWeight>100</CarryWeight>
-						<CarryBulk>20</CarryBulk>
-						<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
-						<ToxicEnvironmentResistance>0.5</ToxicEnvironmentResistance>
-						<PsychicSensitivity>0.05</PsychicSensitivity>
-						<PsychicEntropyRecoveryRate>0.033</PsychicEntropyRecoveryRate>
-					</equippedStatOffsets>
+					<CarryWeight>100</CarryWeight>
+					<CarryBulk>20</CarryBulk>
+					<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
+					<ToxicEnvironmentResistance>0.5</ToxicEnvironmentResistance>
 				</value>
 			</li>
 


### PR DESCRIPTION

## Additions
none
## Changes
fix old patch replacing whole equippedStatOffsets causing other VE mod patching it failing, may need to check other patches that also replaces the whole equippedStatOffsets
## References
Troubleshooting chat
## Reasoning
none
## Alternatives
n/a
## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
