### PR TITLE
Androids Expanded 1.6 Loadfolders update

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -46,7 +46,7 @@
 		<li IfModActive="bbbbilly.ancienthuman">ModPatches/Ancient Human</li>
 		<li IfModActive="Killathon.AndroidTiersReforged">ModPatches/Android Tiers Reforged</li>
 		<li IfModActive="ChJees.Androids, ChJees.Androids14">ModPatches/Androids</li>
-		<li IfModActive="peptide.androidsexpanded, rielle.androidsexpanded">ModPatches/Androids Expanded</li>
+		<li IfModActive="peptide.androidsexpanded, peptide.androidsexpanded14, rielle.androidsexpanded">ModPatches/Androids Expanded</li>
 		<li IfModActive="hh.xrushha.AnimaAnimalsCombined">ModPatches/Anima Animals - Community Temp</li>
 		<li IfModActive="Seti.Victor.AnimaBodies">ModPatches/Anima Bionics</li>
 		<li IfModActive="xrushha.AnimaGear">ModPatches/Anima Gear</li>

--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -513,7 +513,7 @@
 		<li IfModActive="mlie.removeindustrialstuff">ModPatches/Remove Industrial Stuff</li>
 		<li IfModActive="FS.ReviaRace">ModPatches/Revia Race</li>
 		<li IfModActive="FS.ReviaRaceBiotech">ModPatches/Revia Race — biotech</li>
-		<li IfModActive="zerophoenix.contractorsarsenalfaction">ModPatches/Rim Contractors Arsenal</li>
+		<li IfModActive="zerophoenix.contractorsarsenalfaction,zal.contractorsarsenal">ModPatches/Rim Contractors Arsenal</li>
 		<li IfModActive="Fenn.floodrace,zal.floodrace">ModPatches/Rim Flood</li>
 		<li IfModActive="VexedTrees980.RimGnoblinsBiotech">ModPatches/Rim Gnoblins</li>
 		<li IfModActive="JTC.Nordberg">ModPatches/Rim Of Evil Northern Frontier</li>

--- a/ModPatches/Androids Expanded/Patches/Androids Expanded/AlienRace/AlienRace_Drones.xml
+++ b/ModPatches/Androids Expanded/Patches/Androids Expanded/AlienRace/AlienRace_Drones.xml
@@ -53,8 +53,7 @@
 
 	<!-- === Drones === -->
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="NChefDrone" or defName="NEngiDrone" or defName="NMedicDrone"
-			]/statBases </xpath>
+		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="NChefDrone" or defName="NEngiDrone" or defName="NMedicDrone"]/statBases</xpath>
 		<value>
 			<MeleeDodgeChance>0.5</MeleeDodgeChance>
 			<MeleeCritChance>0.5</MeleeCritChance>
@@ -88,7 +87,7 @@
 					</capacities>
 					<power>1</power>
 					<cooldownTime>1.688</cooldownTime>
-					<linkedBodyPartsGroup>DroneHand</linkedBodyPartsGroup>
+					<linkedBodyPartsGroup>AE_DroneHand</linkedBodyPartsGroup>
 					<armorPenetrationBlunt>0.525</armorPenetrationBlunt>
 				</li>
 			</tools>

--- a/ModPatches/Androids Expanded/Patches/Androids Expanded/Bodies/Bodies_DroidsExpanded.xml
+++ b/ModPatches/Androids Expanded/Patches/Androids Expanded/Bodies/Bodies_DroidsExpanded.xml
@@ -160,7 +160,7 @@
 
 	<!-- === Drone Body === -->
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/BodyDef[defName="DroneBody"]//*[def="DroneNeck"]</xpath>
+		<xpath>Defs/BodyDef[defName="DroneBody"]//*[def="AE_DroneNeck"]</xpath>
 		<value>
 			<groups/>
 		</value>
@@ -170,16 +170,16 @@
 		<xpath>
 			Defs/BodyDef[
 			defName="DroneBody"]//*[
-			def="DroneShell" or
-			def="DroneNeck" or
-			def="DroneHead" or
-			def="DroneShoulder" or
-			def="DroneArm" or
-			def="DroneHand" or
-			def="LeftDroneLeg" or
-			def="LeftDroneFoot" or
-			def="RightDroneLeg" or
-			def="RightDroneFoot"
+			def="AE_DroneShell" or
+			def="AE_DroneNeck" or
+			def="AE_DroneHead" or
+			def="AE_DroneShoulder" or
+			def="AE_DroneArm" or
+			def="AE_DroneHand" or
+			def="AE_LeftDroneLeg" or
+			def="AE_LeftDroneFoot" or
+			def="AE_RightDroneLeg" or
+			def="AE_RightDroneFoot"
 			]/groups
 		</xpath>
 		<value>


### PR DESCRIPTION
## Additions
Added Androids Expanded for 1.6 packageid to loadfolders.

## Reasoning
Androids Expanded for 1.6 does not get patched, only the older versions.

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [X] (For compatibility patches) ...with and without patched mod loaded
- [X] Playtested a colony (1 minute just to see if things got patched)