### PR TITLE
Vf damage fix

### DIFF
--- a/Languages/English/Keyed/ModMenu.xml
+++ b/Languages/English/Keyed/ModMenu.xml
@@ -164,10 +164,10 @@
 	<CE_Settings_PatchArmorDamage_Title>Use New Vehicle Armor</CE_Settings_PatchArmorDamage_Title>
 	<CE_Settings_PatchArmorDamage_Desc>Vehicle Armor reduces damage based on relative values, but can be penetrated by high AP attacks.</CE_Settings_PatchArmorDamage_Desc>
 
-        <CE_Settings_HitRandomVehicleComponents_Title>Hit Any Component</CE_Settings_HitRandomVehicleComponents_Title>
+	<CE_Settings_HitRandomVehicleComponents_Title>Hit Any Component</CE_Settings_HitRandomVehicleComponents_Title>
 	<CE_Settings_HitRandomVehicleComponents_Desc>Damage anything when hitting disabled vehicles.</CE_Settings_HitRandomVehicleComponents_Desc>
 
-        <CE_Settings_FragmentsFromVehicles_Title>Fragments From Vehicles</CE_Settings_FragmentsFromVehicles_Title>
+	<CE_Settings_FragmentsFromVehicles_Title>Fragments From Vehicles</CE_Settings_FragmentsFromVehicles_Title>
 	<CE_Settings_FragmentsFromVehicles_Desc>When over penetrating a vehicle, generate a new projectile out the far side.</CE_Settings_FragmentsFromVehicles_Desc>
 
 	<!-- ========== Autopatcher settings ========== -->

--- a/Languages/English/Keyed/ModMenu.xml
+++ b/Languages/English/Keyed/ModMenu.xml
@@ -164,11 +164,11 @@
 	<CE_Settings_PatchArmorDamage_Title>Use New Vehicle Armor</CE_Settings_PatchArmorDamage_Title>
 	<CE_Settings_PatchArmorDamage_Desc>Vehicle Armor reduces damage based on relative values, but can be penetrated by high AP attacks.</CE_Settings_PatchArmorDamage_Desc>
 
-	<CE_Settings_HitRandomVehicleComponents_Title>Hit Any Component</CE_Settings_HitRandomVehicleComponents_Title>
-	<CE_Settings_HitRandomVehicleComponents_Desc>Damage anything when hitting disabled vehicles.</CE_Settings_HitRandomVehicleComponents_Desc>
+	<CE_Settings_HitRandomVehicleComponents_Title>Hit any component</CE_Settings_HitRandomVehicleComponents_Title>
+	<CE_Settings_HitRandomVehicleComponents_Desc>When a vehicle is at low health, projectiles that fail to encounter a surviving component will instead damage a random one.\n\nThis prevents heavily damaged vehicles being kept intact by small, hard-to-hit components.</CE_Settings_HitRandomVehicleComponents_Desc>
 
-	<CE_Settings_FragmentsFromVehicles_Title>Fragments From Vehicles</CE_Settings_FragmentsFromVehicles_Title>
-	<CE_Settings_FragmentsFromVehicles_Desc>When over penetrating a vehicle, generate a new projectile out the far side.</CE_Settings_FragmentsFromVehicles_Desc>
+	<CE_Settings_FragmentsFromVehicles_Title>Fragments from vehicles</CE_Settings_FragmentsFromVehicles_Title>
+	<CE_Settings_FragmentsFromVehicles_Desc>When a projectile over-penetrates a vehicle, generate a fragments on the far side.</CE_Settings_FragmentsFromVehicles_Desc>
 
 	<!-- ========== Autopatcher settings ========== -->
 

--- a/Languages/English/Keyed/ModMenu.xml
+++ b/Languages/English/Keyed/ModMenu.xml
@@ -162,7 +162,13 @@
 	<CE_Settings_Vehicles>Vehicle settings</CE_Settings_Vehicles>
 
 	<CE_Settings_PatchArmorDamage_Title>Use New Vehicle Armor</CE_Settings_PatchArmorDamage_Title>
