### PR TITLE
Add New Recipe Base for 40k Ammo

### DIFF
--- a/Defs/Ammo/AmmoBases.xml
+++ b/Defs/Ammo/AmmoBases.xml
@@ -190,7 +190,7 @@
 	</RecipeDef>
 
 	<!-- Base for Modded Ammo -->
-	<RecipeDef Name="40kAmmoRecipeBase" ParentName="AmmoRecipeBase" Abstract="true">
+	<RecipeDef Name="AmmoRecipeBase_40k" ParentName="AmmoRecipeBase" Abstract="true">
 		<skillRequirements>
 			<Crafting>6</Crafting>
 		</skillRequirements>

--- a/Defs/Ammo/AmmoBases.xml
+++ b/Defs/Ammo/AmmoBases.xml
@@ -189,4 +189,11 @@
 		</recipeUsers>
 	</RecipeDef>
 
+	<!-- Base for Modded Ammo -->
+	<RecipeDef Name="40kAmmoRecipeBase" ParentName="AmmoRecipeBase" Abstract="true">
+		<skillRequirements>
+			<Crafting>6</Crafting>
+		</skillRequirements>
+	</RecipeDef>
+
 </Defs>

--- a/Defs/Ammo/AmmoInjectorOptions.xml
+++ b/Defs/Ammo/AmmoInjectorOptions.xml
@@ -34,6 +34,7 @@
 				<li MayRequire="grimworld.astramilitarum">HP_AM_MilitarumFabricationBench</li>
 				<li MayRequire="happypurging.ageofdarkness">HP_ImperialFabricationBench</li>
 				<li MayRequire="grimworld.talonoftheemperor">GW_SM_TalonOfTheEmperor_WeaponBench</li>
+				<li MayRequire="Buffsboy474.SMWarcaskets.Ideology.Testing.cz">TableMachining</li>
 			</CE_AmmoCrafting_40k>
 
 		</benchesByTag>

--- a/Defs/Ammo/Modded/Warhammer 40k/Bolter.xml
+++ b/Defs/Ammo/Modded/Warhammer 40k/Bolter.xml
@@ -316,7 +316,7 @@
 
 	<!-- ==================== Recipes ========================== -->
 
-	<RecipeDef ParentName="40kAmmoRecipeBase">
+	<RecipeDef ParentName="AmmoRecipeBase_40k">
 		<defName>MakeAmmo_Bolter75_Standard</defName>
 		<label>make .75 Cal Bolter (standard) shell x200</label>
 		<description>Craft 200 .75 Cal Bolter (standard) shells.</description>
@@ -369,7 +369,7 @@
 		<workAmount>21840</workAmount>
 	</RecipeDef>
 
-	<RecipeDef ParentName="40kAmmoRecipeBase">
+	<RecipeDef ParentName="AmmoRecipeBase_40k">
 		<defName>MakeAmmo_Bolter75_Inferno</defName>
 		<label>make .75 Cal Bolter (inferno) shell x200</label>
 		<description>Craft 200 .75 Cal Bolter (inferno) shells.</description>
@@ -422,7 +422,7 @@
 		<workAmount>20880</workAmount>
 	</RecipeDef>
 
-	<RecipeDef ParentName="40kAmmoRecipeBase">
+	<RecipeDef ParentName="AmmoRecipeBase_40k">
 		<defName>MakeAmmo_Bolter75_MetalStorm</defName>
 		<label>make .75 Cal Bolter (metal storm) shell x200</label>
 		<description>Craft 200 .75 Cal Bolter (metal storm) shells.</description>
@@ -475,7 +475,7 @@
 		<workAmount>18480</workAmount>
 	</RecipeDef>
 
-	<RecipeDef ParentName="40kAmmoRecipeBase">
+	<RecipeDef ParentName="AmmoRecipeBase_40k">
 		<defName>MakeAmmo_Bolter75_Kraken</defName>
 		<label>make .75 Cal Bolter (kraken) shell x200</label>
 		<description>Craft 200 .75 Cal Bolter (kraken) shells.</description>
