### PR TITLE
Conditional settings patch op

### DIFF
--- a/Anomaly/Patches/Anomaly/CreepjoinderDefs/Forms.xml
+++ b/Anomaly/Patches/Anomaly/CreepjoinderDefs/Forms.xml
@@ -13,8 +13,9 @@
 		</value>
 	</Operation>
 
-	<Operation Class="CombatExtended.PatchOperation_ConditionalGeneric">
-		<standard Class="PatchOperationAdd">
+	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
+		<settingName>genericammo</settingName>
+		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/CreepJoinerFormKindDef[defName="LeatheryStranger"]</xpath>
 			<value>
 				<inventoryOptions>
@@ -34,8 +35,8 @@
 					</subOptionsChooseOne>
 				</inventoryOptions>
 			</value>
-		</standard>
-		<generic Class="PatchOperationAdd">
+		</nomatch>
+		<match Class="PatchOperationAdd">
 			<xpath>Defs/CreepJoinerFormKindDef[defName="LeatheryStranger"]</xpath>
 			<value>
 				<inventoryOptions>
@@ -55,7 +56,7 @@
 					</subOptionsChooseOne>
 				</inventoryOptions>
 			</value>
-		</generic>
+		</match>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
@@ -68,8 +69,9 @@
 		</value>
 	</Operation>
 
-	<Operation Class="CombatExtended.PatchOperation_ConditionalGeneric">
-		<standard Class="PatchOperationAdd">
+	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
+		<settingName>genericammo</settingName>
+		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/CreepJoinerFormKindDef[defName="DealMaker"]</xpath>
 			<value>
 				<inventoryOptions>
@@ -89,8 +91,8 @@
 					</subOptionsChooseOne>
 				</inventoryOptions>
 			</value>
-		</standard>
-		<generic Class="PatchOperationAdd">
+		</nomatch>
+		<match Class="PatchOperationAdd">
 			<xpath>Defs/CreepJoinerFormKindDef[defName="DealMaker"]</xpath>
 			<value>
 				<inventoryOptions>
@@ -110,7 +112,7 @@
 					</subOptionsChooseOne>
 				</inventoryOptions>
 			</value>
-		</generic>
+		</match>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
@@ -130,8 +132,9 @@
 		</value>
 	</Operation>
 
-	<Operation Class="CombatExtended.PatchOperation_ConditionalGeneric">
-		<standard Class="PatchOperationAdd">
+	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
+		<settingName>genericammo</settingName>
+		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/CreepJoinerFormKindDef[defName="LoneGenius"]</xpath>
 			<value>
 				<inventoryOptions>
@@ -147,8 +150,8 @@
 					</subOptionsChooseOne>
 				</inventoryOptions>
 			</value>
-		</standard>
-		<generic Class="PatchOperationAdd">
+		</nomatch>
+		<match Class="PatchOperationAdd">
 			<xpath>Defs/CreepJoinerFormKindDef[defName="LoneGenius"]</xpath>
 			<value>
 				<inventoryOptions>
@@ -164,7 +167,7 @@
 					</subOptionsChooseOne>
 				</inventoryOptions>
 			</value>
-		</generic>
+		</match>
 	</Operation>
 
 </Patch>

--- a/Anomaly/Patches/Anomaly/CreepjoinderDefs/Forms.xml
+++ b/Anomaly/Patches/Anomaly/CreepjoinderDefs/Forms.xml
@@ -14,7 +14,7 @@
 	</Operation>
 
 	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
-		<settingName>genericammo</settingName>
+		<settingName>genericAmmo</settingName>
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/CreepJoinerFormKindDef[defName="LeatheryStranger"]</xpath>
 			<value>
@@ -70,7 +70,7 @@
 	</Operation>
 
 	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
-		<settingName>genericammo</settingName>
+		<settingName>genericAmmo</settingName>
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/CreepJoinerFormKindDef[defName="DealMaker"]</xpath>
 			<value>
@@ -133,7 +133,7 @@
 	</Operation>
 
 	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
-		<settingName>genericammo</settingName>
+		<settingName>genericAmmo</settingName>
 		<nomatch Class="PatchOperationAdd">
 			<xpath>Defs/CreepJoinerFormKindDef[defName="LoneGenius"]</xpath>
 			<value>

--- a/ModPatches/Integrated Implants/Patches/Integrated Implants/Hediffs_ShoulderWeaponry.xml
+++ b/ModPatches/Integrated Implants/Patches/Integrated Implants/Hediffs_ShoulderWeaponry.xml
@@ -62,7 +62,7 @@
 	</Operation>
 
 	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
-		<settingName>genericammo</settingName>
+		<settingName>genericAmmo</settingName>
 		<nomatch Class="PatchOperationReplace">
 		<xpath>Defs/AbilityDef[defName="LTS_ShoulderMortar"]/comps/li[@Class="LTS_Implants.LTS_CompProperties_AbilityReloadable"]</xpath>
 			<value>

