### PR TITLE
Whitespace, fix patch typo

### DIFF
--- a/ModPatches/Progression Education/Defs/Progression Education/Training_ammo.xml
+++ b/ModPatches/Progression Education/Defs/Progression Education/Training_ammo.xml
@@ -33,7 +33,7 @@
 
 	<ThingDef ParentName="Base556x45mmNATOBullet">
 		<defName>Bullet_556x45mmNATO_FMJ_Training</defName>
-		<label>5.56mm Training NATO bullet (FMJ)</label>
+		<label>5.56mm NATO training bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>1</damageAmountBase>
 			<armorPenetrationSharp>6</armorPenetrationSharp>
@@ -43,7 +43,7 @@
 
 	<ThingDef ParentName="Base6x24mmChargedBullet">
 		<defName>Bullet_6x24mmCharged_Training</defName>
-		<label>6x24mm Training Charged bullet</label>
+		<label>6x24mm  Charged training bullet</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>1</damageAmountBase>
 			<armorPenetrationSharp>15</armorPenetrationSharp>

--- a/ModPatches/Progression Education/Patches/Progression Education/TrainingWeapons.xml
+++ b/ModPatches/Progression Education/Patches/Progression Education/TrainingWeapons.xml
@@ -37,18 +37,8 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[
-			defName="PE_Gun_AssaultRifleTraining" or 
-			defName="PE_Gun_SpacerTraining" or 
-			defName="PE_PracticeShortBow"]</xpath>
-		<value>
-			<generateAllowChance>0</generateAllowChance>
-		</value>
-	</Operation>
-
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="PE_PracticeShortBow"]</xpath>
+		<xpath>Defs/ThingDef[defName="PE_PracticeShortBow"]/tools</xpath>
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
@@ -60,6 +50,16 @@
 					<armorPenetrationBlunt>0.65</armorPenetrationBlunt>
 				</li>
 			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[
+			defName="PE_Gun_AssaultRifleTraining" or 
+			defName="PE_Gun_SpacerTraining" or 
+			defName="PE_PracticeShortBow"]</xpath>
+		<value>
+			<generateAllowChance>0</generateAllowChance>
 		</value>
 	</Operation>
 


### PR DESCRIPTION
## Changes
- Tweak projectile labels for the training ammo.
- Fix a patch

## Reasoning
- I'm an idiot and forgot to actually push the commit with the fixes to #4725 before merging it.

## Alternatives
- Suffer

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
