### PR TITLE
fix autoloader graphics breaking on save load

### DIFF
--- a/Source/CombatExtended/CombatExtended/Building_AmmoContainerCE/Building_AutoloaderCE.cs
+++ b/Source/CombatExtended/CombatExtended/Building_AmmoContainerCE/Building_AutoloaderCE.cs
@@ -115,7 +115,9 @@ public class Building_AutoloaderCE : Building
         mannableComp = GetComp<CompMannable>();
 
         graphicsExt = def.GetModExtension<ModExtension_AutoLoaderGraphics>();
-        CacheGraphics();
+
+        LongEventHandler.ExecuteWhenFinished(CacheGraphics);
+
         if (CompAmmoUser == null)
         {
             Log.Error(this.GetCustomLabelNoCount() + " Requires CompAmmoUser to function properly.");


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Fixes bug which caused autoloader texture switching to break after loading a savegame where an autoloader was already built
- Changes graphics caching to happen later than `SpawnSetup`, so that `graphicsExt.fullGraphic` is not `null`.

## Reasoning

Why did you choose to implement things this way, e.g.
- When you build a new autoloader, `graphicsExt.fullGraphic` is not `null`, but when you load a savegame, it was null.

To reproduce the bug:

1. Use dev branch CE and this Armory PR: https://github.com/CombatExtended-Continued/CombatExtendedArmory/pull/123
2. Build an autoloader
3. Save the game and close to desktop
4. Load the save

upon loading, it will throw red errors about trying to load textures and will show "full" graphic instead of "empty"

## Alternatives
* I don't know if there is better way and how exactly long event handler works, but it fixes the issue and is what people in #mod-development channel seem to suggest in such cases


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)- 