### PR TITLE
Unload ammo when deconstructing turret

### DIFF
--- a/Source/CombatExtended/CombatExtended/Things/Building_TurretGunCE.cs
+++ b/Source/CombatExtended/CombatExtended/Things/Building_TurretGunCE.cs
@@ -244,6 +244,10 @@ public class Building_TurretGunCE : Building_Turret
 
     public override void DeSpawn(DestroyMode mode = DestroyMode.Vanish)    // Added GenClosestAmmo unsubscription
     {
+        if (mode == DestroyMode.Deconstruct)
+        {
+            compAmmo?.TryUnload();
+        }
         Map.GetComponent<TurretTracker>().Unregister(this);
         base.DeSpawn(mode);
         ResetCurrentTarget();


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Before a turret is despawned via Deconstruct destroy type, try to unload its ammo unto the floor. Does not happen when uninstalling turret. Does not happen when violently destroying turret

## Reasoning

Why did you choose to implement things this way, e.g.
- Prevents player from accidentally wasting their ammo

## Alternatives

Describe alternative implementations you have considered, e.g.
- Drop some ammo when killing turrets for funny cookoff?

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)

Tested:
- deconstructing turret in Godmode and without
- uninstalling turret
- destroying world tile with the turret
- killing turret
- deconstructing autoloader