### PR TITLE
fix melee tooltip not showing up for animals and drones

### DIFF
--- a/Languages/English/Keyed/ModMenu.xml
+++ b/Languages/English/Keyed/ModMenu.xml
@@ -99,6 +99,9 @@
 	<CE_Settings_DetailedMeleeTooltip_Desc>Enables extra information about parry, dodge and other attack chance modifiers in melee tooltip.</CE_Settings_DetailedMeleeTooltip_Desc>
 	<CE_Settings_DetailedMeleeTooltip_Title>Show detailed melee tooltip</CE_Settings_DetailedMeleeTooltip_Title>
 
+	<CE_Settings_NonPlayerMeleeTooltip_Desc>Enables melee tooltip for pawns not under player control, such as wild animals, allies and raiders.</CE_Settings_NonPlayerMeleeTooltip_Desc>
+	<CE_Settings_NonPlayerMeleeTooltip_Title>Show melee tooltip for all factions</CE_Settings_NonPlayerMeleeTooltip_Title>
+
 	<CE_Settings_FragmentsFromWalls_Desc>When enabled, damaging walls can generate fragments.</CE_Settings_FragmentsFromWalls_Desc>
 	<CE_Settings_FragmentsFromWalls_Title>Fragments from walls</CE_Settings_FragmentsFromWalls_Title>
 

--- a/Languages/English/Keyed/ModMenu.xml
+++ b/Languages/English/Keyed/ModMenu.xml
@@ -99,8 +99,8 @@
 	<CE_Settings_DetailedMeleeTooltip_Desc>Enables extra information about parry, dodge and other attack chance modifiers in melee tooltip.</CE_Settings_DetailedMeleeTooltip_Desc>
 	<CE_Settings_DetailedMeleeTooltip_Title>Show detailed melee tooltip</CE_Settings_DetailedMeleeTooltip_Title>
 
-	<CE_Settings_NonPlayerMeleeTooltip_Desc>Enables melee tooltip for pawns not under player control, such as wild animals, allies and raiders.</CE_Settings_NonPlayerMeleeTooltip_Desc>
-	<CE_Settings_NonPlayerMeleeTooltip_Title>Show melee tooltip for all factions</CE_Settings_NonPlayerMeleeTooltip_Title>
+	<CE_Settings_NonPlayerMeleeTooltip_Desc>Enables melee tooltip for all pawns, including wild animals, allies and raiders.</CE_Settings_NonPlayerMeleeTooltip_Desc>
+	<CE_Settings_NonPlayerMeleeTooltip_Title>Show melee tooltip for all pawns</CE_Settings_NonPlayerMeleeTooltip_Title>
 
 	<CE_Settings_FragmentsFromWalls_Desc>When enabled, damaging walls can generate fragments.</CE_Settings_FragmentsFromWalls_Desc>
 	<CE_Settings_FragmentsFromWalls_Title>Fragments from walls</CE_Settings_FragmentsFromWalls_Title>

--- a/Source/CombatExtended/CombatExtended/ModSettings/Settings.cs
+++ b/Source/CombatExtended/CombatExtended/ModSettings/Settings.cs
@@ -36,6 +36,7 @@ public class Settings : ModSettings, ISettingsCE
 
     private bool showExtraTooltips = false;
     private bool detailedMeleeTooltip = false;
+    private bool nonPlayerMeleeTooltip = false;
 
     private bool showExtraStats = false;
 
@@ -76,6 +77,7 @@ public class Settings : ModSettings, ISettingsCE
     public bool EnableExtraEffects => enableExtraEffects;
     public bool ShowExtraTooltips => showExtraTooltips;
     public bool DetailedMeleeTooltip => detailedMeleeTooltip;
+    public bool NonPlayerMeleeTooltip => nonPlayerMeleeTooltip;
 
     public bool ShowExtraStats => showExtraStats;
     public bool EnableCIWS => enableCIWS;
@@ -208,6 +210,7 @@ public class Settings : ModSettings, ISettingsCE
         Scribe_Values.Look(ref enableExtraEffects, "enableExtraEffects", true);
         Scribe_Values.Look(ref showExtraTooltips, "showExtraTooltips", false);
         Scribe_Values.Look(ref detailedMeleeTooltip, "detailedMeleeTooltip", false);