-	<CE_Settings_PatchArmorDamage_Desc>Vehicle Armor reduces damage based on relative values, but can be penetrated by high AP attacks..</CE_Settings_PatchArmorDamage_Desc>
+	<CE_Settings_PatchArmorDamage_Desc>Vehicle Armor reduces damage based on relative values, but can be penetrated by high AP attacks.</CE_Settings_PatchArmorDamage_Desc>
+
+        <CE_Settings_HitRandomVehicleComponents_Title>Hit Any Component</CE_Settings_HitRandomVehicleComponents_Title>
+	<CE_Settings_HitRandomVehicleComponents_Desc>Damage anything when hitting disabled vehicles.</CE_Settings_HitRandomVehicleComponents_Desc>
+
+        <CE_Settings_FragmentsFromVehicles_Title>Fragments From Vehicles</CE_Settings_FragmentsFromVehicles_Title>
+	<CE_Settings_FragmentsFromVehicles_Desc>When over penetrating a vehicle, generate a new projectile out the far side.</CE_Settings_FragmentsFromVehicles_Desc>
 
 	<!-- ========== Autopatcher settings ========== -->
 

--- a/Source/CombatExtended/CombatExtended/ModSettings/Settings.cs
+++ b/Source/CombatExtended/CombatExtended/ModSettings/Settings.cs
@@ -188,6 +188,8 @@ public class Settings : ModSettings, ISettingsCE
 
     #region Compatibility Modsettings
     public bool patchArmorDamage = true;
+    public bool hitRandomVehicleComponents = false;
+    public bool fragmentsFromVehicles = false;
 
     #endregion
 

--- a/Source/CombatExtended/CombatExtended/ModSettings/Settings.cs
+++ b/Source/CombatExtended/CombatExtended/ModSettings/Settings.cs
@@ -188,7 +188,7 @@ public class Settings : ModSettings, ISettingsCE
 
     #region Compatibility Modsettings
     public bool patchArmorDamage = true;
-    public bool hitRandomVehicleComponents = false;
+    public bool hitRandomVehicleComponents = true;
     public bool fragmentsFromVehicles = false;
 
     #endregion

--- a/Source/CombatExtended/CombatExtended/ModSettings/Settings.cs
+++ b/Source/CombatExtended/CombatExtended/ModSettings/Settings.cs
@@ -288,6 +288,8 @@ public class Settings : ModSettings, ISettingsCE
 
         // Compatibility
         Scribe_Values.Look(ref patchArmorDamage, "patchArmorDamage", true);
+        Scribe_Values.Look(ref hitRandomVehicleComponents, "hitRandomVehicleComponents", true);
+        Scribe_Values.Look(ref fragmentsFromVehicles, "fragmentsFromVehicles", false);
     }
 
     public void DoWindowContents(Listing_Standard list)
@@ -620,6 +622,8 @@ public class Settings : ModSettings, ISettingsCE
 #endif
         // Compatibility Settings
         patchArmorDamage = true;
+        hitRandomVehicleComponents = true;
+        fragmentsFromVehicles = false;
     }
     #endregion
 

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -107,6 +107,10 @@ public abstract class ProjectileCE : ThingWithComps
 
             return ((float)this.damageAmount) * RemainingKineticEnergyPct;
         }
