### PR TITLE
EMP patch for VQEA gene

### DIFF
--- a/ModPatches/Vanilla Quests Expanded - Ancients/Patches/Vanilla Quests Expanded - Ancients/Genes/GeneDefs_Ancients.xml
+++ b/ModPatches/Vanilla Quests Expanded - Ancients/Patches/Vanilla Quests Expanded - Ancients/Genes/GeneDefs_Ancients.xml
@@ -131,10 +131,21 @@
 			<CarryWeight>1.5</CarryWeight>
 		</value>
 	</Operation>
-	
+
+	<!-- ========== electromagnetized ========== -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/GeneDef[defName="VQEA_Electromagnetized"]</xpath>
+		<value>
+			<damageFactors>
+				<EMP>0</EMP>
+			</damageFactors>
+		</value>
+	</Operation>
+
 	<!-- ========== Hellsphere Blast ========== -->
 	<!-- This one is mostly identical to the hellsphere cannon's blast from base Biotech. That one works as-is without a patch replacing the verb, so I've done the same here -->
-	
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/AbilityDef[defName="VQEA_HellsphereBlast"]/verbProperties/range</xpath>
 		<value>

--- a/ModPatches/Vanilla Quests Expanded - Ancients/Patches/Vanilla Quests Expanded - Ancients/Genes/GeneDefs_Ancients.xml
+++ b/ModPatches/Vanilla Quests Expanded - Ancients/Patches/Vanilla Quests Expanded - Ancients/Genes/GeneDefs_Ancients.xml
@@ -132,7 +132,7 @@
 		</value>
 	</Operation>
 
-	<!-- ========== electromagnetized ========== -->
+	<!-- ========== Electromagnetized ========== -->
 
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/GeneDef[defName="VQEA_Electromagnetized"]</xpath>
@@ -152,4 +152,5 @@
 			<range>23.9</range>
 		</value>
 	</Operation>
+
 </Patch>


### PR DESCRIPTION
## Additions
patch electromagnetized gene so it flat immue to emp damage, match vanilla behavior 
## Changes
non
## References
patch chat
## Reasoning
Vanilla EMP doesn't damage non mechs pawns, only pawns with implants will get effected by emp, so VE emp immune is just immune to brain shock, to match the intent this patch update makes the gene give immunity to emp damage, since in CE they do damage
## Alternatives
100% electric armor, but that will also block all electric based damages
## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
