### PR TITLE
autoloader update for VDE-Deserters

### DIFF
--- a/ModPatches/Vanilla Factions Expanded - Deserters/Patches/Vanilla Factions Expanded - Deserters/Buildings_Security_Turrets.xml
+++ b/ModPatches/Vanilla Factions Expanded - Deserters/Patches/Vanilla Factions Expanded - Deserters/Buildings_Security_Turrets.xml
@@ -89,6 +89,24 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="VFED_Turret_Kontarion"]/building</xpath>
+		<value>
+			<buildingTags>
+				<li>CE_Autoloader_UraniumSlug</li>
+			</buildingTags>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Turret_Sniper"]/building</xpath>
+		<value>
+			<buildingTags>
+				<li>CE_Autoloader_UraniumSlug</li>
+			</buildingTags>
+		</value>
+	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="VFED_Turret_Kontarion"]/costList</xpath>
 		<value>
@@ -176,6 +194,24 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="VFED_Turret_Palintone"]/building</xpath>
+		<value>
+			<buildingTags>
+				<li>CE_Autoloader_20x102mmNATO</li>
+			</buildingTags>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Turret_Autocannon"]/building</xpath>
+		<value>
+			<buildingTags>
+				<li>CE_Autoloader_20x102mmNATO</li>
+			</buildingTags>
+		</value>
+	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="VFED_Turret_Palintone"]/costList</xpath>
 		<value>
@@ -257,6 +293,24 @@
 		<xpath>Defs/ThingDef[defName="VFED_Turret_Onager"]/building/turretBurstCooldownTime</xpath>
 		<value>
 			<turretBurstCooldownTime>4.2</turretBurstCooldownTime>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="VFED_Turret_Onager"]/building</xpath>
+		<value>
+			<buildingTags>
+				<li>CE_Autoloader_50mmRocket</li>
+			</buildingTags>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Turret_RocketswarmLauncher"]/building</xpath>
+		<value>
+			<buildingTags>
+				<li>CE_Autoloader_50mmRocket</li>
+			</buildingTags>
 		</value>
 	</Operation>
 

--- a/ModPatches/Vanilla Factions Expanded - Deserters/Patches/Vanilla Factions Expanded - Deserters/Buildings_Special.xml
+++ b/ModPatches/Vanilla Factions Expanded - Deserters/Patches/Vanilla Factions Expanded - Deserters/Buildings_Special.xml
@@ -20,6 +20,10 @@
 					<reloadTime>7.8</reloadTime>
 					<ammoSet>AmmoSet_40x311mmR</ammoSet>
 				</li>
+				<li Class="CompProperties_Power">
+					<compClass>CompPowerTrader</compClass>
+					<basePowerConsumption>50</basePowerConsumption>
+				</li>
 			</comps>
 		</value>
 	</Operation>
@@ -58,6 +62,10 @@
 				<reloadTime>7.8</reloadTime>
 				<ammoSet>AmmoSet_20x102mmNATO</ammoSet>
 			</li>
+			<li Class="CompProperties_Power">
+				<compClass>CompPowerTrader</compClass>
+				<basePowerConsumption>50</basePowerConsumption>
+			</li>
 		</value>
 	</Operation>
 
@@ -95,6 +103,10 @@
 				<magazineSize>72</magazineSize>
 				<reloadTime>7.8</reloadTime>
 				<ammoSet>AmmoSet_50mmRocket</ammoSet>
+			</li>
+			<li Class="CompProperties_Power">
+				<compClass>CompPowerTrader</compClass>
+				<basePowerConsumption>50</basePowerConsumption>
 			</li>
 		</value>
 	</Operation>

--- a/ModPatches/Vanilla Factions Expanded - Deserters/Patches/Vanilla Factions Expanded - Deserters/Buildings_Special.xml
+++ b/ModPatches/Vanilla Factions Expanded - Deserters/Patches/Vanilla Factions Expanded - Deserters/Buildings_Special.xml
@@ -15,7 +15,7 @@
 		<xpath>Defs/ThingDef[defName="VFED_AmmoBox_UraniumSlug"]</xpath>
 		<value>
 			<comps>
