### PR TITLE
Remove ammo from non-combat merchants

### DIFF
--- a/ModPatches/Android Tiers Reforged/Patches/Android Tiers Reforged/TraderKindDefs/Android_TraderKinds.xml
+++ b/ModPatches/Android Tiers Reforged/Patches/Android Tiers Reforged/TraderKindDefs/Android_TraderKinds.xml
@@ -104,39 +104,6 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/TraderKindDef[defName="ATR_Caravan_AndroidCollective_BulkGoods" or defName="Caravan_AndroidCollective_AndroidMerchant" or defName="Caravan_AndroidCollective_HighTech"]/stockGenerators</xpath>
 		<value>
-			<li Class="StockGenerator_Tag">
-				<tradeTag>CE_Ammo</tradeTag>
-				<countRange>
-					<min>200</min>
-					<max>400</max>
-				</countRange>
-				<thingDefCountRange>
-					<min>1</min>
-					<max>4</max>
-				</thingDefCountRange>
-			</li>
-			<li Class="StockGenerator_Tag">
-				<tradeTag>CE_MediumAmmo</tradeTag>
-				<countRange>
-					<min>20</min>
-					<max>40</max>
-				</countRange>
-				<thingDefCountRange>
-					<min>2</min>
-					<max>6</max>
-				</thingDefCountRange>
-			</li>
-			<li Class="StockGenerator_Tag">
-				<tradeTag>CE_HeavyAmmo</tradeTag>
-				<countRange>
-					<min>5</min>
-					<max>10</max>
-				</countRange>
-				<thingDefCountRange>
-					<min>2</min>
-					<max>4</max>
-				</thingDefCountRange>
-			</li>
 			<li Class="StockGenerator_Category">
 				<categoryDef>Ammo</categoryDef>
 				<thingDefCountRange>

--- a/ModPatches/K4G Rimworld War 2/Patches/K4G Rimworld War 2/TraderKinds_Defs/TraderKinds_Defs.xml
+++ b/ModPatches/K4G Rimworld War 2/Patches/K4G Rimworld War 2/TraderKinds_Defs/TraderKinds_Defs.xml
@@ -218,12 +218,12 @@
 			<li Class="StockGenerator_Tag">
 				<tradeTag>CE_Ammo</tradeTag>
 				<countRange>
-					<min>100</min>
-					<max>250</max>
+					<min>120</min>
+					<max>240</max>
 				</countRange>
 				<thingDefCountRange>
 					<min>0</min>
-					<max>4</max>
+					<max>2</max>
 				</thingDefCountRange>
 			</li>
 			<li Class="StockGenerator_Category">

--- a/ModPatches/The Corporation - Mort's Factions/Patches/The Corporation - Mort's Factions/Corporation_TraderKinds.xml
+++ b/ModPatches/The Corporation - Mort's Factions/Patches/The Corporation - Mort's Factions/Corporation_TraderKinds.xml
@@ -102,39 +102,6 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/TraderKindDef[defName="MF_Corporate_Caravan_BulkGoods"]/stockGenerators</xpath>
 		<value>
-			<li Class="StockGenerator_Tag">
-				<tradeTag>CE_Ammo</tradeTag>
-				<countRange>
-					<min>200</min>
-					<max>400</max>
-				</countRange>
-				<thingDefCountRange>
-					<min>1</min>
-					<max>4</max>
-				</thingDefCountRange>
-			</li>
-			<li Class="StockGenerator_Tag">
-				<tradeTag>CE_MediumAmmo</tradeTag>
-				<countRange>
-					<min>20</min>
-					<max>40</max>
-				</countRange>
-				<thingDefCountRange>
-					<min>2</min>
-					<max>6</max>
-				</thingDefCountRange>
-			</li>
-			<li Class="StockGenerator_Tag">
-				<tradeTag>CE_HeavyAmmo</tradeTag>
-				<countRange>
-					<min>5</min>
-					<max>10</max>
-				</countRange>
-				<thingDefCountRange>
-					<min>2</min>
-					<max>4</max>
-				</thingDefCountRange>
-			</li>
 			<li Class="StockGenerator_Category">
 				<categoryDef>Ammo</categoryDef>
 				<thingDefCountRange>
@@ -168,37 +135,16 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/TraderKindDef[defName="MF_Corporate_Caravan_Slaver"]/stockGenerators</xpath>
 		<value>
+			<!-- A limited amount of ammo added, as I believe slavers would generally be involved in violence and thus always carry some small-arms ammo around -->
 			<li Class="StockGenerator_Tag">
 				<tradeTag>CE_Ammo</tradeTag>
 				<countRange>
-					<min>100</min>
-					<max>300</max>
+					<min>120</min>
+					<max>240</max>
 				</countRange>
 				<thingDefCountRange>
 					<min>1</min>
 					<max>3</max>
