### PR TITLE
105mm empsound

### DIFF
--- a/Defs/Ammo/Shell/105mmHowitzer.xml
+++ b/Defs/Ammo/Shell/105mmHowitzer.xml
@@ -390,6 +390,7 @@
 			<armorPenetrationSharp>0</armorPenetrationSharp>
 			<armorPenetrationBlunt>0</armorPenetrationBlunt>
 			<explosionRadius>6.5</explosionRadius>
+			<soundExplode>Explosion_EMP</soundExplode>
 		</projectile>
 	</ThingDef>
 


### PR DESCRIPTION
## Additions
none
## Changes
so 105mm shells use emp boom sounds
## References
bug chat
## Reasoning
imo it should use
## Alternatives
leave it as is
## Testing
draft cause likely more ammo have the same problem
Check tests you have performed:
- [x] Compiles without warnings 
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
