### PR TITLE
Exclude publicized dlls from all-libs list

### DIFF
--- a/Make.py
+++ b/Make.py
@@ -282,7 +282,7 @@ def main(argv=sys.argv):
 
     if options.all_libs:
         for ref in os.listdir(options.reference):
-            if ref.endswith(".dll"):
+            if ref.endswith(".dll") and not ref.endswith("_publicized.dll"):
                 libraries.append(os.path.join(options.reference, ref))
 
     for p in publicized_libraries:


### PR DESCRIPTION
## Changes

Unless the .csproj specifically asks for the publicized version of a library, include only the base version.

## References

Links to the associated issues or other related pull requests, e.g.
- Needed for  #4638 

## Reasoning

When a .csproj asks for the publicized version, we specifically unlist the unpublicized version from the compiler.  However if the .csproj doesn't specify, it ends up with both versions referenced.  This causes build errors if the compiler tries to reference both and they are unsigned, and it causes transient build errors if the wrong version gets picked, essentially randomly.

## Alternatives

Always prefer the publicized version -- leads to transient build-order issues if something depends on the publicized version without specifically listing it

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
