### PR TITLE
Antigrain shell variety

### DIFF
--- a/Defs/Ammo/Generic/Shell_Artillery.xml
+++ b/Defs/Ammo/Generic/Shell_Artillery.xml
@@ -21,6 +21,7 @@
 			<Ammo_ArtilleryShell_Incendiary>Bullet_155mmHowitzerShell_Incendiary</Ammo_ArtilleryShell_Incendiary>
 			<Ammo_ArtilleryShell_EMP>Bullet_155mmHowitzerShell_EMP</Ammo_ArtilleryShell_EMP>
 			<Ammo_ArtilleryShell_Smoke>Bullet_155mmHowitzerShell_Smoke</Ammo_ArtilleryShell_Smoke>
+			<Ammo_ArtilleryShell_Anti>Bullet_155mmHowitzerShell_Anti</Ammo_ArtilleryShell_Anti>
 		</ammoTypes>
 		<isMortarAmmoSet>true</isMortarAmmoSet>
 	</CombatExtended.AmmoSetDef>
@@ -101,6 +102,45 @@
 		<ammoClass>Smoke</ammoClass>
 		<spawnAsSiegeAmmo>false</spawnAsSiegeAmmo>
 		<detonateProjectile>Bullet_155mmHowitzerShell_Smoke</detonateProjectile>
+	</ThingDef>
+	
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="HeavyMortarShellBase">
+		<defName>Ammo_ArtilleryShell_Anti</defName>
+		<label>artillery shell (Anti)</label>
+		<description>An ultra-tech artillery warhead packed with two grains of antimatter.</description>
+		<graphicData>
+			<texPath>Things/Ammo/Cannon/Howitzer/ANTI</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>2100</MarketValue>
+			<Mass>24</Mass>
+			<Bulk>31.8</Bulk>
+		</statBases>
+		<thingSetMakerTags>
+			<li>RewardStandardCore</li>
+		</thingSetMakerTags>
+		<tradeTags>
+			<li>CE_AutoEnableTrade_Sellable</li>
+		</tradeTags>
+		<ammoClass>Antigrain</ammoClass>
+		<comps>
+			<li Class="CompProperties_Explosive">
+				<explosiveRadius>18.9</explosiveRadius>
+				<!-- One thirds of its projectile damage for cook-off -->
+				<damageAmountBase>436</damageAmountBase>
+				<explosiveDamageType>BombSuper</explosiveDamageType>
+				<startWickHitPointsPercent>0.7</startWickHitPointsPercent>
+				<chanceToStartFire>0.22</chanceToStartFire>
+				<damageFalloff>true</damageFalloff>
+				<explosionEffect>GiantExplosion</explosionEffect>
+				<explosionSound>Explosion_GiantBomb</explosionSound>
+				<preExplosionSpawnSingleThingDef>CraterMedium</preExplosionSpawnSingleThingDef>
+				<wickTicks>60~120</wickTicks>
+				<explodeOnKilled>True</explodeOnKilled>
+				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			</li>
+		</comps>
 	</ThingDef>
 
 	<!-- ==================== Recipes ========================== -->

--- a/Defs/Ammo/Shell/105mmHowitzer.xml
+++ b/Defs/Ammo/Shell/105mmHowitzer.xml
@@ -19,6 +19,7 @@
 			<Ammo_105mmHowitzerShell_Incendiary>Bullet_105mmHowitzerShell_Incendiary</Ammo_105mmHowitzerShell_Incendiary>
 			<Ammo_105mmHowitzerShell_EMP>Bullet_105mmHowitzerShell_EMP</Ammo_105mmHowitzerShell_EMP>
 			<Ammo_105mmHowitzerShell_Smoke>Bullet_105mmHowitzerShell_Smoke</Ammo_105mmHowitzerShell_Smoke>
+			<Ammo_105mmHowitzerShell_Anti>Bullet_105mmHowitzerShell_Anti</Ammo_105mmHowitzerShell_Anti>
 		</ammoTypes>
 		<isMortarAmmoSet>true</isMortarAmmoSet>
 		<similarTo>AmmoSet_ArtilleryShell</similarTo>
@@ -130,6 +131,44 @@
 		</graphicData>
 		<ammoClass>Smoke</ammoClass>
 		<detonateProjectile>Bullet_105mmHowitzerShell_Smoke</detonateProjectile>
