### PR TITLE
Add concealment stat

### DIFF
--- a/Defs/Stats/Stats_Concealment.xml
+++ b/Defs/Stats/Stats_Concealment.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+	<!-- ================================== Pawn's stat =======================================-->
+
+	<StatDef>
+		<defName>ConcealmentEfficiency</defName>
+		<label>concealment efficiency</label>
+		<description>A measure of the creature's overall ability to conceal themselves and blend into surroundings, increasing visibility error against them based on apparel, implants, and their natural abilities.</description>
+		<category>PawnCombat</category>
+		<defaultBaseValue>1</defaultBaseValue>
+		<displayPriorityInCategory>70</displayPriorityInCategory>
+		<toStringStyle>PercentZero</toStringStyle>
+		<showIfUndefined>true</showIfUndefined>
+		<minValue>0</minValue>
+		<maxValue>10.0</maxValue>
+		<parts>
+			<li Class="CombatExtended.StatPart_StatMaxima">
+				<apparelStat>ConcealmentEfficiency_Apparel</apparelStat>
+				<sumApparelsStat>false</sumApparelsStat>
+				<weaponStat>ConcealmentEfficiency_Weapon</weaponStat>
+				<sumImplantsStat>true</sumImplantsStat>
+				<implantStat>ConcealmentEfficiency_Implant</implantStat>
+				<priority>1000</priority>
+			</li>
+		</parts>
+	</StatDef>
+
+	<!-- ================================== Bases - (Parts only) =======================================-->
+
+	<StatDef Name="BaseConcealmentPart" Abstract="true">
+		<minValue>0</minValue>
+		<maxValue>10.0</maxValue>
+		<hideAtValue>1</hideAtValue>
+		<defaultBaseValue>1</defaultBaseValue>
+		<toStringStyle>PercentZero</toStringStyle>
+		<showIfUndefined>false</showIfUndefined>
+	</StatDef>
+
+	<!-- ================================== Implants =======================================-->
+
+	<StatDef ParentName="BaseConcealmentPart">
+		<defName>ConcealmentEfficiency_Implant</defName>
+		<label>implant concealment efficiency</label>
+		<description>The effect of artifical implants on a creature's ability to conceal themselves and blend into surroundings, increasing visibility error against them.</description>
+		<category>PawnCombat</category>
+	</StatDef>
+
+	<!-- ================================== Apparel/Equipment - base =======================================-->
+
+	<StatDef Name="EquipmentConcealmentBase" ParentName="BaseConcealmentPart" Abstract="true">
+		<parts>
+			<li Class="StatPart_Quality">
+				<factorAwful>0.70</factorAwful>
+				<factorPoor>0.85</factorPoor>
+				<factorNormal>1</factorNormal>
+				<factorGood>1.05</factorGood>
+				<factorExcellent>1.1</factorExcellent>
+				<factorMasterwork>1.15</factorMasterwork>
+				<factorLegendary>1.25</factorLegendary>
+			</li>
+		</parts>
+	</StatDef>
+
+	<!-- ================================== Apparel/Equipment =======================================-->
+
+	<StatDef ParentName="EquipmentConcealmentBase">
+		<defName>ConcealmentEfficiency_Weapon</defName>
+		<label>weapon concealment efficiency</label>
+		<description>The effect of a weapon's camouflage on the wielder's ability to conceal themselves and blend into surroundings, increasing visibility error against them.</description>
+		<category>Weapon</category>
+		<parts>
+			<li Class="CombatExtended.StatPart_Attachments" />
+		</parts>
+	</StatDef>
+
+	<StatDef ParentName="EquipmentConcealmentBase">
+		<defName>ConcealmentEfficiency_Apparel</defName>
+		<label>apparel concealment efficiency</label>
+		<description>The effect of apparel items on a creature's ability to conceal themselves and blend into surroundings, increasing visibility error against them.</description>
+		<category>Apparel</category>
+	</StatDef>
+
+</Defs>

--- a/Defs/Stats/Stats_Concealment.xml
+++ b/Defs/Stats/Stats_Concealment.xml
@@ -6,7 +6,7 @@
 	<StatDef>
 		<defName>ConcealmentEfficiency</defName>
 		<label>concealment efficiency</label>
-		<description>A measure of the creature's overall ability to conceal themselves and blend into surroundings, increasing visibility error against them based on apparel, implants, and their natural abilities.</description>
+		<description>A measure of the creature's overall ability to conceal themselves and blend into surroundings, increasing visibility and range errors against them based on apparel, implants, and their natural abilities.</description>
 		<category>PawnCombat</category>
 		<defaultBaseValue>1</defaultBaseValue>
 		<displayPriorityInCategory>70</displayPriorityInCategory>
