### PR TITLE
Re-patching of the VWE Charged Rocket Launcher

### DIFF
--- a/ModPatches/Vanilla Weapons Expanded/Defs/Vanilla Weapons Expanded/Ammo/Ammo_ChargedRockets.xml
+++ b/ModPatches/Vanilla Weapons Expanded/Defs/Vanilla Weapons Expanded/Ammo/Ammo_ChargedRockets.xml
@@ -108,6 +108,35 @@
 				<range>3</range>
 			</shellingProps>
 		</projectile>
+		<comps>
+			<li Class="CombatExtended.CompProperties_ProjectileFleck">
+				<FleckDatas>
+					<li>
+						<fleck>Fleck_CERocketFlame</fleck>
+						<emissionsPerTick>7</emissionsPerTick>
+						<flecksPerEmission>3</flecksPerEmission>
+						<scale>1.5</scale>
+						<cutoffTickRange>25~60</cutoffTickRange>
+						<originOffset>0.4</originOffset>
+					</li>
+					<li>
+						<fleck>Fleck_CERocketSmokeTrail</fleck>
+						<emissionsPerTick>1</emissionsPerTick>
+						<rotation>0~360</rotation>
+						<scale>3</scale>
+						<flecksPerEmission>1</flecksPerEmission>
+					</li>
+					<li>
+						<fleck>Fleck_CERocketSmoke</fleck>
+						<emissionsPerTick>2</emissionsPerTick>
+						<rotation>0~360</rotation>
+						<scale>2</scale>
+						<flecksPerEmission>1</flecksPerEmission>
+						<cutoffTickRange>25~60</cutoffTickRange>
+					</li>
+				</FleckDatas>
+			</li>
+		</comps>		
 	</ThingDef>
 	
 	<ThingDef ParentName="BaseChargedMissile">

--- a/ModPatches/Vanilla Weapons Expanded/Defs/Vanilla Weapons Expanded/Ammo/Ammo_ChargedRockets.xml
+++ b/ModPatches/Vanilla Weapons Expanded/Defs/Vanilla Weapons Expanded/Ammo/Ammo_ChargedRockets.xml
@@ -6,7 +6,9 @@
 		<parent>AmmoRockets</parent>
 		<iconPath>UI/Icons/ThingCategories/CaliberRocket</iconPath>
 	</ThingCategoryDef>
+	
 	<!-- AmmoSet -->
+	
 	<CombatExtended.AmmoSetDef>
 		<defName>AmmoSet_ChargedRockets</defName>
 		<label>Charged rockets</label>
@@ -16,7 +18,9 @@
 			<Ammo_ChargedRocket_BB>Bullet_ThermobaricRocket</Ammo_ChargedRocket_BB>
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
+	
 	<!-- Ammo -->
+	
 	<ThingDef Class="CombatExtended.AmmoDef" Name="ChargedRocketBase" ParentName="MediumAmmoBase" Abstract="True">
 		<description>An advanced rocket with a charged-ion payload. The warhead explodes in the air, releasing a wave of deadly electroshock.</description>
 		<statBases>
@@ -48,6 +52,7 @@
 		<ammoClass>ChargedRocketHEC</ammoClass>
 		<detonateProjectile>Bullet_AntiGrainRocket</detonateProjectile>
 	</ThingDef>
+	
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="ChargedRocketBase">
 		<defName>Ammo_ChargedRocket_ICP</defName>
 		<description>An advanced rocket with a prometheum payload. The magnesium warhead is exploded upon impact, launching molten slag and flaming liquid in all directions.</description>
@@ -64,6 +69,7 @@
 		<ammoClass>ChargedRocketICP</ammoClass>
 		<detonateProjectile>Bullet_PrometheumRocket</detonateProjectile>
 	</ThingDef>
+	
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="ChargedRocketBase">
 		<defName>Ammo_ChargedRocket_BB</defName>
 		<description>An advanced rocket with a thermobaric payload. The warhead is designed to destroy fortifications and structures.</description>
@@ -80,10 +86,32 @@
 		<ammoClass>ChargedRocketBB</ammoClass>
 		<detonateProjectile>Bullet_ThermobaricRocket</detonateProjectile>
 	</ThingDef>
+	
 	<!-- Projectiles -->
