### PR TITLE
Update Items_Resource_Ammo.xml

### DIFF
--- a/Defs/ThingDefs_Items/Items_Resource_Ammo.xml
+++ b/Defs/ThingDefs_Items/Items_Resource_Ammo.xml
@@ -23,7 +23,7 @@
 			<Bulk>1</Bulk>
 		</statBases>
 		<thingCategories>
-			<li>ResourcesRaw</li>
+			<li>Manufactured</li>
 		</thingCategories>
 		<tickerType>Normal</tickerType>
 		<comps>
@@ -65,7 +65,7 @@
 			<Bulk>1</Bulk>
 		</statBases>
 		<thingCategories>
-			<li>ResourcesRaw</li>
+			<li>Manufactured</li>
 		</thingCategories>
 		<tickerType>Normal</tickerType>
 		<comps>


### PR DESCRIPTION
## Changes

The item category of "Prometheum" and "FSX" has been updated so that when filtering for items in storage for example then it is in the same category as "Chemfuel" rather than being in the same category as things like wood, steel, silver, gold.


## References

Image I posted on the discord.

https://media.discordapp.net/attachments/668604879526428713/1536089282626855092/screenshot21.png?ex=6a7a2220&is=6a78d0a0&hm=4292c428c81e3f8eb272978150cf62d6b431d959622cfa76c5c07db3ebdb891c&=&format=webp&quality=lossless


## Reasoning

In vanilla RimWorld "Chemfuel" is already in the "manufactured" category alongside medicine, drugs, components, Neutroamine.
But CE's Prometheum and FSX is set in the "Raw resources" category with stone blocks, metals, jade and wood. But I believe it's much more appropriate for it to be with Chemfuel and drugs due to its organic and chemical nature.


## Testing

It still works. With the category change I'm still able to perform work bills on work benches as normal.

