### PR TITLE
Update AOC compatibility patch

### DIFF
--- a/ModPatches/AOC The Cleanup Devil/Patches/AOC The Cleanup Devil/Apparel/Apparel.xml
+++ b/ModPatches/AOC The Cleanup Devil/Patches/AOC The Cleanup Devil/Apparel/Apparel.xml
@@ -402,6 +402,21 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AOC_CR_Uniform"]/statBases/StuffEffectMultiplierArmor</xpath>
+		<value>
+			<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="AOC_CR_Uniform"]/statBases</xpath>
+		<value>
+			<Bulk>2</Bulk>
+			<WornBulk>1</WornBulk>
+		</value>
+	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="AOC_winter_hat"]/statBases</xpath>
 		<value>

--- a/ModPatches/AOC The Cleanup Devil/Patches/AOC The Cleanup Devil/BodyDef.xml
+++ b/ModPatches/AOC The Cleanup Devil/Patches/AOC The Cleanup Devil/BodyDef.xml
@@ -53,6 +53,16 @@
 		</value>
 	</Operation>
 
+	<!--Collision body shape-->
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="AOC"]</xpath>
+		<value>
+			<li Class="CombatExtended.RacePropertiesExtensionCE">
+				<bodyShape>Humanoid</bodyShape>
+			</li>
+		</value>
+	</Operation>
+
 	<!--Arm Groups-->
 
 	<Operation Class="PatchOperationAdd">

--- a/ModPatches/AOC The Cleanup Devil/Patches/AOC The Cleanup Devil/Hediffs.xml
+++ b/ModPatches/AOC The Cleanup Devil/Patches/AOC The Cleanup Devil/Hediffs.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/HediffDef[defName="InfectedTeeth"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>teeth</label>
+					<capacities>
+						<li>InfectedBite</li>
+					</capacities>
+					<power>1</power>
+					<cooldownTime>2</cooldownTime>
+					<armorPenetrationSharp>0.12</armorPenetrationSharp>
+					<armorPenetrationBlunt>0.95</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/AOC The Cleanup Devil/Patches/AOC The Cleanup Devil/MeleeWeapons.xml
+++ b/ModPatches/AOC The Cleanup Devil/Patches/AOC The Cleanup Devil/MeleeWeapons.xml
@@ -255,4 +255,97 @@
 		</value>
 	</Operation>
 
+	<!-- Upcycling Doll - Dog -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AOC_Doll_Dog"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>bash</label>
+					<labelUsedInLogging>false</labelUsedInLogging>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>1</power>
+					<cooldownTime>2</cooldownTime>
+					<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="AOC_Doll_Dog"]/statBases</xpath>
+		<value>
+			<Bulk>0.2</Bulk>
+		</value>
+	</Operation>
+
+	<!-- Royalty-only Swatter -->
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="AOC_Swatter"]</xpath>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="AOC_Swatter"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>handle</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>4</power>
+								<cooldownTime>1.4</cooldownTime>
+								<chanceFactor>0.15</chanceFactor>
+								<armorPenetrationBlunt>1</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>swatter</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>14</power>
+								<cooldownTime>1.2</cooldownTime>
+								<armorPenetrationBlunt>4.5</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+								<extraMeleeDamages>
+									<li>
+										<def>Flame</def>
+										<amount>3</amount>
+										<chance>0.25</chance>
+									</li>
+									<li>
+										<def>EMP</def>
+										<amount>5</amount>
+									</li>
+								</extraMeleeDamages>
+							</li>
+						</tools>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="AOC_Swatter"]/statBases</xpath>
+					<value>
+						<Bulk>3</Bulk>
+						<MeleeCounterParryBonus>0.15</MeleeCounterParryBonus>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="AOC_Swatter"]</xpath>
+					<value>
+						<equippedStatOffsets>
+							<MeleeCritChance>0.08</MeleeCritChance>
+							<MeleeParryChance>0.12</MeleeParryChance>
+							<MeleeDodgeChance>0.05</MeleeDodgeChance>
+						</equippedStatOffsets>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+
 </Patch>

--- a/ModPatches/AOC The Cleanup Devil/Patches/AOC The Cleanup Devil/RangedWeapons.xml
+++ b/ModPatches/AOC The Cleanup Devil/Patches/AOC The Cleanup Devil/RangedWeapons.xml
@@ -400,12 +400,12 @@
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>AOC_KJW</defName>
 		<statBases>
-			<Mass>7.60</Mass>
-			<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
-			<SightsEfficiency>1</SightsEfficiency>
-			<ShotSpread>0.06</ShotSpread>
-			<SwayFactor>3.22</SwayFactor>
-			<Bulk>10</Bulk>
+			<Mass>8.40</Mass>
+			<RangedWeapon_Cooldown>0.50</RangedWeapon_Cooldown>
+			<SightsEfficiency>1.05</SightsEfficiency>
+			<ShotSpread>0.05</ShotSpread>
+			<SwayFactor>1.30</SwayFactor>
+			<Bulk>12</Bulk>
 			<WorkToMake>15000</WorkToMake>
 		</statBases>
 		<costList>
@@ -413,31 +413,34 @@
 			<ComponentIndustrial>11</ComponentIndustrial>
 		</costList>
 		<Properties>
-			<recoilAmount>0.8</recoilAmount>
+			<recoilAmount>1.25</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
-			<warmupTime>2.1</warmupTime>
+			<warmupTime>1.25</warmupTime>
 			<range>62</range>