-				<li Class="CombatExtended.CompProperties_AmmoUser">
+				<li Class="CombatExtended.CompProperties_AmmoListUser">
 					<magazineSize>180</magazineSize>
 					<reloadTime>7.8</reloadTime>
 					<ammoSet>AmmoSet_40x311mmR</ammoSet>
@@ -42,6 +42,9 @@
 					<li>Turret_Sniper</li>
 					<li>VFED_Turret_Kontarion</li>
 				</allowedTurrets>
+				<allowedTurretTags>
+					<li>CE_Autoloader_UraniumSlug</li>
+				</allowedTurretTags>
 			</li>
 		</value>
 	</Operation>
@@ -50,7 +53,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="VFED_AmmoBox_Autocannon"]/comps</xpath>
 		<value>
-			<li Class="CombatExtended.CompProperties_AmmoUser">
+			<li Class="CombatExtended.CompProperties_AmmoListUser">
 				<magazineSize>600</magazineSize>
 				<reloadTime>7.8</reloadTime>
 				<ammoSet>AmmoSet_20x102mmNATO</ammoSet>
@@ -77,6 +80,9 @@
 					<li>VFED_Turret_Palintone</li>
 					<li MayRequire="vanillaexpanded.vfesecurity">VFES_Turret_AutocannonDouble</li>
 				</allowedTurrets>
+				<allowedTurretTags>
+					<li>CE_Autoloader_20x102mmNATO</li>
+				</allowedTurretTags>
 			</li>
 		</value>
 	</Operation>
@@ -85,7 +91,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="VFED_AmmoBox_Missile"]/comps</xpath>
 		<value>
-			<li Class="CombatExtended.CompProperties_AmmoUser">
+			<li Class="CombatExtended.CompProperties_AmmoListUser">
 				<magazineSize>72</magazineSize>
 				<reloadTime>7.8</reloadTime>
 				<ammoSet>AmmoSet_50mmRocket</ammoSet>
@@ -111,6 +117,9 @@
 					<li>Turret_RocketswarmLauncher</li>
 					<li>VFED_Turret_Onager</li>
 				</allowedTurrets>
+				<allowedTurretTags>
+					<li>CE_Autoloader_50mmRocket</li>
+				</allowedTurretTags>
 			</li>
 		</value>
 	</Operation>

--- a/ModPatches/Vanilla Factions Expanded - Deserters/Patches/Vanilla Factions Expanded - Deserters/Buildings_Special.xml
+++ b/ModPatches/Vanilla Factions Expanded - Deserters/Patches/Vanilla Factions Expanded - Deserters/Buildings_Special.xml
@@ -19,6 +19,18 @@
 					<magazineSize>180</magazineSize>
 					<reloadTime>7.8</reloadTime>
 					<ammoSet>AmmoSet_40x311mmR</ammoSet>
+					<ammoSpawnOptions>
+						<li>
+							<ammoDef>Ammo_40x311mmR_AP</ammoDef>
+							<percentRange>0.75~1</percentRange>
+							<weight>1</weight>
+						</li>
+						<li>
+							<ammoDef>Ammo_40x311mmR_HE</ammoDef>
+							<percentRange>1</percentRange>
+							<weight>1</weight>
+						</li>
+					</ammoSpawnOptions>
 				</li>
 				<li Class="CompProperties_Power">
 					<compClass>CompPowerTrader</compClass>
@@ -61,6 +73,18 @@
 				<magazineSize>600</magazineSize>
 				<reloadTime>7.8</reloadTime>
 				<ammoSet>AmmoSet_20x102mmNATO</ammoSet>
+				<ammoSpawnOptions>
+					<li>
+						<ammoDef>Ammo_20x102mmNATO_AP</ammoDef>
+						<percentRange>0.75~1</percentRange>
+						<weight>1</weight>
+					</li>
+					<li>
+						<ammoDef>Ammo_20x102mmNATO_HE</ammoDef>
+						<percentRange>1</percentRange>
+						<weight>1</weight>
+					</li>
+				</ammoSpawnOptions>
 			</li>
 			<li Class="CompProperties_Power">
 				<compClass>CompPowerTrader</compClass>
