### PR TITLE
7.3 Release Fixes

### DIFF
--- a/ModPatches/Alpha Genes/Patches/Alpha Genes/ThingDefs_Races/Races_OcularSlinger.xml
+++ b/ModPatches/Alpha Genes/Patches/Alpha Genes/ThingDefs_Races/Races_OcularSlinger.xml
@@ -163,28 +163,6 @@
 					</value>
 				</li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="AG_OcularSlinger"]/verbs</xpath>
-					<value>
-						<verbs>
-							<li Class="CombatExtended.VerbPropertiesCE">
-								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-								<hasStandardCommand>true</hasStandardCommand>
-								<defaultProjectile>AG_EyeProjectile</defaultProjectile>
-								<warmupTime>2</warmupTime>
-								<burstShotCount>3</burstShotCount>
-								<ticksBetweenBurstShots>12</ticksBetweenBurstShots>
-								<minRange>2</minRange>
-								<range>18</range>
-								<soundCast>AG_Throw</soundCast>
-								<muzzleFlashScale>0</muzzleFlashScale>
-								<label>eye</label>
-								<commonality>0.8</commonality>
-							</li>
-						</verbs>
-					</value>
-				</li>
-
 				<li Class="PatchOperationConditional">
 					<xpath>Defs/ThingDef[defName="AG_OcularSlinger"]/comps</xpath>
 					<nomatch Class="PatchOperationAdd">

--- a/ModPatches/Thog's Armor/Patches/Thog's Armor/Armor_Thogs.xml
+++ b/ModPatches/Thog's Armor/Patches/Thog's Armor/Armor_Thogs.xml
@@ -138,11 +138,18 @@
 	<!-- === Flak Visor === -->
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="ThogsArmor_FlakVisor"]/statBases/StuffEffectMultiplierArmor</xpath>
+		<xpath>Defs/ThingDef[defName="ThogsArmor_FlakVisor"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
-			<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+			<ArmorRating_Sharp>4</ArmorRating_Sharp>
 			<Bulk>1</Bulk>
 			<WornBulk>0.75</WornBulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="ThogsArmor_FlakVisor"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>4</ArmorRating_Blunt>
 		</value>
 	</Operation>
 

--- a/ModPatches/Vanilla Arsenal/Defs/Vanilla Arsenal/Ammo.xml
+++ b/ModPatches/Vanilla Arsenal/Defs/Vanilla Arsenal/Ammo.xml
@@ -11,4 +11,52 @@
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
 
+	<!-- ==================== AmmoSet ========================== -->
+
+	<RecipeDef ParentName="GrenadeRecipeBase">
+		<defName>MakeStunGrenade</defName>
+		<label>make stun grenades x10</label>
+		<description>Craft 10 stun grenades.</description>
+		<jobString>Making stun grenades.</jobString>
+		<researchPrerequisite>Machining</researchPrerequisite>
+		<workAmount>2200</workAmount>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>6</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Prometheum</li>
+					</thingDefs>
+				</filter>
+				<count>1</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>2</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Prometheum</li>
+				<li>ComponentIndustrial</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<DV_Weapon_StunGrenades>10</DV_Weapon_StunGrenades>
+		</products>
+	</RecipeDef>
+
+
 </Defs>

--- a/ModPatches/Vanilla Arsenal/Patches/RangedIndustrial.xml
+++ b/ModPatches/Vanilla Arsenal/Patches/RangedIndustrial.xml
@@ -400,4 +400,103 @@
 		</value>
 	</Operation>
 
+	<!-- Stun Grenade -->
+
+	<!-- Projectile -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[@Name="DV_BaseStunGrenadeProjectile"]</xpath>
+		<value>
+			<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[@Name="DV_BaseStunGrenadeProjectile"]</xpath>
+		<value>
+			<graphicData>
+				<texPath>Things/Projectile/Grenades/Frag</texPath>
+				<graphicClass>Graphic_Single</graphicClass>
+			</graphicData>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[@Name="DV_BaseStunGrenadeProjectile"]</xpath>
+		<value>
+			<projectile Class="CombatExtended.ProjectilePropertiesCE">
+				<explosionRadius>4</explosionRadius>
+				<damageDef>Stun</damageDef>
+				<damageAmountBase>10</damageAmountBase>
+				<explosionDelay>30</explosionDelay>
+				<soundExplode>Explosion_Stun</soundExplode>
+				<dropsCasings>true</dropsCasings>
+				<casingMoteDefname>Fleck_GrenadePin</casingMoteDefname>
+				<casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
+				<speed>10</speed>
+				<screenShakeFactor>0</screenShakeFactor>
+				<suppressionFactor>2.0</suppressionFactor>
+				<dangerFactor>1.5</dangerFactor>
+				<airborneSuppressionFactor>0.25</airborneSuppressionFactor>
+			</projectile>
+		</value>
+	</Operation>
+
+	<!-- Grenade -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="DV_Weapon_StunGrenades"]/label</xpath>
+		<value>
+			<label>stun grenade</label>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="DV_Weapon_StunGrenades"]</xpath>
+		<value>
+			<thingClass>CombatExtended.AmmoThing</thingClass>
+			<stackLimit>75</stackLimit>
+			<resourceReadoutPriority>First</resourceReadoutPriority>		
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAttributeSet">
+		<xpath>Defs/ThingDef[defName="DV_Weapon_StunGrenades"]</xpath>
+		<attribute>Class</attribute>
+		<value>CombatExtended.AmmoDef</value>
+	</Operation>
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>DV_Weapon_StunGrenades</defName>
+		<statBases>
+			<Mass>0.4</Mass>
+			<Bulk>0.87</Bulk>
+			<MarketValue>11.22</MarketValue>
+			<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+			<SightsEfficiency>1.0</SightsEfficiency>
+		</statBases>
+		<Properties>
+			<label>throw stun grenade</label>
+			<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<range>10</range>
+			<warmupTime>0.8</warmupTime>
+			<noiseRadius>4</noiseRadius>
+			<ai_IsBuildingDestroyer>false</ai_IsBuildingDestroyer>
+			<soundCast>ThrowGrenade</soundCast>
+			<targetParams>
+				<canTargetLocations>true</canTargetLocations>
+			</targetParams>
+			<defaultProjectile>DV_Proj_GrenadeStun</defaultProjectile>
+			<onlyManualCast>true</onlyManualCast>
+			<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
+			<ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
+		</Properties>
+		<weaponTags>
+			<li>CE_GrenadeFlashbang</li>
+			<li>CE_AI_AOE</li>
+			<li>CE_OneHandedWeapon</li>
+		</weaponTags>
+	</Operation>
+
 </Patch>

