### PR TITLE
Create Filth_Various-BugFix

### DIFF
--- a/Source/CombatExtended/Filth_Various-BugFix
+++ b/Source/CombatExtended/Filth_Various-BugFix
@@ -1,0 +1,44 @@
+using HarmonyLib;
+using RimWorld;
+using Verse;
+
+namespace Simplify_Filth_Various
+{
+    [StaticConstructorOnStartup]
+    public static class Simplify_Filth_Various
+    {
+        static Simplify_Filth_Various()
+        {
+            var harmony = new Harmony("Simplify.Filth.Various");
+            harmony.PatchAll();
+        }
+    }
+
+    [HarmonyPatch(typeof(Thing), nameof(Thing.TakeDamage))]
+    public static class Patch_Thing_TakeDamage
+    {
+        public static bool Prefix(Thing __instance, DamageInfo dinfo)
+        {
+            ThingDef def = __instance.def;
+
+            // Only affect filth.
+            if (def.category != ThingCategory.Filth)
+                return true;
+
+            // Must either use hit points or have MaxHitPoints.
+            if (!def.useHitPoints && def.BaseMaxHitPoints <= 0)
+                return true;
+
+            // Must be flammable.
+            if (__instance.GetStatValue(StatDefOf.Flammability) <= 0f)
+                return true;
+
+            // Ignore all explosive damage.
+            if (dinfo.Def != null && dinfo.Def.isExplosive)
+                return false;
+
+            // Everything else behaves normally.
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
This is a simple bug fix for burning fuel filth left on the floor after explosions that applies to vanilla chemfuel puddles, oil puddles, including any modded burning fuel such as CE's prometheum puddles or other hypothetical mods'.

It simply detects any filth which has 2 key parts, hit points and flammability, if those 2 conditions are met then the filth is made to not receive any explosive damage so that explosions don't magically make burning fuel on the ground disappear.

https://www.youtube.com/watch?v=FWRhdkGZLxA

As you can see in this video, with this mod file explosions such as from bombs, ammo and IEDs no longer reliabily make burning fuel on the ground magically disappear.

It's mostly effective but not 100% effective so I'm assuming maybe something like explosion fragments is still reducing some burning fuel's HP by a little bit.

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased regular smoke bomb radius

## References

https://steamcommunity.com/sharedfiles/filedetails/?id=3784849472
Currently a small 1/2 part of my bug fixes mod.

## Reasoning

The reason I made this mod is simply for conserving more realistic physics in combat. Explosive damage should not be making flammable fuel magically disappear.
For example in real life if you have a stone room full of flammable fuel on the ground and you detonate explosives in the room then the explosive damage is not going to make the flammable fuel magically disappear.

## Alternatives

I'm not aware of any other alternatives to fix this bug. I posted this on RimWorld's official Discord bug report and I have received no replies. It's a bug in vanilla RimWorld that has carried over to other mods such as Combat Extended's prometheum puddles.

## Testing

Done multiple tests sparsely across multiple days with explosive ammo including shells and stick bombs, IEDs. There is much more burning fuel left on the ground with this mod than without.