### PR TITLE
Fix Hunkering error

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompSuppressable.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompSuppressable.cs
@@ -121,17 +121,21 @@ public class CompSuppressable : ThingComp
     {
         get
         {
-            if (currentSuppression > (SuppressionThreshold * 10) || (ticksHunkered > 0 && ticksHunkered < hunkeringMinDuration))
+            if (currentSuppression > (SuppressionThreshold * 10) || ticksHunkered is > 0 and < hunkeringMinDuration)
             {
                 if (isSuppressed)
                 {
                     return true;
                 }
                 // Removing suppression log
-                else
+                Pawn pawn = parent as Pawn;
+                currentSuppression = 0f;
+                ticksHunkered = 0;
+                if (pawn != null && pawn.CurJob.def == CE_JobDefOf.HunkerDown)
                 {
-                    Log.Error("CE hunkering without suppression, this should never happen");
+                    pawn.CurJob.Clear();
                 }
+                Log.Error($"CE: {pawn?.Name} is hunkering without suppression, this should never happen. Attempting to fix");
             }
             return false;
         }
@@ -162,6 +166,7 @@ public class CompSuppressable : ThingComp
         Scribe_Values.Look(ref isSuppressed, "isSuppressed", false);
         Scribe_Values.Look(ref ticksUntilDecay, "ticksUntilDecay", 0);
         Scribe_Values.Look(ref lastHelpRequestAt, "lastHelpRequestAt", -1);
+        Scribe_Values.Look(ref ticksHunkered, "ticksHunkered", 0);
     }
 
     public void AddSuppression(float amount, IntVec3 origin)


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Add saving for `ticksHunkered`

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Validates data when getting error
- Clears hunkering job if pawn is hunkering when receiving this error

## Reasoning

Why did you choose to implement things this way, e.g.
- Setting values to 0 will prevent the errors from spamming and should resolve after a one time error
- `ticksHunkered` should be saved so that it is not being reset upon loading the game

## Alternatives

Describe alternative implementations you have considered, e.g.
- Add validation on saving/loading
- Change the Error to a Warning since it should be getting fixed now
- Do nothing

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