--- a/ModPatches/Integrated Implants/Patches/Integrated Implants/Hediffs_ShoulderWeaponry.xml
+++ b/ModPatches/Integrated Implants/Patches/Integrated Implants/Hediffs_ShoulderWeaponry.xml
@@ -61,8 +61,9 @@
 		</value>
 	</Operation>
 
-	<Operation Class="CombatExtended.PatchOperation_ConditionalGeneric">
-		<standard Class="PatchOperationReplace">
+	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
+		<settingName>genericammo</settingName>
+		<nomatch Class="PatchOperationReplace">
 		<xpath>Defs/AbilityDef[defName="LTS_ShoulderMortar"]/comps/li[@Class="LTS_Implants.LTS_CompProperties_AbilityReloadable"]</xpath>
 			<value>
 			<li Class="LTS_Implants.LTS_CompProperties_AbilityReloadable">
@@ -72,8 +73,8 @@
 				<soundReload>Standard_Reload</soundReload>
 			</li>
 			</value>
-		</standard>
-		<generic Class="PatchOperationReplace">
+		</nomatch>
+		<match Class="PatchOperationReplace">
 		<xpath>Defs/AbilityDef[defName="LTS_ShoulderMortar"]/comps/li[@Class="LTS_Implants.LTS_CompProperties_AbilityReloadable"]</xpath>
 			<value>
 			<li Class="LTS_Implants.LTS_CompProperties_AbilityReloadable">
@@ -83,7 +84,7 @@
 				<soundReload>Standard_Reload</soundReload>
 			</li>
 			</value>
-		</generic>
+		</match>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">

--- a/ModPatches/Vanilla Factions Expanded - Ancients/Patches/Vanilla Factions Expanded - Ancients/CustomGenDefs_Vaults.xml
+++ b/ModPatches/Vanilla Factions Expanded - Ancients/Patches/Vanilla Factions Expanded - Ancients/CustomGenDefs_Vaults.xml
@@ -4,7 +4,7 @@
 	<!-- I'm not sure if this works, and it's probably very fragile. -->
 
 	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
-		<settingName>genericammo</settingName>
+		<settingName>genericAmmo</settingName>
 		<nomatch Class="PatchOperationReplace">
 			<xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultAlpha"]/layouts/li[1]/li[66]</xpath>
 			<value>
@@ -20,7 +20,7 @@
 	</Operation>
 
 	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
-		<settingName>genericammo</settingName>
+		<settingName>genericAmmo</settingName>
 		<nomatch Class="PatchOperationReplace">
 			<xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultBravo"]/layouts/li[1]/li[14]</xpath>
 			<value>
@@ -36,7 +36,7 @@
 	</Operation>
 
 	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
-		<settingName>genericammo</settingName>
+		<settingName>genericAmmo</settingName>
 		<nomatch Class="PatchOperationReplace">
 			<xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultCharlie"]/layouts/li[1]/li[10]</xpath>
 			<value>
@@ -52,7 +52,7 @@
 	</Operation>
 
 	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
-		<settingName>genericammo</settingName>
+		<settingName>genericAmmo</settingName>
 		<nomatch Class="PatchOperationReplace">
 			<xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultDelta"]/layouts/li[1]/li[19]</xpath>
 			<value>
@@ -68,7 +68,7 @@
 	</Operation>
 
 	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
-		<settingName>genericammo</settingName>
+		<settingName>genericAmmo</settingName>
 		<nomatch Class="PatchOperationReplace">
 			<xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultF"]/layouts/li[1]/li[35]</xpath>
 			<value>
@@ -84,7 +84,7 @@
 	</Operation>
 
 	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
-		<settingName>genericammo</settingName>
+		<settingName>genericAmmo</settingName>
 		<nomatch Class="PatchOperationReplace">
 			<xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultG"]/layouts/li[1]/li[23]</xpath>
 			<value>
@@ -100,7 +100,7 @@
 	</Operation>
 
 	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
-		<settingName>genericammo</settingName>
+		<settingName>genericAmmo</settingName>
 		<nomatch Class="PatchOperationReplace">
 			<xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultH"]/layouts/li[1]/li[31]</xpath>
 			<value>
@@ -116,7 +116,7 @@
 	</Operation>
 
 	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
-		<settingName>genericammo</settingName>
+		<settingName>genericAmmo</settingName>
 		<nomatch Class="PatchOperationReplace">
 			<xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultH"]/layouts/li[1]/li[35]</xpath>
 			<value>
@@ -132,7 +132,7 @@
 	</Operation>
 
 	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
-		<settingName>genericammo</settingName>
+		<settingName>genericAmmo</settingName>
 		<nomatch Class="PatchOperationReplace">
 			<xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultI"]/layouts/li[1]/li[19]</xpath>
 			<value>
@@ -148,7 +148,7 @@
 	</Operation>
 
 	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
