### PR TITLE
Improve Bounding boxes generation

### DIFF
--- a/Source/CombatExtended/CombatExtended/BoundsInjector.cs
+++ b/Source/CombatExtended/CombatExtended/BoundsInjector.cs
@@ -1,12 +1,9 @@
 ﻿using System;
-using System.Reflection;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using RimWorld;
 using Verse;
-using Verse.AI;
-using Verse.Sound;
 using UnityEngine;
 
 namespace CombatExtended;
@@ -18,7 +15,7 @@ public static class BoundsInjector
         Plant
     }
 
-    private static Dictionary<string, Vector2> boundMap = new Dictionary<string, Vector2>();
+    private static ConcurrentDictionary<string, Vector2> boundMap = new ConcurrentDictionary<string, Vector2>();
 
     public static Vector2 BoundMap(Graphic graphic, GraphicType type, Graphic headGraphic, Vector2 headOffset)
     {
@@ -186,101 +183,118 @@ public static class BoundsInjector
 
     public static void Inject()
     {
-        foreach (PawnKindDef def in DefDatabase<PawnKindDef>.AllDefs.Where(x => !x.RaceProps.Humanlike))
+        List<PawnKindDef> pawnKindsToInject = [];
+        foreach (PawnKindDef pawnKindDef in DefDatabase<PawnKindDef>.AllDefs)
         {
-            for (int i = 0; i < def.lifeStages.Count; i++)
+            if (pawnKindDef.RaceProps.Humanlike)
             {
-                PawnKindLifeStage lifeStage = def.lifeStages[i];
-
-                try
-                {
-                    if (lifeStage.bodyGraphicData != null && lifeStage.bodyGraphicData.Graphic != null)
-                    {
-                        BoundMap(lifeStage.bodyGraphicData.Graphic, GraphicType.Pawn);
-                    }
-                }
-                catch (Exception e)
-                {
-                    throw new Exception(def + ".lifeStages[" + i + "].bodyGraphicData", e);
-                }
-
-                try
-                {
-                    if (lifeStage.femaleGraphicData != null && lifeStage.femaleGraphicData.Graphic != null)
-                    {
-                        BoundMap(lifeStage.femaleGraphicData.Graphic, GraphicType.Pawn);
-                    }
-                }
-                catch (Exception e)
-                {
-                    throw new Exception(def + ".lifeStages[" + i + "].femaleGraphicData", e);
-                }
-
-                try
-                {
-                    if (lifeStage.dessicatedBodyGraphicData != null && lifeStage.dessicatedBodyGraphicData.Graphic != null)
-                    {
-                        BoundMap(lifeStage.dessicatedBodyGraphicData.Graphic, GraphicType.Pawn);
-                    }
-                }
-                catch (Exception e)
-                {
-                    throw new Exception(def + ".lifeStages[" + i + "].dessicatedBodyGraphicData", e);
-                }
-
-                try
-                {
-                    if (lifeStage.femaleDessicatedBodyGraphicData != null && lifeStage.femaleDessicatedBodyGraphicData.Graphic != null)
-                    {
-                        BoundMap(lifeStage.femaleDessicatedBodyGraphicData.Graphic, GraphicType.Pawn);
-                    }
-                }
-                catch (Exception e)
-                {
-                    throw new Exception(def + ".lifeStages[" + i + "].femaleDessicatedBodyGraphicData", e);
-                }
+                pawnKindsToInject.Add(pawnKindDef);
             }
         }
-
-        foreach (ThingDef def in DefDatabase<ThingDef>.AllDefs.Where<ThingDef>(x => x.plant != null))
+        GenThreading.ParallelForEach(pawnKindsToInject, InjectPawnKinds);
+        foreach (ThingDef thingDef in DefDatabase<ThingDef>.AllDefs)
         {
-            try
+            if (thingDef.plant != null)
             {
-                if (def.graphicData != null && def.graphicData.Graphic != null)
-                {
-                    BoundMap(def.graphicData.Graphic, GraphicType.Plant);
-                }
-            }
-            catch (Exception e)
-            {
-                throw new Exception(def + ".graphicData", e);
-            }
-
-            try
-            {
-                if (def.plant.leaflessGraphic != null)
-                {
-                    BoundMap(def.plant.leaflessGraphic, GraphicType.Plant);
-                }
-            }
-            catch (Exception e)
-            {
-                throw new Exception(def + ".plant.leaflessGraphic", e);
-            }
-
-            try
-            {
-                if (def.plant.immatureGraphic != null)
-                {
-                    BoundMap(def.plant.immatureGraphic, GraphicType.Plant);
-                }
-            }
-            catch (Exception e)
-            {
-                throw new Exception(def + ".plant.immatureGraphic", e);
+                InjectPlants(thingDef);
             }
         }
+        Log.Message("Combat Extended :: Bounds pre-generated");
+    }
 
+    private static void InjectPawnKinds(PawnKindDef pawnKindDef)
+    {
+        for (int i = 0; i < pawnKindDef.lifeStages.Count; i++)
+        {
+            PawnKindLifeStage lifeStage = pawnKindDef.lifeStages[i];
+
+            try
+            {
+                if (lifeStage.bodyGraphicData != null && lifeStage.bodyGraphicData.Graphic != null)
+                {
+                    BoundMap(lifeStage.bodyGraphicData.Graphic, GraphicType.Pawn);
+                }
+            }
+            catch (Exception e)
+            {
+                throw new Exception(pawnKindDef + ".lifeStages[" + i + "].bodyGraphicData", e);
+            }
+
+            try
+            {
+                if (lifeStage.femaleGraphicData != null && lifeStage.femaleGraphicData.Graphic != null)
+                {
+                    BoundMap(lifeStage.femaleGraphicData.Graphic, GraphicType.Pawn);
+                }
+            }
+            catch (Exception e)
+            {
+                throw new Exception(pawnKindDef + ".lifeStages[" + i + "].femaleGraphicData", e);
+            }
+
+            try
+            {
+                if (lifeStage.dessicatedBodyGraphicData != null && lifeStage.dessicatedBodyGraphicData.Graphic != null)
+                {
+                    BoundMap(lifeStage.dessicatedBodyGraphicData.Graphic, GraphicType.Pawn);
+                }
+            }
+            catch (Exception e)
+            {
+                throw new Exception(pawnKindDef + ".lifeStages[" + i + "].dessicatedBodyGraphicData", e);
+            }
+
+            try
+            {
+                if (lifeStage.femaleDessicatedBodyGraphicData != null && lifeStage.femaleDessicatedBodyGraphicData.Graphic != null)
+                {
+                    BoundMap(lifeStage.femaleDessicatedBodyGraphicData.Graphic, GraphicType.Pawn);
+                }
+            }
+            catch (Exception e)
+            {
+                throw new Exception(pawnKindDef + ".lifeStages[" + i + "].femaleDessicatedBodyGraphicData", e);
+            }
+        }
+    }
+
+    private static void InjectPlants(ThingDef plantDef)
+    {
+        try
+        {
+            if (plantDef.graphicData != null && plantDef.graphicData.Graphic != null)
+            {
+                BoundMap(plantDef.graphicData.Graphic, GraphicType.Plant);
+            }
+        }
+        catch (Exception e)
+        {
+            throw new Exception(plantDef + ".graphicData", e);
+        }
+
+        try
+        {
+            if (plantDef.plant.leaflessGraphic != null)
+            {
+                BoundMap(plantDef.plant.leaflessGraphic, GraphicType.Plant);
+            }
+        }
+        catch (Exception e)
+        {
+            throw new Exception(plantDef + ".plant.leaflessGraphic", e);
+        }
+
+        try
+        {
+            if (plantDef.plant.immatureGraphic != null)
+            {
+                BoundMap(plantDef.plant.immatureGraphic, GraphicType.Plant);
+            }
+        }
+        catch (Exception e)
+        {
+            throw new Exception(plantDef + ".plant.immatureGraphic", e);
+        }
         Graphic graphicSowing = Plant.GraphicSowing;
 
         try
@@ -294,8 +308,6 @@ public static class BoundsInjector
         {
             throw new Exception("GraphicSowing", e);
         }
-
-        Log.Message("Combat Extended :: Bounds pre-generated");
     }
 
     public static Vector2 ForPawn(Pawn pawn)
@@ -411,28 +423,4 @@ public static class BoundsInjector
         return plant.def.plant.visualSizeRange.LerpThroughRange(plant.Growth) * BoundMap(plant.Graphic, GraphicType.Plant);
     }
 