+        set
+        {
+            damageAmount = value;
+        }
     }
     public virtual float PenetrationAmount
     {

--- a/Source/VehiclesCompat/VehiclesCompat/VehicleArmorPatch.cs
+++ b/Source/VehiclesCompat/VehiclesCompat/VehicleArmorPatch.cs
@@ -78,29 +78,31 @@ public static class VehicleArmorPatch
                 for (int z = 1; z < max_z - 1; z++)
                 {
                     IntVec2 innerCell = new IntVec2(x, z);
-                    stats.componentLocations.TryGetValue(innerCell, out List<VehicleComponent> maybeUnhittable);
-                    foreach (var comp in maybeUnhittable)
+                    if (stats.componentLocations.TryGetValue(innerCell, out List<VehicleComponent> maybeUnhittable))
                     {
-                        if (comp.Depth != VehicleComponent.VehiclePartDepth.External)
+                        foreach (var comp in maybeUnhittable)
                         {
-                            continue;
-                        }
-                        bool unhittable = true;
-                        foreach (var cell in comp.props.hitbox.Hitbox)
-                        {
-                            if (cell.x == 0 || cell.x == max_z || cell.z == 0 || cell.z == max_x)
+                            if (comp.Depth != VehicleComponent.VehiclePartDepth.External)
                             {
-                                unhittable = false;
-                                break;
+                                continue;
                             }
-                        }
-                        if (unhittable)
-                        {
-                            if (Controller.settings.hitRandomVehicleComponents)
+                            bool unhittable = true;
+                            foreach (var cell in comp.props.hitbox.Hitbox)
                             {
-                                unhittableComponents.Add(comp);
+                                if (cell.x == 0 || cell.x == max_z || cell.z == 0 || cell.z == max_x)
+                                {
+                                    unhittable = false;
+                                    break;
+                                }
                             }
-                            unhittableHP += comp.Health;
+                            if (unhittable)
+                            {
+                                if (Controller.settings.hitRandomVehicleComponents)
+                                {
+                                    unhittableComponents.Add(comp);
+                                }
+                                unhittableHP += comp.Health;
+                            }
                         }
                     }
                 }

--- a/Source/VehiclesCompat/VehiclesCompat/VehicleArmorPatch.cs
+++ b/Source/VehiclesCompat/VehiclesCompat/VehicleArmorPatch.cs
@@ -309,20 +309,26 @@ public static class VehicleArmorPatch
         frag.velocity *= Mathf.Sqrt(keRatio);
         frag.initialSpeed = frag.shotSpeed = frag.velocity.magnitude * GenTicks.TicksPerRealSecond;
         frag.ExactPosition = new Vector3(cell.x, height, cell.z);
-        report?.AppendLine($"Spawning fragment");
-        report?.AppendLine($"angle: {frontArc}");
-        report?.AppendLine($"damage: {dinfo.Amount} / {baseAmount}");
-        report?.AppendLine($"mass: {frag.mass} / {baseMass}");
-        report?.AppendLine($"keRatio: {keRatio}");
-        report?.AppendLine($"velocity {frag.velocity} / {baseVel}");
+        if (report != null)
+        {
+            report.AppendLine($"Spawning fragment");
+            report.AppendLine($"angle: {frontArc}");
+            report.AppendLine($"damage: {dinfo.Amount} / {baseAmount}");
+            report.AppendLine($"mass: {frag.mass} / {baseMass}");
+            report.AppendLine($"keRatio: {keRatio}");
+            report.AppendLine($"velocity {frag.velocity} / {baseVel}");
+        }
     }
 
     public static bool TryPenetrateComponents(VehicleStatHandler stats, ref DamageInfo dinfo, List<VehicleComponent> components, VehicleComponent.VehiclePartDepth hitDepth, StringBuilder? report)
     {
         var componentsAtHitDepth = components.Where(comp => comp.Depth == hitDepth && comp.HealthPercent > 0).OrderBy(x => Rand.Value * x.props.hitWeight);
-        report?.AppendLine($"components=({string.Join(",", components.Select(c => c.props.label))})");
-        report?.AppendLine($"hitDepth = {hitDepth}");
-        report?.AppendLine($"components at hitDepth {hitDepth}: ({string.Join(",", componentsAtHitDepth.Select(comp => comp.props.label))})");
+        if (report != null)
+        {
+            report.AppendLine($"components=({string.Join(",", components.Select(c => c.props.label))})");
+            report.AppendLine($"hitDepth = {hitDepth}");
+            report.AppendLine($"components at hitDepth {hitDepth}: ({string.Join(",", componentsAtHitDepth.Select(comp => comp.props.label))})");
+        }
         foreach (var component in componentsAtHitDepth)
         {
             report?.AppendLine($"Hitting Component {component.props.label}");
@@ -384,16 +390,22 @@ public static class VehicleArmorPatch
         float armorDamage = 0;
 
         bool deflected = armorAmount > 0 && DamageArmor(isSharp, armorAmount, ref penAmount, ref dmgAmount, out armorDamage);
-        report?.AppendLine($"deflected by component armor? {deflected}");
-        report?.AppendLine($"Armor Damage: {armorDamage}");
+        if (report != null)
+        {
+            report.AppendLine($"deflected by component armor? {deflected}");
+            report.AppendLine($"Armor Damage: {armorDamage}");
+        }
         dmgAmount += DamageComponent(component, armorDamage, dinfo, deflected ? VehicleComponent.Penetration.Diminished : VehicleComponent.Penetration.Penetrated);
 
         if (!deflected)
         {
             report?.AppendLine($"component health? {component.health}");
             deflected = DamageArmor(isSharp, component.health / 50, ref penAmount, ref dmgAmount, out armorDamage);
-            report?.AppendLine($"deflected by component bulk? {deflected}");
-            report?.AppendLine($"Component Damage: {armorDamage}");
+            if (report != null)
+            {
+                report.AppendLine($"deflected by component bulk? {deflected}");
+                report.AppendLine($"Component Damage: {armorDamage}");
+            }
             dmgAmount += DamageComponent(component, armorDamage, dinfo, VehicleComponent.Penetration.Penetrated);
         }
         dinfo.SetAmount(dmgAmount);

--- a/Source/VehiclesCompat/VehiclesCompat/VehicleArmorPatch.cs
+++ b/Source/VehiclesCompat/VehiclesCompat/VehicleArmorPatch.cs
@@ -199,6 +199,11 @@ public static class VehicleArmorPatch
                         if (hitDepth == VehicleComponent.VehiclePartDepth.External) // Blew a hole out, we're done
                         {
                             report?.AppendLine($"Exiting vehicle");
+                            if (Controller.settings.fragmentsFromVehicles)
+                            {
+                                SpawnFragments(ref dinfo, direction, stats, cell2 + new IntVec2(vehicle.Position.x, vehicle.Position.z), report);
+                            }
+
                             break;
                         }
                         else // Hit any pawns and then move on to the next cell
@@ -247,7 +252,7 @@ public static class VehicleArmorPatch
                 }
                 if (Controller.settings.fragmentsFromVehicles)
                 {
-                    SpawnFragments(ref dinfo, direction, stats, cell2);
+                    SpawnFragments(ref dinfo, direction, stats, cell2 + new IntVec2(vehicle.Position.x, vehicle.Position.z), report);
                 }
             }
         }