-		<settingName>genericammo</settingName>
+		<settingName>genericAmmo</settingName>
 		<nomatch Class="PatchOperationReplace">
 			<xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultJ"]/layouts/li[1]/li[35]</xpath>
 			<value>
@@ -164,7 +164,7 @@
 	</Operation>
 
 	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
-		<settingName>genericammo</settingName>
+		<settingName>genericAmmo</settingName>
 		<nomatch Class="PatchOperationReplace">
 			<xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultJ"]/layouts/li[1]/li[36]</xpath>
 			<value>
@@ -180,7 +180,7 @@
 	</Operation>
 
 	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
-		<settingName>genericammo</settingName>
+		<settingName>genericAmmo</settingName>
 		<nomatch Class="PatchOperationReplace">
 			<xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultJ"]/layouts/li[1]/li[36]</xpath>
 			<value>

--- a/ModPatches/Vanilla Factions Expanded - Ancients/Patches/Vanilla Factions Expanded - Ancients/CustomGenDefs_Vaults.xml
+++ b/ModPatches/Vanilla Factions Expanded - Ancients/Patches/Vanilla Factions Expanded - Ancients/CustomGenDefs_Vaults.xml
@@ -3,184 +3,196 @@
 
 	<!-- I'm not sure if this works, and it's probably very fragile. -->
 
-	<Operation Class="CombatExtended.PatchOperation_ConditionalGeneric">
-		<standard Class="PatchOperationReplace">
+	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
+		<settingName>genericammo</settingName>
+		<nomatch Class="PatchOperationReplace">
 			<xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultAlpha"]/layouts/li[1]/li[66]</xpath>
 			<value>
 				<li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Gun_AssaultRifle,Gun_AssaultRifle,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,Apparel_PowerArmor,Ammo_556x45mmNATO_Incendiary,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
 			</value>
-		</standard>
-		<generic Class="PatchOperationReplace">
+		</nomatch>
+		<match Class="PatchOperationReplace">
 			<xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultAlpha"]/layouts/li[1]/li[66]</xpath>
 			<value>
 				<li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Gun_AssaultRifle,Gun_AssaultRifle,Ammo_RifleIntermediate_Incendiary,Ammo_RifleIntermediate_Incendiary,Ammo_RifleIntermediate_Incendiary,Apparel_PowerArmor,Ammo_RifleIntermediate_Incendiary,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
 			</value>
-		</generic>
+		</match>
 	</Operation>
 
-	<Operation Class="CombatExtended.PatchOperation_ConditionalGeneric">
-		<standard Class="PatchOperationReplace">
+	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
+		<settingName>genericammo</settingName>
+		<nomatch Class="PatchOperationReplace">
 			<xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultBravo"]/layouts/li[1]/li[14]</xpath>
 			<value>
 				<li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Ammo_556x45mmNATO_Incendiary,Gun_AssaultRifle,Ammo_556x45mmNATO_Incendiary,Gun_AssaultRifle,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,Apparel_PowerArmor,.,.,.,.,.,.,.,.,.,.,.</li>
 			</value>
-		</standard>
-		<generic Class="PatchOperationReplace">
+		</nomatch>
+		<match Class="PatchOperationReplace">
 			<xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultBravo"]/layouts/li[1]/li[14]</xpath>
 			<value>
 				<li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Ammo_RifleIntermediate_Incendiary,Gun_AssaultRifle,Ammo_RifleIntermediate_Incendiary,Gun_AssaultRifle,Ammo_RifleIntermediate_Incendiary,Ammo_RifleIntermediate_Incendiary,Apparel_PowerArmor,.,.,.,.,.,.,.,.,.,.,.</li>
 			</value>
-		</generic>
+		</match>
 	</Operation>
 
-	<Operation Class="CombatExtended.PatchOperation_ConditionalGeneric">
-		<standard Class="PatchOperationReplace">
+	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
+		<settingName>genericammo</settingName>
+		<nomatch Class="PatchOperationReplace">
 			<xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultCharlie"]/layouts/li[1]/li[10]</xpath>
 			<value>
 				<li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Ammo_556x45mmNATO_Incendiary,Gun_AssaultRifle,Ammo_556x45mmNATO_Incendiary,Apparel_PowerArmor,Gun_AssaultRifle,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
 			</value>
-		</standard>
-		<generic Class="PatchOperationReplace">
+		</nomatch>
+		<match Class="PatchOperationReplace">
 			<xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultCharlie"]/layouts/li[1]/li[10]</xpath>
 			<value>
 				<li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Ammo_RifleIntermediate_Incendiary,Gun_AssaultRifle,Ammo_RifleIntermediate_Incendiary,Apparel_PowerArmor,Gun_AssaultRifle,Ammo_RifleIntermediate_Incendiary,Ammo_RifleIntermediate_Incendiary,Ammo_RifleIntermediate_Incendiary,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
 			</value>
-		</generic>
+		</match>
 	</Operation>
 