@@ -103,6 +127,12 @@
 				<magazineSize>72</magazineSize>
 				<reloadTime>7.8</reloadTime>
 				<ammoSet>AmmoSet_50mmRocket</ammoSet>
+				<ammoSpawnOptions>
+					<li>
+						<ammoDef>Ammo_50mmRocket_HE</ammoDef>
+						<percentRange>0.75~1</percentRange>
+					</li>
+				</ammoSpawnOptions>
 			</li>
 			<li Class="CompProperties_Power">
 				<compClass>CompPowerTrader</compClass>

--- a/ModPatches/Vanilla Factions Expanded - Deserters/Patches/Vanilla Factions Expanded - Deserters/Buildings_Special.xml
+++ b/ModPatches/Vanilla Factions Expanded - Deserters/Patches/Vanilla Factions Expanded - Deserters/Buildings_Special.xml
@@ -26,9 +26,19 @@
 							<weight>1</weight>
 						</li>
 						<li>
+							<ammoDef>Ammo_40x311mmR_Incendiary</ammoDef>
+							<percentRange>0.75~1</percentRange>
+							<weight>0.65</weight>
+						</li>
+						<li>
 							<ammoDef>Ammo_40x311mmR_HE</ammoDef>
-							<percentRange>1</percentRange>
-							<weight>1</weight>
+							<percentRange>0.75~1</percentRange>
+							<weight>0.65</weight>
+						</li>
+						<li>
+							<ammoDef>Ammo_40x311mmR_Sabot</ammoDef>
+							<percentRange>0.75~1</percentRange>
+							<weight>0.65</weight>
 						</li>
 					</ammoSpawnOptions>
 				</li>
@@ -74,16 +84,26 @@
 				<reloadTime>7.8</reloadTime>
 				<ammoSet>AmmoSet_20x102mmNATO</ammoSet>
 				<ammoSpawnOptions>
-					<li>
-						<ammoDef>Ammo_20x102mmNATO_AP</ammoDef>
-						<percentRange>0.75~1</percentRange>
-						<weight>1</weight>
-					</li>
-					<li>
-						<ammoDef>Ammo_20x102mmNATO_HE</ammoDef>
-						<percentRange>1</percentRange>
-						<weight>1</weight>
-					</li>
+						<li>
+							<ammoDef>Ammo_20x102mmNATO_AP</ammoDef>
+							<percentRange>0.75~1</percentRange>
+							<weight>1</weight>
+						</li>
+						<li>
+							<ammoDef>Ammo_20x102mmNATO_HE</ammoDef>
+							<percentRange>0.75~1</percentRange>
+							<weight>0.65</weight>
+						</li>
+						<li>
+							<ammoDef>Ammo_20x102mmNATO_Incendiary</ammoDef>
+							<percentRange>0.75~1</percentRange>
+							<weight>0.65</weight>
+						</li>
+						<li>
+							<ammoDef>Ammo_20x102mmNATO_Sabot</ammoDef>
+							<percentRange>0.75~1</percentRange>
+							<weight>0.65</weight>
+						</li>
 				</ammoSpawnOptions>
 			</li>
 			<li Class="CompProperties_Power">

--- a/ModPatches/Vanilla Factions Expanded - Deserters/Patches/Vanilla Factions Expanded - Deserters/Things_Security.xml
+++ b/ModPatches/Vanilla Factions Expanded - Deserters/Patches/Vanilla Factions Expanded - Deserters/Things_Security.xml
@@ -11,8 +11,21 @@
 		<mods>
 			<li>Vanilla Furniture Expanded - Security</li>
 		</mods>
-		<match Class="PatchOperationRemove">
-			<xpath>Defs/ThingDef[defName="VFES_Turret_AutocannonDouble"]/comps/li[@Class="VFED.CompProperties_BoxRefuel"]</xpath>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/ThingDef[defName="VFES_Turret_AutocannonDouble"]/comps/li[@Class="VFED.CompProperties_BoxRefuel"]</xpath>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VFES_Turret_AutocannonDouble"]/building</xpath>
+					<value>
+						<buildingTags>
+							<li>CE_Autoloader_20x102mmNATO</li>
+						</buildingTags>
+					</value>
+				</li>
+			</operations>
 		</match>
 	</Operation>
 

