### PR TITLE
fix flamethrower ammo not detonating when on fire

### DIFF
--- a/Defs/Ammo/Other/Flamethrower.xml
+++ b/Defs/Ammo/Other/Flamethrower.xml
@@ -58,6 +58,7 @@
 				<preExplosionSpawnChance>1</preExplosionSpawnChance>
 			</li>
 		</comps>
+		<detonateProjectile>Bullet_Flamethrower_Napalm</detonateProjectile>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="FlamethrowerBase">
@@ -78,6 +79,7 @@
 				<preExplosionSpawnChance>1</preExplosionSpawnChance>
 			</li>
 		</comps>
+		<detonateProjectile>Bullet_Flamethrower_Prometheum</detonateProjectile>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="FlamethrowerBase" MayRequire="Ludeon.Rimworld.Anomaly">
@@ -99,6 +101,7 @@
 				<preExplosionSpawnChance>1</preExplosionSpawnChance>
 			</li>
 		</comps>
+		<detonateProjectile>Bullet_Flamethrower_Bioferrite</detonateProjectile>
 	</ThingDef>
 
 	<!-- ================== Projectiles ================== -->


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Fixes flamer ammo not exploding when its stack is set on fire / hit by explosions

## Reasoning

Why did you choose to implement things this way, e.g.
- Seems weird that it doesnt do that

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