@@ -528,7 +528,7 @@
 		<workAmount>23280</workAmount>
 	</RecipeDef>
 
-	<RecipeDef ParentName="40kAmmoRecipeBase">
+	<RecipeDef ParentName="AmmoRecipeBase_40k">
 		<defName>MakeAmmo_Bolter75_Tempest</defName>
 		<label>make .75 Cal Bolter (tempest) shell x200</label>
 		<description>Craft 200 .75 Cal Bolter (tempest) shells.</description>

--- a/Defs/Ammo/Modded/Warhammer 40k/Bolter.xml
+++ b/Defs/Ammo/Modded/Warhammer 40k/Bolter.xml
@@ -316,7 +316,7 @@
 
 	<!-- ==================== Recipes ========================== -->
 
-	<RecipeDef ParentName="AmmoRecipeBase">
+	<RecipeDef ParentName="40kAmmoRecipeBase">
 		<defName>MakeAmmo_Bolter75_Standard</defName>
 		<label>make .75 Cal Bolter (standard) shell x200</label>
 		<description>Craft 200 .75 Cal Bolter (standard) shells.</description>
@@ -369,7 +369,7 @@
 		<workAmount>21840</workAmount>
 	</RecipeDef>
 
-	<RecipeDef ParentName="AmmoRecipeBase">
+	<RecipeDef ParentName="40kAmmoRecipeBase">
 		<defName>MakeAmmo_Bolter75_Inferno</defName>
 		<label>make .75 Cal Bolter (inferno) shell x200</label>
 		<description>Craft 200 .75 Cal Bolter (inferno) shells.</description>
@@ -422,7 +422,7 @@
 		<workAmount>20880</workAmount>
 	</RecipeDef>
 
-	<RecipeDef ParentName="AmmoRecipeBase">
+	<RecipeDef ParentName="40kAmmoRecipeBase">
 		<defName>MakeAmmo_Bolter75_MetalStorm</defName>
 		<label>make .75 Cal Bolter (metal storm) shell x200</label>
 		<description>Craft 200 .75 Cal Bolter (metal storm) shells.</description>
@@ -475,7 +475,7 @@
 		<workAmount>18480</workAmount>
 	</RecipeDef>
 
-	<RecipeDef ParentName="AmmoRecipeBase">
+	<RecipeDef ParentName="40kAmmoRecipeBase">
 		<defName>MakeAmmo_Bolter75_Kraken</defName>
 		<label>make .75 Cal Bolter (kraken) shell x200</label>
 		<description>Craft 200 .75 Cal Bolter (kraken) shells.</description>
@@ -528,7 +528,7 @@
 		<workAmount>23280</workAmount>
 	</RecipeDef>
 
-	<RecipeDef ParentName="AmmoRecipeBase">
+	<RecipeDef ParentName="40kAmmoRecipeBase">
 		<defName>MakeAmmo_Bolter75_Tempest</defName>
 		<label>make .75 Cal Bolter (tempest) shell x200</label>
 		<description>Craft 200 .75 Cal Bolter (tempest) shells.</description>

--- a/Defs/Ammo/Modded/Warhammer 40k/Bolter_Small.xml
+++ b/Defs/Ammo/Modded/Warhammer 40k/Bolter_Small.xml
@@ -173,7 +173,7 @@
 
 	<!-- ==================== Recipes ========================== -->
 
-	<RecipeDef ParentName="40kAmmoRecipeBase">
+	<RecipeDef ParentName="AmmoRecipeBase_40k">
 		<defName>MakeAmmo_Bolter50_Standard</defName>
 		<label>make .50 Cal Bolter (standard) shell x200</label>
 		<description>Craft 200 .50 Cal Bolter (standard) shells.</description>
@@ -226,7 +226,7 @@
 		<workAmount>9840</workAmount>
 	</RecipeDef>
 
