### PR TITLE
Revert "Downgrade NumCellsInRadius overflow from Log.Error to Log.Warning"

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_GenRadial.cs
+++ b/Source/CombatExtended/Harmony/Harmony_GenRadial.cs
@@ -163,7 +163,7 @@ namespace CombatExtended.HarmonyCE
          */
         private static void LogNotEnoughSquaresError(float radius)
         {
-            Log.Warning($"GenRadial.NumCellsInRadius: requested radius {radius} exceeds maximum {MAX_RADIUS}. Radius capped to {MAX_RADIUS}.");
+            Log.Error($"Not enough squares to get to radius {radius}. Max is {MAX_RADIUS}");
         }
     }
 }


### PR DESCRIPTION
Reverts CombatExtended-Continued/CombatExtended#4645

- After further discussion, it was decided that it's preferable to keep the error closer to the vanilla implementation.