-    /*public static void LogDatabase()
-    {
-        var str = new StringBuilder();
-
-        str.AppendLine("PAWNS");
-
-        foreach (PawnKindDef kindDef in DefDatabase<PawnKindDef>.AllDefs.Where(x => !x.race.race.Humanlike))
-        {
-            str.AppendLine(kindDef.ToString() + ", " + kindDef.race.race.baseBodySize +", " + String.Join(", ", boundMap[kindDef.defName].dict.Select(x => x.Key+"="+x.Value.First+","+x.Key+"="+x.Value.Second).ToArray()));
-        }
-
-        str.AppendLine();
-        str.AppendLine("PLANTS");
-
-        //Fire is dummy name for a sowing plant's texture
-        str.AppendLine("Sowing Plant, " + String.Join(", ", boundMap[ThingDefOf.Fire.defName].dict.Select(x => x.Key+"="+x.Value.First+","+x.Key+"="+x.Value.Second).ToArray()));
-
-        foreach (ThingDef plantDef in DefDatabase<ThingDef>.AllDefs.Where(x => x.plant != null))
-        {
-            str.AppendLine(plantDef.ToString() + ", " + plantDef.fillPercent + ", " +plantDef.plant.visualSizeRange.ToString() +", " + String.Join(", ", boundMap[plantDef.defName].dict.Select(x => x.Key+"="+x.Value.First+","+x.Value.Second).ToArray()));
-        }
-
-        Log.Message(str.ToString());
-    }*/
 }