--- a/Source/CombatExtended/CombatExtended/Building_AmmoContainerCE/Building_AutoloaderCE.cs
+++ b/Source/CombatExtended/CombatExtended/Building_AmmoContainerCE/Building_AutoloaderCE.cs
@@ -22,6 +22,8 @@ public class Building_AutoloaderCE : Building
 
     public bool isReloading;
 
+    private bool hasSpawnedBefore;
+
     public CompAmmoUser TargetAmmoUser => TargetTurret.GetAmmo();
 
     public Building_Turret TargetTurret;
@@ -72,6 +74,7 @@ public class Building_AutoloaderCE : Building
         Scribe_Values.Look(ref ticksToCompleteInitial, "ticksToCompleteInitial");
         Scribe_Values.Look(ref ticksToComplete, "ticksToComplete");
         Scribe_Values.Look(ref isReloading, "isReloading");
+        Scribe_Values.Look(ref hasSpawnedBefore, "hasSpawnedBefore");
 
         Scribe_References.Look(ref TargetTurret, "Turret");
     }
@@ -130,6 +133,37 @@ public class Building_AutoloaderCE : Building
         {
             Log.Error(this.GetCustomLabelNoCount() + " Requires MapMeshAndRealTime drawer type to display progress bar.");
         }
+        if (this.Faction == Faction.OfPlayer || CompAmmoUser == null || hasSpawnedBefore)
+        {
+            return;
+        }
+        if (CompAmmoUser is CompAmmoListUser compAmmoListUser)
+        {
+            AmmoSpawnOption spawnConfig = compAmmoListUser.Props.ammoSpawnOptions.NullOrEmpty() ? null : compAmmoListUser.Props.ammoSpawnOptions.RandomElementByWeight(x => x.weight);
+            if (spawnConfig != null)
+            {
+                AmmoDef ammoDef = spawnConfig.ammoDef;
+                if (ammoDef != null)
+                {
+                    compAmmoListUser.CurrentAmmo = ammoDef;
+                    compAmmoListUser.SelectedAmmo = ammoDef;
+                    AmmoSetDef ammoSet = compAmmoListUser.Props.ammoSet;
+                    compAmmoListUser.SelectedAmmoSet = ammoSet.ammoTypes.Any(x => x.ammo == ammoDef) ? ammoSet : compAmmoListUser.Props.additionalAmmoSets.FirstOrDefault(set => set.ammoTypes.Any(x => x.ammo == ammoDef));
+                    shouldReplaceAmmo = true;
+                }
+                float spawnPercentage = Mathf.Min(spawnConfig.percentRange.RandomInRange, 1f);
+                CompAmmoUser.CurMagCount = Mathf.RoundToInt(CompAmmoUser.MissingToFullMagazine * spawnPercentage);
+            }
+            else
+            {
+                CompAmmoUser.CurMagCount = CompAmmoUser.MissingToFullMagazine;
+            }
+        }
+        else
+        {
+            CompAmmoUser.CurMagCount = CompAmmoUser.MissingToFullMagazine;
+        }
+        hasSpawnedBefore = true;
     }
 
     public override void DeSpawn(DestroyMode mode = DestroyMode.Vanish)