@@ -30,7 +30,7 @@
 	<StatDef>
 		<defName>ConcealmentEfficiency_Apparel</defName>
 		<label>apparel concealment offset</label>
-		<description>The effect of apparel items on a creature's ability to conceal themselves and blend into surroundings, increasing visibility error against them.</description>
+		<description>The effect of apparel items on a creature's ability to conceal themselves and blend into surroundings, increasing visibility and range errors against them.</description>
 		<category>Apparel</category>
 		<minValue>0</minValue>
 		<maxValue>10.0</maxValue>

--- a/Defs/Stats/Stats_Concealment.xml
+++ b/Defs/Stats/Stats_Concealment.xml
@@ -15,40 +15,29 @@
 		<minValue>0</minValue>
 		<maxValue>10.0</maxValue>
 		<parts>
-			<li Class="CombatExtended.StatPart_StatMaxima">
-				<apparelStat>ConcealmentEfficiency_Apparel</apparelStat>
-				<sumApparelsStat>false</sumApparelsStat>
-				<weaponStat>ConcealmentEfficiency_Weapon</weaponStat>
-				<sumImplantsStat>true</sumImplantsStat>
-				<implantStat>ConcealmentEfficiency_Implant</implantStat>
-				<priority>1000</priority>
+			<li Class="StatPart_Stuff">
+				<priority>100</priority>
+				<stuffPowerStat>StuffPower_ConcealmentEfficiency</stuffPowerStat>
+				<multiplierStat>StuffEffectMultiplierConcealment</multiplierStat>
 			</li>
+			<li Class="StatPart_GearStatOffset">
+        		<apparelStat>ConcealmentEfficiency_Apparel</apparelStat>
+      		</li>
 		</parts>
 	</StatDef>
 
-	<!-- ================================== Bases - (Parts only) =======================================-->
-
-	<StatDef Name="BaseConcealmentPart" Abstract="true">
+	<!-- how much this apparel by itself and by its stuff increases concealment -->
+	<StatDef>
+		<defName>ConcealmentEfficiency_Apparel</defName>
+		<label>apparel concealment offset</label>
+		<description>The effect of apparel items on a creature's ability to conceal themselves and blend into surroundings, increasing visibility error against them.</description>
+		<category>Apparel</category>
 		<minValue>0</minValue>
 		<maxValue>10.0</maxValue>
-		<hideAtValue>1</hideAtValue>
-		<defaultBaseValue>1</defaultBaseValue>
+		<hideAtValue>0</hideAtValue>
+		<defaultBaseValue>0</defaultBaseValue>
 		<toStringStyle>PercentZero</toStringStyle>
 		<showIfUndefined>false</showIfUndefined>
-	</StatDef>
-
-	<!-- ================================== Implants =======================================-->
-
-	<StatDef ParentName="BaseConcealmentPart">
-		<defName>ConcealmentEfficiency_Implant</defName>
-		<label>implant concealment efficiency</label>
-		<description>The effect of artifical implants on a creature's ability to conceal themselves and blend into surroundings, increasing visibility error against them.</description>
-		<category>PawnCombat</category>
-	</StatDef>
-
-	<!-- ================================== Apparel/Equipment - base =======================================-->
-
-	<StatDef Name="EquipmentConcealmentBase" ParentName="BaseConcealmentPart" Abstract="true">
 		<parts>
 			<li Class="StatPart_Quality">
 				<factorAwful>0.70</factorAwful>
@@ -59,26 +48,37 @@
 				<factorMasterwork>1.15</factorMasterwork>
 				<factorLegendary>1.25</factorLegendary>
 			</li>
+			<li Class="StatPart_Stuff">
+				<priority>100</priority>
+				<stuffPowerStat>StuffPower_ConcealmentEfficiency</stuffPowerStat>
+				<multiplierStat>StuffEffectMultiplierConcealment</multiplierStat>
+			</li>
 		</parts>
 	</StatDef>
 
-	<!-- ================================== Apparel/Equipment =======================================-->
-
-	<StatDef ParentName="EquipmentConcealmentBase">
-		<defName>ConcealmentEfficiency_Weapon</defName>
-		<label>weapon concealment efficiency</label>
-		<description>The effect of a weapon's camouflage on the wielder's ability to conceal themselves and blend into surroundings, increasing visibility error against them.</description>
-		<category>Weapon</category>
-		<parts>
-			<li Class="CombatExtended.StatPart_Attachments" />
-		</parts>
+	<!-- how much this material improves apparel concealment -->
+	<StatDef>
+		<defName>StuffPower_ConcealmentEfficiency</defName>
+		<label>Concealment Efficiency</label>
+		<description>How much an apparel made of this material improves a wearer's ability to conceal themselves and blend into surroundings.</description>
+		<category>StuffStatFactors</category>
+		<defaultBaseValue>0</defaultBaseValue>
+		<hideAtValue>1</hideAtValue>
+		<minValue>0</minValue>
+		<toStringStyle>PercentZero</toStringStyle>
+		<showIfUndefined>false</showIfUndefined>
+		<displayPriorityInCategory>79</displayPriorityInCategory>
 	</StatDef>
 
