### PR TITLE
Remove movement speed debuff from the VWE anti-materiel rifle

### DIFF
--- a/ModPatches/Vanilla Weapons Expanded/Patches/Vanilla Weapons Expanded/Industrial_Ranged.xml
+++ b/ModPatches/Vanilla Weapons Expanded/Patches/Vanilla Weapons Expanded/Industrial_Ranged.xml
@@ -685,6 +685,10 @@
 		<researchPrerequisite>PrecisionRifling</researchPrerequisite>
 		<AllowWithRunAndGun>false</AllowWithRunAndGun>
 	</Operation>
+	
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="VWE_Gun_AntiMaterialRifle"]/equippedStatOffsets/MoveSpeed</xpath>
+	</Operation>
 
 	<!-- === Marksman Rifle (SVD) === -->
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">


### PR DESCRIPTION
## Changes

- Removed movement stat offset from the anti-materiel rifle
## Reasoning

- Such offsets are usually removed in favor of offsets from Combat Extended's mass and bulk system
- 
## Testing

Check tests you have performed:
- [ ] Compiles without warnings - Changes do not require a recompile
- [X] Game runs without errors
- [X] (For compatibility patches) ...with and without patched mod loaded
- [X] Playtested a colony (specify how long) - A few minutes, made sure the offset wasn't there