### PR TITLE
Fix HoldTracker cleanup skipping first record

### DIFF
--- a/Source/CombatExtended/CombatExtended/Loadouts/Utility_HoldTracker.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/Utility_HoldTracker.cs
@@ -135,7 +135,7 @@ static class Utility_HoldTracker
             return;
         }
 
-        for (int i = recs.Count - 1; i > 0; i--)
+        for (int i = recs.Count - 1; i >= 0; i--)
         {
             if (recs[i].pickedUp && inventory.container.TotalStackCountOfDef(recs[i].thingDef) <= 0)
             {


### PR DESCRIPTION
## Additions

- None.

## Changes

- Include the first `HoldRecord` when pruning picked-up entries whose item def is no longer present in the pawn's inventory.

## References

- No associated issue.

## Reasoning

- I find the problem when using Hauler's Dream (another hual mod like Pick Up and Haul).
- `HoldTrackerCleanUp` iterates backwards so records can be removed safely, but the existing `i > 0` condition skips index `0`.
- A tracker containing a single picked-up record can therefore retain it after the corresponding item has left the inventory, leaving stale forced-hold state.
- Changing the condition to `i >= 0` preserves the existing reverse-removal approach and also remains safe for an empty list, where the initial index is `-1` and the loop is not entered.

## Alternatives

- Remove hold records immediately from every inventory-removal path. This would broaden the change substantially and still risk missing inventory mutations performed through other paths or mods.
- Keep periodic reconciliation as the fallback, while correcting its loop boundary.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) compatible with Hauler's Dream
- [x] Playtested a colony