--- a/Source/CombatExtended/CombatExtended/Comps/AbilityComps/CompProperties_AmmoListUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/AbilityComps/CompProperties_AmmoListUser.cs
@@ -40,7 +40,7 @@ public class CompProperties_AmmoListUser : CompProperties_AmmoUser
 }
 public class AmmoSpawnOption
 {
-    public FloatRange percentRange  = new FloatRange(1,1);
+    public FloatRange percentRange = new FloatRange (1,1);
     public AmmoDef ammoDef;
     public float weight = 1f;
 

--- a/Source/CombatExtended/CombatExtended/Comps/AbilityComps/CompProperties_AmmoListUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/AbilityComps/CompProperties_AmmoListUser.cs
@@ -1,14 +1,72 @@
 ﻿using System.Collections.Generic;
+using System.Xml;
+using Verse;
 
 namespace CombatExtended;
 
 public class CompProperties_AmmoListUser : CompProperties_AmmoUser
 {
     public List<AmmoSetDef> additionalAmmoSets = new List<AmmoSetDef>();
+    public List<AmmoSpawnOption> ammoSpawnOptions = new List<AmmoSpawnOption>();
 
     public CompProperties_AmmoListUser()
     {
         compClass = typeof(CompAmmoListUser);
     }
 
+    public override IEnumerable<string> ConfigErrors(ThingDef parentDef)
+    {
+        foreach (string error in base.ConfigErrors(parentDef))
+        {
+            yield return error;
+        }
+
+        if (ammoSpawnOptions.NullOrEmpty())
+        {
+            yield break;
+        }
+
+        foreach (AmmoSpawnOption spawnConfig in ammoSpawnOptions)
+        {
+            bool valid = (ammoSet != null && ammoSet.ammoTypes.Any(x => x.ammo == spawnConfig.ammoDef)) || additionalAmmoSets.Any(set => set.ammoTypes.Any(x => x.ammo == spawnConfig.ammoDef));
+
+            if (!valid)
+            {
+                yield return $"CE : {parentDef.defName} has incorrect ammoDef {spawnConfig.ammoDef.defName} in CompProperties_AmmoList.ammoSpawnOptions. The ammoDef needs to be included as part of either ammoSet or additionalAmmoSets.";
+            }
+        }
+    }
+
+}
+public class AmmoSpawnOption
+{
+    public FloatRange percentRange  = new FloatRange(1,1);
+    public AmmoDef ammoDef;
+    public float weight = 1f;
+
+    public void LoadDataFromXmlCustom(XmlNode xmlRoot)
+    {
+        foreach (XmlNode node in xmlRoot.ChildNodes)
+        {
+            if (node.Name == "ammoDef")
+            {
+                DirectXmlCrossRefLoader.RegisterObjectWantsCrossRef(this, "ammoDef", node.InnerText);
+            }
+            else if (node.Name == "percentRange")
+            {
+                if (float.TryParse(node.InnerText, out float single))
+                {
+                    percentRange = new FloatRange(single, single);
+                }
+                else
+                {
+                    percentRange = FloatRange.FromString(node.InnerText);
+                }
+            }
+            else if (node.Name == "weight")
+            {
+                weight = ParseHelper.FromString<float>(node.InnerText);
+            }
+        }
+    }
 }

--- a/Source/CombatExtended/CombatExtended/Comps/AbilityComps/CompProperties_AmmoListUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/AbilityComps/CompProperties_AmmoListUser.cs
@@ -40,7 +40,7 @@ public class CompProperties_AmmoListUser : CompProperties_AmmoUser
 }
 public class AmmoSpawnOption
 {
-    public FloatRange percentRange = new FloatRange (1,1);
+    public FloatRange percentRange = new FloatRange(1, 1);
     public AmmoDef ammoDef;
     public float weight = 1f;
 


### PR DESCRIPTION
## Additions
- Autoloaders ammo spawning options for non-player factions.
Will spawn with full ammo and the default ammo if no options are set in XML.

## Changes
update Deserters autoloader to use CompProperties_AmmoListUser, and switch to allowed tag

## References
n/a

## Reasoning
update the patch
- Autoloaders spawned in bases were not spawning with ammo defeating their purpose

## Alternatives
idk
## Testing
Note:
autoloader have C# bug that won't load same ammo from bugs chat
> found a bug with autoloaders
> this one is a bit elaborate
> build an autocannon, set its ammo type to ammo type a
> build an autoloader, set its ammo type to ammo type b, and enable ammo type replacement
> after that, the autoloader will top up the turret as intended
> howver, if you then change the ammo type of the turret without touching the autoloader, the autoloader will then reload the turret forever
> that allows you to load more ammo into a turret than what the turret normally allows

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long) 5mins