--- a/Source/CombatExtended/CombatExtended/BoundsInjector.cs
+++ b/Source/CombatExtended/CombatExtended/BoundsInjector.cs
@@ -72,7 +72,7 @@ public static class BoundsInjector
         // TODO : Refactor
         if (type == GraphicType.Plant)
         {
-            return new Vector2(1f,(vBounds.max - vBounds.min) / (float)vHeight);
+            return new Vector2(1f, (vBounds.max - vBounds.min) / (float)vHeight);
         }
 
         int hWidth;

--- a/Source/CombatExtended/CombatExtended/BoundsInjector.cs
+++ b/Source/CombatExtended/CombatExtended/BoundsInjector.cs
@@ -2,11 +2,14 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using RimWorld;
-using Verse;
 using UnityEngine;
-
+using UnityEngine.Rendering;
+using Verse;
 namespace CombatExtended;
+
 public static class BoundsInjector
 {
     public enum GraphicType
@@ -15,35 +18,19 @@ public static class BoundsInjector
         Plant
     }
 
-    private static ConcurrentDictionary<string, Vector2> boundMap = new ConcurrentDictionary<string, Vector2>();
-
-    public static Vector2 BoundMap(Graphic graphic, GraphicType type, Graphic headGraphic, Vector2 headOffset)
-    {
-        string path = graphic.path + (headGraphic == null ? "" : "+" + headGraphic.path);
-        if (!boundMap.ContainsKey(path))
-        {
-            try
-            {
-                boundMap[path] = ExtractBounds(graphic, type, headGraphic, headOffset);
-            }
-            catch (Exception e)
-            {
-                throw new Exception("BoundMap(,,,)", e);
-            }
-        }
-        return boundMap[path];
-    }
+    private static ConcurrentDictionary<string, Vector2> boundMap = [];
+    private static ConcurrentDictionary<Texture2D, (Color[] pixels, int width, int height)> _textureCache = [];
 
     public static Vector2 BoundMap(Graphic graphic, GraphicType type)
     {
-        if (boundMap.TryGetValue(graphic.path, out var cachedBounds))
+        if (boundMap.TryGetValue(graphic.path, out Vector2 cachedBounds))
         {
             return cachedBounds;
         }
 
         try
         {
-            var bounds = ExtractBounds(graphic, type);
+            Vector2 bounds = ExtractBounds(graphic, type);
             boundMap[graphic.path] = bounds;
             return bounds;
         }
@@ -53,91 +40,19 @@ public static class BoundsInjector
         }
     }
 
-    private static Vector2 ExtractBounds(Graphic graphic, GraphicType type, Graphic headGraphic, Vector2 headOffset)
-    {
-        int vWidth;
-        int vHeight;
-
-        IntRange vBounds;
-
-        try
-        {
-            vBounds = Def_Extensions.CropVertical((graphic.MatEast.mainTexture as Texture2D).GetColorSafe(out vWidth, out vHeight), vWidth, vHeight);
-        }
-        catch (Exception ex)
-        {
-            throw new Exception("Combat Extended :: CropVertical error while cropping Textures/" + graphic.path + "_side", ex);
-        }
-
-        int hWidth;
-        int hHeight;
-
-        IntRange hBounds;
-
-        try
-        {
-            hBounds = Def_Extensions.CropHorizontal((graphic.MatSouth.mainTexture as Texture2D).GetColorSafe(out hWidth, out hHeight), hWidth, hHeight);
-        }
-        catch (Exception ex)
-        {
-            throw new Exception("Combat Extended :: CropHorizontal error while cropping Textures/" + graphic.path + "_front", ex);
-        }
-
-        int vWidthHead;
-        int vHeightHead;
-
-        IntRange vBoundsHead;
-
-        try
-        {
-            vBoundsHead = Def_Extensions.CropVertical((headGraphic.MatEast.mainTexture as Texture2D).GetColorSafe(out vWidthHead, out vHeightHead), vWidthHead, vHeightHead);
-        }
-        catch (Exception ex)
-        {
-            throw new Exception("Combat Extended :: CropVertical error while cropping Textures/" + headGraphic.path + "_side", ex);
-        }
-
-        vBoundsHead.min -= (int)(headOffset.y * (float)vHeightHead);
-        vBoundsHead.max -= (int)(headOffset.y * (float)vHeightHead);
-
-        vBounds.min = Math.Min(vBounds.min, (int)((float)vBoundsHead.min * (float)vHeight / (float)vHeightHead));
-        vBounds.max = Math.Max(vBounds.max, (int)((float)vBoundsHead.max * (float)vHeight / (float)vHeightHead));
-
-        int hWidthHead;
-        int hHeightHead;
-
-        IntRange hBoundsHead;
-
-        try
-        {
-            hBoundsHead = Def_Extensions.CropHorizontal((headGraphic.MatSouth.mainTexture as Texture2D).GetColorSafe(out hWidthHead, out hHeightHead), hWidthHead, hHeightHead);
-        }
-        catch (Exception ex)
-        {
-            throw new Exception("Combat Extended :: CropHorizontal error while cropping Textures/" + headGraphic.path + "_front", ex);
-        }
-
-        hBoundsHead.min += (int)(headOffset.x * (float)hWidthHead);
-        hBoundsHead.max += (int)(headOffset.x * (float)hWidthHead);
-
-        hBounds.max = Math.Max(hBounds.max, (int)((float)hBoundsHead.max * (float)hWidth / (float)hWidthHead));
-        hBounds.min = Math.Min(hBounds.min, (int)((float)hBoundsHead.min * (float)hWidth / (float)hWidthHead));
-
-        return new Vector2(
-                   (float)(hBounds.max - hBounds.min) / (float)hWidth,
-                   (float)(vBounds.max - vBounds.min) / (float)vHeight);
-    }
-    private static Vector2 ExctractBoundCollection(Graphic_Collection graphic, GraphicType type)
+    private static Vector2 ExtractBoundCollection(Graphic_Collection graphic, GraphicType type)
     {
         IEnumerable<Vector2> bounds = graphic.subGraphics.Select(x => ExtractBounds(x, type));
         return new Vector2(bounds.Average(v => v.x), bounds.Average(v => v.y));
     }