-	<StatDef ParentName="EquipmentConcealmentBase">
-		<defName>ConcealmentEfficiency_Apparel</defName>
-		<label>apparel concealment efficiency</label>
-		<description>The effect of apparel items on a creature's ability to conceal themselves and blend into surroundings, increasing visibility error against them.</description>
+	<!-- how much this armor increases the power of stuff's concealment bonus -->
+	<StatDef>
+		<defName>StuffEffectMultiplierConcealment</defName>
+		<label>Concealment - Material effect multiplier</label>
 		<category>Apparel</category>
-	</StatDef>
+		<defaultBaseValue>1</defaultBaseValue>
+		<minValue>0</minValue>
+		<alwaysHide>true</alwaysHide>
+		<displayPriorityInCategory>1</displayPriorityInCategory>
+  	</StatDef>
 
 </Defs>

--- a/Languages/English/Keyed/Keys.xml
+++ b/Languages/English/Keyed/Keys.xml
@@ -44,6 +44,7 @@
 	<CE_CoverHeight>Cover height</CE_CoverHeight>
 	<CE_TargetHeight>Target height</CE_TargetHeight>
 	<CE_TargetWidth>Target width</CE_TargetWidth>
+	<CE_Concealment>Concealment</CE_Concealment>
 
 	<CE_EstimatedHitChance>Estimated hit chance</CE_EstimatedHitChance>
 

--- a/Source/CombatExtended/CombatExtended/DefOfs/CE_StatDefOf.cs
+++ b/Source/CombatExtended/CombatExtended/DefOfs/CE_StatDefOf.cs
@@ -50,6 +50,7 @@ public static class CE_StatDefOf
     public static StatDef BodyPartBluntArmor;
     public static StatDef AverageSharpArmor;
     public static StatDef NightVisionEfficiency;
+    public static StatDef ConcealmentEfficiency;
 
     public static StatDef SmokeSensitivity;
 

--- a/Source/CombatExtended/CombatExtended/ShiftVecReport.cs
+++ b/Source/CombatExtended/CombatExtended/ShiftVecReport.cs
@@ -113,9 +113,22 @@ public class ShiftVecReport
                 {
                     se = 0.02f;
                 }
-                visibilityShiftInt = environmentShift * (shotDist / 50 / se) * (2 - aimingAccuracy);
+                visibilityShiftInt = environmentShift * (shotDist / 50 / se) * (2 - aimingAccuracy) * concealmentFactor;
             }
             return visibilityShiftInt;
+        }
+    }
+
+    public float concealmentFactor
+    {
+        get
+        {
+            if (targetPawn != null)
+            {
+                return targetPawn.GetStatValue(CE_StatDefOf.ConcealmentEfficiency);
+            }
+
+            return 1f;
         }
     }
 
