### PR TITLE
Hide "Usable with shields" stat entry from VEF

### DIFF
--- a/Source/VEFCompat/VEFCompat/Harmony/Harmony_RemoveUsableWIthShields.cs
+++ b/Source/VEFCompat/VEFCompat/Harmony/Harmony_RemoveUsableWIthShields.cs
@@ -1,0 +1,13 @@
+﻿using HarmonyLib;
+using VEF.Apparels;
+
+namespace CombatExtended.Compatibility.VEFCompat;
+
+[HarmonyPatch(typeof(VanillaExpandedFramework_ThingDef_SpecialDisplayStats_Postfix_Patch.SetFaction), nameof(VanillaExpandedFramework_ThingDef_SpecialDisplayStats_Postfix_Patch.SetFaction.Postfix))]
+public class Harmony_RemoveUsableWIthShields
+{
+    public static bool Prefix()
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
## Additions

- Added a patch to hide the "Usable with shields" stat entry added by VE framework.

## Reasoning

- Using an unpatch is not feasible here, as VE use several postfixes on the same method in VEF and an unpatch would remove all of them.

## Alternatives

- Exist as is.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
