### PR TITLE
Update AmmoThing.cs

### DIFF
--- a/Source/CombatExtended/CombatExtended/Things/AmmoThing.cs
+++ b/Source/CombatExtended/CombatExtended/Things/AmmoThing.cs
@@ -30,10 +30,10 @@ public class AmmoThing : ThingWithComps
             {
                 numToCookOff += Mathf.RoundToInt(def.stackLimit * ((float)dinfo.Amount / HitPoints) * (def.smallVolume ? Rand.Range(1f, 2f) : Rand.Range(0.0f, 1f)));
             }
-            //Assume CompExplosive destroys on kill
-            else if (this.TryGetComp<CompExplosive>() == null || !this.TryGetComp<CompExplosive>().Props.explodeOnKilled)
+            //Explosives detonate when destroyed by external damage.
+            else
             {
-                TryDetonate(stackCount);
+                TryDetonate(stackCount, true);
             }
         }
     }
@@ -109,7 +109,7 @@ public class AmmoThing : ThingWithComps
         return stringBuilder.ToString().TrimEndNewlines();
     }
 
-    private bool TryDetonate(float stackCountScale = 1)
+    private bool TryDetonate(float stackCountScale = 1, bool force = false)
     {
         if (Find.Maps.IndexOf(Map) < 0)
         {
@@ -121,7 +121,7 @@ public class AmmoThing : ThingWithComps
 
         if (comp != null || detProps != null)
         {
-            if (Rand.Chance(Mathf.Clamp01(0.75f - Mathf.Pow(HitPoints / MaxHitPoints, 2))))
+            if (force || Rand.Chance(Mathf.Clamp01(0.75f - Mathf.Pow(HitPoints / MaxHitPoints, 2))))
             {
                 if (comp != null)
                 {


### PR DESCRIPTION
## Additions

https://github.com/CombatExtended-Continued/CombatExtended/pull/4698
Source .cs alternative to my older PR request. So a lot less bloated.

## Changes

Forces ammo to explode on external damage so stacks of dozens/hundreds of explosives don't magically disappear when damaged.

## References

https://steamcommunity.com/sharedfiles/filedetails/?id=3784849472
https://www.youtube.com/watch?v=YIR8ab-s9-Y
Same effect as my bug fix mod and old video except instead of .xml based it just uses CE's pre-existing ammo explosion logic. so it is simpler and doesn't make all explosives explode in the same way. It uses CE's better 0.333 multiplier to simulate square cube explosion size increases instead of vanilla RimWorld's "explosiveExpandPerStackcount" which is pretty bad.

## Reasoning

https://www.youtube.com/watch?v=q2x9d6viDW4
Just to fix the bug of CE's ammo being destroyed by damage and making large stacks of explosives magically disappear.

## Alternatives

https://github.com/CombatExtended-Continued/CombatExtended/pull/4692
https://github.com/CombatExtended-Continued/CombatExtended/pull/4698
Only these 2 older PRs which are obviously not as good, the 1st one was .xml based using vanilla RimWorld's flawed logic. The 2nd was just patching CE itself so it was obviously more bloated.

## Testing

https://www.youtube.com/watch?v=q2x9d6viDW4
This old first video shows what happens in the current version of CE when you detonate an IED next to a stack of 1 and a stack of over 100 HE shells.

https://www.youtube.com/watch?v=JehoQzFOK4Y
This new video shows my little test comparing a stack of 1 and a stack of 100 HE shells next to an IED detonation. Obviously it removes the bug of the extra HE shells magically disappearing.

The test load order was just:
Harmony
Core
Combat Extended (my modified version)
CE IED RemoteDetonation
Stack By Weight

And obviously I use the modified behaviour for my own gameplay when I play RimWorld day-to-day. Haven't noticed any visible bugs so far.