### PR TITLE
Fix sos2 shuttle stuck forever exploding

### DIFF
--- a/ModPatches/Save Our Ship 2/Patches/Save Our Ship 2/Creatures_SOS2.xml
+++ b/ModPatches/Save Our Ship 2/Patches/Save Our Ship 2/Creatures_SOS2.xml
@@ -260,9 +260,20 @@
 			defName="SoS2_Shuttle" or
 			defName="SoS2_Shuttle_Heavy" or
 			defName="SoS2_Shuttle_Superheavy"
-			]/statBases/ArmorRating_Sharp </xpath>
+			]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>13</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/Vehicles.VehicleDef[defName="SoS2_Shuttle_Personal" or
+			defName="SoS2_Shuttle" or
+			defName="SoS2_Shuttle_Heavy" or
+			defName="SoS2_Shuttle_Superheavy"
+			]/statBases/ArmorRating_Heat</xpath>
+		<value>
+			<ArmorRating_Heat>0.5</ArmorRating_Heat>
 		</value>
 	</Operation>
 

--- a/ModPatches/Save Our Ship 2/Patches/Save Our Ship 2/Creatures_SOS2.xml
+++ b/ModPatches/Save Our Ship 2/Patches/Save Our Ship 2/Creatures_SOS2.xml
@@ -267,7 +267,8 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/Vehicles.VehicleDef[defName="SoS2_Shuttle_Personal" or
+		<xpath>Defs/Vehicles.VehicleDef[
+			defName="SoS2_Shuttle_Personal" or
 			defName="SoS2_Shuttle" or
 			defName="SoS2_Shuttle_Heavy" or
 			defName="SoS2_Shuttle_Superheavy"


### PR DESCRIPTION
## Additions
lower sos2 Shuttle heat armor
## Changes
same as above
## References
Boris from sos2 server
## Reasoning
rn they keep exploding forever
## Alternatives
change exploding damage works too
## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
