### PR TITLE
Patch Faction - Elves

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -208,6 +208,7 @@
 		<li IfModActive="FrozenSnowFox.AdvancedBionicsExpansion">ModPatches/FSF Advanced Bionics Expansion</li>
 		<li IfModActive="FrozenSnowFox.MorePsycastPowers">ModPatches/FSF More Psycasts Powers</li>
 		<li IfModActive="FrozenSnowFox.VanillaBionicsExpansion">ModPatches/FSF Vanilla Bionics Expansion</li>
+		<li IfModActive="ICC.FOV.ELVES">ModPatches/Faction - Elves</li>
 		<li IfModActive="Qux.factionmafia">ModPatches/Faction - Mafia</li>
 		<li IfModActive="zal.fnveliteriotgear">ModPatches/Fallout New Vegas - Elite Riot Gear</li>
 		<li IfModActive="Phaneron.Vault111Startpack">ModPatches/Fallout Vault 111 Starter Pack</li>

--- a/ModPatches/Faction - Elves/Patches/Faction - Elves/Apparel_Elvish.xml
+++ b/ModPatches/Faction - Elves/Patches/Faction - Elves/Apparel_Elvish.xml
@@ -24,7 +24,6 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_DuelistPlateArmor"]/apparel/bodyPartGroups</xpath>
 		<value>
-			<li>Hands</li>
 			<li>Feet</li>
 		</value>
 	</Operation>
@@ -56,30 +55,6 @@
 						<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
 						<parts>
 							<li>Leg</li>
-						</parts>
-					</li>
-					<li>
-						<ArmorRating_Sharp>0</ArmorRating_Sharp>
-						<parts>
-							<li>Arm</li>
-						</parts>
-					</li>
-					<li>
-						<ArmorRating_Blunt>0</ArmorRating_Blunt>
-						<parts>
-							<li>Arm</li>
-						</parts>
-					</li>				
-					<li>
-						<ArmorRating_Sharp>0</ArmorRating_Sharp>
-						<parts>
-							<li>Hand</li>
-						</parts>
-					</li>
-					<li>
-						<ArmorRating_Blunt>0</ArmorRating_Blunt>
-						<parts>
-							<li>Hand</li>
 						</parts>
 					</li>
 				</stats>

