### PR TITLE
Thog's Armor 1.6 CE Loadfolders update

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -623,7 +623,7 @@
 		<li IfModActive="Goji.TheSimsTraits">ModPatches/The Sims Traits</li>
 		<li IfModActive="TheVanityProject.ShibaInu">ModPatches/The Vanity Project - Shiba Inu</li>
 		<li IfModActive="Serek.TheWildFields">ModPatches/The Wild Fields</li>
-		<li IfModActive="Caninmyham.ThogsArmor">ModPatches/Thog's Armor</li>
+		<li IfModActive="Caninmyham.ThogsArmor, Caninmyham.ThogsArmor.temp15">ModPatches/Thog's Armor</li>
 		<li IfModActive="Caninmyham.ThogsGunsLeadAndPowderPackReprimedfixed">ModPatches/Thog's Guns - Lead and Powder Pack</li>
 		<li IfModActive="Caninmyham.ThogsGun_sBrukkaReprimed">ModPatches/Thog's Guns - More Brukka Pack</li>
 		<li IfModActive="Arquebus.ThrumboPlushie">ModPatches/Thrumbo Plushie</li>


### PR DESCRIPTION
## Additions
added the package id of the unofficial Thog's Armor 1.5/1.6 to the loadfolders.xml

## Changes
added a new packageid

## Reasoning
This version is supported for 1.6 while the version currently on loadfolders.xml is an older outdated version.

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [X] (For compatibility patches) ...with and without patched mod loaded
- [X] Playtested a colony (1 minute just to spawn an armor piece to see if it was patched)