-	<ThingDef ParentName="BaseSPG9Rocket">
-		<defName>Bullet_AntiGrainRocket</defName>
+	
+	<ThingDef Name="BaseChargedMissile" ParentName="BaseExplosiveBullet" Abstract="true">
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+		<graphicData>
+			<shaderType>TransparentPostLight</shaderType>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<speed>0</speed>
+			<gravityFactor>16</gravityFactor>
+			<soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
+			<soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
+			<soundAmbient>MortarRound_Ambient</soundAmbient>
+			<flyOverhead>true</flyOverhead>
+			<dropsCasings>false</dropsCasings>
+			<shellingProps>
+				<iconPath>Things/WorldObjects/Munitions/Mortar</iconPath>
+				<tilesPerTick>0.03</tilesPerTick>
+				<range>3</range>
+			</shellingProps>
+		</projectile>
+	</ThingDef>
+	
+	<ThingDef ParentName="BaseChargedMissile">
+		<defName>Bullet_AntiGrainRocket</defName>
 		<label>charged rocket (HE-C)</label>
 		<graphicData>
 			<texPath>Things/Projectile/RPG/Frag</texPath>
@@ -91,11 +119,9 @@
 			<shaderType>TransparentPostLight</shaderType>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>100</speed>
 			<damageDef>EMP</damageDef>
 			<explosionRadius>8</explosionRadius>
 			<damageAmountBase>300</damageAmountBase>
-			<soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
 			<suppressionFactor>3.0</suppressionFactor>
 		</projectile>
 		<comps>
@@ -113,9 +139,9 @@
 			</li>
 		</comps>
 	</ThingDef>
-	<ThingDef ParentName="BaseSPG9Rocket">
+	
+	<ThingDef ParentName="BaseChargedMissile">
 		<defName>Bullet_PrometheumRocket</defName>
-		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		<label>charged rocket (ICP)</label>
 		<graphicData>
 			<texPath>Things/Projectile/RPG/Frag</texPath>
@@ -123,14 +149,12 @@
 			<shaderType>TransparentPostLight</shaderType>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>100</speed>
 			<damageDef>PrometheumFlame</damageDef>
 			<explosionRadius>6</explosionRadius>
 			<damageAmountBase>45</damageAmountBase>
 			<postExplosionSpawnThingDef>FilthPrometheum</postExplosionSpawnThingDef>
 			<preExplosionSpawnChance>0.8</preExplosionSpawnChance>
 			<soundExplode>MortarIncendiary_Explode</soundExplode>
-			<soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
 			<suppressionFactor>3.0</suppressionFactor>
 			<ai_IsIncendiary>true</ai_IsIncendiary>
 		</projectile>
@@ -148,6 +172,7 @@
 			</li>
 		</comps>
 	</ThingDef>
+	
 	<ThingDef ParentName="BaseFragment">
 		<defName>Bullet_MoltenSlag</defName>
 		<label>molten slag</label>
@@ -161,13 +186,11 @@
 			<explosionRadius>1.9</explosionRadius>
 			<postExplosionSpawnThingDef>FilthPrometheum</postExplosionSpawnThingDef>
 			<preExplosionSpawnChance>0.5</preExplosionSpawnChance>
-			<speed>80</speed>
-			<gravityFactor>12</gravityFactor>
 		</projectile>
 	</ThingDef>
-	<ThingDef ParentName="BaseSPG9Rocket">
+	
+	<ThingDef ParentName="BaseChargedMissile">
 		<defName>Bullet_ThermobaricRocket</defName>
-		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		<label>charged rocket (BB)</label>
 		<graphicData>
 			<texPath>Things/Projectile/RPG/Frag</texPath>
@@ -179,8 +202,6 @@
 			<damageDef>Thump</damageDef>
 			<armorPenetrationSharp>1.2</armorPenetrationSharp>
 			<armorPenetrationBlunt>12.4</armorPenetrationBlunt>
-			<speed>100</speed>
-			<flyOverhead>false</flyOverhead>
 			<explosionRadius>3.9</explosionRadius>
 			<soundExplode>MortarIncendiary_Explode</soundExplode>
 			<soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
@@ -206,7 +227,9 @@
 			</li>
 		</comps>
 	</ThingDef>
+	
 	<!-- Recipes -->
