### PR TITLE
Fix InvalidCastException in StatPart_NaturalArmorDurability

### DIFF
--- a/Source/CombatExtended/CombatExtended/StatParts/StatPart_NaturalArmorDurability.cs
+++ b/Source/CombatExtended/CombatExtended/StatParts/StatPart_NaturalArmorDurability.cs
@@ -32,8 +32,6 @@ public class StatPart_NaturalArmorDurability : StatPart
             var comp = (req.Thing?.TryGetComp<CompArmorDurability>() ?? null);
             if (comp != null)
             {
-                var mech = (Pawn)req.Thing;
-
                 float minArmor = getMinArmor(comp, val);
 
                 val -= (val - minArmor) * (1 - comp.curDurabilityPercent);
@@ -48,8 +46,6 @@ public class StatPart_NaturalArmorDurability : StatPart
         var comp = (req.Thing?.TryGetComp<CompArmorDurability>() ?? null);
         if (comp != null)
         {
-            var mech = (Pawn)req.Thing;
-
             string minArmorExp = getMinArmorExplicit(comp) >= 0 ? "Minimal armor value: " + getMinArmorExplicit(comp).ToString() : "Minimal armor percentage: " + comp.durabilityProps.MinArmorPct.ToStringPercent();
 
             return "Armor durability: " + comp.curDurabilityPercent.ToStringPercent() + "\n" + comp.curDurability.ToString() + "/" + comp.maxDurability.ToString() + "\n" + minArmorExp;


### PR DESCRIPTION
## Changes

- Remove unused `var mech = (Pawn)req.Thing` casts in `StatPart_NaturalArmorDurability.TransformValue` and `ExplanationPart`
- These casts are never used (the `mech` variable is assigned but never read), and cause `InvalidCastException` when `req.Thing` is a non-Pawn with `CompArmorDurability` (e.g. an Apparel item).

## Reasoning

`StatPart_NaturalArmorDurability.TransformValue` is called during projectile impact (both suppression calculation and actual damage). When `req.Thing` is an Apparel with `CompArmorDurability`, the hard `(Pawn)` cast throws `InvalidCastException`, crashing the projectile tick loop.

Stack trace:
```
System.InvalidCastException: Specified cast is not valid. at CombatExtended.StatPart_NaturalArmorDurability.TransformValue at RimWorld.StatWorker.FinalizeValue ... at CombatExtended.ProjectileCE.CheckCellForCollision at CombatExtended.ProjectileCE.Tick

```

The `mech` variable is dead code — removed without replacement.

## Alternatives

Could use a safe `as` cast or null check instead of deleting the variable, but since `mech` is never actually used, deleting is the cleanest fix.

## Testing

- [x] Compiles without warnings (`dotnet build -c Release`: 0 warnings, 0 errors)
- [x] Game runs without errors (tested with real projectile impact on pawns wearing armor with CompArmorDurability)
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony **(45 days)**