-	<Operation Class="CombatExtended.PatchOperation_ConditionalGeneric">
-		<standard Class="PatchOperationReplace">
+	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
+		<settingName>genericammo</settingName>
+		<nomatch Class="PatchOperationReplace">
 			<xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultDelta"]/layouts/li[1]/li[19]</xpath>
 			<value>
 				<li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Gun_AssaultRifle,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,Gun_AssaultRifle,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
 			</value>
-		</standard>
-		<generic Class="PatchOperationReplace">
+		</nomatch>
+		<match Class="PatchOperationReplace">
 			<xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultDelta"]/layouts/li[1]/li[19]</xpath>
 			<value>
 				<li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Gun_AssaultRifle,Ammo_RifleIntermediate_Incendiary,Ammo_RifleIntermediate_Incendiary,Ammo_RifleIntermediate_Incendiary,Gun_AssaultRifle,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
 			</value>
-		</generic>
+		</match>
 	</Operation>
 
-	<Operation Class="CombatExtended.PatchOperation_ConditionalGeneric">
-		<standard Class="PatchOperationReplace">
+	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
+		<settingName>genericammo</settingName>
+		<nomatch Class="PatchOperationReplace">
 			<xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultF"]/layouts/li[1]/li[35]</xpath>
 			<value>
 				<li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Ammo_556x45mmNATO_Incendiary,Gun_AssaultRifle,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
 			</value>
-		</standard>
-		<generic Class="PatchOperationReplace">
+		</nomatch>
+		<match Class="PatchOperationReplace">
 			<xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultF"]/layouts/li[1]/li[35]</xpath>
 			<value>
 				<li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Ammo_RifleIntermediate_Incendiary,Gun_AssaultRifle,Ammo_RifleIntermediate_Incendiary,Ammo_RifleIntermediate_Incendiary,Ammo_RifleIntermediate_Incendiary,Ammo_RifleIntermediate_Incendiary,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
 			</value>
-		</generic>
+		</match>
 	</Operation>
 
-	<Operation Class="CombatExtended.PatchOperation_ConditionalGeneric">
-		<standard Class="PatchOperationReplace">
+	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
+		<settingName>genericammo</settingName>
+		<nomatch Class="PatchOperationReplace">
 			<xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultG"]/layouts/li[1]/li[23]</xpath>
 			<value>
 				<li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,MealSurvivalPack,MealSurvivalPack,.,.,.,.,.,.,.,.,.,.,.,.,.,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,Ammo_12Gauge_Buck,Gun_ChainShotgun,Ammo_12Gauge_Buck,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
 			</value>
-		</standard>
-		<generic Class="PatchOperationReplace">
+		</nomatch>
+		<match Class="PatchOperationReplace">
 			<xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultG"]/layouts/li[1]/li[23]</xpath>
 			<value>
 				<li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,MealSurvivalPack,MealSurvivalPack,.,.,.,.,.,.,.,.,.,.,.,.,.,Ammo_RifleIntermediate_Incendiary,Ammo_RifleIntermediate_Incendiary,Ammo_Shotgun_Buck,Gun_ChainShotgun,Ammo_Shotgun_Buck,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
 			</value>
-		</generic>
+		</match>
 	</Operation>
 
-	<Operation Class="CombatExtended.PatchOperation_ConditionalGeneric">
-		<standard Class="PatchOperationReplace">
+	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
+		<settingName>genericammo</settingName>
+		<nomatch Class="PatchOperationReplace">
 			<xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultH"]/layouts/li[1]/li[31]</xpath>
 			<value>
 				<li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Ammo_762x51mmNATO_Incendiary,Ammo_762x54mmR_HE,Ammo_762x54mmR_HE,Gun_LMG,Ammo_45ACP_AP,Gun_Minigun,Gun_Autopistol,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
 			</value>
-		</standard>
-		<generic Class="PatchOperationReplace">
+		</nomatch>
+		<match Class="PatchOperationReplace">
 			<xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultH"]/layouts/li[1]/li[31]</xpath>
 			<value>
 				<li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Ammo_Rifle_Incendiary,Ammo_Rifle_HE,Ammo_Rifle_HE,Gun_LMG,Ammo_Pistol_AP,Gun_Minigun,Gun_Autopistol,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
 			</value>
-		</generic>
+		</match>
 	</Operation>
 
-	<Operation Class="CombatExtended.PatchOperation_ConditionalGeneric">
-		<standard Class="PatchOperationReplace">
+	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
+		<settingName>genericammo</settingName>
+		<nomatch Class="PatchOperationReplace">
 			<xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultH"]/layouts/li[1]/li[35]</xpath>
 			<value>
 				<li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,MealSurvivalPack,Ammo_762x51mmNATO_Incendiary,Ammo_762x51mmNATO_Incendiary,Ammo_762x51mmNATO_Incendiary,Ammo_762x51mmNATO_Incendiary,.,.,.,.,.,MealSurvivalPack,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Ammo_45ACP_AP,Ammo_45ACP_AP,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,Apparel_PowerArmor,Gun_Autopistol,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
 			</value>