--- a/ModPatches/Vanilla Factions Expanded - Empire/Defs/Vanilla Factions Expanded - Empire/Ammo/ThingDefs_ShuttleTurret.xml
+++ b/ModPatches/Vanilla Factions Expanded - Empire/Defs/Vanilla Factions Expanded - Empire/Ammo/ThingDefs_ShuttleTurret.xml
@@ -37,6 +37,9 @@
 				<muzzleFlashScale>12</muzzleFlashScale>
 			</li>
 		</verbs>
+		<weaponTags>
+			<li>Patched</li>
+		</weaponTags>		
 	</ThingDef>
 
 	<!-- Shuttle Turret Projectile -->

--- a/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Buildings/Buildings_Insectoid.xml
+++ b/ModPatches/Vanilla Factions Expanded - Insectoids 2/Patches/ThingDefs_Buildings/Buildings_Insectoid.xml
@@ -38,6 +38,16 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="VFEI2_Vilelobber_Gun"]</xpath>
+		<value>
+			<weaponTags>
+				<li>Patched</li>
+			</weaponTags>
+		</value>
+	</Operation>
+
+
 	<!-- Thornworm -->
 
 	<Operation Class="PatchOperationAdd">

--- a/ModPatches/Vanilla Factions Expanded - Pirates/Defs/Vanilla Factions Expanded - Pirates/Ammo/ThingDefs_GauntletTurret.xml
+++ b/ModPatches/Vanilla Factions Expanded - Pirates/Defs/Vanilla Factions Expanded - Pirates/Ammo/ThingDefs_GauntletTurret.xml
@@ -33,6 +33,9 @@
 				<muzzleFlashScale>9</muzzleFlashScale>
 			</li>
 		</verbs>
+		<weaponTags>
+			<li>Patched</li>
+		</weaponTags>
 	</ThingDef>
 
 </Defs>


### PR DESCRIPTION
## Changes
Fix various xml errors found during final checks.

- Fix Thog's Armor flak visor--was made non-stuffable.
- Add patched tag to several turrets to prevent autopatching.
- Patch Vanilla Arsenal stun grenades--they're identical to CE flashbangs.
- Fix Alpha Genes Phytokin patch--pawn verb was converted to an abilityDef.

## Reasoning
- Needed fixed.

## Alternatives
- Suffer

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