@@ -283,15 +288,17 @@ public static class VehicleArmorPatch
         stats.RecalculateHealthPercent();
     }
 
-    private static void SpawnFragments(ref DamageInfo dinfo, Vector3 direction, VehicleStatHandler stats, IntVec2 cell)
+    private static void SpawnFragments(ref DamageInfo dinfo, Vector3 direction, VehicleStatHandler stats, IntVec2 cell, StringBuilder? report)
     {
         var height = new FloatRange(0, new CollisionVertical(stats.vehicle).Max).RandomInRange;
-        var frontArc = new FloatRange(dinfo.Angle + 90, dinfo.Angle + 270);
+        var frontArc = new FloatRange(dinfo.Angle - 15, dinfo.Angle + 15);
+        var rotation = frontArc.RandomInRange * Mathf.Deg2Rad;
         var map = stats.vehicle.Map;
         Vector3 spawnOffset = Quaternion.Euler(0, dinfo.Angle, 0) * Vector3.forward * Mathf.Max(1, Mathf.Min(stats.vehicle.RotatedSize.x, stats.vehicle.RotatedSize.z) / 2f);
-        ProjectileCE frag = (ProjectileCE)ThingMaker.MakeThing(CE_ThingDefOf.Fragment_Small, null);
+        spawnOffset.y = height;
+        ProjectileCE frag = (ProjectileCE)ThingMaker.MakeThing(CE_ThingDefOf.Fragment_Large, null);
         GenSpawn.Spawn(frag, new IntVec3(cell.x, 0, cell.z), map);
-        frag.Throw(dinfo.Instigator, spawnOffset, new Vector3(Mathf.Sin(frontArc.RandomInRange * Mathf.Deg2Rad), Mathf.Sin(new FloatRange(-5, 5).RandomInRange * Mathf.Deg2Rad), Mathf.Cos(frontArc.RandomInRange * Mathf.Deg2Rad)), stats.vehicle);
+        frag.Throw(dinfo.Instigator, spawnOffset, new Vector3(Mathf.Sin(rotation), Mathf.Sin(new FloatRange(-5, 5).RandomInRange * Mathf.Deg2Rad), Mathf.Cos(rotation)), stats.vehicle);
         var baseAmount = frag.DamageAmount;
         var baseMass = frag.mass;
         frag.mass = new FloatRange(baseMass, baseMass * 10).RandomInRange;
@@ -301,6 +308,13 @@ public static class VehicleArmorPatch
         var baseVel = frag.velocity;
         frag.velocity *= Mathf.Sqrt(keRatio);
         frag.initialSpeed = frag.shotSpeed = frag.velocity.magnitude * GenTicks.TicksPerRealSecond;
+        frag.ExactPosition = new Vector3(cell.x, height, cell.z);
+        report?.AppendLine($"Spawning fragment");
+        report?.AppendLine($"angle: {frontArc}");
+        report?.AppendLine($"damage: {dinfo.Amount} / {baseAmount}");
+        report?.AppendLine($"mass: {frag.mass} / {baseMass}");
+        report?.AppendLine($"keRatio: {keRatio}");
+        report?.AppendLine($"velocity {frag.velocity} / {baseVel}");
     }
 
     public static bool TryPenetrateComponents(VehicleStatHandler stats, ref DamageInfo dinfo, List<VehicleComponent> components, VehicleComponent.VehiclePartDepth hitDepth, StringBuilder? report)

