### PR TITLE
drone hit chance tweak

### DIFF
--- a/Odyssey/Patches/Odyssey/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Odyssey/Patches/Odyssey/ThingDefs_Buildings/Buildings_Security.xml
@@ -103,14 +103,14 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="HunterDroneTrap"]</xpath>
 		<value>
-			<fillPercent>0.75</fillPercent>
+			<fillPercent>0.1</fillPercent>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="WaspDroneTrap"]</xpath>
 		<value>
-			<fillPercent>0.75</fillPercent>
+			<fillPercent>0.1</fillPercent>
 		</value>
 	</Operation>
 

--- a/Odyssey/Patches/Odyssey/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Odyssey/Patches/Odyssey/ThingDefs_Buildings/Buildings_Security.xml
@@ -100,4 +100,18 @@
 		</FireModes>
 	</Operation>
 
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="HunterDroneTrap"]</xpath>
+		<value>
+			<fillPercent>0.75</fillPercent>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="WaspDroneTrap"]</xpath>
+		<value>
+			<fillPercent>0.75</fillPercent>
+		</value>
+	</Operation>
+
 </Patch>


### PR DESCRIPTION
## Additions
none
## Changes
add fillPercent to drone in building form, before it was impossible to hit them with bullets
make wasp drone bigger in body size 
Edit: body size didn't fix the issue likely need C# work
## References
[bug chat](https://discord.com/channels/278818534069501953/324222101550661663/1511305666776662087)
## Reasoning
before a roomba with bomb glued on see you you should be able to still shoot it
## Alternatives
n/a
## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
