### PR TITLE
Primitive Core and Primitive Workbenches loadfolder update

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -464,8 +464,8 @@
 		<li IfModActive="Pratt.RaW.WWIIWeaponsPackVanilla">ModPatches/Pratt WWII Weapons Pack</li>
 		<li IfModActive="Kilo.PrestigeVacSet">ModPatches/Prestige Vacsuit Set</li>
 		<li IfModActive="PrestigePhoenix.maltum">ModPatches/Prestige Specialist Armor</li>
-		<li IfModActive="PrimitiveCore.velcroboy333">ModPatches/Primitive Core</li>
-		<li IfModActive="primitiveproduction.velcroboy333">ModPatches/Primitive Workbenches</li>
+		<li IfModActive="PrimitiveCore.velcroboy333, zal.primitivecore">ModPatches/Primitive Core</li>
+		<li IfModActive="primitiveproduction.velcroboy333, zal.primitiveproduction">ModPatches/Primitive Workbenches</li>
 		<li IfModActive="botchjob.profaned">ModPatches/Profaned</li>
 		<li IfModActive="PRF.Materials">ModPatches/Project RimFactory - Materials</li>
 		<li IfModActive="DimonSever000.ProsthesesPlus13.Specific">ModPatches/Prostheses+</li>


### PR DESCRIPTION
## Additions
Added the packageids of Primitive Core (Continued and Primitive Workbenches (Continued) to loadfolders.xml

## Reasoning
CE currently only supports the older unsupported versions of primitive core and primitive workbenches

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [X] (For compatibility patches) ...with and without patched mod loaded
- [X] Playtested a colony (1 minute to spawn a weapon to see if CE detects the mod properly)
