### PR TITLE
Prevent building fragments from hitting their source

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompFragments.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompFragments.cs
@@ -27,7 +27,7 @@ public class CompFragments : ThingComp
 
     public CompProperties_Fragments PropsCE => (CompProperties_Fragments)props;
 
-    public static IEnumerator FragRoutine(Vector3 pos, Map map, float height, Thing instigator, ThingDefCountClass frag, float fragSpeedFactor, float fragShadowChance, FloatRange fragAngleRange, FloatRange fragXZAngleRange, float minCollisionDistance = 0f, bool canTargetSelf = true)
+    public static IEnumerator FragRoutine(Vector3 pos, Map map, float height, Thing instigator, ThingDefCountClass frag, float fragSpeedFactor, float fragShadowChance, FloatRange fragAngleRange, FloatRange fragXZAngleRange, float minCollisionDistance = 0f, bool canTargetSelf = true, Thing fragmentSource = null)
     {
         if (height < 0.001f)
         {
@@ -63,6 +63,7 @@ public class CompFragments : ThingComp
                 fragSpeedFactor * projectile.def.projectile.speed,
                 projectile
             );
+            projectile.fragmentSource = fragmentSource;
 
             projectile.castShadow = (Rand.Value < fragShadowChance); // moved after Launch due to it assigning shadow
 

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -146,6 +146,7 @@ public abstract class ProjectileCE : ThingWithComps
 
     public ThingDef equipmentDef;
     public Thing launcher;
+    public Thing fragmentSource;
     public LocalTargetInfo intendedTarget;
     public float minCollisionDistance;
     public bool canTargetSelf;
@@ -382,6 +383,7 @@ public abstract class ProjectileCE : ThingWithComps
 
         Scribe_Values.Look<Vector2>(ref origin, "origin", default(Vector2), true);
         Scribe_References.Look<Thing>(ref launcher, "launcher");
+        Scribe_References.Look<Thing>(ref fragmentSource, "fragmentSource");
         Scribe_References.Look<Thing>(ref equipment, "equipment");
         Scribe_Values.Look<int>(ref intTicksToImpact, "ticksToImpact", 0, true);
         Scribe_Values.Look<float>(ref startingTicksToImpact, "startingTicksToImpact", 0, true);
@@ -1178,6 +1180,10 @@ public abstract class ProjectileCE : ThingWithComps
     {
         dist = -1f;
         if (globalTargetInfo.IsValid)
+        {
+            return false;
+        }
+        if (thing == fragmentSource)
         {
             return false;
         }

--- a/Source/CombatExtended/Harmony/Harmony_DamageWorker.cs
+++ b/Source/CombatExtended/Harmony/Harmony_DamageWorker.cs
@@ -94,7 +94,8 @@ internal static class Harmony_DamageWorker_Apply
                                                            new FloatRange(-10f, 10f),
                                                            frontArc,
                                                            1f,
-                                                           false);
+                                                           false,
+                                                           victim);
                         while (fr.MoveNext()) { }
                     }
                     {
@@ -108,7 +109,8 @@ internal static class Harmony_DamageWorker_Apply
                                                            new FloatRange(-10f, 10f),
                                                            backArc,
                                                            1f,
-                                                           false);
+                                                           false,
+                                                           victim);
                         while (fr.MoveNext()) { }
                     }
 
@@ -125,7 +127,8 @@ internal static class Harmony_DamageWorker_Apply
                                                        new FloatRange(-10f, 10f),
                                                        backArc,
                                                        1f,
-                                                       false);
+                                                       false,
+                                                       victim);
 
                     while (fr.MoveNext()) { }
 


### PR DESCRIPTION
## Additions

- None.

## Changes

- Mark fragments emitted from a damaged building with their source building.
- Exclude that source building from the fragment projectile's collision candidates.
- Serialize the exclusion reference so a fragment saved in flight retains the rule after loading.

## References

- Reproduction symptom: `Tried to destroy already-destroyed thing Turret_AutoChargeBlaster...`
- No upstream issue opened; the causal chain is documented below.

## Reasoning

- `Harmony_DamageWorker_Apply` emits building fragments before the original damage worker runs.
- `CompFragments.FragRoutine` ticks each emitted fragment immediately. A fragment can collide with the building that emitted it, destroy it, and return to the outer damage worker.
- The outer vanilla damage worker then reaches `Kill()` for the same, already-destroyed building and emits a false duplicate-destroy error.
- Excluding only the emission source preserves fragment damage to every other target and leaves ordinary fragment generation unchanged.

## Alternatives

- Disable Fragments from walls globally:
  - Avoids the error, but removes the feature instead of fixing it.
- Use the source building as the projectile launcher:
  - Reuses existing self-collision logic, but misattributes fragment damage and combat logs.
- Defer all building fragments until after damage resolution:
  - Avoids synchronous re-entry, but changes timing and allows surviving buildings to be hit by their own delayed fragments.

## Testing

- [x] Compiles without warnings: `dotnet build Source\CombatExtended\CombatExtended.csproj -c Release --no-restore`
- [x] Existing test suite: `dotnet test Source\Tests\Tests.csproj -c Release --no-restore` (1 passed)
- [ ] Game runs without errors: pending deployment after RimWorld closes
- [ ] Playtested a colony: pending developer-mode high-damage hit against an auto charge turret with Fragments from walls enabled. Local gameplay validation uses a combined branch containing this and my other unmerged CE PRs, so it verifies integration behavior rather than this change in isolation. (#4652 #4653 #4649 #4645 )
