### PR TITLE
Fix high bulk improving negative hit chances

### DIFF
--- a/Source/CombatExtended/CombatExtended/StatParts/StatPart_Bulk.cs
+++ b/Source/CombatExtended/CombatExtended/StatParts/StatPart_Bulk.cs
@@ -32,7 +32,9 @@ public class StatPart_Bulk : StatPart
     {
         if (ValidReq(req))
         {
-            val *= MassBulkUtility.HitChanceBulkFactor(inv(req).currentBulk, inv(req).capacityBulk);
+            float multiplier = MassBulkUtility.HitChanceBulkFactor(inv(req).currentBulk, inv(req).capacityBulk);
+            //so that bulk doesn't increase hit chance when hit chance is negative (before post-processing)
+            val *= val > 0 ? multiplier : 1 + (1 - multiplier);
         }
     }
 }


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Fixes the following situation. When melee hit chance is so low that pre-process value is negative, carrying a lot of bulk made you more likely to hit successfully. This happened due to bulk giving a multiplier in [0.75, 1.00] range , so negative numbers became closer to zero with it.
<img width="940" height="270" alt="изображение" src="https://github.com/user-attachments/assets/eb5d5d58-22a6-4fc0-933c-cd30b05d57cd" />
<img width="909" height="281" alt="изображение" src="https://github.com/user-attachments/assets/369ce4c0-ad55-4c7d-8c4a-cba8a0aa972f" />
- now, it will instead use `1 + (1 - multiplier)` if hit chance is negative, so 0.8 bulk multiplier becomes 1.2, etc.

## References

Links to the associated issues or other related pull requests, e.g.
- [bug report](https://discord.com/channels/278818534069501953/303988654492090370/1491543830518956195)

## Reasoning

Why did you choose to implement things this way, e.g.
- Made no sense previously.

## Alternatives

Describe alternative implementations you have considered, e.g.
- use some alternative equation, so that bulk is more impactful when pre-process hit chance value is close to 0.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