-		</standard>
-		<generic Class="PatchOperationReplace">
+		</nomatch>
+		<match Class="PatchOperationReplace">
 			<xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultH"]/layouts/li[1]/li[35]</xpath>
 			<value>
 				<li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,MealSurvivalPack,Ammo_Rifle_Incendiary,Ammo_Rifle_Incendiary,Ammo_Rifle_Incendiary,Ammo_Rifle_Incendiary,.,.,.,.,.,MealSurvivalPack,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Ammo_Pistol_AP,Ammo_Pistol_AP,Ammo_RifleIntermediate_Incendiary,Ammo_RifleIntermediate_Incendiary,Apparel_PowerArmor,Gun_Autopistol,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
 			</value>
-		</generic>
+		</match>
 	</Operation>
 
-	<Operation Class="CombatExtended.PatchOperation_ConditionalGeneric">
-		<standard Class="PatchOperationReplace">
+	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
+		<settingName>genericammo</settingName>
+		<nomatch Class="PatchOperationReplace">
 			<xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultI"]/layouts/li[1]/li[19]</xpath>
 			<value>
 				<li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,Gun_ChargeRifle,Ammo_6x24mmCharged,Ammo_6x24mmCharged,Gun_HeavySMG,Ammo_45ACP_AP,Ammo_45ACP_AP,Apparel_PowerArmorHelmet,Ammo_556x45mmNATO_Incendiary,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
 			</value>
-		</standard>
-		<generic Class="PatchOperationReplace">
+		</nomatch>
+		<match Class="PatchOperationReplace">
 			<xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultI"]/layouts/li[1]/li[19]</xpath>
 			<value>
 				<li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Ammo_RifleIntermediate_Incendiary,Ammo_RifleIntermediate_Incendiary,Gun_ChargeRifle,Ammo_RifleCharged,Ammo_RifleCharged,Gun_HeavySMG,Ammo_Pistol_AP,Ammo_Pistol_AP,Apparel_PowerArmorHelmet,Ammo_RifleIntermediate_Incendiary,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
 			</value>
-		</generic>
+		</match>
 	</Operation>
 
-	<Operation Class="CombatExtended.PatchOperation_ConditionalGeneric">
-		<standard Class="PatchOperationReplace">
+	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
+		<settingName>genericammo</settingName>
+		<nomatch Class="PatchOperationReplace">
 			<xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultJ"]/layouts/li[1]/li[35]</xpath>
 			<value>
 				<li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Gun_MachinePistol,Ammo_45ACP_AP,Apparel_PowerArmorHelmet,Ammo_45ACP_AP,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
 			</value>
-		</standard>
-		<generic Class="PatchOperationReplace">
+		</nomatch>
+		<match Class="PatchOperationReplace">
 			<xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultJ"]/layouts/li[1]/li[35]</xpath>
 			<value>
 				<li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Gun_MachinePistol,Ammo_Pistol_AP,Apparel_PowerArmorHelmet,Ammo_Pistol_AP,Ammo_RifleIntermediate_Incendiary,Ammo_RifleIntermediate_Incendiary,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
 			</value>
-		</generic>
+		</match>
 	</Operation>
 
-	<Operation Class="CombatExtended.PatchOperation_ConditionalGeneric">
-		<standard Class="PatchOperationReplace">
+	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
+		<settingName>genericammo</settingName>
+		<nomatch Class="PatchOperationReplace">
 			<xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultJ"]/layouts/li[1]/li[36]</xpath>
 			<value>
 				<li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Ammo_762x54mmR_HE,Gun_LMG,Ammo_762x54mmR_HE,Apparel_PowerArmor,Ammo_556x45mmNATO_Incendiary,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
 			</value>
-		</standard>
-		<generic Class="PatchOperationReplace">
+		</nomatch>
+		<match Class="PatchOperationReplace">
 			<xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultJ"]/layouts/li[1]/li[36]</xpath>
 			<value>
 				<li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Ammo_Rifle_HE,Gun_LMG,Ammo_Rifle_HE,Apparel_PowerArmor,Ammo_RifleIntermediate_Incendiary,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
 			</value>
-		</generic>
+		</match>
 	</Operation>
 
-	<Operation Class="CombatExtended.PatchOperation_ConditionalGeneric">
-		<standard Class="PatchOperationReplace">
+	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
+		<settingName>genericammo</settingName>
+		<nomatch Class="PatchOperationReplace">
 			<xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultJ"]/layouts/li[1]/li[36]</xpath>
 			<value>
 				<li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Ammo_556x45mmNATO_Incendiary,Gun_MachinePistol,Ammo_45ACP_AP,Ammo_45ACP_AP,Ammo_762x54mmR_HE,Gun_LMG,Ammo_762x54mmR_HE,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
 			</value>
