### PR TITLE
Fixed secondary damage of shrapnel/fragments not displaying

### DIFF
--- a/Source/CombatExtended/CombatExtended/AmmoUtility.cs
+++ b/Source/CombatExtended/CombatExtended/AmmoUtility.cs
@@ -147,10 +147,53 @@ public static class AmmoUtility
             foreach (var fragmentDef in fragmentComp.fragments)
             {
                 var fragmentProps = fragmentDef?.thingDef?.projectile as ProjectilePropertiesCE;
+
                 stringBuilder.AppendLine("   " + "   " + fragmentDef.LabelCap);
-                stringBuilder.AppendLine("   " + "   " + "   " + "CE_DescDamage".Translate() + ": " + fragmentProps?.damageAmountBase.ToString() + " (" + fragmentProps?.damageDef.LabelCap.ToString() + ")");
-                stringBuilder.AppendLine("   " + "   " + "   " + "CE_DescSharpPenetration".Translate() + ": " + fragmentProps?.armorPenetrationSharp.ToStringByStyle(ToStringStyle.FloatTwo) + " " + "CE_mmRHA".Translate());
-                stringBuilder.AppendLine("   " + "   " + "   " + "CE_DescBluntPenetration".Translate() + ": " + fragmentProps?.armorPenetrationBlunt.ToStringByStyle(ToStringStyle.FloatTwo) + " " + "CE_MPa".Translate());
+
+                // Primary Damage
+                stringBuilder.AppendLine(
+                    "   " + "   " + "   " +
+                    "CE_DescDamage".Translate() + ":"
+                );
+
+                stringBuilder.AppendLine(
+                    "   " + "   " + "   " + "   " +
+                    fragmentProps?.damageAmountBase.ToString() +
+                    " (" + fragmentProps?.damageDef.LabelCap.ToString() + ")"
+                );
+
+                // Check if fragment has secondary Damage
+                if (fragmentProps != null && !fragmentProps.secondaryDamage.NullOrEmpty())
+                {
+                    foreach (var sec in fragmentProps.secondaryDamage)
+                    {
+                        var secondaryChance = sec.chance >= 1.0f
+                            ? ""
+                            : $"({GenText.ToStringByStyle(sec.chance, ToStringStyle.PercentZero)} {"CE_Chance".Translate()})";
+
+                        stringBuilder.AppendLine(
+                            "   " + "   " + "   " + "   " +
+                            GenText.ToStringByStyle(sec.amount, ToStringStyle.Integer) +
+                            " (" + sec.def.LabelCap + ") " +
+                            secondaryChance
+                        );
+                    }
+                }
+                // Sharp penetration
+                stringBuilder.AppendLine(
+                    "   " + "   " + "   " +
+                    "CE_DescSharpPenetration".Translate() + ": " +
+                    fragmentProps?.armorPenetrationSharp.ToStringByStyle(ToStringStyle.FloatTwo) +
+                    " " + "CE_mmRHA".Translate()
+                );
+
+                // Blunt penetration
+                stringBuilder.AppendLine(
+                    "   " + "   " + "   " +
+                    "CE_DescBluntPenetration".Translate() + ": " +
+                    fragmentProps?.armorPenetrationBlunt.ToStringByStyle(ToStringStyle.FloatTwo) +
+                    " " + "CE_MPa".Translate()
+                );
             }
         }
 


### PR DESCRIPTION
## Additions

-When a grenade or bullet has a fragments like mortar rounds, and these fragments have secondary damage beside regular damage, the CE didnt display the secondary damage. Now with this fix it does.

## Changes

-Changed the AmmoUtility.cs to iterate over secondarydamage list in fragmentcomp class references.

## References



## Reasoning



## Alternatives



## Testing

Check tests you have performed:
- [ Y] Compiles without warnings
- [ Y] Game runs without errors
<img width="299" height="711" alt="Zrzut ekranu 2026-09-10 224621" src="https://github.com/user-attachments/assets/10c78461-285b-4adf-9164-0eb95ac81fa2" />

