### PR TITLE
Altered Carbon 2 Graser turret patch

### DIFF
--- a/ModPatches/Altered Carbon Ultratech Unleashed/Patches/Altered Carbon Ultratech Unleashed/AC_Weapons.xml
+++ b/ModPatches/Altered Carbon Ultratech Unleashed/Patches/Altered Carbon Ultratech Unleashed/AC_Weapons.xml
@@ -72,4 +72,48 @@
 		</value>
 	</Operation>
 
+	<!-- ========== Ancient Graser Turret ========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AC_Turret_AncientGraserTurret"]/fillPercent</xpath>
+		<value>
+			<fillPercent>0.85</fillPercent>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AC_Gun_AncientGraserTurret"]/statBases/RangedWeapon_Cooldown</xpath>
+		<value>
+			<RangedWeapon_Cooldown>0.60</RangedWeapon_Cooldown>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AC_Gun_AncientGraserTurret"]/verbs/li/warmupTime</xpath>
+		<value>
+			<warmupTime>1.3</warmupTime>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AC_Gun_AncientGraserTurret"]/verbs/li/range</xpath>
+		<value>
+			<range>55</range>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AC_Gun_AncientGraserTurret"]/verbs/li/burstShotCount</xpath>
+		<value>
+			<burstShotCount>16</burstShotCount>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AC_Gun_AncientGraserTurret"]/verbs/li/ticksBetweenBurstShots</xpath>
+		<value>
+			<ticksBetweenBurstShots>10</ticksBetweenBurstShots>
+		</value>
+	</Operation>
+
 </Patch>


### PR DESCRIPTION
## Additions
patch the turret missed it last time
## Changes
none
## References
patch chat
## Reasoning
Graser patch is formatted after biotech Graser patch
## Alternatives
not patch it or something
## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded,  gazer patch means it works without patch as well
- [x] Playtested a colony (specify how long) 2 mins to see it worked