+	</ThingDef>
+	
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="81mmMortarShellBase">
+		<defName>Ammo_105mmHowitzerShell_Anti</defName>
+		<label>105mm Howitzer shell (Anti)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Cannon/Howitzer/ANTI</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>1600</MarketValue>
+			<Mass>12.8</Mass>
+			<Bulk>17.3</Bulk>
+		</statBases>
+		<thingSetMakerTags>
+			<li>RewardStandardCore</li>
+		</thingSetMakerTags>
+		<tradeTags>
+			<li>CE_AutoEnableTrade_Sellable</li>
+		</tradeTags>
+		<ammoClass>Antigrain</ammoClass>
+		<comps>
+			<!-- Vanilla values -->
+			<li Class="CompProperties_Explosive">
+				<explosiveRadius>14.9</explosiveRadius>
+				<damageAmountBase>300</damageAmountBase>
+				<explosiveDamageType>BombSuper</explosiveDamageType>
+				<startWickHitPointsPercent>0.7</startWickHitPointsPercent>
+				<chanceToStartFire>0.22</chanceToStartFire>
+				<damageFalloff>true</damageFalloff>
+				<explosionEffect>GiantExplosion</explosionEffect>
+				<explosionSound>Explosion_GiantBomb</explosionSound>
+				<preExplosionSpawnSingleThingDef>CraterMedium</preExplosionSpawnSingleThingDef>
+				<wickTicks>60~120</wickTicks>
+				<explodeOnKilled>True</explodeOnKilled>
+				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			</li>
+		</comps>
 	</ThingDef>
 
 	<!-- ================== Projectiles ================== -->
@@ -276,6 +315,34 @@
 			<preExplosionSpawnChance>1</preExplosionSpawnChance>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 			<explosionEffect>ExtinguisherExplosion</explosionEffect>
+		</projectile>
+	</ThingDef>
+	
+	<ThingDef ParentName="Base81mmMortarShell">
+		<defName>Bullet_105mmHowitzerShell_Anti</defName>
+		<label>105mm Howitzer shell (Anti)</label>
+		<graphicData>
+			<texPath>Things/Projectile/Mortar/Antigrain</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>BombSuper</damageDef>
+			<!-- Same damage as 81mm shells. The justification for this is the antigrain warhead being more or less the same, a single grain of antimatter. The delivery platform is just different -->
+			<!-- Mind you, this is still crazy good. This still does 4x damage compared to 105mm HE -->
+			<damageAmountBase>800</damageAmountBase>
+			<explosionRadius>50</explosionRadius>
+			<explosionChanceToStartFire>0.22</explosionChanceToStartFire>
+			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			<flyOverhead>true</flyOverhead>
+			<explosionEffect>GiantExplosion</explosionEffect>
+			<soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
+			<soundExplode>Explosion_GiantBomb</soundExplode>
+			<soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
+			<soundAmbient>MortarRound_Ambient</soundAmbient>
+			<preExplosionSpawnSingleThingDef>CraterMedium</preExplosionSpawnSingleThingDef>
+			<shellingProps>
+				<damage>0.85</damage>
+			</shellingProps>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Shell/105mmHowitzer.xml
+++ b/Defs/Ammo/Shell/105mmHowitzer.xml
@@ -151,6 +151,9 @@
 		<tradeTags>
 			<li>CE_AutoEnableTrade_Sellable</li>
 		</tradeTags>
+		<thingCategories Inherit="False">
+			<li>Ammo105mmHowitzerShells</li>
+		</thingCategories>				
 		<ammoClass>Antigrain</ammoClass>
 		<comps>
 			<!-- Vanilla values -->

--- a/Defs/Ammo/Shell/155mmHowitzer.xml
+++ b/Defs/Ammo/Shell/155mmHowitzer.xml
@@ -131,6 +131,9 @@
 		<thingSetMakerTags>
 			<li>RewardStandardCore</li>
 		</thingSetMakerTags>
+		<thingCategories Inherit="False">
+			<li>Ammo155mmHowitzerShells</li>
+		</thingCategories>		
 		<tradeTags>
 			<li>CE_AutoEnableTrade_Sellable</li>
 		</tradeTags>

--- a/Defs/Ammo/Shell/155mmHowitzer.xml
+++ b/Defs/Ammo/Shell/155mmHowitzer.xml
@@ -19,6 +19,7 @@
 			<Ammo_155mmHowitzerShell_Incendiary>Bullet_155mmHowitzerShell_Incendiary</Ammo_155mmHowitzerShell_Incendiary>
 			<Ammo_155mmHowitzerShell_EMP>Bullet_155mmHowitzerShell_EMP</Ammo_155mmHowitzerShell_EMP>
 			<Ammo_155mmHowitzerShell_Smoke>Bullet_155mmHowitzerShell_Smoke</Ammo_155mmHowitzerShell_Smoke>