--- a/ModPatches/Faction - Elves/Patches/Faction - Elves/Apparel_Elvish.xml
+++ b/ModPatches/Faction - Elves/Patches/Faction - Elves/Apparel_Elvish.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<!-- ========== Duelist Plate Armor ========== -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_DuelistPlateArmor"]/statBases</xpath>
+		<value>
+			<Bulk>90</Bulk>
+			<WornBulk>8</WornBulk>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_DuelistPlateArmor"]/statBases/StuffEffectMultiplierArmor</xpath>
+		<value>
+			<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Apparel_DuelistPlateArmor"]/equippedStatOffsets/MoveSpeed</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_DuelistPlateArmor"]/apparel/bodyPartGroups</xpath>
+		<value>
+			<li>Hands</li>
+			<li>Feet</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="Apparel_DuelistPlateArmor"]</xpath>
+		<value>
+			<li Class="CombatExtended.PartialArmorExt">
+				<stats>
+					<li>
+						<ArmorRating_Sharp>0.70</ArmorRating_Sharp>
+						<parts>
+							<li>Neck</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.70</ArmorRating_Blunt>
+						<parts>
+							<li>Neck</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+						<parts>
+							<li>Leg</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+						<parts>
+							<li>Leg</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0</ArmorRating_Sharp>
+						<parts>
+							<li>Arm</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0</ArmorRating_Blunt>
+						<parts>
+							<li>Arm</li>
+						</parts>
+					</li>				
+					<li>
+						<ArmorRating_Sharp>0</ArmorRating_Sharp>
+						<parts>
+							<li>Hand</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0</ArmorRating_Blunt>
+						<parts>
+							<li>Hand</li>
+						</parts>
+					</li>
+				</stats>
+			</li>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Faction - Elves/Patches/Faction - Elves/Elvish_Weapons.xml
+++ b/ModPatches/Faction - Elves/Patches/Faction - Elves/Elvish_Weapons.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- === Glaive === -->
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_Glaive"]/statBases</xpath>
+		<value>
+			<Bulk>9</Bulk>
+			<MeleeCounterParryBonus>1.68</MeleeCounterParryBonus>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_Glaive"]</xpath>
+		<value>
+			<equippedStatOffsets>
+				<MeleeCritChance>0.19</MeleeCritChance>
+				<MeleeParryChance>1.5</MeleeParryChance>
+				<MeleeDodgeChance>0.83</MeleeDodgeChance>
+			</equippedStatOffsets>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_Glaive"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>shaft</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>6</power>
+					<chanceFactor>0.15</chanceFactor>
+					<cooldownTime>1.16</cooldownTime>
+					<armorPenetrationBlunt>2.025</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Shaft</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>edge</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>35</power>
+					<cooldownTime>1.2</cooldownTime>
+					<armorPenetrationBlunt>4.42</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.97</armorPenetrationSharp>
+					<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<!-- === Rapier === -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_Rapier"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>handle</label>
+					<capacities>
+						<li>Poke</li>
+					</capacities>
+					<power>2</power>
+					<chanceFactor>0.33</chanceFactor>
+					<cooldownTime>1.44</cooldownTime>
+					<armorPenetrationBlunt>0.425</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>point</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>27</power>
+					<cooldownTime>1.44</cooldownTime>
+					<armorPenetrationBlunt>0.425</armorPenetrationBlunt>
+					<armorPenetrationSharp>1.42</armorPenetrationSharp>
+					<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>edge</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>16</power>
+					<cooldownTime>1.34</cooldownTime>
+					<chanceFactor>0.33</chanceFactor>
+					<armorPenetrationBlunt>0.73</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.43</armorPenetrationSharp>
+					<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_Rapier"]/statBases</xpath>
+		<value>
+			<Bulk>6</Bulk>
+			<MeleeCounterParryBonus>0.2</MeleeCounterParryBonus>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_Rapier"]</xpath>
+		<value>
+			<equippedStatOffsets>
+				<MeleeCritChance>0.16</MeleeCritChance>
+				<MeleeParryChance>0.44</MeleeParryChance>
+				<MeleeDodgeChance>0.22</MeleeDodgeChance>
+			</equippedStatOffsets>
+		</value>
+	</Operation>
+
+	<!-- ========== Great Longbow ========== -->
+
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Bow_GreatLong</defName>
+		<statBases>
+			<SightsEfficiency>0.8</SightsEfficiency>
+			<ShotSpread>0.75</ShotSpread>
+			<SwayFactor>1.75</SwayFactor>
+			<Bulk>4.50</Bulk>
+			<RangedWeapon_Cooldown>1.5</RangedWeapon_Cooldown>
+		</statBases>
+		<Properties>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Projectile_GreatArrow_Stone</defaultProjectile>
+			<warmupTime>1.9</warmupTime>
+			<range>40</range>
+			<soundCast>Bow_Large</soundCast>
+		</Properties>
+		<AmmoUser>
+			<ammoSet>AmmoSet_GreatArrow</ammoSet>
+			<AmmoGenPerMagOverride>5</AmmoGenPerMagOverride>
+		</AmmoUser>
+		<FireModes />
+		<weaponTags>
+			<li>CE_Bow</li>
+		</weaponTags>	
+		<AllowWithRunAndGun>false</AllowWithRunAndGun>
+	</Operation>
+
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bow_GreatLong"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>7</power>
+					<cooldownTime>1.6</cooldownTime>
+					<armorPenetrationBlunt>0.65</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Faction - Elves/Patches/Faction - Elves/Elvish_Weapons.xml
+++ b/ModPatches/Faction - Elves/Patches/Faction - Elves/Elvish_Weapons.xml
@@ -103,6 +103,13 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_Rapier"]/weaponTags</xpath>
+		<value>
+			<li>CE_OneHandedWeapon</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="MeleeWeapon_Rapier"]</xpath>
 		<value>
 			<equippedStatOffsets>

