### PR TITLE
Fix ubgl not switching rpm

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmosetSwitcher.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmosetSwitcher.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Reflection;
+using HarmonyLib;
 using RimWorld;
 using Verse;
 using UnityEngine;
@@ -164,6 +165,7 @@ public class CompUnderBarrel : CompRangedGizmoGiver
         // Ensures that there should be a burstFire option
         // If set to aimedBurstShotCount, will result in warning and no burst fire mode. Only full auto
         CompEq.PrimaryVerb.verbProps.burstShotCount = this.Props.verbPropsUnderBarrel.burstShotCount;
+        Traverse.Create(CompEq.PrimaryVerb).Field("cachedTicksBetweenBurstShots").SetValue(null);
         usingUnderBarrel = true;
         CompFireModes.InitAvailableFireModes();
 
@@ -222,6 +224,7 @@ public class CompUnderBarrel : CompRangedGizmoGiver
             }
         }
         CompEq.PrimaryVerb.verbProps.burstShotCount = DefVerbProps.burstShotCount;
+        Traverse.Create(CompEq.PrimaryVerb).Field("cachedTicksBetweenBurstShots").SetValue(null);
         usingUnderBarrel = false;
         CompFireModes.InitAvailableFireModes();
 

--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmosetSwitcher.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmosetSwitcher.cs
@@ -224,7 +224,7 @@ public class CompUnderBarrel : CompRangedGizmoGiver
             }
         }
         CompEq.PrimaryVerb.verbProps.burstShotCount = DefVerbProps.burstShotCount;
-        Traverse.Create(CompEq.PrimaryVerb).Field("cachedTicksBetweenBurstShots").SetValue(null);
+        CompEq.PrimaryVerb.cachedTicksBetweenBurstShots = null;
         usingUnderBarrel = false;
         CompFireModes.InitAvailableFireModes();
 

--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmosetSwitcher.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmosetSwitcher.cs
@@ -165,7 +165,7 @@ public class CompUnderBarrel : CompRangedGizmoGiver
         // Ensures that there should be a burstFire option
         // If set to aimedBurstShotCount, will result in warning and no burst fire mode. Only full auto
         CompEq.PrimaryVerb.verbProps.burstShotCount = this.Props.verbPropsUnderBarrel.burstShotCount;
-        Traverse.Create(CompEq.PrimaryVerb).Field("cachedTicksBetweenBurstShots").SetValue(null);
+        CompEq.PrimaryVerb.cachedTicksBetweenBurstShots = null;
         usingUnderBarrel = true;
         CompFireModes.InitAvailableFireModes();
 


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Fixes UBGL system not being able to update weapon RPM (ticksBetweenBurst) by using reflection to reset vanilla's cache.

## Reasoning

Why did you choose to implement things this way, e.g.
- UBGL functionality was broken for weapons like VE:Anomaly cyclone minigun
- Harmony seems like the easiest way
- There was no other way to reset the cache

## References

Can be tested via
https://github.com/CombatExtended-Continued/CombatExtendedArmory/pull/128

## Alternatives

Describe alternative implementations you have considered, e.g.
- Somehow not use Harmony

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
