### PR TITLE
9x19 LV ammo set label quick fix

### DIFF
--- a/Defs/Ammo/Pistols/9x19mmPara.xml
+++ b/Defs/Ammo/Pistols/9x19mmPara.xml
@@ -23,7 +23,7 @@
 
 	<CombatExtended.AmmoSetDef>
 		<defName>AmmoSet_9x19mmParaSD</defName>
-		<label>9x19mm Para Subsonic</label>
+		<label>9x19mm Para</label>
 		<ammoTypes>
 			<Ammo_9x19mmPara_FMJ>Bullet_9x19mmParaSD_FMJ</Ammo_9x19mmPara_FMJ>
 			<Ammo_9x19mmPara_AP>Bullet_9x19mmParaSD_AP</Ammo_9x19mmPara_AP>


### PR DESCRIPTION
## Changes

Annoyed at the 9x19 ammo set being off standard with label and def names, however, I do not want, nor have the time to change armory, fix every patch, and screw over modders because of this issue. So, this is a simple fix to only change the in game visible low-velocity ammo set label to standard formatting. 

## Reasoning

it's visibly off standard text in game and annoying

## Alternatives

Update the entire thing and screw over other mods in the process