@@ -274,6 +287,10 @@ public class ShiftVecReport
         if (smokeDensity > 0)
         {
             stringBuilder.AppendLine("      " + "CE_SmokeDensity".Translate() + "\t" + AsPercent(smokeDensity));
+        }
+        if (visibilityShift > 0 && !Mathf.Approximately(concealmentFactor, 1f))
+        {
+            stringBuilder.AppendLine("      " + "CE_Concealment".Translate() + "\t" + AsPercent(concealmentFactor));
         }
         if (leadShift > 0)
         {

--- a/Source/CombatExtended/CombatExtended/ShiftVecReport.cs
+++ b/Source/CombatExtended/CombatExtended/ShiftVecReport.cs
@@ -182,7 +182,7 @@ public class ShiftVecReport
     {
         get
         {
-            return shotDist * (shotDist / Math.Max(maxRange, 20)) * Mathf.Min(accuracyFactor * 0.5f, 0.8f);
+            return shotDist * (shotDist / Math.Max(maxRange, 20)) * Mathf.Min(accuracyFactor * 0.5f, 0.8f) * concealmentFactor;
         }
     }
 
@@ -288,10 +288,6 @@ public class ShiftVecReport
         {
             stringBuilder.AppendLine("      " + "CE_SmokeDensity".Translate() + "\t" + AsPercent(smokeDensity));
         }
-        if (visibilityShift > 0 && !Mathf.Approximately(concealmentFactor, 1f))
-        {
-            stringBuilder.AppendLine("      " + "CE_Concealment".Translate() + "\t" + AsPercent(concealmentFactor));
-        }
         if (leadShift > 0)
         {
             stringBuilder.AppendLine("   " + "CE_LeadError".Translate() + "\t" + GenText.ToStringByStyle(leadShift, ToStringStyle.FloatTwo) + " " + "CE_cells".Translate());
@@ -299,6 +295,10 @@ public class ShiftVecReport
         if (distShift > 0)
         {
             stringBuilder.AppendLine("   " + "CE_RangeError".Translate() + "\t" + GenText.ToStringByStyle(distShift, ToStringStyle.FloatTwo) + " " + "CE_cells".Translate());
+        }
+        if ((visibilityShift > 0 || distShift > 0) && !Mathf.Approximately(concealmentFactor, 1f))
+        {
+            stringBuilder.AppendLine("      " + "CE_Concealment".Translate() + "\t" + AsPercent(concealmentFactor));
         }
         if (swayDegrees > 0)
         {


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Adds concealment stat for targets that increases visibility and range penalties against them. 100% by default. Can be increased or reduced, so conspicuous targets can decrease aiming penalties against them. 
- Adds a line to the shooting tooltp about it

## References

Links to the associated issues or other related pull requests, e.g.
- Trimmed down version of #4067 for easier reviewing experience

## Reasoning

Why did you choose to implement things this way, e.g.
- There are multiple mods that try to implement camouflage stats, but CE doesn't support the bonuses it gives.
- Concealment buffs could be used to make certain enemies more elusive, forcing additional aiming errors against them. Could be used to buff silenced weapons. Could use it to make proper ghillie suits. Or it could be used to make certain big armors more undesirable.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)

## Usage examples
1. Material giving concealment. When apparel is made out of plasteel (only works on apparel), wearer would get +30% offset to concealment. Modified by apparel quality.
```xml
	<!-- Testcase: stuff material giving concealment bonus -->
	<Operation Class="PatchOperationAdd">
		<xpath>Defs/ThingDef[defName="Plasteel"]/statBases</xpath>
		<value>
			<StuffPower_ConcealmentEfficiency>0.3</StuffPower_ConcealmentEfficiency>
		</value>
	</Operation>

```
2. Apparel improving material's bonus. Any other apparel made out of that Plasteel we changed above would give 30%, but Plate armor here would give 60% offset now. However, plate armor made out of a different material would give 0.
```xml
	<!-- Testcase: apparel multiplying stuff bonus -->
	<Operation Class="PatchOperationAdd">
		<xpath>Defs/ThingDef[defName="Apparel_PlateArmor"]/statBases</xpath>
		<value>
			<StuffEffectMultiplierConcealment>2</StuffEffectMultiplierConcealment>
		</value>
	</Operation>
```

3. Apparel giving concealment by itself. Wearing a cape gives +5% concealment offset. Doesnt matter what the cape is made of.
```xml
	<!-- apparel giving concealment regardless of stuff -->
	<Operation Class="PatchOperationAdd">
		<xpath>Defs/ThingDef[defName="Apparel_Cape"]</xpath>
		<value>
						<equippedStatOffsets>
										<ConcealmentEfficiency>0.05</ConcealmentEfficiency>
						</equippedStatOffsets>

		</value>
	</Operation>
```
4. Gun giving concealment. While it is equipped, it gives +700% offset.
```xml
	<!-- weapon giving concealment -->
	<Operation Class="PatchOperationAdd">
		<xpath>Defs/ThingDef[defName="Gun_Revolver"]</xpath>
		<value>
						<equippedStatOffsets>
										<ConcealmentEfficiency>7</ConcealmentEfficiency>
						</equippedStatOffsets>

		</value>
	</Operation>
```
5. Hediff giving concealment. First patch is needed to make it work, second patch makes it display the stat in item's infopanel.
```xml
	<!-- implant giving concealment -->

	<Operation Class="PatchOperationAdd">
		<xpath>Defs/HediffDef[defName="ArchotechArm"]</xpath>
		<value>
			<stages>
				<li>
					<statOffsets>
						<ConcealmentEfficiency>0.5</ConcealmentEfficiency>
					</statOffsets>
				</li>
			</stages>
		</value>
	</Operation>

	<!-- for stat panel to display it-->
	<Operation Class="PatchOperationAdd">
		<xpath>Defs/ThingDef[defName="ArchotechArm"]</xpath>
		<value>
			<equippedStatOffsets>
				<ConcealmentEfficiency>0.5</ConcealmentEfficiency>
			</equippedStatOffsets>
		</value>
	</Operation>
```

## Test save
use this to test the patches above
[concealmentTestSave.zip](https://github.com/user-attachments/files/31571512/concealmentTestSave.zip)