--- a/Source/VehiclesCompat/VehiclesCompat/VehicleArmorPatch.cs
+++ b/Source/VehiclesCompat/VehiclesCompat/VehicleArmorPatch.cs
@@ -11,7 +11,7 @@ using HarmonyLib;
 using Vehicles;
 using UnityEngine;
 using CombatExtended;
-
+#nullable enable
 
 namespace CombatExtended.Compatibility.VehiclesCompat;
 [HarmonyPatch(typeof(VehicleStatHandler),
@@ -24,8 +24,12 @@ public static class VehicleArmorPatch
         {
             return true;
         }
-        StringBuilder report = VehicleMod.settings.debug.debugLogging ? new StringBuilder() : null;
+        StringBuilder? report = VehicleMod.settings.debug.debugLogging ? new StringBuilder() : null;
         __instance.ApplyDamageCE(ref dinfo, hitCell, report);
+        if (report != null)
+        {
+            Log.Message(report.ToString());
+        }
         return false;
     }
 
@@ -42,7 +46,7 @@ public static class VehicleArmorPatch
       Projectile Inside, is no inner component, is no outer component -- hit outer component on previous cell, direction reversed
       TODO:  Allow non-linear deflections.
      */
-    public static void ApplyDamageCE(this VehicleStatHandler stats, ref DamageInfo dinfo, IntVec2 hitCell, StringBuilder report)
+    public static void ApplyDamageCE(this VehicleStatHandler stats, ref DamageInfo dinfo, IntVec2 hitCell, StringBuilder? report)
     {
         DamageDef def = dinfo.Def;
         VehiclePawn vehicle = stats.vehicle;
@@ -299,7 +303,7 @@ public static class VehicleArmorPatch
         frag.initialSpeed = frag.shotSpeed = frag.velocity.magnitude * GenTicks.TicksPerRealSecond;
     }
 
-    public static bool TryPenetrateComponents(VehicleStatHandler stats, ref DamageInfo dinfo, List<VehicleComponent> components, VehicleComponent.VehiclePartDepth hitDepth, StringBuilder report)
+    public static bool TryPenetrateComponents(VehicleStatHandler stats, ref DamageInfo dinfo, List<VehicleComponent> components, VehicleComponent.VehiclePartDepth hitDepth, StringBuilder? report)
     {
         var componentsAtHitDepth = components.Where(comp => comp.Depth == hitDepth && comp.HealthPercent > 0).OrderBy(x => Rand.Value * x.props.hitWeight);
         report?.AppendLine($"components=({string.Join(",", components.Select(c => c.props.label))})");
@@ -354,7 +358,7 @@ public static class VehicleArmorPatch
         return overdamage;
     }
 
-    public static bool HitComponent(VehicleComponent component, ref DamageInfo dinfo, StringBuilder report)
+    public static bool HitComponent(VehicleComponent component, ref DamageInfo dinfo, StringBuilder? report)
     {
         report?.AppendLine($"Applying Damage = {dinfo.Amount} to {component.props.key}");
 
@@ -409,7 +413,7 @@ public static class VehicleArmorPatch
         return deflected;
     }
 
-    public static float AdjustDamage(float damage, DamageInfo dinfo, StringBuilder report)
+    public static float AdjustDamage(float damage, DamageInfo dinfo, StringBuilder? report)
     {
         if (dinfo.Weapon?.GetModExtension<VehicleDamageMultiplierDefModExtension>() is VehicleDamageMultiplierDefModExtension weaponMultiplier)
         {
@@ -439,3 +443,4 @@ public static class VehicleArmorPatch
         return damage;
     }
 }
+#nullable restore

--- a/Source/VehiclesCompat/VehiclesCompat/VehicleArmorPatch.cs
+++ b/Source/VehiclesCompat/VehiclesCompat/VehicleArmorPatch.cs
@@ -64,6 +64,45 @@ public static class VehicleArmorPatch
             return;
         }
 