-				</thingDefCountRange>
-			</li>
-			<li Class="StockGenerator_Tag">
-				<tradeTag>CE_MediumAmmo</tradeTag>
-				<countRange>
-					<min>5</min>
-					<max>20</max>
-				</countRange>
-				<thingDefCountRange>
-					<min>1</min>
-					<max>4</max>
-				</thingDefCountRange>
-			</li>
-			<li Class="StockGenerator_Tag">
-				<tradeTag>CE_HeavyAmmo</tradeTag>
-				<countRange>
-					<min>5</min>
-					<max>10</max>
-				</countRange>
-				<thingDefCountRange>
-					<min>1</min>
-					<max>2</max>
 				</thingDefCountRange>
 			</li>
 			<li Class="StockGenerator_Category">
@@ -229,42 +175,6 @@
 					<min>15</min>
 					<max>40</max>
 				</countRange>
-			</li>
-			<li Class="StockGenerator_Tag">
-				<tradeTag>CE_Ammo</tradeTag>
-				<countRange>
-					<min>400</min>
-					<max>1000</max>
-				</countRange>
-				<price>Cheap</price>
-				<thingDefCountRange>
-					<min>3</min>
-					<max>8</max>
-				</thingDefCountRange>
-			</li>
-			<li Class="StockGenerator_Tag">
-				<tradeTag>CE_MediumAmmo</tradeTag>
-				<countRange>
-					<min>30</min>
-					<max>60</max>
-				</countRange>
-				<price>Cheap</price>
-				<thingDefCountRange>
-					<min>3</min>
-					<max>6</max>
-				</thingDefCountRange>
-			</li>
-			<li Class="StockGenerator_Tag">
-				<tradeTag>CE_HeavyAmmo</tradeTag>
-				<countRange>
-					<min>10</min>
-					<max>15</max>
-				</countRange>
-				<price>Cheap</price>
-				<thingDefCountRange>
-					<min>4</min>
-					<max>6</max>
-				</thingDefCountRange>
 			</li>
 			<li Class="StockGenerator_Category">
 				<categoryDef>Ammo</categoryDef>

--- a/ModPatches/VRE Android Factions/Patches/VRE Android Factions/Factions_Misc.xml
+++ b/ModPatches/VRE Android Factions/Patches/VRE Android Factions/Factions_Misc.xml
@@ -7,34 +7,12 @@
 			<li Class="StockGenerator_Tag">
 				<tradeTag>CE_Ammo</tradeTag>
 				<countRange>
-					<min>200</min>
-					<max>500</max>
+					<min>120</min>
+					<max>240</max>
 				</countRange>
 				<thingDefCountRange>
-					<min>2</min>
-					<max>4</max>
-				</thingDefCountRange>
-			</li>
-			<li Class="StockGenerator_Tag">
-				<tradeTag>CE_MediumAmmo</tradeTag>
-				<countRange>
-					<min>20</min>
-					<max>50</max>
-				</countRange>
-				<thingDefCountRange>
-					<min>2</min>
-					<max>6</max>
-				</thingDefCountRange>
-			</li>
-			<li Class="StockGenerator_Tag">
-				<tradeTag>CE_HeavyAmmo</tradeTag>
-				<countRange>
-					<min>5</min>
-					<max>10</max>
-				</countRange>
-				<thingDefCountRange>
-					<min>2</min>
-					<max>4</max>
+					<min>1</min>
+					<max>2</max>
 				</thingDefCountRange>
 			</li>
 		</value>

--- a/Patches/Core/TraderKindDefs/TraderKinds.xml
+++ b/Patches/Core/TraderKindDefs/TraderKinds.xml
@@ -42,17 +42,6 @@
 					<max>40</max>
 				</countRange>
 			</li>
-			<li Class="StockGenerator_Tag">
-				<tradeTag>CE_PreIndustrialAmmo</tradeTag>
-				<countRange>
-					<min>30</min>
-					<max>100</max>
-				</countRange>
-				<thingDefCountRange>
-					<min>0</min>
-					<max>3</max>
-				</thingDefCountRange>
-			</li>
 		</value>
 	</Operation>
 
@@ -137,17 +126,6 @@
 				<thingDefCountRange>
 					<min>0</min>
 					<max>0</max>
-				</thingDefCountRange>
-			</li>
-			<li Class="StockGenerator_Tag">
-				<tradeTag>CE_PreIndustrialAmmo</tradeTag>
-				<countRange>
-					<min>30</min>
-					<max>100</max>
-				</countRange>
-				<thingDefCountRange>
-					<min>0</min>
-					<max>3</max>
 				</thingDefCountRange>
 			</li>
 		</value>
@@ -319,39 +297,6 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/TraderKindDef[defName="Caravan_Outlander_BulkGoods" or defName="Caravan_Outlander_PirateMerchant" or defName="Caravan_Outlander_Exotic"]/stockGenerators</xpath>
 		<value>