-		</standard>
-		<generic Class="PatchOperationReplace">
+		</nomatch>
+		<match Class="PatchOperationReplace">
 			<xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultJ"]/layouts/li[1]/li[36]</xpath>
 			<value>
 				<li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Ammo_RifleIntermediate_Incendiary,Gun_MachinePistol,Ammo_Pistol_AP,Ammo_Pistol_AP,Ammo_Rifle_HE,Gun_LMG,Ammo_Rifle_HE,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
 			</value>
-		</generic>
+		</match>
 	</Operation>
 
 </Patch>

--- a/ModPatches/Vanilla Factions Expanded - Deserters/Patches/Vanilla Factions Expanded - Deserters/Contraband.xml
+++ b/ModPatches/Vanilla Factions Expanded - Deserters/Patches/Vanilla Factions Expanded - Deserters/Contraband.xml
@@ -4,7 +4,7 @@
 	<!-- Allow ammo for Empire/Deserter weapons to be purchased using intel. -->
 
 	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
-		<settingName>genericammo</settingName>
+		<settingName>genericAmmo</settingName>
 		<nomatch Class="PatchOperationAddModExtension">
 			<xpath>Defs/ThingDef[defName="Ammo_6x24mmCharged"]</xpath>
 			<value>
@@ -30,7 +30,7 @@
 	</Operation>
 
 	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
-		<settingName>genericammo</settingName>
+		<settingName>genericAmmo</settingName>
 		<nomatch Class="PatchOperationAddModExtension">
 			<xpath>Defs/ThingDef[defName="Ammo_6x24mmCharged_AP"]</xpath>
 			<value>
@@ -56,7 +56,7 @@
 	</Operation>
 
 	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
-		<settingName>genericammo</settingName>
+		<settingName>genericAmmo</settingName>
 		<nomatch Class="PatchOperationAddModExtension">
 			<xpath>Defs/ThingDef[defName="Ammo_6x24mmCharged_Ion"]</xpath>
 			<value>
@@ -100,7 +100,7 @@
 	</Operation>
 
 	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
-		<settingName>genericammo</settingName>
+		<settingName>genericAmmo</settingName>
 		<nomatch Class="PatchOperationAddModExtension">
 			<xpath>Defs/ThingDef[defName="Ammo_8x50mmCharged"]</xpath>
 			<value>
@@ -115,7 +115,7 @@
 	</Operation>
 
 	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
-		<settingName>genericammo</settingName>
+		<settingName>genericAmmo</settingName>
 		<nomatch Class="PatchOperationAddModExtension">
 			<xpath>Defs/ThingDef[defName="Ammo_8x50mmCharged_AP"]</xpath>
 			<value>
@@ -130,7 +130,7 @@
 	</Operation>
 
 	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
-		<settingName>genericammo</settingName>
+		<settingName>genericAmmo</settingName>
 		<nomatch Class="PatchOperationAddModExtension">
 			<xpath>Defs/ThingDef[defName="Ammo_8x50mmCharged_Ion"]</xpath>
 			<value>

--- a/ModPatches/Vanilla Factions Expanded - Deserters/Patches/Vanilla Factions Expanded - Deserters/Contraband.xml
+++ b/ModPatches/Vanilla Factions Expanded - Deserters/Patches/Vanilla Factions Expanded - Deserters/Contraband.xml
@@ -3,8 +3,9 @@
 
 	<!-- Allow ammo for Empire/Deserter weapons to be purchased using intel. -->
 
-	<Operation Class="CombatExtended.PatchOperation_ConditionalGeneric">
-		<standard Class="PatchOperationAddModExtension">
+	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
+		<settingName>genericammo</settingName>
+		<nomatch Class="PatchOperationAddModExtension">
 			<xpath>Defs/ThingDef[defName="Ammo_6x24mmCharged"]</xpath>
 			<value>
 				<li Class="VFED.ContrabandExtension">
@@ -14,8 +15,8 @@
 					<countMult>100</countMult>
 				</li>
 			</value>
-		</standard>
-		<generic Class="PatchOperationAddModExtension">
+		</nomatch>
+		<match Class="PatchOperationAddModExtension">
 			<xpath>Defs/ThingDef[defName="Ammo_RifleCharged"]</xpath>
 			<value>
 				<li Class="VFED.ContrabandExtension">
@@ -25,11 +26,12 @@
 					<countMult>100</countMult>
 				</li>
 			</value>
-		</generic>
+		</match>
 	</Operation>
 
-	<Operation Class="CombatExtended.PatchOperation_ConditionalGeneric">
-		<standard Class="PatchOperationAddModExtension">
+	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
+		<settingName>genericammo</settingName>
+		<nomatch Class="PatchOperationAddModExtension">
 			<xpath>Defs/ThingDef[defName="Ammo_6x24mmCharged_AP"]</xpath>
 			<value>
 				<li Class="VFED.ContrabandExtension">
@@ -39,8 +41,8 @@
 					<countMult>100</countMult>
 				</li>
 			</value>