-	<RecipeDef ParentName="40kAmmoRecipeBase">
+	<RecipeDef ParentName="AmmoRecipeBase_40k">
 		<defName>MakeAmmo_Bolter50_Inferno</defName>
 		<label>make .50 Cal Bolter (inferno) shell x200</label>
 		<description>Craft 200 .50 Cal Bolter (inferno) shells.</description>
@@ -279,7 +279,7 @@
 		<workAmount>8880</workAmount>
 	</RecipeDef>
 
-	<RecipeDef ParentName="40kAmmoRecipeBase">
+	<RecipeDef ParentName="AmmoRecipeBase_40k">
 		<defName>MakeAmmo_Bolter50_Kraken</defName>
 		<label>make .50 Cal Bolter (kraken) shell x200</label>
 		<description>Craft 200 .50 Cal Bolter (kraken) shells.</description>
@@ -332,7 +332,7 @@
 		<workAmount>12000</workAmount>
 	</RecipeDef>
 
-	<RecipeDef ParentName="40kAmmoRecipeBase">
+	<RecipeDef ParentName="AmmoRecipeBase_40k">
 		<defName>MakeAmmo_Bolter50_Tempest</defName>
 		<label>make .50 Cal Bolter (tempest) shell x200</label>
 		<description>Craft 200 .50 Cal Bolter (tempest) shells.</description>

--- a/Defs/Ammo/Modded/Warhammer 40k/Bolter_Small.xml
+++ b/Defs/Ammo/Modded/Warhammer 40k/Bolter_Small.xml
@@ -173,7 +173,7 @@
 
 	<!-- ==================== Recipes ========================== -->
 
-	<RecipeDef ParentName="AmmoRecipeBase">
+	<RecipeDef ParentName="40kAmmoRecipeBase">
 		<defName>MakeAmmo_Bolter50_Standard</defName>
 		<label>make .50 Cal Bolter (standard) shell x200</label>
 		<description>Craft 200 .50 Cal Bolter (standard) shells.</description>
@@ -226,7 +226,7 @@
 		<workAmount>9840</workAmount>
 	</RecipeDef>
 
-	<RecipeDef ParentName="AmmoRecipeBase">
+	<RecipeDef ParentName="40kAmmoRecipeBase">
 		<defName>MakeAmmo_Bolter50_Inferno</defName>
 		<label>make .50 Cal Bolter (inferno) shell x200</label>
 		<description>Craft 200 .50 Cal Bolter (inferno) shells.</description>
@@ -279,7 +279,7 @@
 		<workAmount>8880</workAmount>
 	</RecipeDef>
 
-	<RecipeDef ParentName="AmmoRecipeBase">
+	<RecipeDef ParentName="40kAmmoRecipeBase">
 		<defName>MakeAmmo_Bolter50_Kraken</defName>
 		<label>make .50 Cal Bolter (kraken) shell x200</label>
 		<description>Craft 200 .50 Cal Bolter (kraken) shells.</description>
@@ -332,7 +332,7 @@
 		<workAmount>12000</workAmount>
 	</RecipeDef>
 
-	<RecipeDef ParentName="AmmoRecipeBase">
+	<RecipeDef ParentName="40kAmmoRecipeBase">
 		<defName>MakeAmmo_Bolter50_Tempest</defName>
 		<label>make .50 Cal Bolter (tempest) shell x200</label>
 		<description>Craft 200 .50 Cal Bolter (tempest) shells.</description>

--- a/Defs/Ammo/Modded/Warhammer 40k/HeavyBolter.xml
+++ b/Defs/Ammo/Modded/Warhammer 40k/HeavyBolter.xml
@@ -205,7 +205,7 @@
 
 	<!-- ==================== Recipes ========================== -->
 
-	<RecipeDef ParentName="40kAmmoRecipeBase">
+	<RecipeDef ParentName="AmmoRecipeBase_40k">
 		<defName>MakeAmmo_Bolter998_Standard</defName>
 		<label>make .998 Cal Bolter (standard) shell x200</label>
 		<description>Craft 200 .998 Cal Bolter (standard) shells.</description>
@@ -258,7 +258,7 @@
 		<workAmount>44400</workAmount>
 	</RecipeDef>
 