-			<li Class="StockGenerator_Tag">
-				<tradeTag>CE_Ammo</tradeTag>
-				<countRange>
-					<min>200</min>
-					<max>400</max>
-				</countRange>
-				<thingDefCountRange>
-					<min>2</min>
-					<max>4</max>
-				</thingDefCountRange>
-			</li>
-			<li Class="StockGenerator_Tag">
-				<tradeTag>CE_MediumAmmo</tradeTag>
-				<countRange>
-					<min>20</min>
-					<max>40</max>
-				</countRange>
-				<thingDefCountRange>
-					<min>2</min>
-					<max>6</max>
-				</thingDefCountRange>
-			</li>
-			<li Class="StockGenerator_Tag">
-				<tradeTag>CE_HeavyAmmo</tradeTag>
-				<countRange>
-					<min>5</min>
-					<max>10</max>
-				</countRange>
-				<thingDefCountRange>
-					<min>2</min>
-					<max>4</max>
-				</thingDefCountRange>
-			</li>
 			<li Class="StockGenerator_Category">
 				<categoryDef>Ammo</categoryDef>
 				<thingDefCountRange>
@@ -409,7 +354,7 @@
 				</countRange>
 				<price>Cheap</price>
 				<thingDefCountRange>
-					<min>3</min>
+					<min>4</min>
 					<max>8</max>
 				</thingDefCountRange>
 			</li>
@@ -488,39 +433,6 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/TraderKindDef[defName="Orbital_BulkGoods" or defName="Orbital_PirateMerchant" or defName="Orbital_Exotic"]/stockGenerators</xpath>
 		<value>
-			<li Class="StockGenerator_Tag">
-				<tradeTag>CE_Ammo</tradeTag>
-				<countRange>
-					<min>400</min>
-					<max>1000</max>
-				</countRange>
-				<thingDefCountRange>
-					<min>2</min>
-					<max>4</max>
-				</thingDefCountRange>
-			</li>
-			<li Class="StockGenerator_Tag">
-				<tradeTag>CE_MediumAmmo</tradeTag>
-				<countRange>
-					<min>60</min>
-					<max>120</max>
-				</countRange>
-				<thingDefCountRange>
-					<min>4</min>
-					<max>7</max>
-				</thingDefCountRange>
-			</li>
-			<li Class="StockGenerator_Tag">
-				<tradeTag>CE_HeavyAmmo</tradeTag>
-				<countRange>
-					<min>15</min>
-					<max>50</max>
-				</countRange>
-				<thingDefCountRange>
-					<min>2</min>
-					<max>4</max>
-				</thingDefCountRange>
-			</li>
 			<li Class="StockGenerator_Category">
 				<categoryDef>Ammo</categoryDef>
 				<thingDefCountRange>

--- a/Royalty/Patches/Royalty/TraderKindDefs/TraderKinds_Royalty.xml
+++ b/Royalty/Patches/Royalty/TraderKindDefs/TraderKinds_Royalty.xml
@@ -105,12 +105,12 @@
 			<li Class="StockGenerator_Tag">
 				<tradeTag>CE_Ammo</tradeTag>
 				<countRange>
-					<min>200</min>
-					<max>400</max>
+					<min>120</min>
+					<max>240</max>
 				</countRange>
 				<thingDefCountRange>
-					<min>2</min>
-					<max>4</max>
+					<min>1</min>
+					<max>2</max>
 				</thingDefCountRange>
 			</li>
 			<li Class="StockGenerator_Category">
@@ -118,28 +118,6 @@
 				<thingDefCountRange>
 					<min>0</min>
 					<max>0</max>
-				</thingDefCountRange>
-			</li>
-			<li Class="StockGenerator_Tag">
-				<tradeTag>CE_MediumAmmo</tradeTag>
-				<countRange>
-					<min>20</min>
-					<max>40</max>
-				</countRange>
-				<thingDefCountRange>
-					<min>3</min>
-					<max>6</max>
-				</thingDefCountRange>
-			</li>
-			<li Class="StockGenerator_Tag">
-				<tradeTag>CE_HeavyAmmo</tradeTag>
-				<countRange>
-					<min>5</min>
-					<max>10</max>
-				</countRange>
-				<thingDefCountRange>
-					<min>0</min>
-					<max>3</max>
 				</thingDefCountRange>
 			</li>
 		</value>


### PR DESCRIPTION
## Changes

Removed ammo stocks from most non-combat traders.
Also made some changes to availability of ammo in traders. Combat merchants are left unchanged, slavers get a small amount of small-caliber ammo because their occupation is basically aligned with violence and it'd make sense for them to sell some alongside other slavery gear.

## Reasoning

- It doesn't make sense for people dealing in metals and fresh produce to stock autocannon shells.
- Combat Extended currently has a feature where if a weapon is found in a trader's inventory/in a quest reward/in a pod drop/etc. it will also have fitting ammo alongside it. If a merchant is selling a gun, it's already going to be selling ammo for that gun. 
- Dedicated combat merchants already exist and it makes them a bit pointless if most traders can stock most ammo.

## Alternatives

Current system:
- Breaks immersion.
- Kinda ruins the point of having seperate combat traders if bulk goods traders are equally as capable of stocking mortar shells.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings - Changes do not require a recompile
- [X] Game runs without errors
- [X] Playtested a colony (specify how long) - 10-20 minutes to make sure I haven't broken anything