+	
 	<RecipeDef ParentName="ChargeAmmoRecipeBase">
 		<defName>MakeAmmo_ChargedRocket</defName>
 		<label>make charged rocket (HE-C) x1</label>
@@ -259,6 +282,7 @@
 			<Ammo_ChargedRocket>1</Ammo_ChargedRocket>
 		</products>
 	</RecipeDef>
+	
 	<RecipeDef ParentName="ChargeAmmoRecipeBase">
 		<defName>MakeAmmo_ChargedRocket_ICP</defName>
 		<label>make charged rocket (ICP) x1</label>
@@ -311,6 +335,7 @@
 			<Ammo_ChargedRocket_ICP>1</Ammo_ChargedRocket_ICP>
 		</products>
 	</RecipeDef>
+	
 	<RecipeDef ParentName="ChargeAmmoRecipeBase">
 		<defName>MakeAmmo_ChargedRocket_BB</defName>
 		<label>make charged rocket (BB) x1</label>

--- a/ModPatches/Vanilla Weapons Expanded/Patches/Vanilla Weapons Expanded/Spacer_Ranged.xml
+++ b/ModPatches/Vanilla Weapons Expanded/Patches/Vanilla Weapons Expanded/Spacer_Ranged.xml
@@ -413,7 +413,7 @@
 			<ComponentSpacer>1</ComponentSpacer>
 		</costList>
 		<Properties>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<verbClass>CombatExtended.Verb_ShootMortarCE</verbClass>
 			<hasStandardCommand>True</hasStandardCommand>
 			<defaultProjectile>Bullet_AntiGrainRocket</defaultProjectile>
 			<warmupTime>2</warmupTime>
@@ -422,6 +422,8 @@
 			<soundCastTail>GunTail_Heavy</soundCastTail>
 			<muzzleFlashScale>14</muzzleFlashScale>
 			<onlyManualCast>True</onlyManualCast>
+			<circularError>1</circularError>
+			<indirectFirePenalty>0.2</indirectFirePenalty>
 			<targetParams>
 				<canTargetLocations>true</canTargetLocations>
 			</targetParams>
@@ -440,5 +442,29 @@
 		</weaponTags>
 		<AllowWithRunAndGun>false</AllowWithRunAndGun>
 	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="VWE_Gun_ChargeRocketLauncher"]/comps</xpath>
+		<value>
+			<li Class="CombatExtended.CompProperties_Charges">
+				<chargeSpeeds>
+					<li>50</li>
+					<li>70</li>
+					<li>90</li>
+					<li>120</li>	
+					<li>150</li>		
+				</chargeSpeeds>
+			</li>
+		</value>
+	</Operation>
 
+	<!-- For some reason, the Combat Extended gun compatibility patch cannot properly remove the VEF.Weapons.Verb_Shoot_FlyOverhead verb from this weapon, so we have to do this -->
+	
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="VWE_Gun_ChargeRocketLauncher"]/verbs/li[verbClass="VEF.Weapons.Verb_Shoot_FlyOverhead"]</xpath>
+		<match Class="PatchOperationRemove">
+			<xpath>Defs/ThingDef[defName="VWE_Gun_ChargeRocketLauncher"]/verbs/li[verbClass="VEF.Weapons.Verb_Shoot_FlyOverhead"]</xpath>
+		</match>
+	</Operation>
+	
 </Patch>


### PR DESCRIPTION
## Changes

The charged missile launcher previously had a bug where it would keep its proprietary VEF verb and thus not use the Combat Extended verb. I've fixed this.

<img width="351" height="133" alt="image" src="https://github.com/user-attachments/assets/f82c46a0-3d10-4c54-9276-e2e5fb20111e" />

The original mod also has the weapon use an indirect fire system. I implemented that too, while I was at it. I've made some tweaks that you wouldn't see in mortars and other indirect weapons. You'll notice that the projectiles have a very high gravity modifier, for example. The missiles, in vanilla, are _incredibly_ rapid. It wouldn't be right to have them slow here. They're still 'realistic' speeds, just not as slow as, say, an 81mm mortar shell.

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #4556

## Reasoning

Why did you choose to implement things this way, e.g.
- I'd like things to work.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings - Changes do not require a recompile
- [X] Game runs without errors
- [X] (For compatibility patches) ...with and without patched mod loaded
- [X] Playtested a colony (specify how long) - 15-20 minutes to make sure all the missiles worked.