-	<RecipeDef ParentName="40kAmmoRecipeBase">
+	<RecipeDef ParentName="AmmoRecipeBase_40k">
 		<defName>MakeAmmo_Bolter998_Inferno</defName>
 		<label>make .998 Cal Bolter (inferno) shell x200</label>
 		<description>Craft 200 .998 Cal Bolter (inferno) shells.</description>
@@ -311,7 +311,7 @@
 		<workAmount>42000</workAmount>
 	</RecipeDef>
 
-	<RecipeDef ParentName="40kAmmoRecipeBase">
+	<RecipeDef ParentName="AmmoRecipeBase_40k">
 		<defName>MakeAmmo_Bolter998_MetalStorm</defName>
 		<label>make .998 Cal Bolter (metal storm) shell x200</label>
 		<description>Craft 200 .998 Cal Bolter (metal storm) shells.</description>
@@ -364,7 +364,7 @@
 		<workAmount>36000</workAmount>
 	</RecipeDef>
 
-	<RecipeDef ParentName="40kAmmoRecipeBase">
+	<RecipeDef ParentName="AmmoRecipeBase_40k">
 		<defName>MakeAmmo_Bolter998_Kraken</defName>
 		<label>make .998 Cal Bolter (kraken) shell x200</label>
 		<description>Craft 200 .998 Cal Bolter (kraken) shells.</description>
@@ -417,7 +417,7 @@
 		<workAmount>48000</workAmount>
 	</RecipeDef>
 
-	<RecipeDef ParentName="40kAmmoRecipeBase">
+	<RecipeDef ParentName="AmmoRecipeBase_40k">
 		<defName>MakeAmmo_Bolter998_Tempest</defName>
 		<label>make .998 Cal Bolter (tempest) shell x200</label>
 		<description>Craft 200 .998 Cal Bolter (tempest) shells.</description>

--- a/Defs/Ammo/Modded/Warhammer 40k/HeavyBolter.xml
+++ b/Defs/Ammo/Modded/Warhammer 40k/HeavyBolter.xml
@@ -205,7 +205,7 @@
 
 	<!-- ==================== Recipes ========================== -->
 
-	<RecipeDef ParentName="AmmoRecipeBase">
+	<RecipeDef ParentName="40kAmmoRecipeBase">
 		<defName>MakeAmmo_Bolter998_Standard</defName>
 		<label>make .998 Cal Bolter (standard) shell x200</label>
 		<description>Craft 200 .998 Cal Bolter (standard) shells.</description>
@@ -258,7 +258,7 @@
 		<workAmount>44400</workAmount>
 	</RecipeDef>
 
-	<RecipeDef ParentName="AmmoRecipeBase">
+	<RecipeDef ParentName="40kAmmoRecipeBase">
 		<defName>MakeAmmo_Bolter998_Inferno</defName>
 		<label>make .998 Cal Bolter (inferno) shell x200</label>
 		<description>Craft 200 .998 Cal Bolter (inferno) shells.</description>
@@ -311,7 +311,7 @@
 		<workAmount>42000</workAmount>
 	</RecipeDef>
 
-	<RecipeDef ParentName="AmmoRecipeBase">
+	<RecipeDef ParentName="40kAmmoRecipeBase">
 		<defName>MakeAmmo_Bolter998_MetalStorm</defName>
 		<label>make .998 Cal Bolter (metal storm) shell x200</label>
 		<description>Craft 200 .998 Cal Bolter (metal storm) shells.</description>
@@ -364,7 +364,7 @@
 		<workAmount>36000</workAmount>
 	</RecipeDef>
 
-	<RecipeDef ParentName="AmmoRecipeBase">
+	<RecipeDef ParentName="40kAmmoRecipeBase">
 		<defName>MakeAmmo_Bolter998_Kraken</defName>
 		<label>make .998 Cal Bolter (kraken) shell x200</label>
 		<description>Craft 200 .998 Cal Bolter (kraken) shells.</description>