-		</standard>
-		<generic Class="PatchOperationAddModExtension">
+		</nomatch>
+		<match Class="PatchOperationAddModExtension">
 			<xpath>Defs/ThingDef[defName="Ammo_RifleCharged_AP"]</xpath>
 			<value>
 				<li Class="VFED.ContrabandExtension">
@@ -50,11 +52,12 @@
 					<countMult>100</countMult>
 				</li>
 			</value>
-		</generic>
+		</match>
 	</Operation>
 
-	<Operation Class="CombatExtended.PatchOperation_ConditionalGeneric">
-		<standard Class="PatchOperationAddModExtension">
+	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
+		<settingName>genericammo</settingName>
+		<nomatch Class="PatchOperationAddModExtension">
 			<xpath>Defs/ThingDef[defName="Ammo_6x24mmCharged_Ion"]</xpath>
 			<value>
 				<li Class="VFED.ContrabandExtension">
@@ -64,8 +67,8 @@
 					<countMult>100</countMult>
 				</li>
 			</value>
-		</standard>
-		<generic Class="PatchOperationAddModExtension">
+		</nomatch>
+		<match Class="PatchOperationAddModExtension">
 			<xpath>Defs/ThingDef[defName="Ammo_RifleCharged_Ion"]</xpath>
 			<value>
 				<li Class="VFED.ContrabandExtension">
@@ -75,7 +78,7 @@
 					<countMult>100</countMult>
 				</li>
 			</value>
-		</generic>
+		</match>
 	</Operation>
 
 	<!-- Combat Extended: Guns -->
@@ -96,8 +99,9 @@
 		</match>
 	</Operation>
 
-	<Operation Class="CombatExtended.PatchOperation_ConditionalGeneric">
-		<standard Class="PatchOperationAddModExtension">
+	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
+		<settingName>genericammo</settingName>
+		<nomatch Class="PatchOperationAddModExtension">
 			<xpath>Defs/ThingDef[defName="Ammo_8x50mmCharged"]</xpath>
 			<value>
 				<li Class="VFED.ContrabandExtension">
@@ -107,11 +111,12 @@
 					<countMult>100</countMult>
 				</li>
 			</value>
-		</standard>
+		</nomatch>
 	</Operation>
 
-	<Operation Class="CombatExtended.PatchOperation_ConditionalGeneric">
-		<standard Class="PatchOperationAddModExtension">
+	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
+		<settingName>genericammo</settingName>
+		<nomatch Class="PatchOperationAddModExtension">
 			<xpath>Defs/ThingDef[defName="Ammo_8x50mmCharged_AP"]</xpath>
 			<value>
 				<li Class="VFED.ContrabandExtension">
@@ -121,11 +126,12 @@
 					<countMult>100</countMult>
 				</li>
 			</value>
-		</standard>
+		</nomatch>
 	</Operation>
 
-	<Operation Class="CombatExtended.PatchOperation_ConditionalGeneric">
-		<standard Class="PatchOperationAddModExtension">
+	<Operation Class="CombatExtended.PatchOperationSettingsConditional">
+		<settingName>genericammo</settingName>
+		<nomatch Class="PatchOperationAddModExtension">
 			<xpath>Defs/ThingDef[defName="Ammo_8x50mmCharged_Ion"]</xpath>
 			<value>
 				<li Class="VFED.ContrabandExtension">
@@ -135,7 +141,7 @@
 					<countMult>100</countMult>
 				</li>
 			</value>
-		</standard>
+		</nomatch>
 	</Operation>
 
 	<!-- Remove Charge Lance from available contraband. -->

--- a/Source/CombatExtended/CombatExtended/ModSettings/Settings.cs
+++ b/Source/CombatExtended/CombatExtended/ModSettings/Settings.cs
@@ -23,7 +23,7 @@ public class Settings : ModSettings, ISettingsCE
     private bool turretsBreakShields = true;
     private bool showBackpacks = true;
     private bool showTacticalVests = true;
-    private bool genericammo = false;
+    private bool genericAmmo = false;
     private bool partialstats = true;
     private bool enableExtraEffects = true;
 
@@ -60,7 +60,7 @@ public class Settings : ModSettings, ISettingsCE
 
     public bool BipodMechanics => bipodMechanics;
 
-    public bool GenericAmmo => genericammo;
+    public bool GenericAmmo => genericAmmo;
     public bool AutoSetUp => autosetup;
     public bool ShowTaunts => showTaunts;
     public bool AllowMeleeHunting => allowMeleeHunting;
@@ -251,7 +251,7 @@ public class Settings : ModSettings, ISettingsCE
         Scribe_Values.Look(ref forbiddenNeolithicProjectiles, "forbiddenNeolithicProjectiles", true);
         Scribe_Values.Look(ref realisticCookOff, "realisticCookOff", true);
         Scribe_Values.Look(ref stuckArrowsAsFlecks, "stuckArrowsAsFlecks", true);
