### PR TITLE
Add option to make off-map artillery markers optional

### DIFF
--- a/Languages/English/Keyed/ModMenu.xml
+++ b/Languages/English/Keyed/ModMenu.xml
@@ -123,6 +123,9 @@
 	<CE_Settings_SuppressionCausesRunning_Title>Suppressed pawns seek cover</CE_Settings_SuppressionCausesRunning_Title>
 	<CE_Settings_SuppressionCausesRunning_Desc>When enabled, pawns under light (yellow) suppression will interupt what they are doing to seek cover. Pawns under heavy (orange) suppression will still hunker.</CE_Settings_SuppressionCausesRunning_Desc>
 
+	<CE_Settings_RequireArtilleryMarkerForOffMapArtillery_Title>Require marker for off-map artillery</CE_Settings_RequireArtilleryMarkerForOffMapArtillery_Title>
+	<CE_Settings_RequireArtilleryMarkerForOffMapArtillery_Desc>When enabled, off-map artillery can only target artillery markers. Disable this to target unmarked cells with the full unspotted accuracy penalty.</CE_Settings_RequireArtilleryMarkerForOffMapArtillery_Desc>
+
 	<CE_Settings_RealWeaponNames_Title>Use real weapon names</CE_Settings_RealWeaponNames_Title>
 	<CE_Settings_RealWeaponNames_Desc>When enabled, base game weapons, as well as some official add-on content, will use their real life names.\n\nRequires a restart to apply.</CE_Settings_RealWeaponNames_Desc>
 

--- a/Source/CombatExtended/CombatExtended/Gizmos/Command_ArtilleryTarget.cs
+++ b/Source/CombatExtended/CombatExtended/Gizmos/Command_ArtilleryTarget.cs
@@ -72,9 +72,14 @@ public class Command_ArtilleryTarget : Command
                     GenDraw.DrawTargetHighlight(target);
                 }, targetValidator: (target) =>
                 {
+                    if (!Controller.settings.RequireArtilleryMarkerForOffMapArtillery)
+                    {
+                        return true;
+                    }
+
                     RoofDef roof = map.roofGrid.RoofAt(target.Cell);
                     if ((roof == null || roof == RoofDefOf.RoofConstructed) &&
-                            (!Controller.settings.RequireArtilleryMarkerForOffMapArtillery || target.Cell.GetFirstThing<ArtilleryMarker>(map) != null))
+                            target.Cell.GetFirstThing<ArtilleryMarker>(map) != null)
                     {
                         return true;
                     }

--- a/Source/CombatExtended/CombatExtended/Gizmos/Command_ArtilleryTarget.cs
+++ b/Source/CombatExtended/CombatExtended/Gizmos/Command_ArtilleryTarget.cs
@@ -74,7 +74,7 @@ public class Command_ArtilleryTarget : Command
                 {
                     RoofDef roof = map.roofGrid.RoofAt(target.Cell);
                     if ((roof == null || roof == RoofDefOf.RoofConstructed) &&
-                            target.Cell.GetFirstThing<ArtilleryMarker>(map) != null)
+                            (!Controller.settings.RequireArtilleryMarkerForOffMapArtillery || target.Cell.GetFirstThing<ArtilleryMarker>(map) != null))
                     {
                         return true;
                     }

--- a/Source/CombatExtended/CombatExtended/ModSettings/Settings.cs
+++ b/Source/CombatExtended/CombatExtended/ModSettings/Settings.cs
@@ -27,6 +27,7 @@ public class Settings : ModSettings, ISettingsCE
     private bool partialstats = true;
     private bool enableExtraEffects = true;
     private bool realWeaponNames = true;
+    private bool requireArtilleryMarkerForOffMapArtillery = true;
 
     private bool enableArcOfFire = false;
 
@@ -77,6 +78,7 @@ public class Settings : ModSettings, ISettingsCE
     public bool PartialStat => partialstats;
     public bool EnableExtraEffects => enableExtraEffects;
     public bool RealWeaponNames => realWeaponNames;
+    public bool RequireArtilleryMarkerForOffMapArtillery => requireArtilleryMarkerForOffMapArtillery;
     public bool ShowExtraTooltips => showExtraTooltips;
     public bool DetailedMeleeTooltip => detailedMeleeTooltip;
     public bool NonPlayerMeleeTooltip => nonPlayerMeleeTooltip;
@@ -221,6 +223,7 @@ public class Settings : ModSettings, ISettingsCE
         Scribe_Values.Look(ref variedHumanHeight, "variedHumanHeight", false);
         Scribe_Values.Look(ref logUnpatchedDefs, "logUnpatchedDefs", false);
         Scribe_Values.Look(ref realWeaponNames, "realWeaponNames", true);
+        Scribe_Values.Look(ref requireArtilleryMarkerForOffMapArtillery, nameof(requireArtilleryMarkerForOffMapArtillery), true);
 
 #if DEBUG
         // Debug settings