+
     private static Vector2 ExtractBounds(Graphic graphic, GraphicType type)
     {
         if (graphic is Graphic_Collection graphic_collection)
         {
-            return ExctractBoundCollection(graphic_collection, type);
+            return ExtractBoundCollection(graphic_collection, type);
         }
+
         int vWidth;
         int vHeight;
 
@@ -145,7 +60,7 @@ public static class BoundsInjector
 
         try
         {
-            vBounds = Def_Extensions.CropVertical((graphic.MatEast.mainTexture as Texture2D).GetColorSafe(out vWidth, out vHeight), vWidth, vHeight);
+            vBounds = Def_Extensions.CropVertical(GetCachedColors((graphic.MatEast.mainTexture as Texture2D), out vWidth, out vHeight), vWidth, vHeight);
         }
         catch (Exception ex)
         {
@@ -157,9 +72,7 @@ public static class BoundsInjector
         // TODO : Refactor
         if (type == GraphicType.Plant)
         {
-            return new Vector2(
-                       1f,
-                       (float)(vBounds.max - vBounds.min) / (float)vHeight);
+            return new Vector2(1f,(vBounds.max - vBounds.min) / (float)vHeight);
         }
 
         int hWidth;
@@ -169,7 +82,7 @@ public static class BoundsInjector
 
         try
         {
-            hBounds = Def_Extensions.CropHorizontal((graphic.MatSouth.mainTexture as Texture2D).GetColorSafe(out hWidth, out hHeight), hWidth, hHeight);
+            hBounds = Def_Extensions.CropHorizontal(GetCachedColors((graphic.MatSouth.mainTexture as Texture2D), out hWidth, out hHeight), hWidth, hHeight);
         }
         catch (Exception ex)
         {
@@ -177,29 +90,134 @@ public static class BoundsInjector
         }
 
         return new Vector2(
-                   (float)(hBounds.max - hBounds.min) / (float)hWidth,
-                   (float)(vBounds.max - vBounds.min) / (float)vHeight);
+            (hBounds.max - hBounds.min) / (float)hWidth,
+            (vBounds.max - vBounds.min) / (float)vHeight);
     }
