### PR TITLE
Added misisng nullcheck

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_GlobalControls.cs
+++ b/Source/CombatExtended/Harmony/Harmony_GlobalControls.cs
@@ -20,7 +20,7 @@ internal static class Harmony_GlobalControls
         if (cachedMap != Find.CurrentMap)
         {
             cachedMap = Find.CurrentMap;
-            weatherTracker = cachedMap.GetComponent<WeatherTracker>();
+            weatherTracker = cachedMap?.GetComponent<WeatherTracker>();
         }
 
         weatherTracker?.DoWindGUI(offsetXFromOriginalMethod + magicExtraOffset, ref curBaseY);


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Added missing null check to prevent trying to get components from a null map

## References

What happens without the null check
```
Root level exception in OnGUI(): System.NullReferenceException: Object reference not set to an instance of an object
[Ref 20C92DC]
  at CombatExtended.HarmonyCE.Harmony_GlobalControls.Postfix (System.Single& curBaseY) [0x0002c] in C:\Program Files (x86)\Steam\steamapps\common\RimWorld\Mods\CombatExtended\Source\CombatExtended\Harmony\Harmony_GlobalControls.cs:23 
  at RimWorld.GlobalControlsUtility.DoDate (System.Single leftX, System.Single width, System.Single& curBaseY) [0x0002d] in <46372f5dadbf4af8939e608076251180>:0 
    - POSTFIX CombatExtended.HarmonyCE: Void CombatExtended.HarmonyCE.Harmony_GlobalControls:Postfix(Single& curBaseY)
  at RimWorld.Planet.WorldGlobalControls.WorldGlobalControlsOnGUI () [0x0007e] in <46372f5dadbf4af8939e608076251180>:0 
  at RimWorld.WorldInterface.WorldInterfaceOnGUI () [0x000b2] in <46372f5dadbf4af8939e608076251180>:0 
    - POSTFIX CombatExtended.HarmonyCE: Void CombatExtended.HarmonyCE.Harmony_WorldInterface+Harmony_WorldInterface_WorldInterfaceOnGUI:Postfix()
  at RimWorld.UIRoot_Play.UIRootOnGUI () [0x0001a] in <46372f5dadbf4af8939e608076251180>:0 
    - PREFIX Dubwise.PerformanceAnalyzer: Void Analyzer.H_KeyPresses:OnGUI()
    - POSTFIX VR.MissileGirl: Void MissileGirl.KeyBinder:OnGUI()
  at Verse.Root.OnGUI () [0x00040] in <46372f5dadbf4af8939e608076251180>:0 
Root level exception in OnGUI(): System.NullReferenceException: Object reference not set to an instance of an object
[Ref 35B0B94B]
  at CombatExtended.WeatherTracker.get_WindStrength () [0x00000] in C:\Program Files (x86)\Steam\steamapps\common\RimWorld\Mods\CombatExtended\Source\CombatExtended\CombatExtended\WeatherTracker.cs:27 
  at CombatExtended.WeatherTracker.get_BeaufortScale () [0x00000] in C:\Program Files (x86)\Steam\steamapps\common\RimWorld\Mods\CombatExtended\Source\CombatExtended\CombatExtended\WeatherTracker.cs:28 
  at CombatExtended.WeatherTracker.get_WindStrengthText () [0x00000] in C:\Program Files (x86)\Steam\steamapps\common\RimWorld\Mods\CombatExtended\Source\CombatExtended\CombatExtended\WeatherTracker.cs:30 
  at CombatExtended.WeatherTracker.DoWindGUI (System.Single xPos, System.Single& yPos) [0x00047] in C:\Program Files (x86)\Steam\steamapps\common\RimWorld\Mods\CombatExtended\Source\CombatExtended\CombatExtended\WeatherTracker.cs:104 
  at CombatExtended.HarmonyCE.Harmony_GlobalControls.Postfix (System.Single& curBaseY) [0x0003c] in C:\Program Files (x86)\Steam\steamapps\common\RimWorld\Mods\CombatExtended\Source\CombatExtended\Harmony\Harmony_GlobalControls.cs:26 
  at RimWorld.GlobalControlsUtility.DoDate (System.Single leftX, System.Single width, System.Single& curBaseY) [0x0002d] in <46372f5dadbf4af8939e608076251180>:0 
    - POSTFIX CombatExtended.HarmonyCE: Void CombatExtended.HarmonyCE.Harmony_GlobalControls:Postfix(Single& curBaseY)
  at RimWorld.Planet.WorldGlobalControls.WorldGlobalControlsOnGUI () [0x0007e] in <46372f5dadbf4af8939e608076251180>:0 
  at RimWorld.WorldInterface.WorldInterfaceOnGUI () [0x000b2] in <46372f5dadbf4af8939e608076251180>:0 
    - POSTFIX CombatExtended.HarmonyCE: Void CombatExtended.HarmonyCE.Harmony_WorldInterface+Harmony_WorldInterface_WorldInterfaceOnGUI:Postfix()
  at RimWorld.UIRoot_Play.UIRootOnGUI () [0x0001a] in <46372f5dadbf4af8939e608076251180>:0 
    - PREFIX Dubwise.PerformanceAnalyzer: Void Analyzer.H_KeyPresses:OnGUI()
    - POSTFIX VR.MissileGirl: Void MissileGirl.KeyBinder:OnGUI()
  at Verse.Root.OnGUI () [0x00040] in <46372f5dadbf4af8939e608076251180>:0 
  ```

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
