### PR TITLE
Update Buildings_Security.xml

### DIFF
--- a/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
@@ -609,14 +609,11 @@
 		</value>
 	</Operation>
 
+	<!-- Incendiary Explosive -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="TrapIED_Incendiary"]/costList</xpath>
+		<xpath>Defs/ThingDef[defName="TrapIED_HighExplosive"]/specialDisplayRadius</xpath>
 		<value>
-			<costList>
-				<Steel>10</Steel>
-				<Prometheum>2</Prometheum>
-				<ComponentIndustrial>1</ComponentIndustrial>
-			</costList>
+			<specialDisplayRadius>4.5</specialDisplayRadius>
 		</value>
 	</Operation>
 
@@ -647,6 +644,25 @@
 		</value>
 	</Operation>
 
+	<!-- Incendiary IED -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="TrapIED_Incendiary"]/specialDisplayRadius</xpath>
+		<value>
+			<specialDisplayRadius>5</specialDisplayRadius>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="TrapIED_Incendiary"]/costList</xpath>
+		<value>
+			<costList>
+				<Steel>10</Steel>
+				<Prometheum>2</Prometheum>
+				<ComponentIndustrial>1</ComponentIndustrial>
+			</costList>
+		</value>
+	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="TrapIED_Incendiary"]/comps/li[@Class="CompProperties_Explosive"]</xpath>
 		<value>
@@ -670,20 +686,4 @@
 		</value>
 	</Operation>
 
-<!-- TrapIED_HighExplosive: specialDisplayRadius -->
-<Operation Class="PatchOperationReplace">
-  <xpath>Defs/ThingDef[defName="TrapIED_HighExplosive"]/specialDisplayRadius</xpath>
-  <value>
-    <specialDisplayRadius>4.5</specialDisplayRadius>
-  </value>
-</Operation>
-
-<!-- TrapIED_Incendiary: specialDisplayRadius -->
-<Operation Class="PatchOperationReplace">
-  <xpath>Defs/ThingDef[defName="TrapIED_Incendiary"]/specialDisplayRadius</xpath>
-  <value>
-    <specialDisplayRadius>5</specialDisplayRadius>
-  </value>
-</Operation>
-  
 </Patch>

--- a/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
@@ -670,4 +670,20 @@
 		</value>
 	</Operation>
 
+<!-- TrapIED_HighExplosive: specialDisplayRadius -->
+<Operation Class="PatchOperationReplace">
+  <xpath>Defs/ThingDef[defName="TrapIED_HighExplosive"]/specialDisplayRadius</xpath>
+  <value>
+    <specialDisplayRadius>4.5</specialDisplayRadius>
+  </value>
+</Operation>
+
+<!-- TrapIED_Incendiary: specialDisplayRadius -->
+<Operation Class="PatchOperationReplace">
+  <xpath>Defs/ThingDef[defName="TrapIED_Incendiary"]/specialDisplayRadius</xpath>
+  <value>
+    <specialDisplayRadius>5</specialDisplayRadius>
+  </value>
+</Operation>
+  
 </Patch>

--- a/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
@@ -609,7 +609,7 @@
 		</value>
 	</Operation>
 
-	<!-- Incendiary Explosive -->
+	<!-- ========== Explosive IED ========== -->
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="TrapIED_HighExplosive"]/specialDisplayRadius</xpath>
 		<value>
@@ -644,7 +644,7 @@
 		</value>
 	</Operation>
 
-	<!-- Incendiary IED -->
+	<!-- ========== Incendiary IED ========== -->
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="TrapIED_Incendiary"]/specialDisplayRadius</xpath>
 		<value>


### PR DESCRIPTION
Bug fix for the CE patched 2 IEDs "TrapIED_HighExplosive" and "TrapIED_Incendiary" not displaying the correct increased explosion radius in the building menu. RimWorld still shows the vanilla explosion radius in the building menu unless we also patch "specialDisplayRadius" at the same time we patch the "CompProperties_Explosive".

## Additions

Creates 2 new patch operations to replace the displayed explosion radius in the building menu to patch the CE patched larger actual explosion radius.

## Changes

2 additional operations.

## References

https://i.imgur.com/YSZ1x8t.jpeg

## Reasoning

CE makes the "TrapIED_HighExplosive" and "TrapIED_Incendiary" explosions' radius bigger, but doesn't display it in the building menu.

## Alternatives

I'm not aware of any pre-existing alternatives. The "specialDisplayRadius" already in the game is already a simple solution.

## Testing

Displays correctly when I build and detonate the 2 IEDs.