+
+    private static void CollectGraphic(Graphic graphic, HashSet<Texture2D> textures)
+    {
+        if (graphic == null)
+        {
+            return;
+        }
+        if (graphic is Graphic_Collection col)
+        {
+            foreach (Graphic sub in col.subGraphics)
+            {
+                CollectGraphic(sub, textures);
+            }
+            return;
+        }
+        if (graphic.MatEast?.mainTexture is Texture2D east)
+        {
+            textures.Add(east);
+        }
+        if (graphic.MatSouth?.mainTexture is Texture2D south)
+        {
+            textures.Add(south);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Color[] GetCachedColors(Texture2D tex, out int width, out int height)
+    {
+        if (_textureCache.TryGetValue(tex, out var cached))
+        {
+            width = cached.width;
+            height = cached.height;
+            return cached.pixels;
+        }
+        //Can't fall back to original GetColorSafe as it is not thread safe
+        throw new Exception($"Combat Extended :: Texture '{tex.name}' was not cached. This is a bug - texture should have been collected in CollectTextures.");
+    }
+
 
     public static void Inject()
     {
         List<PawnKindDef> pawnKindsToInject = [];
         foreach (PawnKindDef pawnKindDef in DefDatabase<PawnKindDef>.AllDefs)
         {
-            if (pawnKindDef.RaceProps.Humanlike)
+            if (!pawnKindDef.RaceProps.Humanlike)
             {
                 pawnKindsToInject.Add(pawnKindDef);
             }
         }
-        GenThreading.ParallelForEach(pawnKindsToInject, InjectPawnKinds);
+
+        List<ThingDef> plantsToInject = [];
         foreach (ThingDef thingDef in DefDatabase<ThingDef>.AllDefs)
         {
             if (thingDef.plant != null)
             {
-                InjectPlants(thingDef);
+                plantsToInject.Add(thingDef);
             }
         }
-        Log.Message("Combat Extended :: Bounds pre-generated");
+
+        // Textures need to be gathered on main thread
+        // Bulk of the time for this method, but no way to speed up texture gathering
+        HashSet<Texture2D> textures = CollectTextures(pawnKindsToInject, plantsToInject);
+
+        int pending = textures.Count;
+        foreach (Texture2D tex in textures)
+        {
+            // Needs to be done on main thread
+            Texture2D capturedTex = tex;
+            (int w, int h) = CE_Utility.GetScaledSize(tex);
+            RenderTexture rt = CE_Utility.BlitToRenderTexture(tex, w, h);
+
+            // Allows the GPU to do the work we need seperate from the CPU. This stops the CPU from stalling while the GPU does it's job
+            AsyncGPUReadback.Request(rt, 0, request =>
+            {
+                RenderTexture.ReleaseTemporary(rt);
+
+                if (!request.hasError)
+                {
+                    _textureCache[capturedTex] = (CE_Utility.ConvertToColors(request.GetData<Color32>()), w, h);
+                }
+                else
+                {
+                    Log.Error($"Combat Extended :: AsyncGPUReadback failed for {capturedTex.name}");
+                }
+
+                // Increments down as GPU gives the CPU the information. Only want to finish injecting after all textures are predone
+                if (Interlocked.Decrement(ref pending) != 0)
+                {
+                    return;
+                }
+
+                GenThreading.ParallelForEach(pawnKindsToInject, InjectPawnKinds);
+                GenThreading.ParallelForEach(plantsToInject, InjectPlants);
+                Log.Message("Combat Extended :: Bounds pre-generated");
+
+            });
+        }
+    }
+
+    private static HashSet<Texture2D> CollectTextures(List<PawnKindDef> pawnKinds, List<ThingDef> plants)
+    {
+        HashSet<Texture2D> textures = [];
+
+        for (int i = 0; i < pawnKinds.Count; i++)
+        {
+            PawnKindDef def = pawnKinds[i];
+            foreach (PawnKindLifeStage ls in def.lifeStages)
+            {
+                CollectGraphic(ls.bodyGraphicData?.Graphic, textures);
+                CollectGraphic(ls.femaleGraphicData?.Graphic, textures);
+                CollectGraphic(ls.dessicatedBodyGraphicData?.Graphic, textures);
+                CollectGraphic(ls.femaleDessicatedBodyGraphicData?.Graphic, textures);
+            }
+        }
+
+        foreach (ThingDef def in plants)
+        {
+            CollectGraphic(def.graphicData?.Graphic, textures);
+            CollectGraphic(def.plant?.leaflessGraphic, textures);
+            CollectGraphic(def.plant?.immatureGraphic, textures);
+        }
+
+        CollectGraphic(Plant.GraphicSowing, textures);
+
+        return textures;
     }
 
     private static void InjectPawnKinds(PawnKindDef pawnKindDef)

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -1,13 +1,16 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
+using CombatExtended.Compatibility;
 using RimWorld;
+using RimWorld.Planet;
+using Unity.Collections;
+using UnityEngine;
 using Verse;
 using Verse.AI;
-using UnityEngine;
-using RimWorld.Planet;
-
+using Random = UnityEngine.Random;
 namespace CombatExtended;
 public static class CE_Utility
 {
@@ -30,8 +33,8 @@ public static class CE_Utility
         float u, v, S;
         do
         {
-            u = 2.0f * UnityEngine.Random.value - 1.0f;
-            v = 2.0f * UnityEngine.Random.value - 1.0f;
+            u = 2.0f * Random.value - 1.0f;
+            v = 2.0f * Random.value - 1.0f;
             S = u * u + v * v;
         }
         while (S >= 1.0f);
@@ -68,7 +71,7 @@ public static class CE_Utility
     public static float GetWeaponStatWith(this WeaponPlatform platform, StatDef stat, List<AttachmentLink> links, bool applyPostProcess = true)
     {
         StatRequest req = StatRequest.For(platform);
-        float val = stat.Worker.GetValueUnfinalized(StatRequest.For(platform), true);
+        float val = stat.Worker.GetValueUnfinalized(StatRequest.For(platform));
         if (stat.parts != null)
         {
             for (int i = 0; i < stat.parts.Count; i++)
@@ -167,7 +170,7 @@ public static class CE_Utility
         bool anyFactors = false;
         foreach (AttachmentLink link in links)
         {
-            StatModifier modifier = link.statReplacers?.FirstOrFallback(m => m.stat == stat, null) ?? null;
+            StatModifier modifier = link.statReplacers?.FirstOrFallback(m => m.stat == stat) ?? null;
             if (modifier == null)
             {
                 continue;
@@ -178,7 +181,7 @@ public static class CE_Utility
         }
         foreach (AttachmentLink link in links)
         {
-            StatModifier modifier = link.statOffsets?.FirstOrFallback(m => m.stat == stat, null) ?? null;
+            StatModifier modifier = link.statOffsets?.FirstOrFallback(m => m.stat == stat) ?? null;
             if (modifier == null || modifier.value == 0)
             {
                 continue;
@@ -192,7 +195,7 @@ public static class CE_Utility
         }
         foreach (AttachmentLink link in links)
         {
-            StatModifier modifier = link.statMultipliers?.FirstOrFallback(m => m.stat == stat, null) ?? null;
+            StatModifier modifier = link.statMultipliers?.FirstOrFallback(m => m.stat == stat) ?? null;
             if (modifier == null || modifier.value == 0 || modifier.value == 1)
             {
                 continue;
@@ -226,7 +229,7 @@ public static class CE_Utility
             {
                 if (stat.parts[i] is StatPart_Quality || stat.parts[i] is StatPart_Quality_Offset)
                 {
-                    stat.parts[i].TransformValue(new StatRequest()
+                    stat.parts[i].TransformValue(new StatRequest
                     {
                         qualityCategoryInt = QualityCategory.Normal
                     }, ref val);
@@ -293,7 +296,7 @@ public static class CE_Utility
         for (int i = 0; i < links.Count; i++)
         {
             AttachmentLink link = links[i];
-            StatModifier modifier = link.statReplacers?.FirstOrFallback(m => m.stat == stat, null) ?? null;
+            StatModifier modifier = link.statReplacers?.FirstOrFallback(m => m.stat == stat) ?? null;
             if (modifier == null)
             {
                 continue;
@@ -305,7 +308,7 @@ public static class CE_Utility
         for (int i = 0; i < links.Count; i++)
         {
             AttachmentLink link = links[i];
-            StatModifier modifier = link.statOffsets?.FirstOrFallback(m => m.stat == stat, null) ?? null;
+            StatModifier modifier = link.statOffsets?.FirstOrFallback(m => m.stat == stat) ?? null;
             if (modifier == null)
             {
                 continue;
@@ -315,7 +318,7 @@ public static class CE_Utility
         for (int i = 0; i < links.Count; i++)
         {
             AttachmentLink link = links[i];
-            StatModifier modifier = link.statMultipliers?.FirstOrFallback(m => m.stat == stat, null) ?? null;
+            StatModifier modifier = link.statMultipliers?.FirstOrFallback(m => m.stat == stat) ?? null;
             if (modifier == null || modifier.value <= 0)
             {
                 continue;
@@ -375,23 +378,7 @@ public static class CE_Utility
     /// <returns>Color[] array after resizing to fit blitMaxDimensions</returns>
     public static Color[] GetColorSafe(this Texture2D texture, out int width, out int height)
     {
-        width = texture.width;
-        height = texture.height;
-        if (texture.width > texture.height)
-        {
-            width = Math.Min(width, blitMaxDimensions);
-            height = (int)((float)width * ((float)texture.height / (float)texture.width));
-        }
-        else if (texture.height > texture.width)
-        {
-            height = Math.Min(height, blitMaxDimensions);
-            width = (int)((float)height * ((float)texture.width / (float)texture.height));
-        }
-        else
-        {
-            width = Math.Min(width, blitMaxDimensions);
-            height = Math.Min(height, blitMaxDimensions);
-        }
+        (width, height) = GetScaledSize(texture);
 
         Color[] color = null;
 
@@ -416,9 +403,51 @@ public static class CE_Utility
         return color;
     }
 
+    public static (int width, int height) GetScaledSize(Texture2D texture)
+    {
+        int width = texture.width;
+        int height = texture.height;
+        if (texture.width > texture.height)
+        {
+            width = Math.Min(width, blitMaxDimensions);
+            height = (int)(width * (texture.height / (float)texture.width));
+        }
+        else if (texture.height > texture.width)
+        {
+            height = Math.Min(height, blitMaxDimensions);
+            width = (int)(height * (texture.width / (float)texture.height));
+        }
+        else
+        {
+            width = Math.Min(width, blitMaxDimensions);
+            height = Math.Min(height, blitMaxDimensions);
+        }
+        return (width, height);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static RenderTexture BlitToRenderTexture(Texture2D tex, int w, int h)
+    {
+        RenderTexture rt = RenderTexture.GetTemporary(w, h, 0, RenderTextureFormat.Default, RenderTextureReadWrite.Default, 1);
+        rt.filterMode = FilterMode.Point;
+        Graphics.Blit(tex, rt);
+        return rt;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Color[] ConvertToColors(NativeArray<Color32> raw)
+    {
+        Color[] colors = new Color[raw.Length];
+        for (int i = 0; i < raw.Length; i++)
+        {
+            colors[i] = new Color(raw[i].r / 255f, raw[i].g / 255f, raw[i].b / 255f, raw[i].a / 255f);
+        }
+        return colors;
+    }
+
     public static Texture2D BlitCrop(this Texture2D texture, Rect blitRect)
     {
-        return texture.Blit(blitRect, new int[] { texture.width, texture.height });
+        return texture.Blit(blitRect, new[] { texture.width, texture.height });
     }
     #endregion
 
@@ -481,7 +510,7 @@ public static class CE_Utility
         Building edifice = pawn.Position.GetEdifice(pawn.Map);
         if (edifice != null)
         {
-            movePerTick += (int)edifice.PathWalkCostFor(pawn);
+            movePerTick += edifice.PathWalkCostFor(pawn);
         }
 
         //Case switch to handle walking, jogging, etc.
@@ -525,7 +554,7 @@ public static class CE_Utility
 
     public static float DistanceBetweenTiles(int firstTile, int endTile, int maxCells = 500)
     {
-        return Find.WorldGrid.TraversalDistanceBetween(firstTile, endTile, true, maxDist: maxCells);
+        return Find.WorldGrid.TraversalDistanceBetween(firstTile, endTile, maxDist: maxCells);
     }
 
     public static IntVec3 ExitCell(this Ray ray, Map map)
@@ -823,7 +852,7 @@ public static class CE_Utility
 
 
         creationData.rotation = (flip ? shotRotation + 90 : shotRotation + 90) + Rand.Range(-3f, 4f);
-        creationData.rotationRate = (float)Rand.Range(-150, 150) / recoilAmount;
+        creationData.rotationRate = Rand.Range(-150, 150) / recoilAmount;
 
 
         float casingAngleOffset = 0;
@@ -879,7 +908,7 @@ public static class CE_Utility
         float makeFilthChance = Rand.Range(0f, 1f);
         if (makeFilthChance > 0.9f && position.Walkable(map))
         {
-            FilthMaker.TryMakeFilth(position, map, casingFilthDef, 1, FilthSourceFlags.None);
+            FilthMaker.TryMakeFilth(position, map, casingFilthDef);
         }
         Rand.PopState();
     }
@@ -1044,13 +1073,13 @@ public static class CE_Utility
             if (!catchOutbound || lp2sq < radSq) // Case 1 or 2
             {
 #if DEBUG
-                Message($"Case 1 or 2");
+                Message("Case 1 or 2");
 #endif
                 return false;
             }
             // Case 3
 #if DEBUG
-            Message($"Case 3");
+            Message("Case 3");
 #endif
             displacement = (lp2 - lp1);
             displacementSq = displacement.sqrMagnitude;
@@ -1058,14 +1087,14 @@ public static class CE_Utility
         else // case 4 or 5
         {
 #if DEBUG
-            Message($"Case 4 or 5");
+            Message("Case 4 or 5");
 #endif
             displacement = (lp2 - lp1);
             displacementSq = displacement.sqrMagnitude;
             if (lp2sq > radSq) // case 5
             {
 #if DEBUG
-                Message($"Case 5");
+                Message("Case 5");
 #endif
                 float length = Mathf.Sqrt(displacementSq);
                 // direction vector is a unit vector along the flight path
@@ -1078,7 +1107,7 @@ public static class CE_Utility
                 if (projectionDistance <= 0 || projectionDistance >= length) // One of the ends is closest, and both are outside, so we didn't cross
                 {
 #if DEBUG
-                    Log.Message($"Endpoint is closest");
+                    Log.Message("Endpoint is closest");
 #endif
                     return false;
                 }
@@ -1138,7 +1167,7 @@ public static class CE_Utility
         }
 
         Vector2 factors;
-        if (Compatibility.Patches.GetCollisionBodyFactors(pawn, out factors))
+        if (Patches.GetCollisionBodyFactors(pawn, out factors))
         {
             return factors;
         }
@@ -1162,7 +1191,7 @@ public static class CE_Utility
 
             if (shape == CE_BodyShapeDefOf.Invalid)
             {
-                Log.ErrorOnce("CE returning BodyType Undefined for pawn " + pawn.ToString(), 35000198 + pawn.GetHashCode());
+                Log.ErrorOnce("CE returning BodyType Undefined for pawn " + pawn, 35000198 + pawn.GetHashCode());
             }
 
             factors.x *= shape.widthLaying / shape.width;
@@ -1421,7 +1450,7 @@ public static class CE_Utility
                                             float shotSpeed)
     {
         projectileDef = projectileDef.GetProjectile();
-        ProjectileCE projectile = (ProjectileCE)ThingMaker.MakeThing(projectileDef, null);
+        ProjectileCE projectile = (ProjectileCE)ThingMaker.MakeThing(projectileDef);
         GenSpawn.Spawn(projectile, shooter.Position, shooter.Map);
 
         projectile.ExactPosition = origin;
@@ -1452,12 +1481,12 @@ public static class CE_Utility
         if (thingDef is AmmoDef ammoDef)
         {
             ThingDef user;
-            if ((user = ammoDef.Users.FirstOrFallback(null)) != null)
+            if ((user = ammoDef.Users.FirstOrFallback()) != null)
             {
                 CompProperties_AmmoUser props = user.GetCompProperties<CompProperties_AmmoUser>();
                 AmmoSetDef asd = props.ammoSet;
                 AmmoLink ammoLink;
-                if ((ammoLink = asd.ammoTypes.FirstOrFallback(null)) != null)
+                if ((ammoLink = asd.ammoTypes.FirstOrFallback()) != null)
                 {
                     return ammoLink.projectile;
                 }
@@ -1501,7 +1530,7 @@ public static class CE_Utility
             return;
         }
 
-        Hediff_Injury hediff_Injury = (Hediff_Injury)HediffMaker.MakeHediff(HealthUtility.GetHediffDefFromDamage(dinfo.Def, pawn, parent), pawn, null);
+        Hediff_Injury hediff_Injury = (Hediff_Injury)HediffMaker.MakeHediff(HealthUtility.GetHediffDefFromDamage(dinfo.Def, pawn, parent), pawn);
         hediff_Injury.Part = parent;
         hediff_Injury.sourceDef = dinfo.Weapon;
         hediff_Injury.sourceBodyPartGroup = dinfo.WeaponBodyPartGroup;
@@ -1524,7 +1553,7 @@ public static class CE_Utility
         }
         Log.Warning($"CE: Couldn't find world pawns for faction {faction}. CE had to create a new one..");
         _validPawnKinds.Clear();
-        foreach (PawnGroupMaker group in capableOfCombat ? faction.def.pawnGroupMakers.Where((PawnGroupMaker x) => x.kindDef == PawnGroupKindDefOf.Combat) : faction.def.pawnGroupMakers)
+        foreach (PawnGroupMaker group in capableOfCombat ? faction.def.pawnGroupMakers.Where(x => x.kindDef == PawnGroupKindDefOf.Combat) : faction.def.pawnGroupMakers)
         {
             foreach (PawnGenOption option in group.options)
             {
@@ -1606,7 +1635,7 @@ public static class CE_Utility
         {
             projectileDef = projectileDef.GetProjectile();
         }
-        var p = ThingMaker.MakeThing(projectileDef, null);
+        var p = ThingMaker.MakeThing(projectileDef);
         ProjectileCE projectile = (ProjectileCE)p;
         GenSpawn.Spawn(projectile, launcher.Position, launcher.Map);
         projectile.ExactPosition = origin;
@@ -1738,7 +1767,7 @@ public static class CE_Utility
             if (allDefsListForReading[i].IsIngredient(thingDef))
             {
                 HediffDef hediffDef = allDefsListForReading[i].addsHediff;
-                HediffCompProperties_VerbGiver hediffCompProperties_VerbGiver = hediffDef?.comps?.FirstOrDefault((HediffCompProperties x) => x is HediffCompProperties_VerbGiver) as HediffCompProperties_VerbGiver;
+                HediffCompProperties_VerbGiver hediffCompProperties_VerbGiver = hediffDef?.comps?.FirstOrDefault(x => x is HediffCompProperties_VerbGiver) as HediffCompProperties_VerbGiver;
                 if (hediffCompProperties_VerbGiver != null && !hediffCompProperties_VerbGiver.tools.NullOrEmpty() && hediffCompProperties_VerbGiver.tools.All(t => t is ToolCE))
                 {
                     techHediffTools = hediffCompProperties_VerbGiver.tools.ToList();


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Change texture portion to utilize ASyncGPUReadback to improve generation speed. Reduces the amount of time CPU is waiting speeding it up overall. Overall improvements will depend on user's hardware, but all should get some benefit out of this.
- Add threading to the bounding box generation
- Housekeeping

Times below are in milliseconds
Current Dev:
<img width="1127" height="261" alt="image" src="https://github.com/user-attachments/assets/689ffdf5-0c6b-4226-9cab-66ccf13b9e4b" />

Profiled after:
<img width="1112" height="251" alt="image" src="https://github.com/user-attachments/assets/afb81e3f-ecd9-4340-bd52-6152e150a866" />


## Reasoning

Why did you choose to implement things this way, e.g.
- Bounding box generation scales with more animals and plants. Could easily reach 30+ seconds on larger lists. My moderate list brings it up from Vanilla's 1.16s to over 7 seconds
- get_Graphic time could only be improved slightly be refactoring due to requiring to be on main thread


## Alternatives

Describe alternative implementations you have considered, e.g.
- Maintain current
- Figure out how to cache bounds for stable mod lists

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (enough to shoot an animal)