@@ -417,7 +417,7 @@
 		<workAmount>48000</workAmount>
 	</RecipeDef>
 
-	<RecipeDef ParentName="AmmoRecipeBase">
+	<RecipeDef ParentName="40kAmmoRecipeBase">
 		<defName>MakeAmmo_Bolter998_Tempest</defName>
 		<label>make .998 Cal Bolter (tempest) shell x200</label>
 		<description>Craft 200 .998 Cal Bolter (tempest) shells.</description>

--- a/Defs/Ammo/Modded/Warhammer 40k/LasGun.xml
+++ b/Defs/Ammo/Modded/Warhammer 40k/LasGun.xml
@@ -141,7 +141,7 @@
 
 	<!-- ==================== Recipes ========================== -->
 
-	<RecipeDef ParentName="AmmoRecipeBase">
+	<RecipeDef ParentName="40kAmmoRecipeBase">
 		<defName>MakeAmmo_LasgunPowerPack</defName>
 		<label>make lasgun power pack x500</label>
 		<description>Craft 500 lasgun batteries.</description>

--- a/Defs/Ammo/Modded/Warhammer 40k/LasGun.xml
+++ b/Defs/Ammo/Modded/Warhammer 40k/LasGun.xml
@@ -141,7 +141,7 @@
 
 	<!-- ==================== Recipes ========================== -->
 
-	<RecipeDef ParentName="40kAmmoRecipeBase">
+	<RecipeDef ParentName="AmmoRecipeBase_40k">
 		<defName>MakeAmmo_LasgunPowerPack</defName>
 		<label>make lasgun power pack x500</label>
 		<description>Craft 500 lasgun batteries.</description>

--- a/Defs/Ammo/Modded/Warhammer 40k/MeltaGun.xml
+++ b/Defs/Ammo/Modded/Warhammer 40k/MeltaGun.xml
@@ -92,7 +92,7 @@
 	</ThingDef>
 
 	<!-- ==================== Recipes ========================== -->
-	<RecipeDef ParentName="40kAmmoRecipeBase">
+	<RecipeDef ParentName="AmmoRecipeBase_40k">
 		<defName>MakeAmmo_MeltaGun</defName>
 		<label>make meltagun canisters x20</label>
 		<description>Craft 20 meltagun canisters</description>

--- a/Defs/Ammo/Modded/Warhammer 40k/MeltaGun.xml
+++ b/Defs/Ammo/Modded/Warhammer 40k/MeltaGun.xml
@@ -92,7 +92,7 @@
 	</ThingDef>
 
 	<!-- ==================== Recipes ========================== -->
-	<RecipeDef ParentName="AmmoRecipeBase">
+	<RecipeDef ParentName="40kAmmoRecipeBase">
 		<defName>MakeAmmo_MeltaGun</defName>
 		<label>make meltagun canisters x20</label>
 		<description>Craft 20 meltagun canisters</description>

--- a/Defs/Ammo/Modded/Warhammer 40k/PlasmaCannon.xml
+++ b/Defs/Ammo/Modded/Warhammer 40k/PlasmaCannon.xml
@@ -299,7 +299,7 @@
 
 	<!-- ==================== Recipes ========================== -->
 
-	<RecipeDef ParentName="AmmoRecipeBase">
+	<RecipeDef ParentName="40kAmmoRecipeBase">
 		<defName>MakeAmmo_PlasmaCanister</defName>
 		<label>make plasma canister x50</label>
 		<description>Craft 50 plasma canisters.</description>

--- a/Defs/Ammo/Modded/Warhammer 40k/PlasmaCannon.xml
+++ b/Defs/Ammo/Modded/Warhammer 40k/PlasmaCannon.xml
@@ -299,7 +299,7 @@
 
 	<!-- ==================== Recipes ========================== -->
 
-	<RecipeDef ParentName="40kAmmoRecipeBase">
+	<RecipeDef ParentName="AmmoRecipeBase_40k">
 		<defName>MakeAmmo_PlasmaCanister</defName>
 		<label>make plasma canister x50</label>
 		<description>Craft 50 plasma canisters.</description>

