### PR TITLE
Prepatcher Compat with VEF

### DIFF
--- a/Source/VEFCompat/VEFCompat/VanillaExpandedFramework.cs
+++ b/Source/VEFCompat/VEFCompat/VanillaExpandedFramework.cs
@@ -5,6 +5,8 @@ using Verse;
 using VEF.Apparels;
 namespace CombatExtended.Compatibility;
 
+// Loaded only through VEF's conditional LoadFolders entry. Patches discovers
+// IPatch implementations across loaded assemblies and installs the callbacks.
 public class VanillaExpandedFramework : IPatch
 {
     const string ModName = "Vanilla Expanded Framework";
@@ -77,4 +79,3 @@ public class VanillaExpandedFramework : IPatch
     }
 
 }
-


### PR DESCRIPTION
Prepatcher tries to load all assemlies soon as they are referenced, no matter whether or not the assembly will be used.
Currently VEF compat code makes prepatcher tries to load the dll directly, but if player doesn't use vef it causes `ReflectionTypeLoadException`.
Move the compat code into separate VEFCompat.dll solves this problem.


## Changes
Move code to where it should be for better compatibility

## References
logs before & after this commit are attached here.
(https://gist.github.com/masakitenchi/802e2f5c81653d73dad6f29b5e8681d4)

## Reasoning
Not everyone uses VEF


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