@@ -336,6 +339,7 @@ public class Settings : ModSettings, ISettingsCE
         left.CheckboxLabeled("CE_Settings_EnableArcOfFire_Title".Translate(), ref enableArcOfFire, "CE_Settings_EnableArcOfFire_Desc".Translate());
         left.CheckboxLabeled("CE_Settings_EnableCIWS".Translate(), ref enableCIWS, "CE_Settings_EnableCIWS_Desc".Translate());
         left.CheckboxLabeled("CE_Settings_SuppressionCausesRunning_Title".Translate(), ref suppressionCausesRunning, "CE_Settings_SuppressionCausesRunning_Desc".Translate());
+        left.CheckboxLabeled("CE_Settings_RequireArtilleryMarkerForOffMapArtillery_Title".Translate(), ref requireArtilleryMarkerForOffMapArtillery, "CE_Settings_RequireArtilleryMarkerForOffMapArtillery_Desc".Translate());
         left.CheckboxLabeled("CE_Settings_FragmentsFromWalls_Title".Translate(), ref fragmentsFromWalls, "CE_Settings_FragmentsFromWalls_Desc".Translate());
         left.CheckboxLabeled("CE_Settings_FragmentsFromWallsReflected_Title".Translate(), ref fragmentsFromWallsReflected, "CE_Settings_FragmentsFromWallsReflected_Desc".Translate());
         left.Gap();
@@ -559,6 +563,7 @@ public class Settings : ModSettings, ISettingsCE
         autosetup = true;
         medicineSearchRadius = 5f;
         suppressionCausesRunning = true;
+        requireArtilleryMarkerForOffMapArtillery = true;
         opportunisticReloadMode = OpportunisticReloadMode.Any;
         opportunisticReloadSafeDistance = 12.9f;
         secondsAfterFightToOpportunisticReload = 5;

--- a/Source/CombatExtended/CombatExtended/ModSettings/Settings.cs
+++ b/Source/CombatExtended/CombatExtended/ModSettings/Settings.cs
@@ -223,7 +223,7 @@ public class Settings : ModSettings, ISettingsCE
         Scribe_Values.Look(ref variedHumanHeight, "variedHumanHeight", false);
         Scribe_Values.Look(ref logUnpatchedDefs, "logUnpatchedDefs", false);
         Scribe_Values.Look(ref realWeaponNames, "realWeaponNames", true);
-        Scribe_Values.Look(ref requireArtilleryMarkerForOffMapArtillery, nameof(requireArtilleryMarkerForOffMapArtillery), true);
+        Scribe_Values.Look(ref requireArtilleryMarkerForOffMapArtillery, "requireArtilleryMarkerForOffMapArtillery", true);
 
 #if DEBUG
         // Debug settings


### PR DESCRIPTION

## Additions

<img width="1345" height="1048" alt="image" src="https://github.com/user-attachments/assets/980be201-ce34-4598-8474-8cb50b6b1e9c" />

- Adds an opt-out option `Require marker for off-map artillery`
  - when ON (default ON): same as before
  - when OFF: you'll be able to use off-map artillery without markers with accuracy penalty, just like in-map artillery

## Reasoning

Felt weird that you can bombard other base with artillery, but cannot when your pawns are raiding said base. I think player should be able to bomb the enemy base even if there's friendlies in it (if you're willing to risk friendly fire) ~~_totally not because i got annoyed forgetting to bring radio pack binoculars for Nth time_~~

## Alternatives

add optional slider for inaccuracy modifier? but it works in this form and it's as simple as it can get

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a quick dev playthrough, and confirmed both with-binoculars and without-binoculars work normally.

<img width="2560" height="1440" alt="20260802132956_1" src="https://github.com/user-attachments/assets/c0091fd2-e798-4a1b-ad84-d79953261a85" />
used for testing: 9 105mm howitzers

<img width="2560" height="1440" alt="20260802133145_1" src="https://github.com/user-attachments/assets/a54c4b17-24ff-4364-b819-80bdac51490c" />
targetting works without binoculars and radio pack

<img width="2560" height="1440" alt="20260802133348_1" src="https://github.com/user-attachments/assets/a42a356e-64ac-46b3-b336-236c121fcaa3" />
notice the inaccuracy (targetted: base structure)

<img width="2560" height="1440" alt="20260802134009_1" src="https://github.com/user-attachments/assets/0e3e1344-bb0b-4354-a772-6ef060952a74" />
binoculars work normally

## Extra

AI usage disclosure: I used assistance of AI when writing code for this PR (GPT 5.6 sol on pi), and disclosed it on [`820733b` (this PR)](https://github.com/CombatExtended-Continued/CombatExtended/pull/4679/commits/820733bb3b525d8065f5a0fe8a137fc883286208). everything else, including testing and this PR body, is done by human (me)