--- a/ModPatches/Faction - Elves/Patches/Faction - Elves/PawnKinds_Elves.xml
+++ b/ModPatches/Faction - Elves/Patches/Faction - Elves/PawnKinds_Elves.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- Celestria Elves (Spacers) -->
+
+	<!-- === Trader & Leader === -->
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/PawnKindDef[defName="CelestiaElvish_Trader" or defName="CelestiaElvish_Council"]</xpath>
+		<value>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>3</min>
+					<max>5</max>
+				</primaryMagazineCount>
+			</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/PawnKindDef[defName="CelestiaElvish_Ranger" or defName="CelestiaElvish_Mechanitor"]</xpath>
+		<value>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>4</min>
+					<max>6</max>
+				</primaryMagazineCount>
+				<sidearms>
+					<li>
+						<generateChance>0.5</generateChance>
+						<sidearmMoney>
+							<min>10</min>
+							<max>100</max>
+						</sidearmMoney>
+						<weaponTags>
+							<li>CE_Sidearm_Melee</li>
+						</weaponTags>
+					</li>
+					<li>
+						<generateChance>0.1</generateChance>
+						<sidearmMoney>
+							<min>80</min>
+							<max>160</max>
+						</sidearmMoney>
+						<weaponTags>
+							<li>CE_GrenadeFlashbang</li>
+							<li>GrenadeSmoke</li>
+							<li>GrenadeDestructive</li>
+						</weaponTags>
+						<magazineCount>
+							<min>0</min>
+							<max>0</max>
+						</magazineCount>
+					</li>
+				</sidearms>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- Dark, High, and Wild Elves (Medieval) -->
+
+	<!-- === Civilians === -->
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/PawnKindDef[defName="WildElvish_Trader" or defName="WildElvish_Hunter"]</xpath>
+		<value>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>2</min>
+					<max>3</max>
+				</primaryMagazineCount>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- === Archers === -->
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/PawnKindDef[
+			defName="HighElvish_Archer" or
+			defName="HighElvish_HeavyArcher" or
+			defName="WildElvish_Archer" or
+			defName="WildElvish_HeavyArcher" or
+			defName="DarkElvish_Archer"
+			]</xpath>
+		<value>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>4</min>
+					<max>6</max>
+				</primaryMagazineCount>
+				<sidearms>
+					<li>
+						<sidearmMoney>
+							<min>80</min>
+							<max>160</max>
+						</sidearmMoney>
+						<weaponTags>
+							<li>MedievalMeleeDecent</li>
+						</weaponTags>
+					</li>
+				</sidearms>
+			</li>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Faction - Elves/Patches/Faction - Elves/PawnKinds_Elves.xml
+++ b/ModPatches/Faction - Elves/Patches/Faction - Elves/PawnKinds_Elves.xml
@@ -101,4 +101,24 @@
 		</value>
 	</Operation>
 
+	<!-- === Add Backpacks === -->
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/PawnKindDef[
+			defName="HighElvish_Archer" or
+			defName="HighElvish_HeavyArcher" or
+			defName="WildElvish_Archer" or
+			defName="WildElvish_HeavyArcher" or
+			defName="DarkElvish_Archer" or
+			defName="HighElvish_Ranger" or
+			defName="DarkElvish_Ranger" or
+			defName="CelestiaElvish_Ranger" or
+			defName="HighElvish_Spearmen" or
+			defName="DarkElvish_Spearmen" or
+			defName="DarkElvish_Swordmaster"
+			]/apparelRequired</xpath>
+		<value>
+			<li>CE_Apparel_Backpack</li>
+		</value>
+	</Operation>
+
 </Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -253,6 +253,7 @@ Expanded Prosthetics and Organ Engineering (EPOE) - Forked	|
 EPOE-Forked: Royalty DLC expansion	|
 Expanded Woodworking (Forked)   |
 Extended Storage	|
+Faction - Elves |
 Faction: Mafia  |
 Fallout New Vegas - Elite Riot Gear |
 Fallout: Vault 111 Starter Pack |


### PR DESCRIPTION
## Additions
- Add a patch for Faction - Elves.
  - Adds pawnkinds, a few weapons, and one piece of apparel with armor.

## Reasoning
- Rapier is roughly a half-way point between the gladius and longsword. Strong stab AP, but weaker slashing.
- Duelist plate armor has same armor value as regular plate armor, but no arm coverage.
- Preserved base mod ability to make weapons from wood, because elves.

## Alternatives
- Could get more exotic with balancing choices, I suppose.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