+        var unhittableComponents = new List<VehicleComponent>();
+        float unhittableHP = 0;
+        {
+            var max_x = vehicle.VehicleDef.Size.x;
+            var max_z = vehicle.VehicleDef.Size.z;
+            for (int x = 1; x < max_x - 1; x++)
+            {
+                for (int z = 1; z < max_z - 1; z++)
+                {
+                    IntVec2 innerCell = new IntVec2(x, z);
+                    stats.componentLocations.TryGetValue(innerCell, out List<VehicleComponent> maybeUnhittable);
+                    foreach (var comp in maybeUnhittable)
+                    {
+                        if (comp.Depth != VehicleComponent.VehiclePartDepth.External)
+                        {
+                            continue;
+                        }
+                        bool unhittable = true;
+                        foreach (var cell in comp.props.hitbox.Hitbox)
+                        {
+                            if (cell.x == 0 || cell.x == max_z || cell.z == 0 || cell.z == max_x)
+                            {
+                                unhittable = false;
+                                break;
+                            }
+                        }
+                        if (unhittable)
+                        {
+                            if (Controller.settings.hitRandomVehicleComponents)
+                            {
+                                unhittableComponents.Add(comp);
+                            }
+                            unhittableHP += comp.Health;
+                        }
+                    }
+                }
+            }
+        }
+
         dinfo.SetAmount(damage);
         float maxLength = vehicle.VehicleDef.Size.x + vehicle.VehicleDef.Size.z;
         Vector3 direction = new Vector3(Mathf.Sin(Mathf.Deg2Rad * dinfo.Angle) * maxLength, 0, Mathf.Cos(Mathf.Deg2Rad * dinfo.Angle) * maxLength);
@@ -197,6 +236,11 @@ public static class VehicleArmorPatch
                     cidx += cdirection;
                     continue;
                 }
+                if (hcount == 1 && Controller.settings.hitRandomVehicleComponents) // our first time through, never hit anything.
+                {
+                    TryPenetrateComponents(stats, ref dinfo, unhittableComponents, hitDepth, report);
+                    break;
+                }
                 if (Controller.settings.fragmentsFromVehicles)
                 {
                     SpawnFragments(ref dinfo, direction, stats, cell2);
@@ -211,7 +255,29 @@ public static class VehicleArmorPatch
             cell = hitCell
         });
 
