### PR TITLE
Vanilla Plants Expanded cache error workaround

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -686,6 +686,7 @@
 		<li IfModActive="VanillaExpanded.VIEHAR">ModPatches/Vanilla Ideology Expanded - Hats and Rags</li>
 		<li IfModActive="VanillaExpanded.VMemesE">ModPatches/Vanilla Ideology Expanded - Memes and Structures</li>
 		<li IfModActive="VanillaExpanded.VPersonaWeaponsE">ModPatches/Vanilla Persona Weapons Expanded</li>
+		<li IfModActive="VanillaExpanded.VPlantsE">ModPatches/Vanilla Plants Expanded</li>
 		<li IfModActive="VanillaExpanded.VPlantsEMushrooms">ModPatches/Vanilla Plants Expanded - Mushrooms</li>
 		<li IfModActive="PrestigeSpecialistArmours.Final">ModPatches/Vanilla Prestige Specialist Armours Reworked</li>
 		<li IfModActive="VanillaExpanded.VPsycastsE">ModPatches/Vanilla Psycasts Expanded</li>

--- a/ModPatches/Vanilla Plants Expanded/Patches/Vanilla Plants Expanded/Items_Plants_Cultivated_Trees.xml
+++ b/ModPatches/Vanilla Plants Expanded/Patches/Vanilla Plants Expanded/Items_Plants_Cultivated_Trees.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VCE_CherryTree"]/thingClass</xpath>
+		<value>
+			<thingClass>Plant</thingClass>
+		</value>
+	</Operation>
+
+</Patch>


### PR DESCRIPTION
## Additions
Patch VCE_CherryTree thing class to Tree VE thing class with conditional texture is causing bug with CE
## Changes
None
## References
Bug chat
## Reasoning
Way easier than adding C# patch for one plant 
## Alternatives
C# so it also accept current texture, for ONE TREE
## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