-			<burstShotCount>50</burstShotCount>
-			<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
-			<soundCast>Shot_Minigun</soundCast>
+			<burstShotCount>12</burstShotCount>
+			<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+			<soundCast>Shot_CE_BattleRifle</soundCast>
 			<soundCastTail>GunTail_Medium</soundCastTail>
 			<muzzleFlashScale>9</muzzleFlashScale>
 		</Properties>
 		<AmmoUser>
-			<magazineSize>150</magazineSize>
-			<reloadTime>4.0</reloadTime>
+			<magazineSize>60</magazineSize>
+			<reloadTime>4.8</reloadTime>
 			<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
 		</AmmoUser>
 		<FireModes>
-			<aimedBurstShotCount>25</aimedBurstShotCount>
-			<aiAimMode>Snapshot</aiAimMode>
+			<aimedBurstShotCount>6</aimedBurstShotCount>
+			<aiUseBurstMode>false</aiUseBurstMode>
+			<aiAimMode>SuppressFire</aiAimMode>
 		</FireModes>
 		<weaponTags>
-			<li>CE_AI_Suppressive</li>
-			<li>NoSwitch</li>
+			<li>CE_MachineGun</li>
+			<li>CE_AI_LMG</li>
+			<li>Bipod_LMG</li>
 		</weaponTags>
+		<AllowWithRunAndGun>false</AllowWithRunAndGun>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
@@ -466,12 +469,12 @@
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>AOC_KJW_H</defName>
 		<statBases>
-			<Mass>8.50</Mass>
-			<RangedWeapon_Cooldown>0.4</RangedWeapon_Cooldown>
+			<Mass>28</Mass>
+			<RangedWeapon_Cooldown>0.50</RangedWeapon_Cooldown>
 			<SightsEfficiency>1.25</SightsEfficiency>
-			<ShotSpread>0.08</ShotSpread>
-			<SwayFactor>3.22</SwayFactor>
-			<Bulk>12</Bulk>
+			<ShotSpread>0.05</ShotSpread>
+			<SwayFactor>2.30</SwayFactor>
+			<Bulk>22</Bulk>
 			<WorkToMake>15000</WorkToMake>
 		</statBases>
 		<costList>
@@ -479,31 +482,36 @@
 			<ComponentIndustrial>11</ComponentIndustrial>
 		</costList>
 		<Properties>
-			<recoilAmount>1.1</recoilAmount>
+			<recoilAmount>1.55</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_50BMG_FMJ</defaultProjectile>
-			<warmupTime>2.3</warmupTime>
+			<warmupTime>1.8</warmupTime>
 			<range>75</range>
-			<burstShotCount>50</burstShotCount>
-			<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+			<burstShotCount>10</burstShotCount>
+			<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
 			<soundCast>Shot_Minigun</soundCast>
 			<soundCastTail>GunTail_Medium</soundCastTail>
 			<muzzleFlashScale>11</muzzleFlashScale>
+			<recoilPattern>Mounted</recoilPattern>
 		</Properties>
 		<AmmoUser>
-			<magazineSize>250</magazineSize>
-			<reloadTime>4.0</reloadTime>
+			<magazineSize>100</magazineSize>
+			<reloadTime>9.0</reloadTime>
 			<ammoSet>AmmoSet_50BMG</ammoSet>
 		</AmmoUser>
 		<FireModes>
-			<aimedBurstShotCount>25</aimedBurstShotCount>
-			<aiAimMode>Snapshot</aiAimMode>
+			<aimedBurstShotCount>5</aimedBurstShotCount>
+			<aiUseBurstMode>true</aiUseBurstMode>
+			<aiAimMode>SuppressFire</aiAimMode>
+			<noSingleShot>true</noSingleShot>
 		</FireModes>
 		<weaponTags>
+			<li>CE_MachineGun</li>
 			<li>CE_AI_Suppressive</li>
-			<li>NoSwitch</li>
+			<li>Bipod_LMG</li>
 		</weaponTags>
+		<AllowWithRunAndGun>false</AllowWithRunAndGun>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">


### PR DESCRIPTION
## Additions

- Add CE apparel stats for the AOC Rash Guard.
- Add CE melee tools and bulk for the Upcycling Doll - Dog.
- Add a CE melee profile for the Royalty-only AOC Swatter while safely skipping it when the def is absent.
- Add a humanoid CE collision body shape to the AOC race.

## Changes

- Rework the AOC KJW LMG as a 60-round 7.62x51 mm squad-support weapon with LMG AI and bipod tags.
- Rework the AOC KJW HMG as a 100-round .50 BMG support weapon with heavy mass/bulk, mounted recoil, suppressive AI, and no single-shot mode.
- Apply CE's RunAndGun restriction to both heavy weapons.

## Reasoning

- The existing compatibility patch does not cover several current AOC defs, leaving the rash guard, doll, Royalty weapon, and race collision data without complete CE behavior.
- The KJW definitions currently use minigun-style 50-shot bursts and oversized magazines despite their LMG/HMG roles.
- Updating the existing `PatchOperationMakeGunCECompatible` entries keeps CE as the single source of compatibility data and avoids a second post-processing override that could duplicate CE components.

## Alternatives

- Keep these adjustments in a standalone override mod. That works locally, but leaves the upstream compatibility patch incomplete and requires users to load another mod.

## Testing

- [x] `dotnet test Source/CombatExtended.sln` (1/1 passed)
- [x] All changed XML files parse successfully
- [x] `git diff --check`
- [x] Game runs without errors
- [ ] Tested with and without AOC loaded
- [ ] Playtested a colony