+        Scribe_Values.Look(ref nonPlayerMeleeTooltip, "nonPlayerMeleeTooltip", false);
         Scribe_Values.Look(ref enableArcOfFire, "enableArcOfFire", false);
 
         Scribe_Values.Look(ref showExtraStats, "showExtraStats", false);
@@ -425,6 +428,7 @@ public class Settings : ModSettings, ISettingsCE
         list.CheckboxLabeled("CE_Settings_ShowExtraTooltips_Title".Translate(), ref showExtraTooltips, "CE_Settings_ShowExtraTooltips_Desc".Translate());
         list.CheckboxLabeled("CE_Settings_ShowExtraStats_Title".Translate(), ref showExtraStats, "CE_Settings_ShowExtraStats_Desc".Translate());
         list.CheckboxLabeled("CE_Settings_DetailedMeleeTooltip_Title".Translate(), ref detailedMeleeTooltip, "CE_Settings_DetailedMeleeTooltip_Desc".Translate());
+        list.CheckboxLabeled("CE_Settings_NonPlayerMeleeTooltip_Title".Translate(), ref nonPlayerMeleeTooltip, "CE_Settings_NonPlayerMeleeTooltip_Desc".Translate());
         list.CheckboxLabeled("CE_Settings_VariedHumanHeight_Title".Translate(), ref variedHumanHeight, "CE_Settings_VariedHumanHeight_Desc".Translate());
         list.CheckboxLabeled("CE_Settings_LogUnpatchedDefs_Title".Translate(), ref logUnpatchedDefs, "CE_Settings_LogUnpatchedDefs_Desc".Translate());
         list.Gap();
@@ -577,6 +581,7 @@ public class Settings : ModSettings, ISettingsCE
         showExtraTooltips = false;
         showExtraStats = false;
         detailedMeleeTooltip = false;
+        nonPlayerMeleeTooltip = false;
         // AutoPatcher Settings
         debugAutopatcherLogger = false;
         enableApparelAutopatcher = false;

--- a/Source/CombatExtended/Harmony/Harmony_TooltipUtility.cs
+++ b/Source/CombatExtended/Harmony/Harmony_TooltipUtility.cs
@@ -69,7 +69,8 @@ public class Harmony_TooltipUtility_ShotCalculationTipString_Patch
                 }
             }
             // melee tooltip
-            else if (pawn != null && pawn2 != null && pawn != pawn2 && (pawn.Drafted || !pawn.IsColonist || pawn.Faction != Faction.OfPlayer || pawn.InAggroMentalState))
+            else if (pawn != null && pawn2 != null && pawn != pawn2
+                     && ((pawn.IsColonist && (pawn.Drafted || pawn.InAggroMentalState)) || (!pawn.IsColonist && (pawn.Faction == Faction.OfPlayer || Controller.settings.NonPlayerMeleeTooltip))))
             {
                 //if pawn doesn't have a melee weapon equipped, find another source of melee verb
                 if (meleeVerbCE == null)

--- a/Source/CombatExtended/Harmony/Harmony_TooltipUtility.cs
+++ b/Source/CombatExtended/Harmony/Harmony_TooltipUtility.cs
@@ -69,7 +69,7 @@ public class Harmony_TooltipUtility_ShotCalculationTipString_Patch
                 }
             }
             // melee tooltip
-            else if (pawn != null && pawn2 != null && pawn != pawn2 && (pawn.Drafted || pawn.Faction != Faction.OfPlayer || pawn.InAggroMentalState))
+            else if (pawn != null && pawn2 != null && pawn != pawn2 && (pawn.Drafted || !pawn.IsColonist || pawn.Faction != Faction.OfPlayer || pawn.InAggroMentalState))
             {
                 //if pawn doesn't have a melee weapon equipped, find another source of melee verb
                 if (meleeVerbCE == null)


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- allows melee hit chance hover tooltip to show up, when selected pawn is a not colonist under player's control

## Reasoning

Why did you choose to implement things this way, e.g.
- melee tooltip had restrictions to not show up on undrafted colonists to avoid clutter. Since animals cant usually interact with anyone other than by attacking them, melee tooltip always showing up for them wouldn't be annoying.
- fixes the issue of being unable to view melee hit chance on tame animals and drones.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