+			<Ammo_155mmHowitzerShell_Anti>Bullet_155mmHowitzerShell_Anti</Ammo_155mmHowitzerShell_Anti>
 		</ammoTypes>
 		<isMortarAmmoSet>true</isMortarAmmoSet>
 		<similarTo>AmmoSet_ArtilleryShell</similarTo>
@@ -112,6 +113,45 @@
 		<ammoClass>Smoke</ammoClass>
 		<detonateProjectile>Bullet_155mmHowitzerShell_Smoke</detonateProjectile>
 		<spawnAsSiegeAmmo>false</spawnAsSiegeAmmo>
+	</ThingDef>
+	
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="81mmMortarShellBase">
+		<defName>Ammo_155mmHowitzerShell_Anti</defName>
+		<label>155mm Howitzer shell (Anti)</label>
+		<description>An ultra-tech artillery warhead packed with two grains of antimatter.</description>
+		<graphicData>
+			<texPath>Things/Ammo/Cannon/Howitzer/ANTI</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>2100</MarketValue>
+			<Mass>24</Mass>
+			<Bulk>31.8</Bulk>
+		</statBases>
+		<thingSetMakerTags>
+			<li>RewardStandardCore</li>
+		</thingSetMakerTags>
+		<tradeTags>
+			<li>CE_AutoEnableTrade_Sellable</li>
+		</tradeTags>
+		<ammoClass>Antigrain</ammoClass>
+		<comps>
+			<li Class="CompProperties_Explosive">
+				<explosiveRadius>18.9</explosiveRadius>
+				<!-- One thirds of its projectile damage for cook-off -->
+				<damageAmountBase>436</damageAmountBase>
+				<explosiveDamageType>BombSuper</explosiveDamageType>
+				<startWickHitPointsPercent>0.7</startWickHitPointsPercent>
+				<chanceToStartFire>0.22</chanceToStartFire>
+				<damageFalloff>true</damageFalloff>
+				<explosionEffect>GiantExplosion</explosionEffect>
+				<explosionSound>Explosion_GiantBomb</explosionSound>
+				<preExplosionSpawnSingleThingDef>CraterMedium</preExplosionSpawnSingleThingDef>
+				<wickTicks>60~120</wickTicks>
+				<explodeOnKilled>True</explodeOnKilled>
+				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			</li>
+		</comps>
 	</ThingDef>
 
 	<!-- ================== Projectiles ================== -->
@@ -265,6 +305,37 @@
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 			<explosionEffect>ExtinguisherExplosion</explosionEffect>
 		</projectile>
+	</ThingDef>
+	
+	<ThingDef ParentName="Base155mmHowitzerShell">
+		<defName>Bullet_155mmHowitzerShell_Anti</defName>
+		<label>155mm Howitzer shell (Anti)</label>
+		<graphicData>
+			<texPath>Things/Projectile/Mortar/Antigrain</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>BombSuper</damageDef>
+			<damageAmountBase>1310</damageAmountBase>
+			<explosionRadius>56</explosionRadius>
+			<explosionChanceToStartFire>0.21</explosionChanceToStartFire>
+			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			<flyOverhead>true</flyOverhead>
+			<explosionEffect>GiantExplosion</explosionEffect>
+			<soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
+			<soundExplode>Explosion_GiantBomb</soundExplode>
+			<soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
+			<soundAmbient>MortarRound_Ambient</soundAmbient>
+			<preExplosionSpawnSingleThingDef>CraterMedium</preExplosionSpawnSingleThingDef>
+			<shellingProps>
+				<damage>0.85</damage>
+			</shellingProps>
+		</projectile>
+		<modExtensions>
+			<li Class="CombatExtended.GenericLabelExtension">
+				<genericLabel>mortar shell (Anti)</genericLabel>
+			</li>
+		</modExtensions>
 	</ThingDef>
 
 	<!-- direct fire-->


### PR DESCRIPTION
## Additions
Antigrain shells for 105mm and 155mm Howitzer shells, alongside generic artillery shells.
105mm shells have the same damage values as 81mm antigrain as the warhead being practically the same. 155mm gets a twin-load of two grains, so does more damage.

## Reasoning

- This feels like a 'no one got around to it' thing. Combat Extended even has sprites for antigrain artillery shells, seperate from antigrain mortar shells.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings - Changes do not require a recompile
- [X] Game runs without errors
- [X] Playtested a colony (specify how long) - 15-20 minutes of testing the shells