+        if (!Controller.settings.hitRandomVehicleComponents)
+        {
+            float current = 0;
+            float total = 0;
+            foreach (VehicleComponent component in stats.components)
+            {
+                current += component.Health;
+                total += component.MaxHealth;
+            }
+            current -= unhittableHP;
+            total -= unhittableHP;
+            if (total < 1)
+            {
+                total = 1;
+            }
+            float pct = (current / total);
+            if (pct < 0.01)
+            {
+                vehicle.Kill(dinfo);
+            }
+        }
         stats.RecalculateHealthPercent();
+    }
 
     private static void SpawnFragments(ref DamageInfo dinfo, Vector3 direction, VehicleStatHandler stats, IntVec2 cell)
     {
@@ -221,7 +287,7 @@ public static class VehicleArmorPatch
         Vector3 spawnOffset = Quaternion.Euler(0, dinfo.Angle, 0) * Vector3.forward * Mathf.Max(1, Mathf.Min(stats.vehicle.RotatedSize.x, stats.vehicle.RotatedSize.z) / 2f);
         ProjectileCE frag = (ProjectileCE)ThingMaker.MakeThing(CE_ThingDefOf.Fragment_Small, null);
         GenSpawn.Spawn(frag, new IntVec3(cell.x, 0, cell.z), map);
-        frag.Throw(dinfo.Instigator, spawnOffset, new Vector3(Mathf.Sin(frontArc.RandomInRange * Mathf.Deg2Rad), Mathf.Sin(new FloatRange(-5,5).RandomInRange * Mathf.Deg2Rad), Mathf.Cos(frontArc.RandomInRange * Mathf.Deg2Rad)), stats.vehicle);
+        frag.Throw(dinfo.Instigator, spawnOffset, new Vector3(Mathf.Sin(frontArc.RandomInRange * Mathf.Deg2Rad), Mathf.Sin(new FloatRange(-5, 5).RandomInRange * Mathf.Deg2Rad), Mathf.Cos(frontArc.RandomInRange * Mathf.Deg2Rad)), stats.vehicle);
         var baseAmount = frag.DamageAmount;
         var baseMass = frag.mass;
         frag.mass = new FloatRange(baseMass, baseMass * 10).RandomInRange;

--- a/Source/VehiclesCompat/VehiclesCompat/VehicleArmorPatch.cs
+++ b/Source/VehiclesCompat/VehiclesCompat/VehicleArmorPatch.cs
@@ -197,6 +197,10 @@ public static class VehicleArmorPatch
                     cidx += cdirection;
                     continue;
                 }
+                if (Controller.settings.fragmentsFromVehicles)
+                {
+                    SpawnFragments(ref dinfo, direction, stats, cell2);
+                }
             }
         }
 
@@ -209,6 +213,24 @@ public static class VehicleArmorPatch
 
         stats.RecalculateHealthPercent();
 
+    private static void SpawnFragments(ref DamageInfo dinfo, Vector3 direction, VehicleStatHandler stats, IntVec2 cell)
+    {
+        var height = new FloatRange(0, new CollisionVertical(stats.vehicle).Max).RandomInRange;
+        var frontArc = new FloatRange(dinfo.Angle + 90, dinfo.Angle + 270);
+        var map = stats.vehicle.Map;
+        Vector3 spawnOffset = Quaternion.Euler(0, dinfo.Angle, 0) * Vector3.forward * Mathf.Max(1, Mathf.Min(stats.vehicle.RotatedSize.x, stats.vehicle.RotatedSize.z) / 2f);
+        ProjectileCE frag = (ProjectileCE)ThingMaker.MakeThing(CE_ThingDefOf.Fragment_Small, null);
+        GenSpawn.Spawn(frag, new IntVec3(cell.x, 0, cell.z), map);
+        frag.Throw(dinfo.Instigator, spawnOffset, new Vector3(Mathf.Sin(frontArc.RandomInRange * Mathf.Deg2Rad), Mathf.Sin(new FloatRange(-5,5).RandomInRange * Mathf.Deg2Rad), Mathf.Cos(frontArc.RandomInRange * Mathf.Deg2Rad)), stats.vehicle);
+        var baseAmount = frag.DamageAmount;
+        var baseMass = frag.mass;
+        frag.mass = new FloatRange(baseMass, baseMass * 10).RandomInRange;
+        frag.DamageAmount = dinfo.Amount;
+        var damageRatio = dinfo.Amount / baseAmount;
+        var keRatio = damageRatio / (frag.mass / baseMass);
+        var baseVel = frag.velocity;
+        frag.velocity *= Mathf.Sqrt(keRatio);
+        frag.initialSpeed = frag.shotSpeed = frag.velocity.magnitude * GenTicks.TicksPerRealSecond;
     }
 
     public static bool TryPenetrateComponents(VehicleStatHandler stats, ref DamageInfo dinfo, List<VehicleComponent> components, VehicleComponent.VehiclePartDepth hitDepth, StringBuilder report)

