### PR TITLE
Fix Autoloader Bug

### DIFF
--- a/Source/CombatExtended/CombatExtended/Building_AmmoContainerCE/Building_AutoloaderCE.cs
+++ b/Source/CombatExtended/CombatExtended/Building_AmmoContainerCE/Building_AutoloaderCE.cs
@@ -99,7 +99,6 @@ public class Building_AutoloaderCE : Building
 
     public bool CanReplaceAmmo(CompAmmoUser ammoUser)
     {
-        //return shouldReplaceAmmo && ammoUser.Props.ammoSet == CompAmmoUser.Props.ammoSet && ammoUser.CurrentAmmo != CompAmmoUser.CurrentAmmo;
         return shouldReplaceAmmo && ammoUser.CurAmmoSet == CompAmmoUser.CurAmmoSet && ammoUser.CurrentAmmo != CompAmmoUser.CurrentAmmo;
     }
 
@@ -407,22 +406,31 @@ public class Building_AutoloaderCE : Building
         }
 
         bool canReplaceAmmo = CanReplaceAmmo(TurretMagazine);
-
-        if ((TurretMagazine.FullMagazine && !canReplaceAmmo))
+        if (TurretMagazine.SelectedAmmo != CompAmmoUser.CurrentAmmo)
+        {
+            if (shouldReplaceAmmo)
+            {
+                TurretMagazine.SelectedAmmo = CompAmmoUser.CurrentAmmo;
+            }
+            else
+            {
+                return false;
+            }
+        }
+        if (TurretMagazine.FullMagazine && !canReplaceAmmo)
         {
             return false;
         }
-
-        if (TurretMagazine.CurrentAmmo == CompAmmoUser.CurrentAmmo || canReplaceAmmo)
+        if (TurretMagazine.CurrentAmmo != CompAmmoUser.CurrentAmmo && !canReplaceAmmo)
         {
-            TargetTurret = TurretMagazine.turret;
-            ticksToComplete = Mathf.CeilToInt(TurretMagazine.ReloadTime.SecondsToTicks() / this.GetStatValue(CE_StatDefOf.ReloadSpeed));
-            ticksToCompleteInitial = ticksToComplete;
-            turret.SetReloading(true);
-            return true;
+            return false;
         }
+        TargetTurret = TurretMagazine.turret;
+        ticksToComplete = Mathf.CeilToInt(TurretMagazine.ReloadTime.SecondsToTicks() / this.GetStatValue(CE_StatDefOf.ReloadSpeed));
+        ticksToCompleteInitial = ticksToComplete;
+        turret.SetReloading(true);
+        return true;
 
-        return false;
     }
 
     public bool ReloadFinalize()


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Fixes unique autoloader bug. By checking if SelectedAmmo is different than ammo in autoloader, if replaced ammo is on than it will change the selected ammo on the turret to the current ammo in autoloader.
- Refactored last bit of method for readability

```
Note:
autoloader have C# bug that won't load same ammo from bugs chat

    found a bug with autoloaders
    this one is a bit elaborate
    build an autocannon, set its ammo type to ammo type a
    build an autoloader, set its ammo type to ammo type b, and enable ammo type replacement
    after that, the autoloader will top up the turret as intended
    howver, if you then change the ammo type of the turret without touching the autoloader, the autoloader will then reload the turret forever    that allows you to load more ammo into a turret than what the turret normally allows
```

## Reasoning

Why did you choose to implement things this way, e.g.
- Bug Requires fixing. FullMagazine uses SelectedAmmo to determine if it is true or false.
- Readability

## Alternatives

Describe alternative implementations you have considered, e.g.
- Suffer

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