-        Scribe_Values.Look(ref genericammo, "genericAmmo", false);
+        Scribe_Values.Look(ref genericAmmo, "genericAmmo", false);
 
         Scribe_Values.Look(ref ShowTutorialPopup, "ShowTutorialPopup", true);
 
@@ -385,7 +385,7 @@ public class Settings : ModSettings, ISettingsCE
                 list.CheckboxLabeled("CE_Settings_ForbiddenNeolithicProjectiles_Title".Translate(), ref forbiddenNeolithicProjectiles, "CE_Settings_ForbiddenNeolithicProjectiles_Desc".Translate());
             }
             list.CheckboxLabeled("CE_Settings_RealisticCookOff_Title".Translate(), ref realisticCookOff, "CE_Settings_RealisticCookOff_Desc".Translate());
-            list.CheckboxLabeled("CE_Settings_GenericAmmo".Translate(), ref genericammo, "CE_Settings_GenericAmmo_Desc".Translate());
+            list.CheckboxLabeled("CE_Settings_GenericAmmo".Translate(), ref genericAmmo, "CE_Settings_GenericAmmo_Desc".Translate());
         }
         else
         {
@@ -557,7 +557,7 @@ public class Settings : ModSettings, ISettingsCE
         reuseNeolithicProjectiles = true;
         forbiddenNeolithicProjectiles = true;
         realisticCookOff = true;
-        genericammo = false;
+        genericAmmo = false;
         LastAmmoSystemStatusChanged();
 
     }

--- a/Source/CombatExtended/CombatExtended/PatchOperationSettingsConditional.cs
+++ b/Source/CombatExtended/CombatExtended/PatchOperationSettingsConditional.cs
@@ -24,7 +24,7 @@ public class PatchOperationSettingsConditional : PatchOperation
             Log.Error($"[Combat Extended] Setting field named {settingName} is not a bool");
             return false;
         }
-        
+
         if ((bool)settingRef.GetValue(Controller.settings)) //1-to-1 copy of vanilla conditional patch op
         {
             if (match != null)

--- a/Source/CombatExtended/CombatExtended/PatchOperationSettingsConditional.cs
+++ b/Source/CombatExtended/CombatExtended/PatchOperationSettingsConditional.cs
@@ -1,0 +1,45 @@
+﻿using System.Xml;
+using HarmonyLib;
+using Verse;
+
+namespace CombatExtended;
+
+public class PatchOperationSettingsConditional : PatchOperation
+{
+    public PatchOperation match;
+    public PatchOperation nomatch;
+    public string settingName;
+
+    public override bool ApplyWorker(XmlDocument xml)
+    {
+        var settingRef = AccessTools.Field(typeof(Settings), settingName);
+        if (settingRef == null)
+        {
+            Log.Error($"[Combat Extended] Cannot find the settings field named {settingName}");
+            return false;
+        }
+
+        if (settingRef.FieldType != typeof(bool))
+        {
+            Log.Error($"[Combat Extended] Setting field named {settingName} is not a bool");
+            return false;
+        }
+        
+        if ((bool)settingRef.GetValue(Controller.settings)) //1-to-1 copy of vanilla conditional patch op
+        {
+            if (match != null)
+            {
+                return match.Apply(xml);
+            }
+        }
+        else if (nomatch != null)
+        {
+            return nomatch.Apply(xml);
+        }
+        if (match == null)
+        {
+            return nomatch != null;
+        }
+        return true;
+    }
+}

--- a/Source/CombatExtended/CombatExtended/PatchOperation_ConditionalGeneric.cs
+++ b/Source/CombatExtended/CombatExtended/PatchOperation_ConditionalGeneric.cs
@@ -1,7 +1,9 @@
-﻿using System.Xml;
+﻿using System;
+using System.Xml;
 using Verse;
 
 namespace CombatExtended;
+[Obsolete("ConditionalGeneric patch op has been deprecated in favor of PatchOperationSettingsConditional", false)]
 public class PatchOperation_ConditionalGeneric : PatchOperation
 {
     public PatchOperation standard;
@@ -22,5 +24,11 @@ public class PatchOperation_ConditionalGeneric : PatchOperation
         }
 
         return true;
+    }
+
+    public override void Complete(string modIdentifier)
+    {
+        base.Complete(modIdentifier);
+        Log.WarningOnce($"[{modIdentifier}] PatchOperation_ConditionalGeneric has been deprecated in favor of PatchOperationSettingsConditional and will be removed in a future version", modIdentifier.GetHashCode());
     }
 }


### PR DESCRIPTION
## Additions

- Added `PatchOperationSettingsConditional`, a conditional patch op that can be keyed off any settings bool.

## Changes

- Migrated previous generic conditional ops to the new one.
- Marked the generic ammo patch op as obsolete and added a deprecation warning to it.

## Reasoning

- Between previous requests to add a "no ammo" conditional patch op and the need for another conditional to trigger weapon renaming, it felt easier to just have a universal settings-based conditional instead.

## Alternatives

- Keep making bespoke patch op classes.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
