### PR TITLE
Downgrade NumCellsInRadius overflow from Log.Error to Log.Warning

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_GenRadial.cs
+++ b/Source/CombatExtended/Harmony/Harmony_GenRadial.cs
@@ -163,7 +163,7 @@ namespace CombatExtended.HarmonyCE
          */
         private static void LogNotEnoughSquaresError(float radius)
         {
-            Log.Error($"Not enough squares to get to radius {radius}. Max is {MAX_RADIUS}");
+            Log.Warning($"GenRadial.NumCellsInRadius: requested radius {radius} exceeds maximum {MAX_RADIUS}. Radius capped to {MAX_RADIUS}.");
         }
     }
 }


### PR DESCRIPTION
## Changes

- `Harmony_GenRadial.LogNotEnoughSquaresError()`: Downgrade `Log.Error` → `Log.Warning`
- Reword the message from "Not enough squares to get to radius X. Max is Y" to "requested radius X exceeds maximum Y. Radius capped to Y."

## Reasoning

`GenRadial.MaxRadialPatternRadius` is a compile-time const in vanilla RimWorld (~200). Third-party mods compiled against vanilla have this value baked into their IL, and CE cannot override it at runtime. When such a mod (e.g. WVC Work Modes) calls `NumCellsInRadius` with a radius exceeding CE's cap of 119, the prefix correctly caps the result — the game does not crash. But `Log.Error` causes unnecessary red error spam that alarms users.

`Log.Warning` better communicates that this is a compatibility note, not a failure. The updated message also accurately describes the cap behavior instead of sounding like a crash.

The performance-conscious design (separate method to avoid string formatting cost in hot path) is preserved unchanged.

## Alternatives

- Keep `Log.Error` — causes user-facing red error for a non-fatal compatibility edge case
- Remove the log entirely — loses useful diagnostic info for mod compatibility debugging
- Try to modify the compile-time const at runtime — not technically feasible through Harmony

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] with and without patched mod loaded
- [x] Playtested a colony (30 days)