--- a/ModPatches/Warcaskets - Adeptus Astartes/Patches/Warcaskets - Adeptus Astartes/Patch_AmmoRecipes.xml
+++ b/ModPatches/Warcaskets - Adeptus Astartes/Patches/Warcaskets - Adeptus Astartes/Patch_AmmoRecipes.xml
@@ -1,21 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 
-	<!-- === Tools === -->
-	<Operation Class="PatchOperationAdd">
-		<xpath>
-			Defs/ThingDef[
-			@Name="AmmoBolter75Base" or
-			@Name="AmmoBolter50Base" or
-			@Name="AmmoBolter998Base" or
-			@Name="AmmoPlasmaCannonBase"
-			]/tradeTags
-		</xpath>
-		<value>
-			<li>CE_AutoEnableCrafting_TableMachining</li>
-		</value>
-	</Operation>
-
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/RecipeDef[@Name="AmmoRecipeBase_40k"]</xpath>
 		<value>

--- a/ModPatches/Warcaskets - Adeptus Astartes/Patches/Warcaskets - Adeptus Astartes/Patch_AmmoRecipes.xml
+++ b/ModPatches/Warcaskets - Adeptus Astartes/Patches/Warcaskets - Adeptus Astartes/Patch_AmmoRecipes.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- === Tools === -->
+	<Operation Class="PatchOperationAdd">
+		<xpath>
+			Defs/ThingDef[
+			@Name="AmmoBolter75Base" or
+			@Name="AmmoBolter50Base" or
+			@Name="AmmoBolter998Base" or
+			@Name="AmmoPlasmaCannonBase"
+			]/tradeTags
+		</xpath>
+		<value>
+			<li>CE_AutoEnableCrafting_TableMachining</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/RecipeDef[@Name="40kAmmoRecipeBase"]</xpath>
+		<value>
+			<researchPrerequisite>VFEP_WarcasketWeaponry</researchPrerequisite>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Warcaskets - Adeptus Astartes/Patches/Warcaskets - Adeptus Astartes/Patch_AmmoRecipes.xml
+++ b/ModPatches/Warcaskets - Adeptus Astartes/Patches/Warcaskets - Adeptus Astartes/Patch_AmmoRecipes.xml
@@ -17,7 +17,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/RecipeDef[@Name="40kAmmoRecipeBase"]</xpath>
+		<xpath>Defs/RecipeDef[@Name="AmmoRecipeBase_40k"]</xpath>
 		<value>
 			<researchPrerequisite>VFEP_WarcasketWeaponry</researchPrerequisite>
 		</value>


### PR DESCRIPTION
## Additions
- Create a new `AmmoRecipeBase_40k` to allow 40k ammo to be managed more centrally.
- Added to the Adeptus Astartes Warcaskets patch.
   - Patch the needed recipes into the machining table.
   - Add the warcaskets weaponry as a research prereq to 40k ammo.

## Changes
- Increasing crafting skill requirement for 40k ammo to level 6, matching advanced ammo.
- Bolter, plasma, lasgun, and melta gun ammo recipes now use `AmmoRecipeBase_40k` instead of `AmmoRecipeBase`.
  - Didn't add it to stub gun ammo, since these are basically just conventional bullets.

## Reasoning
- Because the mod's weaponry uses the bolter ammo but doesn't add a crafting bench, it's necessary to add the recipes to an existing bench. Since 30/40mm grenades are already made a the machining table, it seemed the best option.

## Alternatives
- This arrangement could create some issues when playing with Adeptus Astartes Warcaskets + other 40k mods, because it would require the warcasket weaponry research project to be complete to craft ammo. Though, this mod list would strike me as add since most other 40k mod series have their own Space Marine armor that doesn't use the warcasket framework.
  - A more wholistic compatibility patch might be better in such cases, but we'll probably be best off addressing those specific cases as they arise.
  - This could potentially be managed via defensive patching using FindMod - > `nomatch`.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
