### PR TITLE
155mm Antigrain Projectile Texture Fix

### DIFF
--- a/Defs/Ammo/Shell/155mmHowitzer.xml
+++ b/Defs/Ammo/Shell/155mmHowitzer.xml
@@ -314,7 +314,7 @@
 		<defName>Bullet_155mmHowitzerShell_Anti</defName>
 		<label>155mm Howitzer shell (Anti)</label>
 		<graphicData>
-			<texPath>Things/Projectile/Mortar/Antigrain</texPath>
+			<texPath>Things/Projectile/Cannon/Howitzer/ANTI</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">


### PR DESCRIPTION
## Changes

Modify the texture path of the 155mm Antigrain projectile so that it uses the correct texture.