### PR TITLE
## Additions

### DIFF
--- a/Source/CombatExtended/CombatExtended/Building_AmmoContainerCE/Building_AutoloaderCE.cs
+++ b/Source/CombatExtended/CombatExtended/Building_AmmoContainerCE/Building_AutoloaderCE.cs
@@ -311,6 +311,7 @@ public class Building_AutoloaderCE : Building
                 TargetTurret?.SetReloading(false);
                 TargetTurret = null;
                 ticksToCompleteInitial = 0;
+                return;
             }
 
             ticksToComplete--;

--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoExploder.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoExploder.cs
@@ -40,7 +40,7 @@ public class CompAmmoExploder : ThingComp
         {
             foreach (AmmoThing ammo in ((Pawn)this.parent).inventory.innerContainer.Where(x => x is AmmoThing))
             {
-                var projdef = ((AmmoDef)ammo.def)?.AmmoSetDefs[0]?.ammoTypes[0]?.projectile ?? null;
+                var projdef = ((AmmoDef)ammo.def)?.AmmoSetDefs.FirstOrDefault()?.ammoTypes.FirstOrDefault()?.projectile ?? null;
                 var proj = (projdef?.projectile ?? null) as ProjectilePropertiesCE;
                 if (proj != null)
                 {

--- a/Source/CombatExtended/CombatExtended/Comps/CompMeleeTargettingGizmo.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompMeleeTargettingGizmo.cs
@@ -145,6 +145,7 @@ public class CompMeleeTargettingGizmo : ThingComp
                         return BodyPartHeight.Bottom;
                     }
                     targetBodyPart = bp.def;
+                    return BodyPartHeight.Top;
                 }
             }
             return BodyPartHeight.Top;

--- a/Source/CombatExtended/CombatExtended/WorldObjects/WorldObjectDamageWorker.cs
+++ b/Source/CombatExtended/CombatExtended/WorldObjects/WorldObjectDamageWorker.cs
@@ -28,7 +28,7 @@ public class WorldObjectDamageWorker
             {
                 empModifier = Mathf.Pow(3.3f, (int)faction.def.techLevel) / 1800f / ((int)faction.def.techLevel - 2f);
             }
-            if (faction.def.pawnGroupMakers.SelectMany(x => x.options).All(k => k.kind.RaceProps.IsMechanoid))
+            if (faction.def.pawnGroupMakers != null && faction.def.pawnGroupMakers.SelectMany(x => x.options).All(k => k.kind.RaceProps.IsMechanoid))
             {
                 empModifier = 1f;
             }


### PR DESCRIPTION


No new functionality added.



## Changes



- Ensured faction pawnGroupMakers is not null before checking mechanoid options to prevent null reference exceptions.

- Added an early return in reload logic to enhance stability.

- Corrected body part height retrieval in CompMeleeTargettingGizmo.

- Updated projectile definition retrieval to use FirstOrDefault for safety.



## References



No associated issues.



## Reasoning



Implemented these changes to improve code stability and prevent potential null reference exceptions during gameplay. Ensuring safety in data retrieval enhances overall reliability.



## Alternatives



Considered maintaining the previous checks but opted for null safety to avoid runtime errors.



## Testing



- [x] Compiles without warnings

- [x] Game runs without errors

- [ ] (For compatibility patches) ...with and without patched mod loaded

- [ ] Playtested a colony (specify how long)

