### PR TITLE
Fix non human hit chance

### DIFF
--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
@@ -566,10 +566,11 @@ public class Verb_MeleeAttackCE : Verb_MeleeAttack
         {
             return 1f;
         }
+
+        float chance = CasterPawn.GetStatValue(StatDefOf.MeleeHitChance, true);
+
         if (CasterPawn.skills != null)
         {
-            float chance = CasterPawn.GetStatValue(StatDefOf.MeleeHitChance, true);
-
             if (ModsConfig.IdeologyActive && target.HasThing)
             {
                 if (DarknessCombatUtility.IsOutdoorsAndLit(target.Thing))
@@ -604,10 +605,9 @@ public class Verb_MeleeAttackCE : Verb_MeleeAttack
                     chance *= 0.7f;
                     break;
             }
-
-            return chance;
         }
-        return DefaultHitChance;
+        
+        return chance;
     }
 
     private float GetDodgeChance(Pawn defender)

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
@@ -606,7 +606,7 @@ public class Verb_MeleeAttackCE : Verb_MeleeAttack
                     break;
             }
         }
-        
+
         return chance;
     }
 


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Makes melee verb check for creature's melee attack stat even if it doesnt have skills.
- Fixes animals and mechs always having 60% hit chance, regardless of stats or health.
- Note that this indirectly raises base hit chance for all non humans from 60% to 80% (by using their race's default skill lvl instead of a const value)

## References

Links to the associated issues or other related pull requests, e.g.
- Investigation discussion: https://discord.com/channels/278818534069501953/303988654492090370/1491168270215024710

## Reasoning

Why did you choose to implement things this way, e.g.
- Vanilla does it this way too
- health and stat offsets should impact hit chance

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
