### PR TITLE
Fix Apparel_Shield Bugs

### DIFF
--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -80,7 +80,16 @@ public static class ArmorUtilityCE
             var apparel = pawn.apparel.WornApparel;
 
             // Check for shields first
-            var shield = apparel.FirstOrDefault(x => x is Apparel_Shield);
+            Apparel_Shield shield = null;
+            for (int i = 0; i < apparel.Count; i++)
+            {
+                if (apparel[i] is Apparel_Shield loopShield)
+                {
+                    shield = loopShield;
+                    break;
+                }
+            }
+
             if (shield != null)
             {
 

--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -93,12 +93,10 @@ public static class ArmorUtilityCE
             if (shield != null)
             {
 
-                // Removes shield from list so that the part we use to get it on the apparel list is not calculated armor twice
-                apparel.Swap(apparel.IndexOf(shield), apparel.Count - 1);
-                apparel.RemoveLast();
-                // Determine whether the hit is blocked by the shield
                 var blockedByShield = false;
-                if (!(dinfo.Weapon?.IsMeleeWeapon ?? false))
+
+                bool isMeleeOrToolAttack = dinfo.Tool != null || (dinfo.Weapon?.IsMeleeWeapon ?? false);
+                if (!isMeleeOrToolAttack)
                 {
                     var shieldDef = shield.def.GetModExtension<ShieldDefExtension>();
                     if (shieldDef == null)
@@ -203,9 +201,11 @@ public static class ArmorUtilityCE
             for (var i = apparel.Count - 1; i >= 0; i--)
             {
                 var app = apparel[i];
-                if (app != null
-                        && app.def.apparel.CoversBodyPart(hitPart)
-                        && !TryPenetrateArmor(dinfo.Def, app.PartialStat(dinfo.Def.armorCategory.armorRatingStat, hitPart), ref penAmount, ref dmgAmount, app))
+                if (app == shield)
+                {
+                    continue;
+                }
+                if (app.def.apparel.CoversBodyPart(hitPart) && !TryPenetrateArmor(dinfo.Def, app.PartialStat(dinfo.Def.armorCategory.armorRatingStat, hitPart), ref penAmount, ref dmgAmount, app))
                 {
                     if (dinfo.Def.armorCategory.armorRatingStat == StatDefOf.ArmorRating_Sharp)
                     {

--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -95,8 +95,8 @@ public static class ArmorUtilityCE
 
                 var blockedByShield = false;
 
-                bool isMeleeOrToolAttack = dinfo.Tool != null || (dinfo.Weapon?.IsMeleeWeapon ?? false);
-                if (!isMeleeOrToolAttack)
+                bool isMeleeOrNull = dinfo.Tool != null || (dinfo.Weapon?.IsMeleeWeapon ?? true);
+                if (!isMeleeOrNull)
                 {
                     var shieldDef = shield.def.GetModExtension<ShieldDefExtension>();
                     if (shieldDef == null)

--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -85,7 +85,7 @@ public static class ArmorUtilityCE
             {
 
                 // Removes shield from list so that the part we use to get it on the apparel list is not calculated armor twice
-                apparel.Swap(apparel.IndexOf(shield), apparel.Count -1);
+                apparel.Swap(apparel.IndexOf(shield), apparel.Count - 1);
                 apparel.RemoveLast();
                 // Determine whether the hit is blocked by the shield
                 var blockedByShield = false;

--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -83,6 +83,10 @@ public static class ArmorUtilityCE
             var shield = apparel.FirstOrDefault(x => x is Apparel_Shield);
             if (shield != null)
             {
+
+                // Removes shield from list so that the part we use to get it on the apparel list is not calculated armor twice
+                apparel.Swap(apparel.IndexOf(shield), apparel.Count -1);
+                apparel.RemoveLast();
                 // Determine whether the hit is blocked by the shield
                 var blockedByShield = false;
                 if (!(dinfo.Weapon?.IsMeleeWeapon ?? false))

--- a/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
@@ -543,6 +543,10 @@ public class ITab_Inventory : ITab_Pawn_Gear
                 {
                     foreach (Apparel apparel in wornApparel)
                     {
+                        if (apparel == shield)
+                        {
+                            continue;
+                        }
                         armorValue += apparel.PartialStat(stat, part);
                     }
                     if (shield != null)


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Compare apparel to shield to prevent it from adding to armor values.
- Checking ``dinfo.Tool`` is a cheap way to see if it is a melee attack. This prevents PawnKind natural tools and ranged weapon's melee tools from having to get through both the Melee block and than armor penetration on shield after a missed block
- Refactor LINQ statement to a for loop
- Fixes shield armor being applied twice to inventory UI tab
- Fixes recursive blunt damage calculating against shield coverage again

## Reasoning

Why did you choose to implement things this way, e.g.
- The body part we use to attach shield to pawn was being double dipped for protection. Once during shield coverage calculation and than again if that is the part to be shot during apparel penetration. Logically each piece of apparel should only get one shot at preventing penetration and damage.
- Apparel should never be null, but comparing it to Shield is a clean way to prevent the shield from being used in apparel penetration calculations
- Defaulting to true on null weapon prevents the recursive blunt damage from checking against shield armor all over again. (If intended can reverse)

## Side Effects
- Melee combat will be more deadly as melee attacks are not being double penalized by both the block system and than again on penetration. Melee combat has always been complained by users, particularly medieval combat, bionic weapons and fighting animals being rather lack luster.

## Alternatives

Describe alternative implementations you have considered, e.g.
- Double armor
- Add back extra null check
- Extra allocations and cycles from doing work on a List

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
