### PR TITLE
Add Suppression Debug Tools

### DIFF
--- a/Source/CombatExtended/CombatExtended/CE_DebugUtility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_DebugUtility.cs
@@ -51,19 +51,19 @@ public static class CE_DebugUtility
     private static void SetSuppressionZero(Pawn p)
     {
         CompSuppressable comp = p.TryGetComp<CompSuppressable>();
-        comp?.SetSuppression(0);
+        comp?.DebugSetSuppression(0);
     }
     [DebugAction("CE", "Set Suppression: 50%", false, false, false, false, false, 0, false, actionType = DebugActionType.ToolMapForPawns, allowedGameStates = AllowedGameStates.PlayingOnMap)]
     private static void SetSuppressionHalf(Pawn p)
     {
         CompSuppressable comp = p.TryGetComp<CompSuppressable>();
-        comp?.SetSuppression(comp.SuppressionThreshold);
+        comp?.DebugSetSuppression(comp.SuppressionThreshold);
     }
 
     [DebugAction("CE", "Set Suppression: 100%", false, false, false, false, false, 0, false, actionType = DebugActionType.ToolMapForPawns, allowedGameStates = AllowedGameStates.PlayingOnMap)]
     private static void SetSuppressionMax(Pawn p)
     {
         CompSuppressable comp = p.TryGetComp<CompSuppressable>();
-        comp?.SetSuppression(1050f);
+        comp?.DebugSetSuppression(1050f);
     }
 }

--- a/Source/CombatExtended/CombatExtended/CE_DebugUtility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_DebugUtility.cs
@@ -33,7 +33,7 @@ public static class CE_DebugUtility
         array[4] = new TableDataGetter<WorldObjectDef>("HealthPatched", (WorldObjectDef d) => d.comps.Any(comp => comp is WorldObjectCompProperties_Health));
         DebugTables.MakeTablesDialog<WorldObjectDef>(notPatched, array);
     }
-    [DebugAction("CE", actionType = DebugActionType.ToolWorld)]
+    [DebugAction("CE", "Heal World Object", actionType = DebugActionType.ToolWorld)]
     public static void Heal()
     {
         int tileID = GenWorld.MouseTile(false);
@@ -46,5 +46,24 @@ public static class CE_DebugUtility
                 comp.recentShells.Clear();
             }
         }
+    }
+    [DebugAction("CE", "Set Suppression: 0", false, false, false, false, false, 0, false, actionType = DebugActionType.ToolMapForPawns, allowedGameStates = AllowedGameStates.PlayingOnMap)]
+    private static void SetSuppressionZero(Pawn p)
+    {
+        CompSuppressable comp = p.TryGetComp<CompSuppressable>();
+        comp?.SetSuppression(0);
+    }
+    [DebugAction("CE", "Set Suppression: 50%", false, false, false, false, false, 0, false, actionType = DebugActionType.ToolMapForPawns, allowedGameStates = AllowedGameStates.PlayingOnMap)]
+    private static void SetSuppressionHalf(Pawn p)
+    {
+        CompSuppressable comp = p.TryGetComp<CompSuppressable>();
+        comp?.SetSuppression(comp.SuppressionThreshold);
+    }
+
+    [DebugAction("CE", "Set Suppression: 100%", false, false, false, false, false, 0, false, actionType = DebugActionType.ToolMapForPawns, allowedGameStates = AllowedGameStates.PlayingOnMap)]
+    private static void SetSuppressionMax(Pawn p)
+    {
+        CompSuppressable comp = p.TryGetComp<CompSuppressable>();
+        comp?.SetSuppression(1050f);
     }
 }

--- a/Source/CombatExtended/CombatExtended/Comps/CompSuppressable.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompSuppressable.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Linq;
 using RimWorld;
 using Verse;
 using Verse.AI;
 using UnityEngine;
-using CombatExtended.AI;
 using CombatExtended.Compatibility;
 
 namespace CombatExtended;
@@ -59,7 +55,7 @@ public class CompSuppressable : ThingComp
     public IntVec3 SuppressorLoc => suppressorLoc;
 
     public float CurrentSuppression => currentSuppression;
-    private float SuppressionThreshold
+    public float SuppressionThreshold
     {
         get
         {
@@ -167,6 +163,12 @@ public class CompSuppressable : ThingComp
         Scribe_Values.Look(ref ticksUntilDecay, "ticksUntilDecay", 0);
         Scribe_Values.Look(ref lastHelpRequestAt, "lastHelpRequestAt", -1);
         Scribe_Values.Look(ref ticksHunkered, "ticksHunkered", 0);
+    }
+
+    public void SetSuppression(float amount)
+    {
+        currentSuppression = 0f;
+        AddSuppression(amount, parent.positionInt);
     }
 
     public void AddSuppression(float amount, IntVec3 origin)

--- a/Source/CombatExtended/CombatExtended/Comps/CompSuppressable.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompSuppressable.cs
@@ -165,7 +165,7 @@ public class CompSuppressable : ThingComp
         Scribe_Values.Look(ref ticksHunkered, "ticksHunkered", 0);
     }
 
-    public void SetSuppression(float amount)
+    public void DebugSetSuppression(float amount)
     {
         currentSuppression = 0f;
         AddSuppression(amount, parent.positionInt);


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Adds Debug Tools Related to Suppression
- 0, Suppression Threshold, and Max suppression settings.

## Reasoning

Why did you choose to implement things this way, e.g.
- To allow forcing pawns into certain suppression levels. 
- Pawn positionInt as source of suppression as need a IntVec3 to feed into system
- Allows testing of features easier

## Alternatives

Describe alternative implementations you have considered, e.g.
- Suffer

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
