### PR TITLE
Fix Shield Secondary Damage Calculation

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_CompShield.cs
+++ b/Source/CombatExtended/Harmony/Harmony_CompShield.cs
@@ -66,7 +66,6 @@ internal static class CompShield_PatchCheckPreAbsorbDamage
                             secondaryDamageMultiplierValue = secondaryDamageModExt.shieldDamageMultiplier;
                         }
                         secondaryShieldDamageAmount += (secondaryDamageInfo.amount * secondaryDamageMultiplierValue);
-                        dinfo.amountInt += secondaryDamageInfo.amount;
 
                     }
                 }
@@ -96,7 +95,6 @@ internal static class CompShield_PatchCheckPreAbsorbDamage
         }
         else
         {
-            dinfo.amountInt -= secondaryShieldDamageAmount;
             __instance.AbsorbedDamage(dinfo);
         }
         return false;

--- a/Source/VEFCompat/VEFCompat/Harmony/Harmony_CompShieldBubble.cs
+++ b/Source/VEFCompat/VEFCompat/Harmony/Harmony_CompShieldBubble.cs
@@ -50,8 +50,6 @@ public static class Harmony_CompShieldBubble_Patch
                             secondaryDamageMultiplierValue = secondaryDamageModExt.shieldDamageMultiplier;
                         }
                         secondaryShieldDamageAmount += (secondaryDamageInfo.amount * secondaryDamageMultiplierValue);
-                        dinfo.amountInt += secondaryDamageInfo.amount;
-
                     }
                 }
             }
@@ -80,7 +78,6 @@ public static class Harmony_CompShieldBubble_Patch
         }
         else
         {
-            dinfo.amountInt -= secondaryShieldDamageAmount;
             __instance.AbsorbedDamage(dinfo);
         }
         return false;


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Fixes math for secondary damage
- Remove dinfo.Amount modification

## Reasoning

Why did you choose to implement things this way, e.g.
- Secondary damage was being added twice to total value
- Default dinfo value is fine enough for determining fleck amount to create on shield absorb

## Alternatives

Describe alternative implementations you have considered, e.g.
- Bad math

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
