### PR TITLE
Better Grenade Handling harmony patch

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -102,6 +102,7 @@
 		<li>DankPyon.Medieval.Overhaul</li>
 		<li>vanillaquestsexpanded.deadlife</li>
 		<li>vanillaracesexpanded.android</li>
+		<li>UracosVereches.bettergrenadehandling</li>
 	</loadAfter>
 
 </ModMetaData>

--- a/Source/CombatExtended/Harmony/Compatibility/Harmony_BetterGrenadeHandling.cs
+++ b/Source/CombatExtended/Harmony/Compatibility/Harmony_BetterGrenadeHandling.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Reflection;
+using HarmonyLib;
+using Verse;
+
+namespace CombatExtended.HarmonyCE.Compatibility;
+
+public class Harmony_BetterGrenadeHandling
+{
+    private static Type TypeOfBGHUtils
+    {
+        get
+        {
+            return AccessTools.TypeByName("BetterGrenadeHandling.BGHUtils");
+        }
+    }
+
+    [HarmonyPatch]
+    public static class Harmony_ShouldBeHitByEMP
+    {
+        public static bool Prepare()
+        {
+            return TypeOfBGHUtils != null;
+        }
+
+        public static MethodBase TargetMethod()
+        {
+            return AccessTools.Method(TypeOfBGHUtils, "ShouldBeHitByEMP");
+        }
+
+        public static bool Prefix(Thing target, ref bool __result)
+        {
+            Pawn targetPawn = target as Pawn;
+            __result = targetPawn?.stances?.stunner?.StunFromEMP == false;
+            
+            return false;
+        }
+    }
+}

--- a/Source/CombatExtended/Harmony/Compatibility/Harmony_BetterGrenadeHandling.cs
+++ b/Source/CombatExtended/Harmony/Compatibility/Harmony_BetterGrenadeHandling.cs
@@ -32,7 +32,7 @@ public class Harmony_BetterGrenadeHandling
         {
             Pawn targetPawn = target as Pawn;
             __result = targetPawn?.stances?.stunner?.StunFromEMP == false;
-            
+
             return false;
         }
     }

--- a/Source/CombatExtended/Harmony/Compatibility/Harmony_BetterGrenadeHandling.cs
+++ b/Source/CombatExtended/Harmony/Compatibility/Harmony_BetterGrenadeHandling.cs
@@ -5,9 +5,9 @@ using Verse;
 
 namespace CombatExtended.HarmonyCE.Compatibility;
 
-public class Harmony_BetterGrenadeHandling
+public class Harmony_BetterGrenadeHandling  //manually patched from HarmonyBase
 {
-    private static Type TypeOfBGHUtils
+    internal static Type TypeOfBGHUtils
     {
         get
         {
@@ -15,25 +15,11 @@ public class Harmony_BetterGrenadeHandling
         }
     }
 
-    [HarmonyPatch]
-    public static class Harmony_ShouldBeHitByEMP
+    public static bool Prefix(Thing target, ref bool __result)
     {
-        public static bool Prepare()
-        {
-            return TypeOfBGHUtils != null;
-        }
+        Pawn targetPawn = target as Pawn;
+        __result = targetPawn?.stances?.stunner?.StunFromEMP == false;
 
-        public static MethodBase TargetMethod()
-        {
-            return AccessTools.Method(TypeOfBGHUtils, "ShouldBeHitByEMP");
-        }
-
-        public static bool Prefix(Thing target, ref bool __result)
-        {
-            Pawn targetPawn = target as Pawn;
-            __result = targetPawn?.stances?.stunner?.StunFromEMP == false;
-
-            return false;
-        }
+        return false;
     }
 }

--- a/Source/CombatExtended/Harmony/HarmonyBase.cs
+++ b/Source/CombatExtended/Harmony/HarmonyBase.cs
@@ -5,6 +5,7 @@ using System;
 using System.Reflection.Emit;
 using System.Linq;
 using System.Collections.Generic;
+using CombatExtended.HarmonyCE.Compatibility;
 
 /* Note to those unfamiliar with Reflection/Harmony (like me, ProfoundDarkness), operands have some specific types and it's useful to know these to make good patches (Transpiler).
  * Below I'm noting the operators and what type of operand I've observed.
@@ -57,7 +58,19 @@ public static class HarmonyBase
         Harmony_GenRadial.Patch();
         PawnColumnWorkers_Resize.Patch();
         PawnColumnWorkers_SwapButtons.Patch();
-    }
+
+        // Patches that require being ran later into loading
+        LongEventHandler.ExecuteWhenFinished(() =>
+        {
+            if (Harmony_BetterGrenadeHandling.TypeOfBGHUtils == null)
+            {
+                return;
+            }
+        
+            instance.Patch(AccessTools.Method(Harmony_BetterGrenadeHandling.TypeOfBGHUtils, "ShouldBeHitByEMP"),
+                new HarmonyMethod(typeof(Harmony_BetterGrenadeHandling).GetMethod("Prefix")));
+        });
+}
 
     #region Patch helper methods
 

--- a/Source/CombatExtended/Harmony/HarmonyBase.cs
+++ b/Source/CombatExtended/Harmony/HarmonyBase.cs
@@ -66,11 +66,11 @@ public static class HarmonyBase
             {
                 return;
             }
-        
+
             instance.Patch(AccessTools.Method(Harmony_BetterGrenadeHandling.TypeOfBGHUtils, "ShouldBeHitByEMP"),
                 new HarmonyMethod(typeof(Harmony_BetterGrenadeHandling).GetMethod("Prefix")));
         });
-}
+    }
 
     #region Patch helper methods
 

--- a/Source/CombatExtended/Harmony/HarmonyBase.cs
+++ b/Source/CombatExtended/Harmony/HarmonyBase.cs
@@ -68,7 +68,7 @@ public static class HarmonyBase
             }
 
             instance.Patch(AccessTools.Method(Harmony_BetterGrenadeHandling.TypeOfBGHUtils, "ShouldBeHitByEMP"),
-                new HarmonyMethod(typeof(Harmony_BetterGrenadeHandling).GetMethod("Prefix")));
+                prefix: new HarmonyMethod(typeof(Harmony_BetterGrenadeHandling).GetMethod("Prefix")));
         });
     }
 

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -136,6 +136,7 @@ Beeralope Squad	|
 Beliar Xenotype |
 Beta Anime Hair	|
 Beta Girls und Panzer Hair and Apparel	|
+Better Grenade Handling |
 Better Traders Guild    |
 Better Wool Production - C# Edition	|
 Big and Small - Genes & More	|


### PR DESCRIPTION
## Additions

- Patches BGH's EMP check to skip the IsFlesh check, as CE makes flesh also take EMP damage.

## References

- Closes #4604

## Reasoning

- Better to patch the mod's behavior than drastically change our projectile stats to account for it.

## Alternatives

- Move on with the projectile changes.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