--- a/Source/VehiclesCompat/VehiclesCompat/VehicleSettings.cs
+++ b/Source/VehiclesCompat/VehiclesCompat/VehicleSettings.cs
@@ -31,6 +31,6 @@ public class VehicleSettings : ISettingsCE
         {
             Controller.settings.fragmentsFromVehicles = false;
         }
-    }
 #endif
+    }
 }

--- a/Source/VehiclesCompat/VehiclesCompat/VehicleSettings.cs
+++ b/Source/VehiclesCompat/VehiclesCompat/VehicleSettings.cs
@@ -21,6 +21,8 @@ public class VehicleSettings : ISettingsCE
         Text.Font = GameFont.Small;
         list.Gap();
         list.CheckboxLabeled("CE_Settings_PatchArmorDamage_Title".Translate(), ref Controller.settings.patchArmorDamage, "CE_Settings_PatchArmorDamage_Desc".Translate());
+        list.CheckboxLabeled("CE_Settings_HitRandomVehicleComponents_Title".Translate(), ref Controller.settings.hitRandomVehicleComponents, "CE_Settings_HitRandomVehicleComponents_Desc".Translate());
+        list.CheckboxLabeled("CE_Settings_FragmentsFromVehicles_Title".Translate(), ref Controller.settings.fragmentsFromVehicles, "CE_Settings_FragmentsFromVehicles_Desc".Translate());
     }
 
 }

--- a/Source/VehiclesCompat/VehiclesCompat/VehicleSettings.cs
+++ b/Source/VehiclesCompat/VehiclesCompat/VehicleSettings.cs
@@ -22,7 +22,15 @@ public class VehicleSettings : ISettingsCE
         list.Gap();
         list.CheckboxLabeled("CE_Settings_PatchArmorDamage_Title".Translate(), ref Controller.settings.patchArmorDamage, "CE_Settings_PatchArmorDamage_Desc".Translate());
         list.CheckboxLabeled("CE_Settings_HitRandomVehicleComponents_Title".Translate(), ref Controller.settings.hitRandomVehicleComponents, "CE_Settings_HitRandomVehicleComponents_Desc".Translate());
-        list.CheckboxLabeled("CE_Settings_FragmentsFromVehicles_Title".Translate(), ref Controller.settings.fragmentsFromVehicles, "CE_Settings_FragmentsFromVehicles_Desc".Translate());
+#if DEBUG
+        if (Controller.settings.DebuggingMode)
+        {
+            list.CheckboxLabeled("CE_Settings_FragmentsFromVehicles_Title".Translate(), ref Controller.settings.fragmentsFromVehicles, "CE_Settings_FragmentsFromVehicles_Desc".Translate());
+        }
+        else
+        {
+            Controller.settings.fragmentsFromVehicles = false;
+        }
     }
-
+#endif
 }


### PR DESCRIPTION
## Additions

- projectiles leaving vehicles spawn fragments
- mod option to make all components reachable 

## Changes
- vehicles die when all reachable components are destroyed
 
## Reasoning

Currently, some vehicles are nearly unkillable, when they have an external component that can never be hit due to not being on the vehicle perimiter.  This resolves that in either of 2 ways, depending on player setting.  Both have edge cases involving the AI.

## Alternatives

Force one choice.  
Let some vehicles remain effectively immortal.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
