### PR TITLE
Fix NRE in CompSuppressable.IsHunkering when pawn.CurJob is null

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompSuppressable.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompSuppressable.cs
@@ -131,7 +131,7 @@ public class CompSuppressable : ThingComp
                 Pawn pawn = parent as Pawn;
                 currentSuppression = 0f;
                 ticksHunkered = 0;
-                if (pawn != null && pawn.CurJob.def == CE_JobDefOf.HunkerDown)
+                if (pawn != null && pawn.CurJob?.def == CE_JobDefOf.HunkerDown)
                 {
                     pawn.CurJob.Clear();
                 }


### PR DESCRIPTION
## Changes

Add null-conditional access (`pawn.CurJob?.def`) in `CompSuppressable.IsHunkering` to prevent NullReferenceException when a pawn enters the hunkering recovery path with no current job.

## Reasoning

`CompSuppressable.IsHunkering` has a recovery path that runs when a pawn has suppression buildup but `isSuppressed == false` (an abnormal but possible state). In this path, it checks if the pawn currently has a `HunkerDown` job by accessing `pawn.CurJob.def`. However, `pawn.CurJob` can be `null` when the pawn is idle or between jobs, causing `NullReferenceException`.

Stack trace:
```
Exception ticking XXX: System.NullReferenceException
  at CombatExtended.CompSuppressable.get_IsHunkering()
  at CombatExtended.CompTacticalManager.TryGiveTacticalJobs()
  at CombatExtended.CompTacticalManager.CompTickRare()
  at Verse.ThingWithComps.TickRare()
  at Verse.Pawn.Tick()
```

The same codebase already uses this null-check pattern in `ExternalPawnDrafter.cs:11`:
```csharp
(pawn.CurJob == null || pawn.CurJob.def.playerInterruptible)
```

## Alternatives

Could use `pawn.CurJob != null && pawn.CurJob.def == ...` instead of `?.`, but the null-conditional operator is more concise and already in use elsewhere in the CE codebase.

## Testing

- [x] Compiles without warnings (`dotnet build -c Release`: 0 warnings, 0 errors)
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony **(45 days)**