### PR TITLE
Fix TendSelf/TendPatient reservation conflict in CompTend

### DIFF
--- a/Source/CombatExtended/CombatExtended/AI/Comps/CompTend.cs
+++ b/Source/CombatExtended/CombatExtended/AI/Comps/CompTend.cs
@@ -73,6 +73,20 @@ public class CompTend : ICompTactics
             lastTendJobCheckedAt = GenTicks.TicksGame - COOLDOWN_TEND_JOB_CHECK / 2;
             return SuppressionUtility.GetRunForCoverJob(SelPawn);
         }
+        // 如果 SelPawn 已被其他 pawn 预约（如正在被 TendPatient），不要分配 TendSelf
+        // 否则会导致 TryMakePreToilReservations 中的预约冲突红字
+        var reservations = SelPawn.Map?.reservationManager?.ReservationsReadOnly;
+        if (reservations != null)
+        {
+            for (int i = 0; i < reservations.Count; i++)
+            {
+                if (reservations[i].Target == SelPawn && reservations[i].Claimant != SelPawn)
+                {
+                    lastTendJobCheckedAt = GenTicks.TicksGame;
+                    return null;
+                }
+            }
+        }
         lastTendJobAt = GenTicks.TicksGame;
         Job job = JobMaker.MakeJob(CE_JobDefOf.TendSelf, SelPawn);
         job.endAfterTendedOnce = false;

--- a/Source/CombatExtended/CombatExtended/AI/Comps/CompTend.cs
+++ b/Source/CombatExtended/CombatExtended/AI/Comps/CompTend.cs
@@ -73,8 +73,8 @@ public class CompTend : ICompTactics
             lastTendJobCheckedAt = GenTicks.TicksGame - COOLDOWN_TEND_JOB_CHECK / 2;
             return SuppressionUtility.GetRunForCoverJob(SelPawn);
         }
-        // 如果 SelPawn 已被其他 pawn 预约（如正在被 TendPatient），不要分配 TendSelf
-        // 否则会导致 TryMakePreToilReservations 中的预约冲突红字
+        // Do not assign TendSelf if SelPawn is already reserved by another pawn (e.g currently being treated via TendPatient)
+        // Otherwise, this will trigger reservation conflict errors in TryMakePreToilReservations.
         var reservations = SelPawn.Map?.reservationManager?.ReservationsReadOnly;
         if (reservations != null)
         {


### PR DESCRIPTION
## Additions

- None (pure bugfix)

## Changes

- `CompTend.TryGiveTacticalJob()` now checks `ReservationManager.ReservationsReadOnly` before creating a `TendSelf` job. If another pawn has already reserved the target (e.g., a doctor performing `TendPatient`), the assignment is skipped and the cooldown counter (`lastTendJobCheckedAt`) is updated.

## References

- Closes #[ISSUE_NUMBER] (if an issue exists, otherwise: N/A)

## Reasoning

- In combat, when a non-player pawn (prisoner, ally, animal) is bleeding, CE's `CompTend` simultaneously assigns a `TendSelf` job while a doctor pawn may already be tending them via `TendPatient`. Both jobs call `pawn.Reserve(Deliveree, ...)` through `JobDriver_TendPatient.TryMakePreToilReservations` with `maxPawns: 1` on the same target, causing `LogCouldNotReserveError` red error spam in the console.
- The fix prevents this by checking the reservation manager before creating the job — if the target pawn is already reserved by someone else, TendSelf is deferred. This is a minimal, targeted change that preserves all existing CompTend logic (cooldown, enemy proximity check, capability checks, etc.).
- The reservation check iterates `ReservationsReadOnly` directly rather than using `IsReservedByAnyoneOf(target, faction)` to cover cross-faction scenarios (e.g., a player-faction doctor tending a prisoner from a different faction).

## Alternatives

- Check reservation in `TryGiveTacticalJobs` prefix instead (the caller):
  - Would catch reservation conflicts for ALL tactical comps, not just CompTend.
  - But each comp has different reservation patterns — a generic check in the caller cannot know what targets each job type needs to reserve.
  - Placing the check inside CompTend keeps the fix scoped to the actual problem.
- Use `IsReservedByAnyoneOf(target, pawn.Faction)`:
  - Simpler API, but filters by faction — would miss cross-faction reservation conflicts (doctor from faction A tending prisoner from faction B).
  - `ReservationsReadOnly` with explicit iteration covers all cases.

## Testing

- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony **60+ days**

Note: fix verified through a local Harmony prefix patch (same logic, built and deployed). In-game testing pending.